### PR TITLE
Added numeric ability for text nodes.

### DIFF
--- a/lib/active_admin/arbre/builder.rb
+++ b/lib/active_admin/arbre/builder.rb
@@ -102,7 +102,9 @@ module Arbre
       def insert_text_node_if_string(tag)
         if tag.is_a?(String)
           current_dom_context << Arbre::HTML::TextNode.from_string(tag)
-        end
+        elsif tag.kind_of?(Numeric)
+          current_dom_context << Arbre::HTML::TextNode.from_string(tag.to_s)
+        end 
       end
     end
 

--- a/spec/unit/arbre/html/tag_spec.rb
+++ b/spec/unit/arbre/html/tag_spec.rb
@@ -16,8 +16,14 @@ describe Arbre::HTML::Tag do
     it "should set the hash of options to the attributes" do
       tag.attributes.should == { :id => "my_id" }
     end
+    
+    it "should set contents to a string if passed a numeric value" do
+      numeric_tag = Arbre::HTML:Tag.new 
+      numeric_tag.build 42, :id => "answer_to_life"
+      numeric_tag.content.should == 42.to_s
+    end
   end
-
+  
   describe "creating a tag 'for' an object" do
     let(:model_name){ mock(:singular => "resource_class")}
     let(:resource_class){ mock(:model_name => model_name) }


### PR DESCRIPTION
I discovered that table_for (and any tag really) created with Arbre with the content of a numeric value would just not display anything. For example:

```
table_for(article) do
  column("Article Comments") { |a| a.comments_count }
end
```

The column for comments will be blank because "comments_count" is a number.
The code in builder.rb prevents this on this line:

```
if tag.is_a?(String)
  current_dom_context << Arbre::HTML::TextNode.from_string(tag)
end
```

I added spec but wasn't sure if it was to par, sorry if isn't.
