### PR TITLE
Add dependency checks for rails 3.1.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,11 +12,7 @@ when /^3\.0/
   gem "meta_search",    '~> 1.0.0'
 when /^3\.1/
   gem "meta_search",    '>= 1.1.0.pre'
-  gem "uglifier"
   gem 'sass-rails',     "~> 3.1.0.rc"
-  gem 'coffee-script'
-  gem 'execjs'
-  gem 'therubyracer'
 else
   raise "Rails #{rails_version} is not supported yet"
 end

--- a/lib/active_admin.rb
+++ b/lib/active_admin.rb
@@ -4,7 +4,6 @@ require 'kaminari'
 require 'sass'
 require 'active_admin/arbre'
 require 'active_admin/engine'
-require 'rails/version'
 
 module ActiveAdmin
 
@@ -17,6 +16,7 @@ module ActiveAdmin
   autoload :ControllerAction,         'active_admin/controller_action'
   autoload :CSVBuilder,               'active_admin/csv_builder'
   autoload :Dashboards,               'active_admin/dashboards'
+  autoload :DependencyChecker,        'active_admin/dependency_checker'
   autoload :Deprecation,              'active_admin/deprecation'
   autoload :Devise,                   'active_admin/devise'
   autoload :DSL,                      'active_admin/dsl'
@@ -65,16 +65,18 @@ module ActiveAdmin
     # Returns true if this rails application has the asset
     # pipeline enabled.
     def use_asset_pipeline?
-      return false unless Rails::VERSION::MINOR > 0
-      Rails.application.config.assets.enabled
+      DependencyChecker.rails_3_1? && Rails.application.config.assets.enabled
     end
 
     # Migration MoveAdminNotesToComments generated with version 0.2.2 might reference
     # to ActiveAdmin.default_namespace.
     delegate :default_namespace, :to => :application
-    ActiveAdmin::Deprecation.deprecate self, :default_namespace, "Please use ActiveAdmin.application.default_namespace instead."
+    ActiveAdmin::Deprecation.deprecate self, :default_namespace, 
+      "ActiveAdmin.default_namespace is deprecated. Please use ActiveAdmin.application.default_namespace"
 
   end
 end
+
+ActiveAdmin::DependencyChecker.check!
 
 require 'active_admin/comments'

--- a/lib/active_admin/dependency_checker.rb
+++ b/lib/active_admin/dependency_checker.rb
@@ -1,0 +1,28 @@
+require 'rails/version'
+
+module ActiveAdmin
+  module DependencyChecker
+    class << self
+      def check!
+        if rails_3_1?
+          unless meta_search_1_1? && sass_rails_3_1?
+            warn "ActiveAdmin requires meta_search >= 1.1.0.pre and sass-rails ~> 3.1.0.rc to work with rails >= 3.1.0"
+          end
+        end
+      end
+
+      def rails_3_1?
+        Rails::VERSION::MAJOR == 3 && Rails::VERSION::MINOR >= 1
+      end
+
+      def meta_search_1_1?
+        Gem.loaded_specs['meta_search'].version.to_s >= "1.1"
+      end
+
+      def sass_rails_3_1?
+        require 'sass/rails/version'
+        Sass::Rails::VERSION >= "3.1"
+      end
+    end
+  end
+end


### PR DESCRIPTION
ActiveAdmin will warn if meta_search and sass_rails versions are
not compatible with the current rails version.

Also removed useless dependencies from Gemfile.
