### PR TITLE
Numeric filters don't use label option or translation.

### DIFF
--- a/lib/active_admin/view_helpers/filter_form_helper.rb
+++ b/lib/active_admin/view_helpers/filter_form_helper.rb
@@ -82,7 +82,7 @@ module ActiveAdmin
                                   :onchange => "document.getElementById('#{method}_numeric').name = 'q[' + this.value + ']';"
       filter_input = text_field current_filter, :size => 10, :id => "#{method}_numeric"
 
-      [ label(method),
+      [ label(method, options[:label]),
         filter_select,
         " ",
         filter_input


### PR DESCRIPTION
The numeric filter type was not using the value of the
'label' option or the attribute's translation from i18n.
It always used the method name.
