### PR TITLE
Don't display unused action-links on index-as-table

### DIFF
--- a/lib/active_admin/views/index_as_table.rb
+++ b/lib/active_admin/views/index_as_table.rb
@@ -126,9 +126,16 @@ module ActiveAdmin
             :name => ""
           }.merge(options)
           column options[:name] do |resource|
-            links = link_to I18n.t('active_admin.view'), resource_path(resource), :class => "member_link view_link"
-            links += link_to I18n.t('active_admin.edit'), edit_resource_path(resource), :class => "member_link edit_link"
-            links += link_to I18n.t('active_admin.delete'), resource_path(resource), :method => :delete, :confirm => I18n.t('active_admin.delete_confirmation'), :class => "member_link delete_link"
+            links = ''.html_safe
+            if controller.action_methods.include?('show')
+              links += link_to I18n.t('active_admin.view'), resource_path(resource), :class => "member_link view_link"
+            end
+            if controller.action_methods.include?('edit')
+              links += link_to I18n.t('active_admin.edit'), edit_resource_path(resource), :class => "member_link edit_link"
+            end
+            if controller.action_methods.include?('destroy')
+              links += link_to I18n.t('active_admin.delete'), resource_path(resource), :method => :delete, :confirm => I18n.t('active_admin.delete_confirmation'), :class => "member_link delete_link"
+            end
             links
           end
         end


### PR DESCRIPTION
When using index-as-table, only show links to view/edit/delete if the respective actions exists
