### PR TITLE
compile sass files to Sass::Plugins.options[:css_template]/admin

### DIFF
--- a/lib/active_admin.rb
+++ b/lib/active_admin.rb
@@ -127,7 +127,7 @@ module ActiveAdmin
 
       # Setup SASS
       require 'sass/plugin' # This must be required after initialization
-      Sass::Plugin.add_template_location(File.expand_path("../active_admin/stylesheets/", __FILE__), File.join(Rails.root, "public/stylesheets/admin"))
+      Sass::Plugin.add_template_location(File.expand_path("../active_admin/stylesheets/", __FILE__), File.join(Sass::Plugin.options[:css_location], 'admin'))
     end
 
     # Registers a brand new configuration for the given resource.


### PR DESCRIPTION
compile sass files to Sass::Plugins.options[:css_template]/admin instead of /public/stylesheets/admin (not everyone keeps their compiled css on public/stylesheets) 
