### PR TITLE
Want the ActiveAdmin filter() DSL to execute the :collection param in view context

### DIFF
--- a/lib/active_admin/inputs/filter_base.rb
+++ b/lib/active_admin/inputs/filter_base.rb
@@ -21,7 +21,7 @@ module ActiveAdmin
       # Override the standard finder to accept a proc
       def collection_from_options
         if options[:collection].is_a?(Proc)
-          options[:collection].call
+          template.instance_eval &options[:collection]
         else
           super
         end


### PR DESCRIPTION
Intended usage:

``` ruby
ActiveAdmin.register Post do
  filter :author, :collection => proc { current_admin_user.posts }
end
```
