### PR TITLE
#592: "stack level too deep" error when using :logout_path named route

### DIFF
--- a/features/dashboard.feature
+++ b/features/dashboard.feature
@@ -24,3 +24,13 @@ Feature: Dashboard
     Then I should not see the default welcome message
     And I should see a dashboard widget "Hello World"
     And I should see "Hello world from the content"
+
+  Scenario: With logout_link_path set to :logout_path (the symbol)
+    Given a configuration of:
+      """
+      ActiveAdmin.setup do |config|
+        config.logout_link_path = :logout_path
+      end
+      """
+    When I go to the dashboard
+    Then I should see the default welcome message

--- a/lib/active_admin/views/header_renderer.rb
+++ b/lib/active_admin/views/header_renderer.rb
@@ -19,7 +19,7 @@ module ActiveAdmin
           title_image
         end
       end
-
+      
       # Renders an image for the site's header/branding area
       def title_image
         if !active_admin_namespace.site_title_link.blank?
@@ -28,7 +28,7 @@ module ActiveAdmin
           content_tag 'h1', image_tag( active_admin_namespace.site_title_image, :id => "site_title_image", :alt => active_admin_namespace.site_title ), :id => "site_title"
         end
       end
-
+      
       # Renders a the site's header/branding area as a string
       def title_text
         if !active_admin_namespace.site_title_link || active_admin_namespace.site_title_link == ""
@@ -52,14 +52,14 @@ module ActiveAdmin
             html = content_tag(:span, display_name(current_active_admin_user), :class => "current_user")
 
             if active_admin_namespace.logout_link_path
-              html << link_to(I18n.t('active_admin.logout'), logout_path, :method => logout_method)
+              html << link_to(I18n.t('active_admin.logout'), application_logout_path, :method => logout_method)
             end
           end
         end
       end
 
       # Returns the logout path from the application settings
-      def logout_path
+      def application_logout_path
         if active_admin_namespace.logout_link_path.is_a?(Symbol)
           send(active_admin_namespace.logout_link_path)
         else

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -22,6 +22,14 @@ run "rm -r test"
 run "rm -r spec"
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+
+# we need this routing path, named "logout_path", for testing
+route <<-EOS
+  devise_scope :user do
+    match '/admin/logout' => 'active_admin/devise/sessions#destroy', :as => :logout
+  end
+EOS
+
 generate :'active_admin:install'
 
 # Setup a root path for devise


### PR DESCRIPTION
See Issue #592

`rake test` passes, but `rake test:major_supported_rails --trace` gives me:

``` text
in /Users/george/work/open_source_contributions/active_admin)
** Invoke test:major_supported_rails (first_time)
** Execute test:major_supported_rails

== Using Rails 3.0.10
Removing the current Gemfile.lock
rm Gemfile.lock
export RAILS=3.0.10 && ./script/use_rails 3.0.10
Bundler could not find compatible versions for gem "activesupport":
  In Gemfile:
    activeadmin (>= 0) ruby depends on
      activesupport (~> 3.1.0) ruby

    rails (= 3.0.10) ruby depends on
      activesupport (3.0.10)


rake aborted!

/Users/george/work/open_source_contributions/active_admin/Rakefile:9:in `cmd'
/Users/george/work/open_source_contributions/active_admin/tasks/test.rake:27:in `block (3 levels) in <top (required)>'
/Users/george/work/open_source_contributions/active_admin/tasks/test.rake:18:in `each'
/Users/george/work/open_source_contributions/active_admin/tasks/test.rake:18:in `block (2 levels) in <top (required)>'
/Users/george/.rvm/gems/ruby-1.9.2-p290@active_admin/gems/rake-0.8.7/lib/rake.rb:636:in `call'
/Users/george/.rvm/gems/ruby-1.9.2-p290@active_admin/gems/rake-0.8.7/lib/rake.rb:636:in `block in execute'
/Users/george/.rvm/gems/ruby-1.9.2-p290@active_admin/gems/rake-0.8.7/lib/rake.rb:631:in `each'
/Users/george/.rvm/gems/ruby-1.9.2-p290@active_admin/gems/rake-0.8.7/lib/rake.rb:631:in `execute'
/Users/george/.rvm/gems/ruby-1.9.2-p290@active_admin/gems/rake-0.8.7/lib/rake.rb:597:in `block in invoke_with_call_chain'
/Users/george/.rvm/rubies/ruby-1.9.2-p290/lib/ruby/1.9.1/monitor.rb:201:in `mon_synchronize'
/Users/george/.rvm/gems/ruby-1.9.2-p290@active_admin/gems/rake-0.8.7/lib/rake.rb:590:in `invoke_with_call_chain'
/Users/george/.rvm/gems/ruby-1.9.2-p290@active_admin/gems/rake-0.8.7/lib/rake.rb:583:in `invoke'
/Users/george/.rvm/gems/ruby-1.9.2-p290@active_admin/gems/rake-0.8.7/lib/rake.rb:2051:in `invoke_task'
/Users/george/.rvm/gems/ruby-1.9.2-p290@active_admin/gems/rake-0.8.7/lib/rake.rb:2029:in `block (2 levels) in top_level'
/Users/george/.rvm/gems/ruby-1.9.2-p290@active_admin/gems/rake-0.8.7/lib/rake.rb:2029:in `each'
/Users/george/.rvm/gems/ruby-1.9.2-p290@active_admin/gems/rake-0.8.7/lib/rake.rb:2029:in `block in top_level'
/Users/george/.rvm/gems/ruby-1.9.2-p290@active_admin/gems/rake-0.8.7/lib/rake.rb:2068:in `standard_exception_handling'
/Users/george/.rvm/gems/ruby-1.9.2-p290@active_admin/gems/rake-0.8.7/lib/rake.rb:2023:in `top_level'
/Users/george/.rvm/gems/ruby-1.9.2-p290@active_admin/gems/rake-0.8.7/lib/rake.rb:2001:in `block in run'
/Users/george/.rvm/gems/ruby-1.9.2-p290@active_admin/gems/rake-0.8.7/lib/rake.rb:2068:in `standard_exception_handling'
/Users/george/.rvm/gems/ruby-1.9.2-p290@active_admin/gems/rake-0.8.7/lib/rake.rb:1998:in `run'
/Users/george/.rvm/gems/ruby-1.9.2-p290@active_admin/gems/rake-0.8.7/bin/rake:31:in `<top (required)>'
./bin/rake:16:in `load'
./bin/rake:16:in `<main>'
```

Not sure what to do with that.
