### PR TITLE
#664 - Preserve case of Scope title when provided a string

### DIFF
--- a/lib/active_admin/scope.rb
+++ b/lib/active_admin/scope.rb
@@ -20,7 +20,7 @@ module ActiveAdmin
     #   # => Scope with name 'Published' using a block to scope
     #
     def initialize(name, method = nil, options = {}, &block)
-      @name = name.to_s.titleize
+      @name = name.is_a?( String ) ? name : name.to_s.titleize
       @scope_method = method
       # Scope ':all' means no scoping
       @scope_method ||= name.to_sym unless name.to_sym == :all

--- a/spec/unit/scope_spec.rb
+++ b/spec/unit/scope_spec.rb
@@ -23,10 +23,10 @@ describe ActiveAdmin::Scope do
     end
 
     context "when a name and scope method" do
-      let(:scope)        { ActiveAdmin::Scope.new "My Scope", :scope_method }
-      its(:name)         { should == "My Scope"}
-      its(:id)           { should == "my_scope"}
-      its(:scope_method) { should == :scope_method }
+      let(:scope)        { ActiveAdmin::Scope.new "With API Access", :with_api_access }
+      its(:name)         { should == "With API Access"}
+      its(:id)           { should == "with_api_access"}
+      its(:scope_method) { should == :with_api_access }
     end
 
     context "when a name and scope block" do


### PR DESCRIPTION
This adds testing & fixes the following issue:

``` ruby
ActiveAdmin.register Post do
  scope "With API Access", :with_api_access {}
end
```

The above configuration yields a scope of "With Api Access" without this fix.  Fixes issue #664.
