### PR TITLE
Allow returning objects responding to :to_s from an Arbre block.

### DIFF
--- a/lib/active_admin/arbre/html.rb
+++ b/lib/active_admin/arbre/html.rb
@@ -73,8 +73,8 @@ module Arbre
 
       # Inserts a text node if the tag is a string
       def insert_text_node_if_string(tag)
-        if tag.is_a?(String)
-          current_dom_context << TextNode.from_string(tag)
+        if tag.respond_to?(:to_s) && !tag.is_a?(Arbre::HTML)
+          current_dom_context << TextNode.from_string(tag.to_s)
         end
       end
     end

--- a/spec/unit/arbre/html_spec.rb
+++ b/spec/unit/arbre/html_spec.rb
@@ -146,6 +146,12 @@ HTML
         "Hello World"
       end.children.first.should be_instance_of(Arbre::HTML::TextNode)
     end
+
+    it "should turn objects that respond to :to_s into text nodes" do
+      li do
+        42
+      end.children.first.should be_instance_of(Arbre::HTML::TextNode)
+    end
   end
 
   describe "self-closing nodes" do


### PR DESCRIPTION
Not sure if this is the best way to do this.

I wasted a few minutes trying to figure out why this wasn't working, until I found that only Strings were being accepted by the block.

```
column "Post Length" do |post|
  post.content.size
end
```
