### PR TITLE
Sti bug on new admin notes

### DIFF
--- a/lib/active_admin/admin_notes/renderers.rb
+++ b/lib/active_admin/admin_notes/renderers.rb
@@ -85,7 +85,7 @@ module ActiveAdmin
       def form
         active_admin_form_for(ActiveAdmin::AdminNotes::Note.new, :as => :admin_note, :url => admin_admin_notes_path, :html => {:class => "inline_form"}) do |form|
           form.inputs do
-            form.input :resource_type, :value => resource.class.to_s, :as => :hidden
+            form.input :resource_type, :value => resource.class.base_class.name.to_s, :as => :hidden
             form.input :resource_id, :value => resource.id, :as => :hidden
             form.input :body, :input_html => {:size => "80x12"}, :label => false
           end


### PR DESCRIPTION
You cannot currently add an admin note to STI objects. This is a fix for that.
