### PR TITLE
Fix breadcrumb_helper plural model i18n

### DIFF
--- a/lib/active_admin/view_helpers/breadcrumb_helper.rb
+++ b/lib/active_admin/view_helpers/breadcrumb_helper.rb
@@ -20,7 +20,7 @@ module ActiveAdmin
 					end
 					name = part.titlecase if name == ""
 					begin
-						crumbs << link_to( I18n.translate!("activerecord.models.#{part.singularize}"), "/" + parts[0..index].join('/'))
+						crumbs << link_to( I18n.translate!("activerecord.models.#{part.singularize}", :count => 2), "/" + parts[0..index].join('/'))
 					rescue I18n::MissingTranslationData
 						crumbs << link_to( name, "/" + parts[0..index].join('/'))
 					end


### PR DESCRIPTION
The breadcrumb_helper's current I18n.translate call doesn't pass a count, so if we define plural in the locale, it'll instead return a hash.

Example:

<pre>
de:
  activerecord:
    mymodel:
      one: Mein Modell
      others: Meine Modelle
</pre>


The patch fixes this and does not break definition without plural forms:

<pre>
de:
  activerecord:
    mymodel: Mein Modell
</pre>
