### PR TITLE
Add guard-rspec and Guardfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,4 +36,5 @@ group :test do
   gem 'shoulda',        '2.11.2',           :require => nil
   gem 'launchy'
   gem 'jslint_on_rails',    '~> 1.0.6'
+  gem 'guard-rspec'
 end

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,8 @@
+# More info at https://github.com/guard/guard#readme
+
+guard 'rspec', :all_on_start => false, :version => 2 do
+  watch(%r{^spec/.+_spec\.rb$})
+  watch(%r{^lib/active_admin/(.+)\.rb$})     { |m| "spec/unit/#{m[1]}_spec.rb" }
+  watch('spec/spec_helper.rb')  { "spec/" }
+end
+


### PR DESCRIPTION
Run `guard`.

Whenever you save a file in `lib/active_admin` it runs the corresponding spec in `spec/unit/`.

The Guardfile is setup not to run the entire suite on load. The entire suite will run when the specs pass though.
