### PR TITLE
Display correct pagination figures when @per_page is set

### DIFF
--- a/features/index/pagination.feature
+++ b/features/index/pagination.feature
@@ -1,17 +1,35 @@
 Feature: Index Pagination
 
   Background:
+  Scenario: Viewing index when one page of resources exist
     Given an index configuration of:
     """
       ActiveAdmin.register Post
     """
-  Scenario: Viewing index when one page of resources exist
     Given 20 posts exist
     When I am on the index page for posts
     Then I should see "Displaying all 20 Posts"
     And I should not see pagination
 
   Scenario: Viewing index when multiple pages of resources exist
+    Given an index configuration of:
+    """
+      ActiveAdmin.register Post
+    """
     Given 31 posts exist
     When I am on the index page for posts
     Then I should see pagination with 2 pages
+
+  Scenario: Viewing index with a custom per page set
+    Given an index configuration of:
+    """
+      ActiveAdmin.register Post do
+        before_filter :only => :index do |controller|
+          @per_page = 10
+        end
+      end
+    """
+    Given 11 posts exist
+    When I am on the index page for posts
+    Then I should see pagination with 2 pages
+    And I should see "Displaying Posts 1 - 10 of 11 in total"

--- a/lib/active_admin/views/components/paginated_collection.rb
+++ b/lib/active_admin/views/components/paginated_collection.rb
@@ -42,7 +42,7 @@ module ActiveAdmin
         unless collection.respond_to?(:num_pages)
           raise(StandardError, "Collection is not a paginated scope. Set collection.page(params[:page]).per(10) before calling :paginated_collection.")
         end
-        
+
         div(page_entries_info(options).html_safe, :class => "pagination_information")
         @contents = div(:class => "paginated_collection_contents")
         build_pagination_with_formats
@@ -70,7 +70,7 @@ module ActiveAdmin
       def build_pagination
         options =  request.query_parameters.except(:commit, :format)
         options[:param_name] = @param_name if @param_name
-        
+
         text_node paginate(collection, options.symbolize_keys)
       end
 
@@ -107,9 +107,9 @@ module ActiveAdmin
           else;   I18n.t('active_admin.pagination.one_page', :model => entries_name, :n => collection.size)
           end
         else
-          offset = collection.current_page * active_admin_application.default_per_page
+          offset = collection.current_page * collection.size
           total  = collection.total_count
-          I18n.t('active_admin.pagination.multiple', :model => entries_name, :from => (offset - active_admin_application.default_per_page + 1), :to => offset > total ? total : offset, :total => total)
+          I18n.t('active_admin.pagination.multiple', :model => entries_name, :from => (offset - collection.size + 1), :to => offset > total ? total : offset, :total => total)
         end
       end
 


### PR DESCRIPTION
Setting a custom @per_page through a before_filter fetches the correct number of records but the text in the pagination is incorrect. 

Using collection.size rather than active_admin_application.default_per_page yields the correct text.
