### PR TITLE
Dashboard: section alone: true

### DIFF
--- a/lib/active_admin/views/pages/dashboard.rb
+++ b/lib/active_admin/views/pages/dashboard.rb
@@ -23,11 +23,20 @@ module ActiveAdmin
         def render_sections(sections)
           table :class => "dashboard" do
             sections.in_groups_of(3, false).each do |row|
-              tr do
-                row.each do |section|
-                  td do
-                    render_section(section)
+              tr_sections = row.select do |section|
+                if section.options[:alone]
+                  tr do
+                    td colspan: 3 do
+                      render_section(section)
+                    end
                   end
+                  next
+                end
+                section
+              end
+              tr do
+                tr_sections.each do |section|
+                  td render_section(section)
                 end
               end
             end


### PR DESCRIPTION
In the dashboard of my project, I need a big section (colspan: 3) and other normal sections.

So I've added an `alone` option in order to have it alone in the row:

``` ruby
ActiveAdmin::Dashboards.build do
  section "My big section", alone: true do
    span render "big_section"
  end

  section "Top 5 artists" do
    ol do
      Artist.top_five.each do |artist|
         li artist.name
       end
     end
  end

  section "Top 10 songs" do
    ol do
      Song.top_ten.each do |song|
         li song.name
       end
     end
  end
end
```

That's not the greatest solution (There will be some lines with only one or two sections together, leaving a blank cell), but it cover my case ;)

Hope this can help.

P.S: About tests I've tried to start them (`rake`) but it failed under Ruby 1.9.3 with the following error:

``` bash
/Users/zedtux/.rvm/gems/ruby-1.9.3-p0@active_admin/gems/rake-0.8.7/lib/rake/alt_system.rb:32: Use RbConfig instead of obsolete and deprecated Config.
(in /Users/zedtux/Developments/active_admin)
/Users/zedtux/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/rake/file_utils.rb:9: warning: already initialized constant RUBY
/Users/zedtux/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/rake/file_utils.rb:86: warning: already initialized constant LN_SUPPORTED
WARNING: Global access to Rake DSL methods is deprecated.  Please include
    ...  Rake::DSL into classes and modules which use the Rake DSL methods.
WARNING: DSL method RSpec::Core::RakeTask#ruby called at /Users/zedtux/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/rake/file_utils_ext.rb:39:in `ruby'
rake aborted!
stack level too deep

(See full trace by running task with --trace)
```
