### PR TITLE
Documented action items

### DIFF
--- a/docs/8-custom-actions.md
+++ b/docs/8-custom-actions.md
@@ -81,6 +81,16 @@ For example, create app/views/admin/posts/comments.html.arb with:
         simple_format comment.body
       end
     end
+    
+### Custom Action Items
+
+To include your own action items (like the New, Edit and Delete buttons), add an 
+`action_item` block. For example, to add a "View on site" button to view a blog
+post:
+
+    action_item :only => :show do
+      link_to 'View on site', post_path(params[:id])
+    end
 
 ### Page Titles
 


### PR DESCRIPTION
Action items were missing (from what I saw) in the documentation and demo site. I had to look at https://github.com/gregbell/active_admin/blob/master/features/specifying_actions.feature to figure out how to use them.

I added a small section to the docs to demonstrate how to use them.
