### PR TITLE
Fix bug returning trancated response

### DIFF
--- a/lib/active_admin/arbre/context.rb
+++ b/lib/active_admin/arbre/context.rb
@@ -7,10 +7,10 @@ module Arbre
       super - 1
     end
 
-    def length
-      cached_html.length
+    def bytesize
+      cached_html.bytesize
     end
-    alias :bytesize :length
+    alias :length :bytesize
 
     def respond_to?(method)
       super || cached_html.respond_to?(method)

--- a/spec/unit/arbre/context_spec.rb
+++ b/spec/unit/arbre/context_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'spec_helper'
 
 describe Arbre::Context do
@@ -5,7 +6,7 @@ describe Arbre::Context do
   setup_arbre_context!
 
   before do
-    h1 # Add some HTML to the context
+    h1 "札幌市北区" # Add some HTML to the context
   end
 
   it "should not increment the indent_level" do
@@ -13,11 +14,11 @@ describe Arbre::Context do
   end
 
   it "should return a bytesize" do
-    current_dom_context.bytesize.should == 10
+    current_dom_context.bytesize.should == 25
   end
 
   it "should return a length" do
-    current_dom_context.length.should == 10
+    current_dom_context.length.should == 25
   end
 
   it "should delegate missing methods to the html string" do
@@ -26,7 +27,7 @@ describe Arbre::Context do
   end
 
   it "should use a cached version of the HTML for method delegation" do
-    current_dom_context.should_receive(:to_html).once.and_return("<h1></h1>")
+    current_dom_context.should_receive(:to_html).once.and_return("<h1>札幌市北区</h1>")
     current_dom_context.index('<').should == 0
     current_dom_context.index('<').should == 0
   end


### PR DESCRIPTION
I fixed a bug that the response body that contains multi-byte character has been trancated.
Cause of #455.

Return bytesize instead of length, because String#length and String#bytesize have a different meaning at ruby1.9.
