### PR TITLE
Change dependency on Formtastic from <2.0.0 do >=1.1.0

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -17,12 +17,12 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency("rails", ">= 3.0.0")
-  s.add_dependency("meta_search", ">= 0.9.2")
-  s.add_dependency("devise", ">= 1.1.2")
-  s.add_dependency("formtastic", "< 2.0.0")
-  s.add_dependency("inherited_resources", "< 1.3.0")
-  s.add_dependency("kaminari", ">= 0.12.4")
-  s.add_dependency("sass", ">= 3.1.0")
-  s.add_dependency("fastercsv", ">= 0")
+  s.add_dependency('rails', '>= 3.0.0')
+  s.add_dependency('meta_search', '>= 0.9.2')
+  s.add_dependency('devise', '>= 1.1.2')
+  s.add_dependency('formtastic', '>= 1.1.0')
+  s.add_dependency('inherited_resources', '< 1.3.0')
+  s.add_dependency('kaminari', '>= 0.12.4')
+  s.add_dependency('sass', '>= 3.1.0')
+  s.add_dependency('fastercsv', '>= 0')
 end


### PR DESCRIPTION
When i've tried to use active_admin and client_side_validations in my app, i've got an error when trying to run server:

```
uninitialized constant Formtastic::FormBuilder
```

I've found some info about this issue here: http://stackoverflow.com/questions/6438449/rails-3-uninitialized-constant-formtasticformbuilder-error-after-deploying-a and it turns out that it is beouse client_side_validations needs Formtastic 2, but activeadmin has dependency on formtastic `< 2.0.0`, changing it to `>= 1.1.0` fixed it.
