### PR TITLE
Issue #874 - Changed class name from "status" to "status_tag"

### DIFF
--- a/app/assets/stylesheets/active_admin/components/_status_tags.scss
+++ b/app/assets/stylesheets/active_admin/components/_status_tags.scss
@@ -1,4 +1,4 @@
-.status {
+.status_tag {
   background: darken($secondary-color, 15%);
   color: #fff;
   text-transform: uppercase;

--- a/lib/active_admin/views/components/status_tag.rb
+++ b/lib/active_admin/views/components/status_tag.rb
@@ -9,7 +9,7 @@ module ActiveAdmin
       end
 
       def default_class_name
-        'status'
+        'status_tag'
       end
 
       # @method status_tag(status, type = nil, options = {})
@@ -22,13 +22,13 @@ module ActiveAdmin
       #
       # Examples:
       #   status_tag('In Progress')
-      #   # => <span class='status in_progress'>In Progress</span>
+      #   # => <span class='status_tag in_progress'>In Progress</span>
       #
       #   status_tag('active', :ok)
-      #   # => <span class='status active ok'>Active</span>
+      #   # => <span class='status_tag active ok'>Active</span>
       #
       #   status_tag('active', :ok, :class => 'important', :id => 'status_123', :label => 'on')
-      #   # => <span class='status active ok important' id='status_123'>on</span>
+      #   # => <span class='status_tag active ok important' id='status_123'>on</span>
       # 
       def build(*args)
         options = args.extract_options!

--- a/spec/unit/views/components/status_tag_spec.rb
+++ b/spec/unit/views/components/status_tag_spec.rb
@@ -8,13 +8,13 @@ describe ActiveAdmin::Views::StatusTag do
     subject { status_tag(nil) }
 
     its(:tag_name)    { should == 'span' }
-    its(:class_list)  { should include('status') }
+    its(:class_list)  { should include('status_tag') }
 
     context "when status is 'completed'" do
       subject { status_tag('completed') }
 
       its(:tag_name)    { should == 'span' }
-      its(:class_list)  { should include('status') }
+      its(:class_list)  { should include('status_tag') }
       its(:class_list)  { should include('completed') }
       its(:content)     { should == 'Completed' }
     end
@@ -36,21 +36,21 @@ describe ActiveAdmin::Views::StatusTag do
     context "when status is an empty string" do
       subject { status_tag('') }
 
-      its(:class_list)  { should include('status') }
+      its(:class_list)  { should include('status_tag') }
       its(:content)     { should == '' }
     end
 
     context "when status is nil" do
       subject { status_tag(nil) }
 
-      its(:class_list)  { should include('status') }
+      its(:class_list)  { should include('status_tag') }
       its(:content)     { should == '' }
     end
 
     context "when status is 'Active' and type is :ok" do
       subject { status_tag('Active', :ok) }
 
-      its(:class_list)  { should include('status') }
+      its(:class_list)  { should include('status_tag') }
       its(:class_list)  { should include('active') }
       its(:class_list)  { should include('ok') }
     end
@@ -58,7 +58,7 @@ describe ActiveAdmin::Views::StatusTag do
     context "when status is 'Active' and class is 'ok'" do
       subject { status_tag('Active', :class => 'ok') }
 
-      its(:class_list)  { should include('status') }
+      its(:class_list)  { should include('status_tag') }
       its(:class_list)  { should include('active') }
       its(:class_list)  { should include('ok') }
     end
@@ -67,7 +67,7 @@ describe ActiveAdmin::Views::StatusTag do
       subject { status_tag('Active', :label => 'on') }
 
       its(:content)     { should == 'on' }
-      its(:class_list)  { should include('status') }
+      its(:class_list)  { should include('status_tag') }
       its(:class_list)  { should include('active') }
       its(:class_list)  { should_not include('on') }
     end
@@ -76,7 +76,7 @@ describe ActiveAdmin::Views::StatusTag do
       subject { status_tag('So useless', :ok, :class => 'woot awesome', :id => 'useless') }
 
       its(:content)     { should == 'So Useless' }
-      its(:class_list)  { should include('status') }
+      its(:class_list)  { should include('status_tag') }
       its(:class_list)  { should include('ok') }
       its(:class_list)  { should include('so_useless') }
       its(:class_list)  { should include('woot') }


### PR DESCRIPTION
As described on the issue, there was a conflict between this css class and models named Status. The views became messy.
