### PR TITLE
Add active_admin assets to precompile list in engine

### DIFF
--- a/lib/active_admin/engine.rb
+++ b/lib/active_admin/engine.rb
@@ -1,7 +1,9 @@
 module ActiveAdmin
   class Engine < Rails::Engine
-    initializer "ActiveAdmin precompile hook" do |app|
-      app.config.assets.precompile += ['active_admin.js', 'active_admin.css']
+    if Rails.version > "3.1"
+      initializer "ActiveAdmin precompile hook" do |app|
+        app.config.assets.precompile += ['active_admin.js', 'active_admin.css']
+      end
     end
   end
 end


### PR DESCRIPTION
This pull request solves the problem of adding active_admin assets in the application. What is does is configuring the engine to add them to the precompile list so the application using ActiveAdmin does not need to do it.

Related issue: https://github.com/gregbell/active_admin/issues/483
