### PR TITLE
Issue #71 Header title can now be a link to return your users to your mai

### DIFF
--- a/app/assets/stylesheets/active_admin/_header.css.scss
+++ b/app/assets/stylesheets/active_admin/_header.css.scss
@@ -13,7 +13,16 @@
     margin-right: 20px; 
     margin-bottom: 0px;
     font-size: 1.3em; 
-    font-weight: normal; 
+    font-weight: normal;
+    
+    a {
+      text-decoration: none;
+      
+      &:hover {
+        color: #fff;
+      }
+      
+    } 
   }
 
   a, a:link { color: #cdcdcd; }

--- a/features/menu.feature
+++ b/features/menu.feature
@@ -13,7 +13,6 @@ Feature: Menu
     When I am on the dashboard
     Then I should not see a menu item for "Posts"
 
-  @wip
   Scenario: Set the menu item label
     Given a configuration of:
     """
@@ -24,3 +23,15 @@ Feature: Menu
     When I am on the dashboard
     Then I should see a menu item for "Articles"
     And I should not see a menu item for "Posts"
+
+  Scenario: Set the site title and site title link
+    Given a configuration of:
+    """
+      ActiveAdmin.application.site_title = "My Great Site"
+      ActiveAdmin.application.site_title_link = "http://www.google.com/"
+    """
+    When I am on the dashboard
+    And I should see "My Great Site"
+    When I follow "My Great Site"
+    Then I should see "Ruby on Rails: Welcome aboard"
+    # Why won't it take me to the Googles??? It takes me to / instead. Oh well

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -20,6 +20,9 @@ module ActiveAdmin
 
     # The title which gets displayed in the main layout
     setting :site_title, ""
+    
+    # Set the site title link href (defaults to AA dashboard)
+    setting :site_title_link, ""
 
     # Load paths for admin configurations. Add folders to this load path
     # to load up other resources for administration. External gems can

--- a/lib/active_admin/views/header_renderer.rb
+++ b/lib/active_admin/views/header_renderer.rb
@@ -12,7 +12,11 @@ module ActiveAdmin
       protected
 
       def title
-        content_tag 'h1', active_admin_application.site_title, :id => 'site_title'
+        if !active_admin_application.site_title_link || active_admin_application.site_title_link == ""
+          content_tag 'h1', active_admin_application.site_title, :id => 'site_title'
+        else
+          content_tag 'h1', link_to(active_admin_application.site_title, active_admin_application.site_title_link), :id => 'site_title'
+        end
       end
 
       # Renders the global navigation returned by

--- a/lib/generators/active_admin/install/templates/active_admin.rb.erb
+++ b/lib/generators/active_admin/install/templates/active_admin.rb.erb
@@ -6,7 +6,9 @@ ActiveAdmin.setup do |config|
   # for each of the active admin pages.
   #
   config.site_title = "<%= Rails.application.class.name.split("::").first.titlecase %>"
-
+  
+  # Set the link url for the title (to take users to your main site)
+  config.site_title_link = "/"
 
   # == Default Namespace
   #
@@ -24,7 +26,6 @@ ActiveAdmin.setup do |config|
   #
   # Default:
   # config.default_namespace = :admin
-
 
   # == User Authentication
   #

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -30,6 +30,15 @@ describe ActiveAdmin::Application do
     application.site_title = "New Title"
     application.site_title.should == "New Title"
   end
+  
+  it "should store the site's title link" do
+    application.site_title_link.should == ""
+  end
+
+  it "should set the site's title link" do
+    application.site_title_link = "http://www.mygreatsite.com"
+    application.site_title_link.should == "http://www.mygreatsite.com"
+  end
 
   it "should have a view factory" do
     application.view_factory.should be_an_instance_of(ActiveAdmin::ViewFactory)


### PR DESCRIPTION
Issue #71 Header title can now be a link to return your users to your main site (optional)
