### PR TITLE
Vanilla install has working "Log out" link.

### DIFF
--- a/lib/active_admin/views/header_renderer.rb
+++ b/lib/active_admin/views/header_renderer.rb
@@ -27,7 +27,7 @@ module ActiveAdmin
         content_tag 'p', :id => "utility_nav" do
           if current_active_admin_user?
             content_tag(:span, display_name(current_active_admin_user), :class => "current_user") +
-              link_to(I18n.t('active_admin.logout'), :destroy_admin_user_session_path, :method => :delete)
+              link_to(I18n.t('active_admin.logout'), :destroy_admin_user_session, :method => :delete)
           end
         end
       end


### PR DESCRIPTION
I was getting a route error for the Log Out link in a new rails app with just Active Admin installed. I changed the view factory to use the named route, and add the method as :delete.
