### PR TITLE
Fix linking to ActiveAdmin actions for models that define to_param

### DIFF
--- a/lib/active_admin/comments.rb
+++ b/lib/active_admin/comments.rb
@@ -44,7 +44,7 @@ ActiveAdmin::Event.subscribe ActiveAdmin::Application::LoadEvent do |app|
           flash[:notice] = flash[:notice].dup if flash[:notice]
           comment = ActiveAdmin::Comment.find(params[:id])
           resource_config = active_admin_config.namespace.resource_for(comment.resource.class)
-          redirect_to send(resource_config.route_instance_path, comment.resource.id)
+          redirect_to send(resource_config.route_instance_path, :id => comment.resource.id)
         end
 
         # Store the author and namespace
@@ -61,7 +61,7 @@ ActiveAdmin::Event.subscribe ActiveAdmin::Application::LoadEvent do |app|
               failure.html do 
                 resource_config = active_admin_config.namespace.resource_for(@comment.resource.class)
                 flash[:error] = "Comment wasn't saved, text was empty."
-                redirect_to send(resource_config.route_instance_path, @comment.resource.id)
+                redirect_to send(resource_config.route_instance_path, :id => @comment.resource.id)
               end
             end
           end

--- a/lib/active_admin/resource/action_items.rb
+++ b/lib/active_admin/resource/action_items.rb
@@ -56,7 +56,7 @@ module ActiveAdmin
         # Edit link on show
         add_action_item :only => :show do
           if controller.action_methods.include?('edit')
-            link_to(I18n.t('active_admin.edit_model', :model => active_admin_config.resource_name), edit_resource_path(resource.id))
+            link_to(I18n.t('active_admin.edit_model', :model => active_admin_config.resource_name), edit_resource_path(:id => resource.id))
           end
         end
 
@@ -64,7 +64,7 @@ module ActiveAdmin
         add_action_item :only => :show do
           if controller.action_methods.include?("destroy")
             link_to(I18n.t('active_admin.delete_model', :model => active_admin_config.resource_name),
-              resource_path(resource.id),
+              resource_path(:id => resource.id),
               :method => :delete, :confirm => I18n.t('active_admin.delete_confirmation'))
           end
         end

--- a/lib/active_admin/view_helpers/auto_link_helper.rb
+++ b/lib/active_admin/view_helpers/auto_link_helper.rb
@@ -15,7 +15,7 @@ module ActiveAdmin
         content = link_content || display_name(resource)
         if registration = active_admin_resource_for(resource.class)
           begin
-            content = link_to(content, send(registration.route_instance_path, resource.id))
+            content = link_to(content, send(registration.route_instance_path, :id => resource.id))
           rescue
           end
         end

--- a/lib/active_admin/views/index_as_blog.rb
+++ b/lib/active_admin/views/index_as_blog.rb
@@ -109,7 +109,7 @@ module ActiveAdmin
       def build_title(post)
         if @title
           h3 do
-            link_to(call_method_or_proc_on(post, @title), resource_path(post.id))
+            link_to(call_method_or_proc_on(post, @title), resource_path(:id => post.id))
           end
         else
           h3 do

--- a/lib/active_admin/views/index_as_grid.rb
+++ b/lib/active_admin/views/index_as_grid.rb
@@ -8,7 +8,7 @@ module ActiveAdmin
      # index block.
      #
      #     index :as => :grid do |product|
-     #       link_to(image_tag(product.image_path), admin_products_path(product.id))
+     #       link_to(image_tag(product.image_path), admin_products_path(product))
      #     end
      #
      # The block is rendered within a cell in the grid once for each resource in the
@@ -18,7 +18,7 @@ module ActiveAdmin
      # option:
      #
      #     index :as => :grid, :columns => 5 do |product|
-     #       link_to(image_tag(product.image_path), admin_products_path(product.id))
+     #       link_to(image_tag(product.image_path), admin_products_path(product))
      #     end
      #
      class IndexAsGrid < ActiveAdmin::Component

--- a/lib/active_admin/views/index_as_table.rb
+++ b/lib/active_admin/views/index_as_table.rb
@@ -31,7 +31,7 @@ module ActiveAdmin
     #
     #     index do
     #       column "Title" do |post|
-    #         link_to post.title, admin_post_path(post.id)
+    #         link_to post.title, admin_post_path(post)
     #       end
     #     end
     #
@@ -50,7 +50,7 @@ module ActiveAdmin
     #     index do
     #       column :title
     #       column "Actions" do |post|
-    #         link_to "View", admin_post_path(post.id)
+    #         link_to "View", admin_post_path(post)
     #       end
     #     end
     #
@@ -66,7 +66,7 @@ module ActiveAdmin
     #
     #     index do
     #       column "Title", :sortable => :title do |post|
-    #         link_to post.title, admin_post_path(post.id)
+    #         link_to post.title, admin_post_path(post)
     #       end
     #     end
     #
@@ -117,7 +117,7 @@ module ActiveAdmin
 
         # Display a column for the id
         def id_column
-          column('ID', :sortable => :id){|resource| link_to resource.id, resource_path(resource.id), :class => "resource_id_link"}
+          column('ID', :sortable => :id){|resource| link_to resource.id, resource_path(:id => resource.id), :class => "resource_id_link"}
         end
 
         # Adds links to View, Edit and Delete
@@ -128,13 +128,13 @@ module ActiveAdmin
           column options[:name] do |resource|
             links = ''.html_safe
             if controller.action_methods.include?('show')
-              links += link_to I18n.t('active_admin.view'), resource_path(resource.id), :class => "member_link view_link"
+              links += link_to I18n.t('active_admin.view'), resource_path(resource, :id => resource.id), :class => "member_link view_link"
             end
             if controller.action_methods.include?('edit')
-              links += link_to I18n.t('active_admin.edit'), edit_resource_path(resource.id), :class => "member_link edit_link"
+              links += link_to I18n.t('active_admin.edit'), edit_resource_path(resource, :id => resource.id), :class => "member_link edit_link"
             end
             if controller.action_methods.include?('destroy')
-              links += link_to I18n.t('active_admin.delete'), resource_path(resource.id), :method => :delete, :confirm => I18n.t('active_admin.delete_confirmation'), :class => "member_link delete_link"
+              links += link_to I18n.t('active_admin.delete'), resource_path(resource, :id => resource.id), :method => :delete, :confirm => I18n.t('active_admin.delete_confirmation'), :class => "member_link delete_link"
             end
             links
           end


### PR DESCRIPTION
If a model defines `to_param` in order to display pretty SEO-friendly URL's, ActiveAdmin links don't work.  For example:

``` ruby
class Post < ActiveRecord::Base
  attr_accessible :title, :permalink

  before_create :generate_permalink

  def to_param
    permalink
  end

protected

  def generate_permalink
    permalink ||= title.parameterize
  end
end
```

In ActiveAdmin, all the links are called in a manner such as `admin_post_path(post)`, which will become `/admin/posts/hello-world` for example.  When ActiveAdmin attempts to load that page, RecordNotFound is raised since it's performing a find on the `id` column, not the `permalink` column.

The solution is to build all links with the record's `id`, e.g.: `admin_post_path(post.id)`.

This pull request implements the above fix.  It also includes an updated test that, if tested on the code prior to this pull request, will demonstrate the error.
