### PR TITLE
Stop using deprecated attr_accessor_with_default

### DIFF
--- a/lib/active_admin/comments/configuration.rb
+++ b/lib/active_admin/comments/configuration.rb
@@ -9,7 +9,11 @@ module ActiveAdmin
         #
         #   config.allow_comments_in = [:admin, :root]
         #
-        attr_accessor_with_default :allow_comments_in, [:admin]
+        attr_writer :allow_comments_in
+
+        def allow_comments_in
+          @allow_comments_in ||= [:admin]
+        end
       end
 
     end


### PR DESCRIPTION
Hey, this commit quiets the deprecation warning on launch with rails 3.1.0.rc4
