### PR TITLE
Support no paginator on large tables

### DIFF
--- a/lib/active_admin/views/components/paginated_collection.rb
+++ b/lib/active_admin/views/components/paginated_collection.rb
@@ -38,6 +38,7 @@ module ActiveAdmin
         @collection = collection
         @param_name     = options.delete(:param_name)
         @download_links = options.delete(:download_links)
+        @paginator      = options.delete(:paginator)
 
         unless collection.respond_to?(:num_pages)
           raise(StandardError, "Collection is not a paginated scope. Set collection.page(params[:page]).per(10) before calling :paginated_collection.")
@@ -62,8 +63,10 @@ module ActiveAdmin
 
       def build_pagination_with_formats(options)
         div :id => "index_footer" do
-          build_pagination
-          div(page_entries_info(options).html_safe, :class => "pagination_information")
+          if @paginator != false
+            build_pagination
+            div(page_entries_info(options).html_safe, :class => "pagination_information")
+          end
           build_download_format_links unless @download_links == false
         end
       end

--- a/lib/active_admin/views/components/table_for.rb
+++ b/lib/active_admin/views/components/table_for.rb
@@ -10,7 +10,9 @@ module ActiveAdmin
       def build(collection, options = {})
         @sortable = options.delete(:sortable)
         @resource_class = options.delete(:i18n)
-        @collection = collection
+        @paginator = options.delete(:paginator)
+        # Kaminari will call count(*) from <table_name> on non-paginated tables if we don't get rid of their scopes here
+        @collection = @paginator ? collection : collection.except(:page, :per).limit(collection.except(:page, :per).per_page).offset(0)
         @columns = []
         build_table
         super(options)

--- a/lib/active_admin/views/index_as_table.rb
+++ b/lib/active_admin/views/index_as_table.rb
@@ -97,7 +97,8 @@ module ActiveAdmin
           :id => active_admin_config.plural_underscored_resource_name,
           :sortable => true,
           :class => "index_table",
-          :i18n => active_admin_config.resource_class
+          :i18n => active_admin_config.resource_class,
+          :paginator => page_presenter[:paginator] != false
         }
 
         table_for collection, table_options do |t|

--- a/lib/active_admin/views/pages/index.rb
+++ b/lib/active_admin/views/pages/index.rb
@@ -17,7 +17,7 @@ module ActiveAdmin
         def main_content
           build_scopes
 
-          if collection.any?
+          if collection.limit(1).exists?
             render_index
           else
             if params[:q]
@@ -87,9 +87,13 @@ module ActiveAdmin
         
         def render_index
           renderer_class = find_index_renderer_class(config[:as])
+          paginator      = config[:paginator].nil?      ? true : config[:paginator]
+          download_links = config[:download_links].nil? ? true : config[:download_links]
           
-          paginated_collection(collection, :entry_name   => active_admin_config.resource_name,
-                                           :entries_name => active_admin_config.plural_resource_name) do
+          paginated_collection(collection, :entry_name     => active_admin_config.resource_name,
+                                           :entries_name   => active_admin_config.plural_resource_name,
+                                           :download_links => download_links,
+                                           :paginator      => paginator) do
             div :class => 'index_content' do
               insert_tag(renderer_class, config, collection)
             end


### PR DESCRIPTION
We have a very large user table (~5M records) and on Postgres count(*) from users is a very slow operation. We still want to be able to use filtering and scopes, but we just need to be able to turn off the paginator for that index page.

At the same time, I passed through download_links from the index to the paginator to allow those index pages to allow dropping the download links.

---
## Usage:

  index :as => :table, :paginator => false, :download_links => false do
    column :id
    column :email_address
    default_actions
  end

---
## Commit message:

Pass download_links from index down to paginator.
Add option for non-paginated index pages.
Prevent 'select count(*) from <table_name>' from being called on non-paginated tables.
