### PR TITLE
Add custom pagination to Resource config Closes #497

### DIFF
--- a/docs/3-index-pages.md
+++ b/docs/3-index-pages.md
@@ -61,3 +61,18 @@ You can define the default sort order for index pages:
     ActiveAdmin.register Post do
       config.sort_order = "name_asc"
     end
+
+## Index pagination
+
+
+You can set the number of records per page per resources:
+
+    ActiveAdmin.register Post do
+      config.per_page = 10
+    end
+
+You can also disable pagination:
+
+    ActiveAdmin.register Post do
+      config.paginate = false
+    end

--- a/features/index/pagination.feature
+++ b/features/index/pagination.feature
@@ -24,12 +24,21 @@ Feature: Index Pagination
     Given an index configuration of:
     """
       ActiveAdmin.register Post do
-        before_filter :only => :index do |controller|
-          @per_page = 10
-        end
+        config.per_page = 2
       end
     """
-    Given 11 posts exist
+    Given 3 posts exist
     When I am on the index page for posts
     Then I should see pagination with 2 pages
-    And I should see "Displaying Posts 1 - 10 of 11 in total"
+    And I should see "Displaying Posts 1 - 2 of 3 in total"
+
+  Scenario: Viewing index with pagination disabled
+    Given an index configuration of:
+    """
+      ActiveAdmin.register Post do
+        config.paginate = false
+      end
+    """
+    Given 31 posts exist
+    When I am on the index page for posts
+    Then I should not see pagination

--- a/lib/active_admin/resource.rb
+++ b/lib/active_admin/resource.rb
@@ -2,6 +2,7 @@ require 'active_admin/resource/action_items'
 require 'active_admin/resource/controllers'
 require 'active_admin/resource/menu'
 require 'active_admin/resource/page_presenters'
+require 'active_admin/resource/pagination'
 require 'active_admin/resource/naming'
 require 'active_admin/resource/scopes'
 require 'active_admin/resource/sidebars'
@@ -59,6 +60,7 @@ module ActiveAdmin
     include Base
     include Controllers
     include PagePresenters
+    include Pagination
     include ActionItems
     include Naming
     include Scopes

--- a/lib/active_admin/resource/pagination.rb
+++ b/lib/active_admin/resource/pagination.rb
@@ -1,0 +1,19 @@
+module ActiveAdmin
+
+  class Resource
+    module Pagination
+
+      # The default number of records to display per page
+      attr_accessor :per_page
+
+      # Enable / disable pagination (defaults to true)
+      attr_accessor :paginate
+
+      def initialize(*args)
+        super
+        @paginate = true
+        @per_page = namespace.default_per_page
+      end
+    end
+  end
+end

--- a/spec/unit/resource/pagination_spec.rb
+++ b/spec/unit/resource/pagination_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper' 
+
+module ActiveAdmin
+  describe Resource, "Pagination" do
+
+    before { load_defaults! }
+
+    let(:application){ ActiveAdmin::Application.new }
+    let(:namespace){ Namespace.new(application, :admin) }
+
+    def config(options = {})
+      @config ||= Resource.new(namespace, Category, options)
+    end
+
+    describe "#paginate" do
+      it "should default to true" do
+        config.paginate.should == true
+      end
+
+      it "should be settable to false" do
+        config.paginate = false
+        config.paginate.should == false
+      end
+    end
+
+    describe "#per_page" do
+      it "should default to namespace.default_per_page" do
+        namespace.should_receive(:default_per_page).and_return(5)
+        config.per_page.should == 5
+      end
+      
+      it "should be settable" do
+        config.per_page = 5
+        config.per_page.should == 5
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Index pagination

You can set the number of records per page per resources:

``` ruby
    ActiveAdmin.register Post do
      config.per_page = 10
    end
```

You can also disable pagination:

``` ruby
    ActiveAdmin.register Post do
      config.paginate = false
    end
```

I attempted to implement this feature as an option to the index method.

``` ruby
index :paginate => 5 do
end
```

I am not sure that the controller should know about the index presenter (with stores the :paginate option), so I refactored it to use the config object.
