### PR TITLE
always_reload_paths config parameter implemented

### DIFF
--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -31,6 +31,11 @@ module ActiveAdmin
     # to load up other resources for administration. External gems can
     # include their paths in this load path to provide active_admin UIs
     setting :load_paths, [File.expand_path('app/admin', Rails.root)]
+    
+    # Always reload paths on development environments that are unable to
+    # correctly report file changes. This could be useful for instance.
+    # if project is mounted within Vagrant box
+    setting :always_reload_paths, false
 
     # The view factory to use to generate all the view classes. Take
     # a look at ActiveAdmin::ViewFactory

--- a/lib/active_admin/reloader.rb
+++ b/lib/active_admin/reloader.rb
@@ -14,12 +14,11 @@ module ActiveAdmin
     # Attach to Rails and perform the reload on each request.
     def attach!
       file_update_checker = ActiveSupport::FileUpdateChecker.new(@app.load_paths) do
-        ActiveAdmin.application.unload!
-        Rails.application.reload_routes!
+        Reloader.do_reload
       end
 
       reloader_class.to_prepare do
-        file_update_checker.execute_if_updated
+        ActiveAdmin.application.always_reload_paths ? Reloader.do_reload : file_update_checker.execute_if_updated
       end
     end
 
@@ -29,6 +28,11 @@ module ActiveAdmin
       else
         ActionDispatch::Callbacks
       end
+    end
+    
+    def self.do_reload
+      ActiveAdmin.application.unload!
+      Rails.application.reload_routes!
     end
 
   end

--- a/lib/generators/active_admin/install/templates/active_admin.rb.erb
+++ b/lib/generators/active_admin/install/templates/active_admin.rb.erb
@@ -107,4 +107,24 @@ ActiveAdmin.setup do |config|
   #
   # To load a javascript file:
   #   config.register_javascript 'my_javascript.js'
+  
+  # == App paths and their reloading
+  # 
+  # Load paths for admin configurations. Add folders to this load path
+  # to load up other resources for administration. External gems can
+  # include their paths in this load path to provide active_admin UIs
+  #   
+  # Default:
+  #   config.load_paths = [File.expand_path('app/admin', Rails.root)]
+  #
+  # You can force paths reload on development environments that are.
+  # unable to correctly report file changes. This could be useful for
+  # instance if project is mounted within Vagrant box and is not.
+  # reacting on changes within app/admin.
+  # 
+  # Default:
+  #   config.always_reload_paths = false
+  #
+  # To make reloader Vagrant-aware:
+  #   config.always_reload_paths = true if ENV['LOGNAME'] == 'vagrant'
 end


### PR DESCRIPTION
Trying out to use ActiveAdmin in Vagrant i've found version v0.3.2 works fine, but version v0.3.3 does not react to the changes under app/admin. So to see the result one has to restart whole rails.
It turned out that this behaviour was introduced by commit ef255e5119cd585e1f3bb36428651b9d7dd9704f. The reason is that in Vagrant virtual environment the project directory is mounted through VirtualBox similarily to the network disk. This way if one edits the file under app/admin being outside of the box - ActiveAdmin never detects the change.
I have implemented an on/off parameter that makes ActiveAdmin to work similarily to v0.3.2 when needed. Thus, having something like 

``` ruby
config.always_reload_paths = true if ENV['LOGNAME'] == 'vagrant'
```

in ActiveAdmin initializer solves the problem.
