### PR TITLE
Add notes on precompiling assets

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -36,12 +36,18 @@ on Rails 3 application. To install, simply add the following to your Gemfile:
   # Gemfile in Rails < 3.1
   gem 'activeadmin'
 
-If you are using Rails >= 3.1, you must also have sass-rails and meta_search in your Gemfile:
+If you are using Rails >= 3.1, you must also have sass-rails and meta_search in your Gemfile (if sass-rails is already present in assets group, move it out):
 
   # Gemfile in Rails >= 3.1
   gem 'activeadmin'
   gem 'sass-rails'
   gem 'meta_search',    '>= 1.1.0.pre'
+
+and add activeadmin assets into precompiling by adding the following line into your config/environments/production.rb:
+
+  config.assets.precompile += %w[active_admin.css active_admin.js]
+
+There is also some issue with precompiling activeadmin images in Rails 3.1.0, it is fixed in Rails 3.1.1.
 
 After updating your bundle, run the installer
 


### PR DESCRIPTION
There are some issues with assets, which aren't desribed in README, so i've added it - moving sass-rails out of assets group, adding `active_admin` assets to `config.assets.precompile` in `config/enrivonments/production.rb`, issue with precompiling images in Rails 3.1.0
