### PR TITLE
Updated Validations on ActiveAdmin::Comment

### DIFF
--- a/lib/active_admin/comments/comment.rb
+++ b/lib/active_admin/comments/comment.rb
@@ -11,8 +11,7 @@ module ActiveAdmin
     belongs_to :resource, :polymorphic => true
     belongs_to :author, :polymorphic => true
 
-    validates_presence_of :resource_id
-    validates_presence_of :resource_type
+    validates_presence_of :resource
     validates_presence_of :body
     validates_presence_of :namespace
   end

--- a/spec/unit/comments_spec.rb
+++ b/spec/unit/comments_spec.rb
@@ -18,8 +18,7 @@ describe "Comments" do
       it { should belong_to :resource }
       it { should belong_to :author }
 
-      it { should validate_presence_of :resource_id }
-      it { should validate_presence_of :resource_type }
+      it { should validate_presence_of :resource }
       it { should validate_presence_of :body }
       it { should validate_presence_of :namespace }
     end


### PR DESCRIPTION
Validations on the Comment model should be on the resource rather than the resource_id / resource_type. This allows comments to be created with the parent model and accepts_nested_attributes_for
