### PR TITLE
extract stylesheet generation to its own method.

### DIFF
--- a/lib/active_admin.rb
+++ b/lib/active_admin.rb
@@ -125,6 +125,10 @@ module ActiveAdmin
 
       yield self
 
+      generate_stylesheets
+    end
+
+    def generate_stylesheets
       # Setup SASS
       require 'sass/plugin' # This must be required after initialization
       Sass::Plugin.add_template_location(File.expand_path("../active_admin/stylesheets/", __FILE__), File.join(Rails.root, "public/stylesheets/admin"))


### PR DESCRIPTION
Allows anyone to customize generation of stylesheets.

Changes no actual functionality of the gem.

Based on v0.2.1. Should merge cleanly to current master.

For example, can be used to fix bug #44 with heroku readonly filesystem.

Example usage in the heroku case:

``` ruby

# must happen before ActiveAdmin.setup
module ActiveAdmin
  class << self
    def generate_stylesheets_with_env_check
      # Override sass integration
      unless Rails.env.production? or Rails.env.demo?
        generate_stylesheets_without_env_check
      end
    end
    alias_method_chain :generate_stylesheets, :env_check
  end
end

```
