### PR TITLE
Adds ability to suppress scope count on a per-scope basis

### DIFF
--- a/features/index/index_scopes.feature
+++ b/features/index/index_scopes.feature
@@ -56,6 +56,19 @@ Feature: Index Scoping
     And I should see the scope "All" with no count
     And I should see 10 posts in the table
 
+  @scope
+  Scenario: Viewing resources with a scope and scope count turned off for a single scope
+    Given 10 posts exist
+    And an index configuration of:
+      """
+      ActiveAdmin.register Post do
+        scope :all, :default => true, :show_count => false
+      end
+      """
+    Then I should see the scope "All" selected
+    And I should see the scope "All" with no count
+    And I should see 10 posts in the table
+
   Scenario: Viewing resources when scoping
     Given 6 posts exist
     And 4 published posts exist

--- a/lib/active_admin/scope.rb
+++ b/lib/active_admin/scope.rb
@@ -1,7 +1,7 @@
 module ActiveAdmin
   class Scope
 
-    attr_reader :name, :scope_method, :id, :scope_block, :display_if_block
+    attr_reader :name, :scope_method, :id, :scope_block, :display_if_block, :show_count
 
     # Create a Scope
     #
@@ -30,6 +30,7 @@ module ActiveAdmin
         @scope_block = block
       end
 
+      @show_count = options[:show_count].nil? ? true : options[:show_count]
       @display_if_block = options[:if]
     end
 

--- a/lib/active_admin/views/components/scopes.rb
+++ b/lib/active_admin/views/components/scopes.rb
@@ -38,7 +38,7 @@ module ActiveAdmin
             text_node scope_name
             span :class => 'count' do
               "(" + get_scope_count(scope).to_s + ")"
-            end if options[:scope_count]
+            end if options[:scope_count] && scope.show_count
           end
         end
       end

--- a/spec/unit/scope_spec.rb
+++ b/spec/unit/scope_spec.rb
@@ -52,4 +52,18 @@ describe ActiveAdmin::Scope do
 
   end
 
+  describe "show_count" do
+
+    it "should allow setting of show_count to prevent showing counts" do
+      scope = ActiveAdmin::Scope.new(:default, nil, :show_count => false)
+      scope.show_count.should == false
+    end
+
+    it "should set show_count to true if not passed in" do
+      scope = ActiveAdmin::Scope.new(:default)
+      scope.show_count.should == true
+    end
+
+  end
+
 end


### PR DESCRIPTION
Suppress scope count on the index page by passing :show_count => false to a scope definition.

This fixes issue #804.
