### PR TITLE
Fixing issue where camelcase classes were rendering spaces in ID attribut

### DIFF
--- a/lib/active_admin/views/index_as_table.rb
+++ b/lib/active_admin/views/index_as_table.rb
@@ -78,7 +78,7 @@ module ActiveAdmin
 
       def build(page_config, collection)
         table_options = {
-          :id => active_admin_config.plural_resource_name.underscore,
+          :id => active_admin_config.resource.model_name.tableize,
           :sortable => true,
           :class => "index_table",
           :i18n => active_admin_config.resource


### PR DESCRIPTION
Fixing issue where camelcase classes were rendering spaces in ID attribute of IndexAsTable

eg. class FooFighters would have produced <table id="foo fighters"> instead of "foo_fighters"

I started putting a unit test together for this, but it became difficult figuring out how I'd set the test up. Hope a one line change is acceptable.
