### PR TITLE
#293 - Scopes shouldn't show up when no filter results

### DIFF
--- a/features/index/index_scopes.feature
+++ b/features/index/index_scopes.feature
@@ -26,7 +26,24 @@ Feature: Index Scoping
     And I should see the scope "All" with the count 10
     And I should see 10 posts in the table
 
-  Scenario: Viewing resources with mulitple scopes as blocks
+  Scenario: Viewing resources with one scope and no results
+	Given 10 posts exist
+	And an index configuration of:
+	 """
+ 	 ActiveAdmin.register Post do
+	   scope :all, :default => true
+	   filter :title
+	 end
+	 """
+
+	When I fill in "Search Title" with "Hello World 17"
+    And I press "Filter"
+	And I should not see the scope "All"
+
+    When I am on the index page for posts
+	Then I should see the scope "All" selected
+
+  Scenario: Viewing resources with multiple scopes as blocks
     Given 10 posts exist
     And an index configuration of:
       """

--- a/lib/active_admin/views/components/scopes.rb
+++ b/lib/active_admin/views/components/scopes.rb
@@ -7,8 +7,10 @@ module ActiveAdmin
       builder_method :scopes_renderer
 
       def build(scopes)
-        scopes.each do |scope|
-          build_scope(scope)
+        unless collection.empty? and params.include?( :q )
+          scopes.each do |scope|
+            build_scope(scope) if call_method_or_proc_on(self, scope.display_if_block)
+          end
         end
       end
 


### PR DESCRIPTION
This fixes bug report #293, making the scopes hidden if the filter form was used on the `index` view and there were no results.  If one of the scopes was clicked and there were no results, the scopes still show up as they should.
