### PR TITLE
uninitialized constant InheritedResources::Base on Rails3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,17 +4,18 @@ gemspec
 
 require File.expand_path('../spec/support/detect_rails_version', __FILE__)
 
-rails_version = ENV['RAILS'] || detect_rails_version || "3.1.0.rc10"
+rails_version = ENV['RAILS'] || detect_rails_version || '3.1.0.rc10'
 gem 'rails',          rails_version
 
 case rails_version
 when /^3\.0/
-  gem "meta_search",    '~> 1.0.0'
+  gem 'meta_search',         '~> 1.0.0'
 when /^3\.1/
-  gem "meta_search",    '>= 1.1.0.pre'
-  gem 'sass-rails',     "~> 3.1.0.rc"
+  gem 'meta_search',         '>= 1.1.0.pre'
+  gem 'sass-rails',          '~> 3.1.0.rc'
+  gem 'inherited_resources', '>= 1.3.0'
 else
-  raise "Rails #{rails_version} is not supported yet"
+  raise 'Rails #{rails_version} is not supported yet'
 end
 
 group :development, :test do


### PR DESCRIPTION
I've migrated my Rails 3.0.10 app to 3.1.0, i'm using active_admin from github, and when trying to "rails server" I get the following:

(...)gems/active_admin-d6293514b99d/lib/active_admin/resource_controller/actions.rb:2:in `module:ActiveAdmin': uninitialized constant InheritedResources::Base (NameError)

adding inhertied_resources to Gemfile fixed it.
