### PR TITLE
Fix views path for custom actions.

### DIFF
--- a/features/specifying_actions.feature
+++ b/features/specifying_actions.feature
@@ -1,6 +1,7 @@
 Feature: Specifying Actions
 
   Specifying which actions to allow on my resource
+  Adding custom actions
 
   @allow-rescue
   Scenario: Only creating the index action
@@ -10,7 +11,52 @@ Feature: Specifying Actions
           actions :index
         end
       """
-	And I am logged in
+    And I am logged in
     And a post with the title "Hello World" exists
     When I am on the index page for posts
     Then an "AbstractController::ActionNotFound" exception should be raised when I follow "View"
+
+
+  Scenario: Specify a custom collection action with template
+    Given a configuration of:
+      """
+        ActiveAdmin.register Post do
+          action_item(:only => :index) do
+            link_to('Import Posts', import_admin_posts_path)
+          end
+
+          collection_action :import
+        end
+      """
+    Given "app/views/admin/posts/import.html.erb" contains:
+      """
+        <p>We are currently working on this feature...</p>
+      """
+    And I am logged in
+    When I am on the index page for posts
+    And I follow "Import"
+    Then I should see "We are currently working on this feature"
+
+  Scenario: Specify a custom member action with template
+    Given a configuration of:
+      """
+        ActiveAdmin.register Post do
+          action_item(:only => :show) do
+            link_to('Review', review_admin_post_path)
+          end
+
+          member_action :review do
+            @post = Post.find(params[:id])
+          end
+        end
+      """
+    Given "app/views/admin/posts/review.html.erb" contains:
+      """
+        <h1>Review: <%= @post.title %></h1>
+      """
+    And I am logged in
+    And a post with the title "Hello World" exists
+    When I am on the index page for posts
+    And I follow "View"
+    And I follow "Review"
+    Then I should see "Review: Hello World"

--- a/lib/active_admin/resource_controller.rb
+++ b/lib/active_admin/resource_controller.rb
@@ -77,13 +77,22 @@ module ActiveAdmin
 
     protected
 
-    # Override _prefix so we force ActionController to render the
-    # views from active_admin/resource instead of default path
+    # Override _prefix so we force ActionController to render the views from
+    # active_admin/resource for the implemented actions
     def _prefix
-      'active_admin/resource'
+      if implemented_actions.include?(params[:action])
+        'active_admin/resource'
+      else
+        super
+      end
     end
 
-    # By default Rails will render un-implemented actions when the view exists. Becuase Active
+    # Action methods that active admin implements
+    def implemented_actions
+      %w(index new create edit update show delete)
+    end
+
+    # By default Rails will render un-implemented actions when the view exists. Because Active
     # Admin allows you to not render any of the actions by using the #actions method, we need
     # to check if they are implemented.
     def only_render_implemented_actions

--- a/spec/unit/resource_controller_spec.rb
+++ b/spec/unit/resource_controller_spec.rb
@@ -43,7 +43,7 @@ describe ActiveAdmin::ResourceController do
       let(:resource){ mock(:parent_menu_item_name => "Admin", :menu_item_name => "Resources", :belongs_to? => false) }
       it { should == "Admin/Resources" }
     end
-  end
+  end # describe "setting the current tab"
 
   ActiveAdmin.register Post do
     after_build :call_after_build
@@ -142,6 +142,25 @@ describe ActiveAdmin::ResourceController do
         controller.send :destroy_resource, resource
       end
     end
-  end
+  end # describe "callbacks"
 
+  describe "#_prefix" do
+    let(:controller){ Admin::PostsController.new }
+    context "when action is implemented (index, new...)" do
+      it "should be overwritten to active_admin/resource" do
+        %w(index new create edit update show delete).each do |action|
+          controller.stub!(:params).and_return(:action => action)
+          controller.send(:_prefix).should == "active_admin/resource"
+        end
+      end
+    end
+
+    context "when custom action" do
+      it "should be the default one" do
+        action = 'import'
+        controller.stub!(:params).and_return(:action => action)
+        controller.send(:_prefix).should == "admin/posts"
+      end
+    end
+  end # describe "#_prefix"
 end


### PR DESCRIPTION
The resource controller was setting the views path to the directory containing the active admin views. This would prevent developers from getting their own template rendered in custom actions. 

This commit fixes that by overwritting the views path only for actions implemented by active admin.
