### PR TITLE
Fixed bug with active_admin_comments

### DIFF
--- a/lib/active_admin/comments/views/active_admin_comments.rb
+++ b/lib/active_admin/comments/views/active_admin_comments.rb
@@ -55,8 +55,9 @@ module ActiveAdmin
           end
         end
 
-        def comment_form_url
-          send(:"#{active_admin_namespace.name}_comments_path")
+        def comment_form_url # modified to allow for no default_namespace or :root default_namespace
+          send_path = active_admin_namespace.name == "root" ? "comments_path" : "#{active_admin_namespace.name}_comments_path"
+          send(:"#{send_path}")
         end
 
         def build_comment_form


### PR DESCRIPTION
I'm working on an application using activeadmin that has no public facing side. As a result, I have default_namespace => false. The problem is, when I use active_admin_comments in a custom show template, comment_form_url attempts to return root_comments_path rather than the correct comments_path.

I added a check in that method so that it will return comments_path if the namespace is root. Otherwise, it returns namespace_comments_path per usual.
