### PR TITLE
Add deprecated method ActiveAdmin.default_namespace

### DIFF
--- a/lib/active_admin.rb
+++ b/lib/active_admin.rb
@@ -69,6 +69,11 @@ module ActiveAdmin
       Rails.application.config.assets.enabled
     end
 
+    # Migration MoveAdminNotesToComments generated with version 0.2.2 might reference
+    # to ActiveAdmin.default_namespace.
+    delegate :default_namespace, :to => :application
+    ActiveAdmin::Deprecation.deprecate self, :default_namespace, "Please use ActiveAdmin.application.default_namespace instead."
+
   end
 end
 

--- a/spec/unit/active_admin_spec.rb
+++ b/spec/unit/active_admin_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe ActiveAdmin do
+  describe "#default_namespace" do
+    it "should delegate to ActiveAdmin.application" do
+      ActiveAdmin.application.should_receive(:default_namespace)
+
+      ActiveAdmin.default_namespace
+    end
+
+    it "should be deprecated" do
+      ActiveAdmin::Deprecation.should_receive(:warn)
+
+      ActiveAdmin.default_namespace
+    end
+  end
+end


### PR DESCRIPTION
for backward compatibility with migration MoveAdminNotesToComment
generated with ActiveAdmin <= 0.2.2

Closes #383.
