### PR TITLE
Issue #1001 - Sidebar conditional :if handles controller methods

### DIFF
--- a/features/sidebar_sections.feature
+++ b/features/sidebar_sections.feature
@@ -101,8 +101,11 @@ Feature: Sidebar Sections
   Scenario: Create a sidebar for only one action with if clause with method symbol
     Given a configuration of:
     """
+    module SidebarHelper
+      def can_sidebar?; false; end
+    end
     ActiveAdmin.register Post do
-      controller { def can_sidebar?; false; end }
+      controller { helper SidebarHelper }
       sidebar :help, :only => :index, :if => :can_sidebar? do
         "Need help? Email us at help@example.com"
       end

--- a/lib/active_admin/helpers/optional_display.rb
+++ b/lib/active_admin/helpers/optional_display.rb
@@ -21,7 +21,7 @@ module ActiveAdmin
         symbol_or_proc = @options[:if]
         return case symbol_or_proc
         when Symbol, String
-          render_context ? render_context.controller.send(symbol_or_proc) : self.send(symbol_or_proc)
+          render_context ? render_context.send(symbol_or_proc) : self.send(symbol_or_proc)
         when Proc
             render_context ? render_context.instance_exec(&symbol_or_proc) : instance_exec(&symbol_or_proc)
         else symbol_or_proc


### PR DESCRIPTION
Proposal solution to #1001

It would be nice to use controller helpers as symbols for sidebar conditionals.

The current implementation would call they symbol on SidebarSecition which is a bit useless.

It feels dirty to call `render_context.controller.send(:method)`, yet controller is the context that's most useful.

Alternatively, maybe `ActiveAdmin::Resource::Sidebars#sidebar_sections_for` could pass `render_context.controller` to `display_on?` since `Page::Base` is also useless.
