### PR TITLE
Use current_admin_user instead of current_user in scope for test-rails-app

### DIFF
--- a/spec/support/rails_template_with_data.rb
+++ b/spec/support/rails_template_with_data.rb
@@ -22,7 +22,7 @@ scopes = <<-EOF
   end
 
   scope :my_posts do |posts|
-    posts.where(:author_id => current_user.id)
+    posts.where(:author_id => current_admin_user.id)
   end
 EOF
 inject_into_file 'app/admin/posts.rb', scopes , :after => "ActiveAdmin.register Post do\n"


### PR DESCRIPTION
Right now the usage of current_user.posts in rails_template_with_data causes an error because the test app defaults to current_admin_user instead of current user. This pull request changes that scope to use current_admin_user.posts.
