### PR TITLE
Upgrade Kaminari & use config option to reduce conflicts 

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency("devise", ">= 1.1.2")
   s.add_dependency("formtastic", ">= 2.0.0")
   s.add_dependency("inherited_resources", "< 1.3.0")
-  s.add_dependency("kaminari", ">= 0.12.4")
+  s.add_dependency("kaminari", ">= 0.13.0")
   s.add_dependency("sass", ">= 3.1.0")
   s.add_dependency("fastercsv", ">= 0")
 end

--- a/lib/active_admin/resource_controller/collection.rb
+++ b/lib/active_admin/resource_controller/collection.rb
@@ -124,7 +124,7 @@ module ActiveAdmin
         end
 
         def paginate(chain)
-          chain.page(params[:page]).per(@per_page || active_admin_namespace.default_per_page)
+          chain.send(Kaminari.config.page_method_name, params[:page]).per(@per_page || active_admin_namespace.default_per_page)
         end
       end
 


### PR DESCRIPTION
Kaminari added a config option to customize the pagination method to elminiate conflicts with will_paginate. 

Note: I was unable to get rake test to work even on vanilla active admin. Got this error https://gist.github.com/1510308 . Tested it with ./script/local server and it works fine.
