### PR TITLE
fixes plural for multiple word model name translation

### DIFF
--- a/lib/active_admin/resource/naming.rb
+++ b/lib/active_admin/resource/naming.rb
@@ -33,7 +33,7 @@ module ActiveAdmin
         else
           # Check if we have a translation available otherwise pluralize
           begin
-            I18n.translate!("activerecord.models.#{resource.model_name.downcase}")
+            I18n.translate!("activerecord.models.#{resource.model_name.i18n_key}")
             resource.model_name.human(:count => 3)
           rescue I18n::MissingTranslationData
             resource_name.pluralize

--- a/spec/unit/resource/naming_spec.rb
+++ b/spec/unit/resource/naming_spec.rb
@@ -55,6 +55,7 @@ module ActiveAdmin
           I18n.stub(:translate) { 'Categorie' }
         end
         it "should return the plural version defined in the i18n if available" do
+          config.resource.model_name.should_receive(:i18n_key).twice
           config.plural_resource_name.should == "Categorie"
         end
       end


### PR DESCRIPTION
since plural_resource_name uses the .downcase method when using i18n keys, it breaks translation when pluralizing a multiple word model.

for example, when translating a model named BlogPost, it searches for a yaml key such as:

```
activerecord.models.blogpost
```

instead of:

```
activerecord.models.blog_post
```

as rails does.

By using i18n_key instead of downcase the problem is fixed.
