### PR TITLE
fix SQL error with unquoted column names (#971)

### DIFF
--- a/lib/active_admin/resource.rb
+++ b/lib/active_admin/resource.rb
@@ -77,6 +77,10 @@ module ActiveAdmin
       resource_class.quoted_table_name
     end
 
+    def resource_quoted_column_name(column)
+      resource_class.connection.quote_column_name(column)
+    end
+
     # Returns the named route for an instance of this resource
     def route_instance_path
       [route_prefix, controller.resources_configuration[:self][:route_instance_name], 'path'].compact.join('_').to_sym

--- a/lib/active_admin/resource_controller/collection.rb
+++ b/lib/active_admin/resource_controller/collection.rb
@@ -46,7 +46,8 @@ module ActiveAdmin
             column = $1
             order  = $2
             table  = active_admin_config.resource_table_name
-            table_column = (column =~ /\./) ? column : "#{table}.#{column}"
+            table_column = (column =~ /\./) ? column :
+              "#{table}.#{active_admin_config.resource_quoted_column_name(column)}"
 
             chain.order("#{table_column} #{order}")
           else

--- a/spec/unit/resource_controller/collection_spec.rb
+++ b/spec/unit/resource_controller/collection_spec.rb
@@ -26,7 +26,7 @@ describe ActiveAdmin::ResourceController::Collection do
     let(:params){ {:order => "id_asc" }}
     it "should prepend the table name" do
       chain = mock("ChainObj")
-      chain.should_receive(:order).with("\"posts\".id asc").once.and_return(Post.search)
+      chain.should_receive(:order).with("\"posts\".\"id\" asc").once.and_return(Post.search)
       controller.send :sort_order, chain
     end
   end


### PR DESCRIPTION
Hi, I've put together a patch to fix the bug I observed. I've run the test suite and tested sorting in the tester Rails app and it does not appear to affect any other functionality. Please let me know if this is adequate or if there are other aspects you'd like tested to feel comfortable including the patch.

Here is a summary of the changes:
- Add ActiveAdmin::Resource#resource_quoted_column_name to provide access to ActiveRecord's built-in column name quoting
- Modify ActiveAdmin::ResourceController::Collection::BaseCollection::Sorting#sort_order to quote the column name used in sorting
- Modify spec for ActiveAdmin::ResourceController::Collection to reflect expectation of having column name quoted

Thanks!
-Gabriel
