### PR TITLE
Fix for issue #197

### DIFF
--- a/features/edit_page.feature
+++ b/features/edit_page.feature
@@ -52,6 +52,35 @@ Feature: Edit Page
     And I should see the attribute "Title" with "Hello World from update"
     And I should see the attribute "Author" with "John Doe"
 
+  Scenario: Generating a custom form with :html set, visiting the new page first (bug probing issue #109)
+    Given a configuration of:
+    """
+      ActiveAdmin.register Post do
+        form :html => {} do |f|
+          f.inputs "Your Post" do
+            f.input :title
+            f.input :body
+          end
+          f.inputs "Publishing" do
+            f.input :published_at
+          end
+          f.buttons
+        end
+      end
+    """
+    Given I follow "New"
+    Then I follow "Posts"
+    Then I follow "Edit"
+    Then I should see a fieldset titled "Your Post"
+    And I should see a fieldset titled "Publishing"
+    And the "Title" field should contain "Hello World"
+    And the "Body" field should contain ""
+    When I fill in "Title" with "Hello World from update"
+    When I press "Update Post"
+    Then I should see "Post was successfully updated."
+    And I should see the attribute "Title" with "Hello World from update"
+    And I should see the attribute "Author" with "John Doe"
+
   Scenario: Generating a form from a partial
     Given "app/views/admin/posts/_form.html.erb" contains:
     """

--- a/lib/active_admin/view_helpers/form_helper.rb
+++ b/lib/active_admin/view_helpers/form_helper.rb
@@ -3,6 +3,7 @@ module ActiveAdmin
     module FormHelper
       
       def active_admin_form_for(resource, options = {}, &block)
+        options = Marshal.load( Marshal.dump(options) )
         options[:builder] ||= ActiveAdmin::FormBuilder
         semantic_form_for resource, options, &block
       end


### PR DESCRIPTION
Fixed by marshalling (deep duping) options before it's sent to formtastic.

This fix should be backported as it will basically mess up every form
by overriding :method used by all forms for a resource and giving an error of missing routes.

Tests are green with Rails 3.0.9.
