### PR TITLE
Renamed auto_link helper to auto_admin_link so that it doesn't conflict

### DIFF
--- a/docs/3-index-pages/index-as-block.md
+++ b/docs/3-index-pages/index-as-block.md
@@ -8,7 +8,7 @@ resource.
 
     index :as => :block do |product|
       div :for => product do
-        h2 auto_link(product.title)
+        h2 auto_admin_link(product.title)
         div do
           simple_format product.description
         end

--- a/features/index/index_as_grid.feature
+++ b/features/index/index_as_grid.feature
@@ -8,7 +8,7 @@ Feature: Index as Grid
       """
       ActiveAdmin.register Post do
         index :as => :grid do |post|
-          h2 auto_link(post)
+          h2 auto_admin_link(post)
         end
       end
       """
@@ -22,7 +22,7 @@ Feature: Index as Grid
       """
       ActiveAdmin.register Post do
       index :as => :grid, :columns => 1 do |post|
-          h2 auto_link(post)
+          h2 auto_admin_link(post)
         end
       end
       """
@@ -36,7 +36,7 @@ Feature: Index as Grid
       """
       ActiveAdmin.register Post do
       index :as => :grid, :columns => 2 do |post|
-          h2 auto_link(post)
+          h2 auto_admin_link(post)
         end
       end
       """

--- a/features/index/index_blank_slate.feature
+++ b/features/index/index_blank_slate.feature
@@ -29,7 +29,7 @@ Feature: Index Blank Slate
       """
       ActiveAdmin.register Post do
         index :as => :grid do |post|
-          h2 auto_link(post)
+          h2 auto_admin_link(post)
         end
       end
       """

--- a/lib/active_admin/comments.rb
+++ b/lib/active_admin/comments.rb
@@ -70,8 +70,8 @@ ActiveAdmin::Event.subscribe ActiveAdmin::Namespace::RegisterEvent do |namespace
 
       # Display as a table
       index do
-        column("Resource"){|comment| auto_link(comment.resource) }
-        column("Author"){|comment| auto_link(comment.author) }
+        column("Resource"){|comment| auto_admin_link(comment.resource) }
+        column("Author"){|comment| auto_admin_link(comment.author) }
         column :body
       end
     end

--- a/lib/active_admin/comments/views/active_admin_comments.rb
+++ b/lib/active_admin/comments/views/active_admin_comments.rb
@@ -38,7 +38,7 @@ module ActiveAdmin
         def build_comment(comment)
           div :for => comment do
             div :class => "active_admin_comment_meta" do
-              user_name = comment.author ? auto_link(comment.author) : "Anonymous"
+              user_name = comment.author ? auto_admin_link(comment.author) : "Anonymous"
               h4(user_name, :class => "active_admin_comment_author")
               span(pretty_format(comment.created_at))
             end

--- a/lib/active_admin/view_helpers/auto_link_helper.rb
+++ b/lib/active_admin/view_helpers/auto_link_helper.rb
@@ -9,9 +9,9 @@ module ActiveAdmin
       # The default content in the link is returned from ActiveAdmin::ViewHelpers::DisplayHelper#display_name
       #
       # You can pass in the content to display
-      #   eg: auto_link(@post, "My Link Content")
+      #   eg: auto_admin_link(@post, "My Link Content")
       #
-      def auto_link(resource, link_content = nil)
+      def auto_admin_link(resource, link_content = nil)
         content = link_content || display_name(resource)
         if registration = active_admin_resource_for(resource.class)
           begin

--- a/lib/active_admin/view_helpers/display_helper.rb
+++ b/lib/active_admin/view_helpers/display_helper.rb
@@ -16,7 +16,7 @@ module ActiveAdmin
 
       # Return a pretty string for any object
       # Date Time are formatted via #localize with :format => :long
-      # ActiveRecord objects are formatted via #auto_link
+      # ActiveRecord objects are formatted via #auto_admin_link
       # We attempt to #display_name of any other objects
       def pretty_format(object)
         case object
@@ -27,7 +27,7 @@ module ActiveAdmin
         when Date, Time
           localize(object, :format => :long)
         when ActiveRecord::Base
-          auto_link(object)
+          auto_admin_link(object)
         else
           display_name(object)
         end

--- a/lib/active_admin/views/index_as_block.rb
+++ b/lib/active_admin/views/index_as_block.rb
@@ -9,7 +9,7 @@ module ActiveAdmin
     #
     #     index :as => :block do |product|
     #       div :for => product do
-    #         h2 auto_link(product.title)
+    #         h2 auto_admin_link(product.title)
     #         div do
     #           simple_format product.description
     #         end

--- a/lib/active_admin/views/index_as_blog.rb
+++ b/lib/active_admin/views/index_as_blog.rb
@@ -113,7 +113,7 @@ module ActiveAdmin
           end
         else
           h3 do
-            auto_link(post)
+            auto_admin_link(post)
           end
         end
       end

--- a/spec/unit/auto_link_spec.rb
+++ b/spec/unit/auto_link_spec.rb
@@ -22,7 +22,7 @@ describe "auto linking resources" do
 
   context "when the resource is not registered" do
     it "should return the display name of the object" do
-      auto_link(post).should == "Hello World"
+      auto_admin_link(post).should == "Hello World"
     end
   end
 
@@ -32,7 +32,7 @@ describe "auto linking resources" do
     end
     it "should return a link with the display name of the object" do
       self.should_receive(:link_to).with("Hello World", admin_post_path(post))
-      auto_link(post)
+      auto_admin_link(post)
     end
   end
 

--- a/spec/unit/pretty_format_spec.rb
+++ b/spec/unit/pretty_format_spec.rb
@@ -18,9 +18,9 @@ describe "#pretty_format" do
   end
 
   context "when an ActiveRecord object is passed in" do
-    it "should delegate to auto_link" do
+    it "should delegate to auto_admin_link" do
       post = Post.new
-      self.should_receive(:auto_link).with(post) { "model name" }
+      self.should_receive(:auto_admin_link).with(post) { "model name" }
       pretty_format(post).should == "model name"
     end
   end


### PR DESCRIPTION
Renamed auto_link helper to auto_admin_link so that it doesn't conflict with rails_autolink or rails implementaiton of auto_link in versions < 3.1.

Redefining this function with different functionality and a different interface was causing issues for us and I expect it might cause issues for others down the track.
