### PR TITLE
Add a link to the wiki (closes #941)

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -9,6 +9,7 @@ to implement beautiful and elegant interfaces with very little effort.
 == Documentation & Support
 
 * Documentation & Guides: http://activeadmin.info/documentation.html
+* Wiki: https://github.com/gregbell/active_admin/wiki
 * RDoc: http://rubydoc.info/github/gregbell/active_admin/master/frames
 * Live demo: http://demo.activeadmin.info/admin
 * Website: http://www.activeadmin.info


### PR DESCRIPTION
Hi folks,

as it took me a while to figure out that the Wiki had plenty of stuff (like https://github.com/gregbell/active_admin/issues/941) it seems, here's a quick patch for that!

-- Thibaut
