### PR TITLE
wrapping the render comment in the dashbard template with a div

### DIFF
--- a/lib/generators/active_admin/install/templates/dashboards.rb
+++ b/lib/generators/active_admin/install/templates/dashboards.rb
@@ -20,7 +20,9 @@ ActiveAdmin::Dashboards.build do
   # easily render a partial rather than build content in ruby.
   #
   #   section "Recent Posts" do
-  #     render 'recent_posts' # => this will render /app/views/admin/dashboard/_recent_posts.html.erb
+  #     div do
+  #       render 'recent_posts' # => this will render /app/views/admin/dashboard/_recent_posts.html.erb
+  #     end
   #   end
   
   # == Section Ordering


### PR DESCRIPTION
the render comment implied that I didn't need anything around it, but wouldn't render until I wrapped it.
