### PR TITLE
ActiveAdmin::Scope.new now accepts options hash, stores :if as block

### DIFF
--- a/features/index/index_scopes.feature
+++ b/features/index/index_scopes.feature
@@ -26,7 +26,30 @@ Feature: Index Scoping
     And I should see the scope "All" with the count 10
     And I should see 10 posts in the table
 
-  Scenario: Viewing resources with mulitple scopes as blocks
+  Scenario: Viewing resources with optional scopes
+	Given 10 posts exist
+	And an index configuration of:
+	 """
+	 ActiveAdmin.register Post do
+	   scope :all, :if => proc { false }
+	   scope "Shown", :if => proc { true } do |posts|
+		posts
+	   end 
+	   scope "Default", :default => true do |posts|
+		posts
+	   end
+	   scope 'Today', :if => proc { false } do |posts|
+         posts.where(["created_at > ? AND created_at < ?", ::Time.zone.now.beginning_of_day, ::Time.zone.now.end_of_day])
+       end
+	 end
+	 """
+	Then I should see the scope "Default" selected
+	And I should not see the scope "All"
+	And I should not see the scope "Today"
+	And I should see the scope "Shown"
+	And I should see the scope "Default" with the count of 10
+
+  Scenario: Viewing resources with multiple scopes as blocks
     Given 10 posts exist
     And an index configuration of:
       """

--- a/features/step_definitions/index_scope_steps.rb
+++ b/features/step_definitions/index_scope_steps.rb
@@ -2,6 +2,10 @@ Then /^I should see the scope "([^"]*)"$/ do |name|
   Then %{I should see "#{name}" within ".scopes"}
 end
 
+Then /^I should not see the scope "([^"]*)"$/ do |name|
+  Then %{I should not see "#{name}" within ".scopes"}
+end
+
 Then /^I should see the scope "([^"]*)" selected$/ do |name|
   Then %{I should see "#{name}" within ".scopes span.selected"}
 end

--- a/lib/active_admin/resource/scopes.rb
+++ b/lib/active_admin/resource/scopes.rb
@@ -22,7 +22,9 @@ module ActiveAdmin
       # to your i18n files a key like "active_admin.scopes.scope_method".
       def scope(*args, &block)
         options = args.extract_options!
-        self.scopes << ActiveAdmin::Scope.new(*args, &block)
+        title = args[0] rescue nil
+        method = args[1] rescue nil
+        self.scopes << ActiveAdmin::Scope.new(title, method, options,  &block)
         if options[:default]
           @default_scope = scopes.last
         end

--- a/lib/active_admin/scope.rb
+++ b/lib/active_admin/scope.rb
@@ -1,7 +1,7 @@
 module ActiveAdmin
   class Scope
 
-    attr_reader :name, :scope_method, :id, :scope_block
+    attr_reader :name, :scope_method, :id, :scope_block, :display_if_block
 
     # Create a Scope
     #
@@ -13,10 +13,13 @@ module ActiveAdmin
     #   Scope.new('Published', :public)
     #   # => Scope with name 'Published' and scope method :public
     #
+    #   Scope.new('Published', :public, :if => proc { current_admin_user.can?( :manage, active_admin_config.resource_class ) } ) { |articles| articles.where(:published => true) }
+    #   # => Scope with name 'Published' and scope method :public, optionally displaying the scope per the :if block, using a block
+    #
     #   Scope.new('Published') { |articles| articles.where(:published => true) }
     #   # => Scope with name 'Published' using a block to scope
     #
-    def initialize(name, method = nil, &block)
+    def initialize(name, method = nil, options = {}, &block)
       @name = name.to_s.titleize
       @scope_method = method
       # Scope ':all' means no scoping
@@ -26,6 +29,16 @@ module ActiveAdmin
         @scope_method = nil
         @scope_block = block
       end
+      
+      @display_if_block = options.delete(:if)
+      
     end
+    
+    # Returns the display if block. If the block was not explicitly defined
+    # a default block always returning true will be returned.
+    def display_if_block
+      @display_if_block || lambda { |_| true }
+    end
+    
   end
 end

--- a/lib/active_admin/views/components/scopes.rb
+++ b/lib/active_admin/views/components/scopes.rb
@@ -8,7 +8,7 @@ module ActiveAdmin
 
       def build(scopes)
         scopes.each do |scope|
-          build_scope(scope)
+          build_scope(scope) if call_method_or_proc_on(self, scope.display_if_block)
         end
       end
 


### PR DESCRIPTION
ActiveAdmin::Scope.new now accepts options hash, stores :if as block, ActiveAdmin::Views::Scopes component optionally displays the scope if the block returns true.

If no :if block is provided, the scope defaults to shown.  Updated cukes to reflect & test these changes.

Can be used as:

``` ruby
ActiveAdmin.register Post do

  scope :published, :if => proc { current_admin_user.can?( :manage, Post ) }
  scope "Published", :published, :if => proc { current_admin_user.can?( :manage, Post) }
  scope "Published", :if => proc { current_admin_user.can?( :manage, Posts) } do |posts|
    posts.published
  end

end
```
