### PR TITLE
Fix 500 errors on Heroku when NewRelic is installed.

### DIFF
--- a/lib/active_admin/arbre/context.rb
+++ b/lib/active_admin/arbre/context.rb
@@ -12,5 +12,9 @@ module Arbre
     end
     alias :bytesize :length
 
+    def method_missing(sym, *args, &block)
+      to_html.send sym, *args, &block
+    end
+
   end
 end


### PR DESCRIPTION
Fixed errors on Heroku with NewRelic relating to Arbre::Context, by passing string methods to its to_html.  This will resolve issue 404 (https://github.com/gregbell/active_admin/issues/404).

Worked great on our Heroku staging and production apps for our site, DueProps.

Thanks again for ActiveAdmin, it's a vital part of our app.
-Trace
