### PR TITLE
Updated DeviseGenerator to respect singular tables.

### DIFF
--- a/lib/generators/active_admin/devise/devise_generator.rb
+++ b/lib/generators/active_admin/devise/devise_generator.rb
@@ -31,7 +31,7 @@ module ActiveAdmin
 
       def set_namespace_for_path
         routes_file = File.join(destination_root, "config", "routes.rb")
-        gsub_file routes_file, /devise_for :#{table_name}/, "devise_for :#{table_name}, ActiveAdmin::Devise.config"
+        gsub_file routes_file, /devise_for :#{plural_table_name}/, "devise_for :#{plural_table_name}, ActiveAdmin::Devise.config"
       end
 
       def add_default_user_to_migration


### PR DESCRIPTION
If ActiveRecord::Base.pluralize_table_names is set to false,
the table for AdminUser will be admin_user, but the route
generated by Devise will still be admin_users.  However, the
Active Admin route generation assumed the route name would
always be the same as the table name when doing a gsub in the
routes file.  Since the gsub didn't match the trailing 's' in
the route name, you ended up with the following in routes.rb:

  devise_for :admin_user, ActiveAdmin::Devise.configs

This resulted in a NoMethodError because of the leftover 's'
on the end of the line:

  undefined method `configs' for ActiveAdmin::Devise:Module (NoMethodError)

Switching from table_name to plural_table_name in the generator
ensures it matches the complete route name regardless of the
value of ActiveRecord::Base.pluralize_table_names.
