### PR TITLE
Change dependency from inherited resource

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency("meta_search", ">= 0.9.2")
   s.add_dependency("devise", ">= 1.1.2")
   s.add_dependency("formtastic", ">= 2.0.0")
-  s.add_dependency("inherited_resources", "< 1.3.0")
+  s.add_dependency("inherited_resources")
   s.add_dependency("kaminari", ">= 0.13.0")
   s.add_dependency("sass", ">= 3.1.0")
   s.add_dependency("fastercsv", ">= 0")


### PR DESCRIPTION
I'm using in my project `inherited_resources` gem, but it has bug in 1.3.0 version related with auto-reloading changes in helpers. Full description is here: https://github.com/josevalim/inherited_resources/issues/95
So, I want to fetch `inherited_resources` from master brunch, but I can't do it because active_admin depends on version < 1.3.0. I fixed it and it is working now for me
