### PR TITLE
This allows ActiveAdmin::ResourceController::Sorting to sort by a column in another table

### DIFF
--- a/lib/active_admin/resource_controller/collection.rb
+++ b/lib/active_admin/resource_controller/collection.rb
@@ -46,9 +46,13 @@ module ActiveAdmin
 
         def sort_order(chain)
           params[:order] ||= active_admin_config.sort_order
-          table_name = active_admin_config.resource_table_name
           if params[:order] && params[:order] =~ /^([\w\_\.]+)_(desc|asc)$/
-            chain.order("#{table_name}.#{$1} #{$2}")
+            column = $1
+            order  = $2
+            table  = active_admin_config.resource_table_name
+            table_column = (column =~ /\./) ? column : "#{table}.#{column}"
+
+            chain.order("#{table_column} #{order}")
           else
             chain # just return the chain
           end


### PR DESCRIPTION
The previous behavior always appended the current table name at the beginning of the column.
With this patch it only appends the current table name if the column was given without any specific table.

So now when you can call something like this:

column :name, sortable: 'people.name'

It works as expected. Though when loading the model it has to be joined to the other table, of course.
