### PR TITLE
Fixes a but with overridden to_param method

### DIFF
--- a/lib/active_admin/views/index_as_table.rb
+++ b/lib/active_admin/views/index_as_table.rb
@@ -128,13 +128,13 @@ module ActiveAdmin
           column options[:name] do |resource|
             links = ''.html_safe
             if controller.action_methods.include?('show')
-              links += link_to I18n.t('active_admin.view'), resource_path(resource), :class => "member_link view_link"
+              links += link_to I18n.t('active_admin.view'), resource_path(resource.id), :class => "member_link view_link"
             end
             if controller.action_methods.include?('edit')
-              links += link_to I18n.t('active_admin.edit'), edit_resource_path(resource), :class => "member_link edit_link"
+              links += link_to I18n.t('active_admin.edit'), edit_resource_path(resource.id), :class => "member_link edit_link"
             end
             if controller.action_methods.include?('destroy')
-              links += link_to I18n.t('active_admin.delete'), resource_path(resource), :method => :delete, :confirm => I18n.t('active_admin.delete_confirmation'), :class => "member_link delete_link"
+              links += link_to I18n.t('active_admin.delete'), resource_path(resource.id), :method => :delete, :confirm => I18n.t('active_admin.delete_confirmation'), :class => "member_link delete_link"
             end
             links
           end


### PR DESCRIPTION
If a resource has a AR model that has overridden the default to_param method with something else, the default_actions method will not work properly.  This bugfix will now ensure the id will always be used.
