### PR TITLE
Remove noisy logging

### DIFF
--- a/lib/active_admin/reloader.rb
+++ b/lib/active_admin/reloader.rb
@@ -70,7 +70,6 @@ module ActiveAdmin
 
       class FileUpdateChecker < ::ActiveSupport::FileUpdateChecker
         def paths
-          Rails.logger.info [@files, @paths].inspect
           # hack to support both Rails 3.1 and 3.2
           @files || @paths
         end


### PR DESCRIPTION
This is my first pull request to ActiveAdmin! :)

I noticed output noise coming from ActiveAdmin during every request. It looked something like this:

```
Started GET "/" for 127.0.0.1 at 2012-01-30 13:51:37 -0800
[nil, ["/Users/erik/Projects/my_app/app/admin", "/Users/erik/Projects/my_app/app/admin/admin_users.rb", "/Users/erik/Projects/my_app/app/admin/credit_cards.rb", "/Users/erik/Projects/my_app/app/admin/dashboards.rb", "/Users/erik/Projects/my_app/app/admin/device_identifiers.rb", "/Users/erik/Projects/my_app/app/admin/facebook_updates.rb", "/Users/erik/Projects/my_app/app/admin/invite_codes.rb", "/Users/erik/Projects/my_app/app/admin/listing_images.rb", "/Users/erik/Projects/my_app/app/admin/listings.rb", "/Users/erik/Projects/my_app/app/admin/mobile_wait_list_users.rb", "/Users/erik/Projects/my_app/app/admin/offers.rb", "/Users/erik/Projects/my_app/app/admin/ongoing_searches.rb", "/Users/erik/Projects/my_app/app/admin/transactions.rb", "/Users/erik/Projects/my_app/app/admin/twitter_updates.rb", "/Users/erik/Projects/my_app/app/admin/user_images.rb", "/Users/erik/Projects/my_app/app/admin/users.rb", "/Users/erik/Projects/my_app/app/admin/web_wait_list_users.rb"]]
Rendered index/show.html.erb within layouts/application (17.9ms)
Completed 200 OK in 33ms (Views: 28.9ms | ActiveRecord: 3.2ms)


Started GET "/assets/global.css?body=1" for 127.0.0.1 at 2012-01-30 13:51:37 -0800
[nil, ["/Users/erik/Projects/my_app/app/admin", "/Users/erik/Projects/my_app/app/admin/admin_users.rb", "/Users/erik/Projects/my_app/app/admin/credit_cards.rb", "/Users/erik/Projects/my_app/app/admin/dashboards.rb", "/Users/erik/Projects/my_app/app/admin/device_identifiers.rb", "/Users/erik/Projects/my_app/app/admin/facebook_updates.rb", "/Users/erik/Projects/my_app/app/admin/invite_codes.rb", "/Users/erik/Projects/my_app/app/admin/listing_images.rb", "/Users/erik/Projects/my_app/app/admin/listings.rb", "/Users/erik/Projects/my_app/app/admin/mobile_wait_list_users.rb", "/Users/erik/Projects/my_app/app/admin/offers.rb", "/Users/erik/Projects/my_app/app/admin/ongoing_searches.rb", "/Users/erik/Projects/my_app/app/admin/transactions.rb", "/Users/erik/Projects/my_app/app/admin/twitter_updates.rb", "/Users/erik/Projects/my_app/app/admin/user_images.rb", "/Users/erik/Projects/my_app/app/admin/users.rb", "/Users/erik/Projects/my_app/app/admin/web_wait_list_users.rb"]]
Served asset /global.css - 304 Not Modified (5ms)


Started GET "/assets/jquery-placeholder.js?body=1" for 127.0.0.1 at 2012-01-30 13:51:37 -0800
[nil, ["/Users/erik/Projects/my_app/app/admin", "/Users/erik/Projects/my_app/app/admin/admin_users.rb", "/Users/erik/Projects/my_app/app/admin/credit_cards.rb", "/Users/erik/Projects/my_app/app/admin/dashboards.rb", "/Users/erik/Projects/my_app/app/admin/device_identifiers.rb", "/Users/erik/Projects/my_app/app/admin/facebook_updates.rb", "/Users/erik/Projects/my_app/app/admin/invite_codes.rb", "/Users/erik/Projects/my_app/app/admin/listing_images.rb", "/Users/erik/Projects/my_app/app/admin/listings.rb", "/Users/erik/Projects/my_app/app/admin/mobile_wait_list_users.rb", "/Users/erik/Projects/my_app/app/admin/offers.rb", "/Users/erik/Projects/my_app/app/admin/ongoing_searches.rb", "/Users/erik/Projects/my_app/app/admin/transactions.rb", "/Users/erik/Projects/my_app/app/admin/twitter_updates.rb", "/Users/erik/Projects/my_app/app/admin/user_images.rb", "/Users/erik/Projects/my_app/app/admin/users.rb", "/Users/erik/Projects/my_app/app/admin/web_wait_list_users.rb"]]
Served asset /jquery-placeholder.js - 304 Not Modified (0ms)
```

This patch removes the logger statement that was generating this noise, which looks like it was just being used for debugging purposes and is no longer necessary.
