### PR TITLE
Update assets_generator to place assets in vendor assets directory.

### DIFF
--- a/lib/generators/active_admin/assets/assets_generator.rb
+++ b/lib/generators/active_admin/assets/assets_generator.rb
@@ -17,8 +17,8 @@ module ActiveAdmin
         require 'active_admin'
 
         if ActiveAdmin.use_asset_pipeline?
-          template '3.1/active_admin.js', 'app/assets/javascripts/active_admin.js'
-          template '3.1/active_admin.css.scss', 'app/assets/stylesheets/active_admin.css.scss'
+          template '3.1/active_admin.js', 'vendor/assets/javascripts/active_admin.js'
+          template '3.1/active_admin.css.scss', 'vendor/assets/stylesheets/active_admin.css.scss'
         else
           template '../../../../../app/assets/javascripts/active_admin/application.js', 'public/javascripts/active_admin.js'
           directory '../../../../../app/assets/images/active_admin', 'public/images/active_admin'


### PR DESCRIPTION
This is the correct place for assets that are added to an app. Per the Rails documentation "vendor/assets is for assets that are owned by outside entities, such as code for JavaScript plugins." This also fixes a problem where using the sprockets directive require_tree in application.css automatically includes the active admin CSS everywhere - organizing assets into vendor like this will load them only on active admin pages.
