### PR TITLE
Added kaminari and formtastic keys to the 'es' locale

### DIFF
--- a/lib/active_admin/locales/es.yml
+++ b/lib/active_admin/locales/es.yml
@@ -38,3 +38,19 @@ es:
     blank_slate:
       content: "No hay %{resource_name} aún."
       link: "Crea uno(a)"
+  views:
+      pagination:
+          truncate: "..."
+          first: "Inicio"
+          previous: "Anterior"
+          next: "Siguiente"
+          last: "Ultimo"
+  formtastic:
+    yes: "Sí"
+    no: "No"
+    create: "Guardar %{model}"
+    update: "Guardar %{model}"
+    submit: "Aceptar"
+    cancel: "Cancelar"
+    reset: "Resetear %{model}"
+    required: "requerido"


### PR DESCRIPTION
These keys translate the missing parts of ActiveAdmin, including the
pagination div and formtastic action buttons.
