### PR TITLE
Pass record to the block when creating a row

### DIFF
--- a/lib/active_admin/views/components/attributes_table.rb
+++ b/lib/active_admin/views/components/attributes_table.rb
@@ -45,7 +45,7 @@ module ActiveAdmin
       def content_for(attr_or_proc)
         value = case attr_or_proc
                 when Proc
-                  attr_or_proc.call
+                  attr_or_proc.call(@record)
                 else
                   content_for_attribute(attr_or_proc)
                 end


### PR DESCRIPTION
I noticed that the syntax for creating a column in a table and a row in an attributes_table wasn't the same.

With a column I could do:

``` ruby
index do
  column :name do |user|
    link_to user.name, admin_user_path(user)
  end
end
```

But when I tried to do the same with a row in a attributes_table I noticed that there wasn't a record passed to that block for me to work off of, and active_admin was throwing an error.

This patch allows for doing things like:

``` ruby
show do
  attributes_table do
    row :company do |user|
      link_to user.company, user.company_link
    end
  end
end
```
