### PR TITLE
Issue #185 - Add support for conditionally display Dashboard sections at 

### DIFF
--- a/lib/active_admin/dashboards.rb
+++ b/lib/active_admin/dashboards.rb
@@ -26,6 +26,10 @@ module ActiveAdmin
 
       # Add a new dashboard section to a namespace. If no namespace is given
       # it will be added to the default namespace.
+      #
+      # Options include:
+      #   :namespace => only display for specified namespace.
+      #   :if        => specify a method or block to determine whether the section is rendered at run time.
       def add_section(name, options = {}, &block)
         namespace = options.delete(:namespace) || ActiveAdmin.application.default_namespace || :root
         self.sections[namespace] ||= [] 

--- a/lib/active_admin/dashboards/dashboard_controller.rb
+++ b/lib/active_admin/dashboards/dashboard_controller.rb
@@ -16,9 +16,21 @@ module ActiveAdmin
       end
 
       def find_sections
-        ActiveAdmin::Dashboards.sections_for_namespace(namespace)
+        sections = ActiveAdmin::Dashboards.sections_for_namespace(namespace)        
+        sections.select do |section|
+          if section.options.has_key?(:if)
+            symbol_or_proc = section.options[:if]
+            case symbol_or_proc
+            when Symbol, String then self.send(symbol_or_proc)
+            when Proc           then instance_exec(&symbol_or_proc)
+            else symbol_or_proc
+            end
+          else
+            true
+          end
+        end
       end
-
+      
       def namespace
         class_name = self.class.name
         if class_name.include?('::')

--- a/lib/generators/active_admin/install/templates/dashboards.rb
+++ b/lib/generators/active_admin/install/templates/dashboards.rb
@@ -34,5 +34,11 @@ ActiveAdmin::Dashboards.build do
   #   section "Recent User", :priority => 1
   #
   # Will render the "Recent Users" then the "Recent Posts" sections on the dashboard.
+  
+  # == Conditionally Display
+  # Provide a method name or Proc object to conditionally render a section at run time.
+  #
+  # section "Membership Summary", :if => :memberships_enabled?
+  # section "Membership Summary", :if => Proc.new { current_admin_user.account.memberships.any? }
 
 end

--- a/spec/unit/dashboard_controller_spec.rb
+++ b/spec/unit/dashboard_controller_spec.rb
@@ -23,4 +23,48 @@ describe ActiveAdmin::Dashboards::DashboardController do
     end
   end
 
+  describe "conditionally displaying sections" do
+    before { ActiveAdmin::Dashboards.clear_all_sections! }
+    let(:controller){ Admin::DashboardController.new }
+    
+    context "when :if not specified" do
+      before do
+        @section = ActiveAdmin::Dashboards.add_section('Stats').last
+      end
+      
+      it "should include section" do
+        controller.send(:find_sections).should include(@section)
+      end
+    end
+    
+    context "when :if option specified as a method" do
+      before do
+        @section = ActiveAdmin::Dashboards.add_section('Secret Codes', :if => :i_am_awesome?).last
+      end
+      
+      it "should call the method of the same name" do
+        controller.should_receive(:i_am_awesome?).and_return(true)
+        controller.send(:find_sections).should include(@section)
+        
+        controller.should_receive(:i_am_awesome?).and_return(false)
+        controller.send(:find_sections).should_not include(@section)
+      end
+    end
+    
+    context "when :if option specified as block" do
+      before do
+        @proc    = Proc.new { true }
+        @section = ActiveAdmin::Dashboards.add_section('Secret Codes', :if => proc {}).last
+      end
+      
+      it "should evaluate the block" do
+        controller.should_receive(:instance_exec).with(&@proc).and_return(true)
+        controller.send(:find_sections).should include(@section)
+        
+        controller.should_receive(:instance_exec).with(&@proc).and_return(false)
+        controller.send(:find_sections).should_not include(@section)
+      end
+    end
+  end
+  
 end


### PR DESCRIPTION
Issue #185 - Add support for conditionally display Dashboard sections at run-time
#### Provide a method name or Proc object to conditionally render a section at run time

`section "Membership Summary", :if => :memberships_enabled?`
`section "Membership Summary", :if => Proc.new { current_admin_user.account.memberships.any? }`
