### PR TITLE
Classy body

### DIFF
--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -5,11 +5,18 @@ module ActiveAdmin
 
         def build(*args)
           super
+          add_classes_to_body
           build_active_admin_head
           build_page
         end
 
         private
+
+
+        def add_classes_to_body
+          @body.add_class(params[:action])
+          @body.add_class(params[:controller].gsub('/', '_'))
+        end
 
         def build_active_admin_head
           within @head do


### PR DESCRIPTION
ActiveAdmin used to add the current action and controller name to the `<body>`. I put this feature back in. It should be cuked.
