### PR TITLE
Removed Object#to_html.

### DIFF
--- a/lib/active_admin/arbre.rb
+++ b/lib/active_admin/arbre.rb
@@ -1,5 +1,4 @@
 require "active_admin/arbre/builder"
-require "active_admin/arbre/core_extensions"
 require "active_admin/arbre/context"
 require "active_admin/arbre/html/element"
 require "active_admin/arbre/html/attributes"

--- a/lib/active_admin/arbre/core_extensions.rb
+++ b/lib/active_admin/arbre/core_extensions.rb
@@ -1,5 +1,0 @@
-class Object
-  def to_html
-    to_s
-  end
-end

--- a/lib/active_admin/arbre/html/text_node.rb
+++ b/lib/active_admin/arbre/html/text_node.rb
@@ -27,7 +27,7 @@ module Arbre
       end
 
       def to_html
-        ERB::Util.html_escape(@content.to_html)
+        ERB::Util.html_escape(@content.to_s)
       end
     end
 

--- a/spec/unit/arbre/html/element_spec.rb
+++ b/spec/unit/arbre/html/element_spec.rb
@@ -96,7 +96,7 @@ describe Arbre::HTML::Element do
       it "should html escape the string" do
         string = "Goodbye <br />"
         element.content = string
-        element.content.to_html.should == "Goodbye &lt;br /&gt;"
+        element.to_html.should == "Goodbye &lt;br /&gt;"
       end
     end
 


### PR DESCRIPTION
I have removed Object#to_html because it conflicts with `kramdown` gem and also there are some issues reported in #151.

ActiveAdmin should avoid extending Ruby core classes.
