### PR TITLE
Fixed i18n pluralization with spec 

### DIFF
--- a/lib/active_admin/resource/naming.rb
+++ b/lib/active_admin/resource/naming.rb
@@ -28,7 +28,17 @@ module ActiveAdmin
 
       # Returns the plural version of this resource
       def plural_resource_name
-        @plural_resource_name ||= resource_name.pluralize
+        @plural_resource_name ||= if @options[:as] || !resource.respond_to?(:model_name)
+          resource_name.pluralize
+        else
+          # Check if we have a translation available otherwise pluralize
+          begin
+            I18n.translate!("activerecord.models.#{resource.model_name.downcase}")
+            resource.model_name.human(:count => 3)
+          rescue I18n::MissingTranslationData
+            resource_name.pluralize
+          end
+        end
       end
 
     end

--- a/spec/unit/resource/naming_spec.rb
+++ b/spec/unit/resource/naming_spec.rb
@@ -50,6 +50,14 @@ module ActiveAdmin
           config(:as => "My Category").resource_name.should == "My Category"
         end
       end
+      context "I18n" do
+        before do
+          I18n.stub(:translate) { 'Categorie' }
+        end
+        it "should return the plural version defined in the i18n if available" do
+          config.plural_resource_name.should == "Categorie"
+        end
+      end
     end
 
   end


### PR DESCRIPTION
use model_name.human to implement plural_resource_name so that it plays well with i18n

This is a fix to a previous commit from hvirring 255f7d1
