### PR TITLE
fix invalid model name i18n path (with multi-word model names)

### DIFF
--- a/lib/active_admin/resource/naming.rb
+++ b/lib/active_admin/resource/naming.rb
@@ -33,7 +33,7 @@ module ActiveAdmin
         else
           # Check if we have a translation available otherwise pluralize
           begin
-            I18n.translate!("activerecord.models.#{resource.model_name.downcase}")
+            I18n.translate!("activerecord.models.#{resource.model_name.underscore}")
             resource.model_name.human(:count => 3)
           rescue I18n::MissingTranslationData
             resource_name.pluralize


### PR DESCRIPTION
Hi,
I've fixed a bug which prevented from model name localization when using multi-word model names.

E.g. For model CarManufacturer the i18n path was _cs.activerecord.models.carmanufacturer_ while

``` CarManufacturer.model_name.human```
uses _cs.activerecord.models.car_manufacturer_
```
