### PR TITLE
Logout now works with Devise < 1.2. Closes #381.

### DIFF
--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -42,7 +42,7 @@ module ActiveAdmin
     setting :logout_link_path, :destroy_admin_user_session_path
 
     # The method to use when generating the link for user logout
-    setting :logout_link_method, :delete
+    setting :logout_link_method, :get
 
     # Active Admin makes educated guesses when displaying objects, this is
     # the list of methods it tries calling in order

--- a/lib/active_admin/devise.rb
+++ b/lib/active_admin/devise.rb
@@ -4,13 +4,18 @@ module ActiveAdmin
   module Devise
 
     def self.config
-      {
+      config = {
         :path => ActiveAdmin.application.default_namespace,
         :controllers => ActiveAdmin::Devise.controllers,
-        :path_names => { :sign_in => 'login', :sign_out => "logout" },
-        # Support sign_out via :get and Devise default (:get or :delete depending on version)
-        :sign_out_via => [::Devise.sign_out_via, :get].flatten.uniq
+        :path_names => { :sign_in => 'login', :sign_out => "logout" }
       }
+
+      if ::Devise.respond_to?(:sign_out_via)
+        logout_methods = [::Devise.sign_out_via, ActiveAdmin.application.logout_link_method].flatten.uniq
+        config.merge!( :sign_out_via => logout_methods)
+      end
+
+      config
     end
 
     def self.controllers

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -53,12 +53,12 @@ describe ActiveAdmin::Application do
       application.authentication_method.should == false
     end
 
-    it "should have a logout link path" do
+    it "should have a logout link path (Devise's default)" do
       application.logout_link_path.should == :destroy_admin_user_session_path
     end
 
-    it "should have a logout link method" do
-      application.logout_link_method.should == :delete
+    it "should have a logout link method (Devise's default)" do
+      application.logout_link_method.should == :get
     end
   end
 

--- a/spec/unit/devise_spec.rb
+++ b/spec/unit/devise_spec.rb
@@ -22,4 +22,45 @@ describe ActiveAdmin::Devise::Controller do
     controller.root_path.should == "/"
   end
 
+  describe "#config" do
+    let(:config) { ActiveAdmin::Devise.config }
+
+    describe ":sign_out_via option" do
+
+      subject { config[:sign_out_via] }
+
+      context "when Devise does not implement sign_out_via (version < 1.2)" do
+        before do
+          ::Devise.should_receive(:respond_to?).with(:sign_out_via).and_return(false)
+        end
+
+        it "should not contain any customization for sign_out_via" do
+          config.should_not have_key(:sign_out_via)
+        end
+      end
+
+      context "when Devise implements sign_out_via (version >= 1.2)" do
+        before do
+          ::Devise.should_receive(:respond_to?).with(:sign_out_via).and_return(true)
+          ::Devise.stub!(:sign_out_via) { :delete }
+        end
+
+        it "should contain the application.logout_link_method" do
+            ::Devise.should_receive(:sign_out_via).and_return(:delete)
+            ActiveAdmin.application.should_receive(:logout_link_method).and_return(:get)
+
+            config[:sign_out_via].should include(:get)
+        end
+
+        it "should contain Devise's logout_via_method(s)" do
+            ::Devise.should_receive(:sign_out_via).and_return([:delete, :post])
+            ActiveAdmin.application.should_receive(:logout_link_method).and_return(:get)
+
+            config[:sign_out_via].should == [:delete, :post, :get]
+        end
+      end
+
+    end # describe ":sign_out_via option"
+  end # describe "#config"
+
 end


### PR DESCRIPTION
Devise < 1.2 does not implement `sign_out_via` method. Devise 1.1 signs out via `:get`.

I set `:get` as the default `logout_link_method`.

With Devise >= 1.2, :sign_out_via is set to the `logout_link_method` + Devise.sign_out_via.
