### PR TITLE
Move require statements to generated file for easy overriding

### DIFF
--- a/app/assets/javascripts/active_admin/base.js
+++ b/app/assets/javascripts/active_admin/base.js
@@ -1,5 +1,3 @@
-//= require "active_admin/vendor"
-
 /* Active Admin JS */
 
 $(function(){

--- a/lib/generators/active_admin/assets/templates/3.1/active_admin.js
+++ b/lib/generators/active_admin/assets/templates/3.1/active_admin.js
@@ -1,1 +1,2 @@
+//= require active_admin/vendor
 //= require active_admin/base


### PR DESCRIPTION
Potential solution for #468. Obviously this only helps folks running Rails 3.1, but it's an ultra-light, ultra-easy patch.
