### PR TITLE
Fixed bug with active_admin_comments

### DIFF
--- a/lib/active_admin/comments/views/active_admin_comments.rb
+++ b/lib/active_admin/comments/views/active_admin_comments.rb
@@ -56,7 +56,7 @@ module ActiveAdmin
         end
 
         def comment_form_url # modified to allow for no default_namespace or :root default_namespace
-          send_path = active_admin_namespace.name == "root" ? "comments_path" : "#{active_admin_namespace.name}_comments_path"
+          send_path = active_admin_namespace.name.to_s == "root" ? "comments_path" : "#{active_admin_namespace.name}_comments_path"
           send(:"#{send_path}")
         end
 


### PR DESCRIPTION
Fixed problem with active_admin_comments not working if default_namespace is set to false or :root.

comment_form_url prepends comments_path with the namespace. If it's root, this means you end up with root_comments_path, which won't work.

I added a simple check to see if it's root. If so, it returns comments_path instead.
