### PR TITLE
Fix scope i18n for 'all' scope

### DIFF
--- a/lib/active_admin/views/components/scopes.rb
+++ b/lib/active_admin/views/components/scopes.rb
@@ -17,7 +17,7 @@ module ActiveAdmin
       def build_scope(scope)
         span :class => classes_for_scope(scope) do
           begin
-            scope_name = I18n.t!("active_admin.scopes.#{scope.scope_method}")
+            scope_name = I18n.t!("active_admin.scopes.#{scope.scope_method||'all'}")
           rescue I18n::MissingTranslationData
             scope_name = scope.name
           end


### PR DESCRIPTION
When using active_admin's i18n for scopes and the 'all' scope is included on a resource, scope.scope_method is nil and so the i18n scope resolves to '<lang>.active_admin.scopes', which outputs the hash of all keys under this i18n key.

The fix falls back to the key active_admin.scopes.all, if the scope_method is not set.

See also this post on the mailing list from another user, that describes the problem and ways to reproduce:

http://groups.google.com/group/activeadmin/browse_thread/thread/3e52dd49c3669d4d
