### PR TITLE
Exclude devise :timedout from flash messages

### DIFF
--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -102,10 +102,10 @@ module ActiveAdmin
         end
 
         def build_flash_messages
-          if flash.keys.any?
+          if flash.keys.except(:timedout).any?
             div :class => 'flashes' do
-              flash.each do |type, message|
-                div message, :class => "flash flash_#{type}"
+              flash.keys.except(:timedout).each do |k|
+                div flash[k], :class => "flash flash_#{k}"
               end
             end
           end


### PR DESCRIPTION
This is the change to exclude the devise :timedout key from showing up in the flash messages (Issue #1005). I don't have a spec for this because I'm not quite sure how to add one for this functionality but this is my proposed fix.

Note that this is a Rails-specific fix because it relies on ActiveSupport's addition of Hash#except
