### PR TITLE
Allow options hash for routes. 

### DIFF
--- a/lib/active_admin/controller_action.rb
+++ b/lib/active_admin/controller_action.rb
@@ -1,12 +1,20 @@
 module ActiveAdmin
   class ControllerAction
-    attr_reader :name
+    
+    attr_reader :options
+    
     def initialize(name, options = {})
+      options[:action] = name
       @name, @options = name, options
     end
 
     def http_verb
       @options[:method] ||= :get
     end
+    
+    def name
+      @options[:as] || @name
+    end
+    
   end
 end

--- a/lib/active_admin/router.rb
+++ b/lib/active_admin/router.rb
@@ -40,14 +40,14 @@ module ActiveAdmin
                 member do
                   config.member_actions.each do |action|
                     # eg: get :comment
-                    send(action.http_verb, action.name)
+                    send(action.http_verb, action.name, action.options)
                   end
                 end
 
                 # Define any collection actions
                 collection do
                   config.collection_actions.each do |action|
-                    send(action.http_verb, action.name)
+                    send(action.http_verb, action.name, action.options)
                   end
                 end
               end


### PR DESCRIPTION
This allows multiple routes to share the same path with different verbs.

For example, you can now have a 'GET /posts/1/publish' and a 'PUT /posts/1/publish' by using syntax like the following in your resource registration, e.g., 'app/admin/posts.rb':

  member_action :publish!, :as => :publish, :method => :put do
    resource.publish!
    redirect_to [:admin, resource], :notice => "Post was published"
  end

  member_action :publish, :method => :get do
    @post = resource
  end
