### PR TITLE
Fix the dependency check for pry-rails

### DIFF
--- a/lib/active_admin/dependency_checker.rb
+++ b/lib/active_admin/dependency_checker.rb
@@ -10,7 +10,7 @@ module ActiveAdmin
           end
         end
 
-        unless pry_rails_0_1_6?
+        if pry_rails_before_0_1_6?
           warn "ActiveAdmin is not compatible with pry-rails < 0.1.6. Please upgrade pry-rails."
         end
       end
@@ -30,7 +30,7 @@ module ActiveAdmin
         false
       end
 
-      def pry_rails_0_1_6?
+      def pry_rails_before_0_1_6?
         begin
           PryRails::VERSION < "0.1.6"
         rescue NameError


### PR DESCRIPTION
The check was just backwards so I made the name of the method more explicit
and changed the if to an unless.
