### PR TITLE
rename pt.yml to pt-BR.yml

### DIFF
--- a/lib/active_admin/locales/pt-BR.yml
+++ b/lib/active_admin/locales/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+"pt-BR":
   active_admin:
     dashboard_welcome:
       welcome: "Bem vindo ao Active Admin. Esta é a página de painéis padrão."
@@ -31,6 +31,6 @@ pt:
     pagination:
       empty: "Nenhum(a) %{model} encontrado(a)"
       one: "Exibindo <b>1</b> %{model}"
-      one_page: "Exibindo <b>todos os(a) %{n}</b> %{model}"
+      one_page: "Exibindo <b>todos(as) os(as) %{n}</b> %{model}"
       multiple: "Exibindo %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> de um total de <b>%{total}</b>"
 


### PR DESCRIPTION
I believe it's the correct(and standard) name for brazilian portuguese locale, as seen in http://pt.wikipedia.org/wiki/Predefini%C3%A7%C3%A3o:Tabela_de_locale and https://github.com/svenfuchs/rails-i18n
