### PR TITLE
temporary fix for 'build status failing', cucumber 1.1.4 explicit in Gem...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ end
 
 group :test do
   gem 'rspec-rails',    '~> 2.8.1'
+  gem 'cucumber', '1.1.4'
   gem 'cucumber-rails', '1.2.1'
   gem 'capybara',       '1.1.2'
   gem 'database_cleaner'


### PR DESCRIPTION
Greg,  When I updated my gemset I was able to get all of my cukes failing.  To fix the issue, I had to back down cucumber explicitly in my Gemfile.  This should fix the Travis-CI issue to get the green light back on master. I guess the reason none of us got it this morning is because we've had our gems bundled since before cucumber released 1.1.5.
