### PR TITLE
Activeadmin admin#login page template should respect devise authentication_keys config

### DIFF
--- a/lib/active_admin/views/templates/active_admin/devise/sessions/new.html.erb
+++ b/lib/active_admin/views/templates/active_admin/devise/sessions/new.html.erb
@@ -4,7 +4,7 @@
   <% scope = Devise::Mapping.find_scope!(resource_name) %>
   <%= active_admin_form_for(resource, :as => resource_name, :url => send(:"#{scope}_session_path"), :html => { :id => "session_new" }) do |f| 
     f.inputs do
-      f.input :email
+      Devise.authentication_keys.each { |key| f.input key }
       f.input :password
       f.input :remember_me, :as => :boolean, :if =>  false  #devise_mapping.rememberable? }
     end


### PR DESCRIPTION
I installed activeadmin to a site where I had already implemented devise for authentication. I was getting an error because I had set my authentication key to a nondefault field ('login'):
`config.authentication_keys = [ :login ]`

This is a one-line change to create the login page using the authentication keys setting rather than the hardcoded 'email' field to make it easier for projects already using devise to use activeadmin.
