### PR TITLE
fix 'recent posts' example to be syntactically correct

### DIFF
--- a/lib/generators/active_admin/install/templates/dashboards.rb
+++ b/lib/generators/active_admin/install/templates/dashboards.rb
@@ -8,9 +8,10 @@ ActiveAdmin::Dashboards.build do
   # Here is an example of a simple dashboard section
   #
   #   section "Recent Posts" do
-  #   ul do
-  #     Post.recent(5).collect do |post|
-  #       li link_to(post.title, admin_post_path(post)))
+  #     ul do
+  #       Post.recent(5).collect do |post|
+  #         li link_to(post.title, admin_post_path(post))
+  #       end
   #     end
   #   end
   


### PR DESCRIPTION
I tried to uncomment the example in dashboard.rb and plugin my local models variables but there were 2 sytax errors.
1. missing 'end' for the 'section "Recent Posts" do' block on line 10
2. One too many ")" after the "link_to(post.title..." on line 13

No specs written because it's not changing code.
