### PR TITLE
Fix FormBuilder#inputs content capturing

### DIFF
--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -11,7 +11,11 @@ module ActiveAdmin
     def inputs(*args, &block)
       # Store that we are creating inputs without a block
       @inputs_with_block = block_given? ? true : false
-      content = with_new_form_buffer { super }
+      content = with_new_form_buffer do
+        super
+        # Ensure the buffer is returned instead of the block result itself
+        form_buffers.last
+      end
       form_buffers.last << content.html_safe
     end
 


### PR DESCRIPTION
Without this change this would return an empty fieldset

``` ruby
ActiveAdmin.register Member do
  form do |f|
    f.inputs 'Authentication' do
      f.input :email

      # when the following is false the block returns nil
      unless f.object.persisted?
        f.input :password
        f.input :password_confirmation
      end
    end
  end  
end
```

**edit:**

A quick workaround (yet not definitive), thanks to @thbar:

``` ruby
ActiveAdmin.register Member do
  form do |f|
    f.inputs 'Authentication' do
      f.input :email

      # when the following is false the block returns nil
      unless f.object.persisted?
        f.input :password
        f.input :password_confirmation
      end
      f.form_buffers.last # <<< add this
    end
  end  
end
```
