### PR TITLE
Isolate necessary styles to active_admin

### DIFF
--- a/lib/active_admin/stylesheets/active_admin.scss
+++ b/lib/active_admin/stylesheets/active_admin.scss
@@ -56,7 +56,7 @@ body {
 }
 
 // ----------------------------------- Main Structure 
-#content { 
+#active_admin_content { 
   margin: 0; 
   padding: 25px $horizontal-page-margin; 
   
@@ -271,7 +271,7 @@ body.logged_out {
   #content_wrapper{
     width: 500px;
     margin: 70px auto;
-    #content {
+    #active_admin_content {
       @include shadow;
       background: #fff;
       padding: 13px 30px;

--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -71,7 +71,7 @@ module ActiveAdmin
         end
 
         def build_page_content
-          div :id => "content", :class => (skip_sidebar? ? "without_sidebar" : "with_sidebar") do
+          div :id => "active_admin_content", :class => (skip_sidebar? ? "without_sidebar" : "with_sidebar") do
             build_flash_messages
             build_main_content_wrapper
             build_sidebar


### PR DESCRIPTION
Use more specific ID for content and isolate styles from markup that is not from active admin.
