### PR TITLE
Locked gemset to old versions of Formtastic because 2.0.0 was just releas

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency("rails", ">= 3.0.0")
   s.add_dependency("meta_search", ">= 0.9.2")
   s.add_dependency("devise", ">= 1.1.2")
-  s.add_dependency("formtastic", ">= 1.1.0")
+  s.add_dependency("formtastic", "< 2.0.0")
   s.add_dependency("inherited_resources", "< 1.3.0")
   s.add_dependency("kaminari", ">= 0.12.4")
   s.add_dependency("sass", ">= 3.1.0")

--- a/lib/active_admin/locales/sv-SE.yml
+++ b/lib/active_admin/locales/sv-SE.yml
@@ -1,4 +1,4 @@
-sv-SE:
+"sv-SE":
   active_admin:
     dashboard: Skrivbord
     dashboard_welcome:


### PR DESCRIPTION
Locked gemset to old versions of Formtastic because 2.0.0 was just released and was breaking our forms. Also fixed a broken translation name for the swedish translation
