### PR TITLE
Fix root namespace usage

### DIFF
--- a/lib/active_admin.rb
+++ b/lib/active_admin.rb
@@ -132,7 +132,7 @@ module ActiveAdmin
 
     # Registers a brand new configuration for the given resource.
     def register(resource, options = {}, &block)
-      namespace_name = options[:namespace] == false ? :root : (options[:namespace] || default_namespace)
+      namespace_name = (options[:namespace] || default_namespace) == false ? :root : (options[:namespace] || default_namespace)
       namespace = find_or_create_namespace(namespace_name)
       namespace.register(resource, options, &block)
     end


### PR DESCRIPTION
Should be self-explanatory. "false" was getting captured as a string. See "rake routes" when set to false without this fix to see what I mean.
