### PR TITLE
repair of class name from resource without I18n transation

### DIFF
--- a/lib/active_admin/resource/naming.rb
+++ b/lib/active_admin/resource/naming.rb
@@ -1,6 +1,16 @@
 module ActiveAdmin
   class Resource
     module Naming
+		
+	  def name_of_resource_class
+        tmp_resource_name ||= @options[:as]
+        tmp_resource_name ||= resource_class.name.gsub('::','')
+	  end
+
+  	  def plural_name_of_resource_class
+        name_of_resource_class.pluralize
+	  end
+
       # Returns the name to call this resource such as "Bank Account"
       def resource_name
         @resource_name ||= @options[:as]
@@ -22,11 +32,11 @@ module ActiveAdmin
 
       # A camelized safe representation for this resource
       def camelized_resource_name
-        resource_name.titleize.gsub(' ', '')
+        name_of_resource_class.titleize.gsub(' ', '')
       end
 
       def plural_camelized_resource_name
-        plural_resource_name.titleize.gsub(' ', '')
+        plural_name_of_resource_class.titleize.gsub(' ', '')
       end
 
       # An underscored safe representation internally for this resource


### PR DESCRIPTION
Hallo.
I had a problem to get translated menu and title of page for my Models. I found solution here: #434 (iain)
but running web writes out some strange errors with my native language. Some thing like ...UživatelControler...
## After long code crawling i found problem.

There was used methods **resource_name** and **plural_resource_name**. They uses singular_human_name / plural_human_name inside. It is good for menu and other output but not for methods like **resource_key**, **camelized_resource_name**, etc.

So I pulling my solution which works for me. 

Other things for translation support are:

<pre>
 iain  commented at September 29, 2011 

I've done the following workaround: I've made an initializer (config/initializers/i18n.rb) with the following:
I18n.locale = :nl # or whatever your default locale is
I18n.load_path += Dir[Rails.root.join("config/locales/**/*.yml")]
I18n.reload!
</pre>


put active admin translation **yourlang.yml** to config\locales\activeadmin (e.g.)
in your translation use 
xx:
  activerecord:
    models:
      yourmodel: #singular
        one: "singular transl."
        other: "plural transl."

Could by good mention it somewhere in documentation!
