### PR TITLE
add compatibility for comments with model ids that are strings issue 34

### DIFF
--- a/features/comments/commenting.feature
+++ b/features/comments/commenting.feature
@@ -89,7 +89,7 @@ Feature: Commenting
     Then I should see a flash with "Comment wasn't saved, text was empty."
     And I should see "Comments (0)"
 
-  Scenario: Viewing all commments for a namespace
+  Scenario: Viewing all comments for a namespace
     Given a show configuration of:
       """
         ActiveAdmin.register Post
@@ -111,3 +111,16 @@ Feature: Commenting
     When I add a comment "Hello World"
     Then I should see a flash with "Comment was successfully created"
     And I should be in the resource section for users
+
+  Scenario: Commenting on a class with string id
+		Given a tag with the name "coolness" exists
+		Given a configuration of:
+		"""
+			ActiveAdmin.register Tag
+		"""
+		Given I am logged in
+		When I am on the index page for tags
+		And I follow "View"
+		When I add a comment "Tag Comment"
+		Then I should see a flash with "Comment was successfully created"
+		And I should be in the resource section for tags

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -6,3 +6,8 @@ When /^I add a comment "([^"]*)"$/ do |comment|
   step %{I fill in "active_admin_comment_body" with "#{comment}"}
   step  %{I press "Add Comment"}
 end
+
+
+Given /^a tag with the name "([^"]*)" exists$/ do |tag_name|
+  Tag.create(:name => tag_name)
+end

--- a/lib/generators/active_admin/install/templates/migrations/1_create_admin_notes.rb
+++ b/lib/generators/active_admin/install/templates/migrations/1_create_admin_notes.rb
@@ -1,7 +1,8 @@
 class CreateAdminNotes < ActiveRecord::Migration
   def self.up
     create_table :admin_notes do |t|
-      t.references :resource, :polymorphic => true, :null => false
+      t.string :resource_id, :null => false
+      t.string :resource_type, :null => false
       t.references :admin_user, :polymorphic => true
       t.text :body
       t.timestamps

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -17,6 +17,24 @@ generate :model, "publisher --migration=false --parent=User"
 generate :model, 'category name:string description:text'
 inject_into_file 'app/models/category.rb', "  has_many :posts\n", :after => "class Category < ActiveRecord::Base\n"
 
+# Generate a model with string ids
+generate :model, "tag name:string"
+gsub_file(Dir['db/migrate/*_create_tags.rb'][0], /\:tags\sdo\s.*/, ":tags, :id => false, :primary_key => :id do |t|\n\t\t\tt.string :id\n" )
+id_model_setup = <<-EOF
+  self.primary_key = :id
+  before_create :set_id
+  
+  private
+  def set_id
+    self.id = 8.times.inject("") { |s,e| s << (i = Kernel.rand(62); i += ((i < 10) ? 48 : ((i < 36) ? 55 : 61 ))).chr }
+  end
+EOF
+inject_into_file 'app/models/tag.rb', id_model_setup, :after => "class Tag < ActiveRecord::Base\n"
+
+if Rails::VERSION::MAJOR == 3 && Rails::VERSION::MINOR == 1 #Rails 3.1 Gotcha
+  gsub_file 'app/models/tag.rb', /self\.primary_key.*$/, "define_attr_method :primary_key, :id"
+end
+
 # Add our local Active Admin to the load path
 inject_into_file "config/environment.rb", "\n$LOAD_PATH.unshift('#{File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'lib'))}')\nrequire \"active_admin\"\n", :after => "require File.expand_path('../application', __FILE__)"
 

--- a/spec/unit/comments_spec.rb
+++ b/spec/unit/comments_spec.rb
@@ -36,6 +36,19 @@ describe "Comments" do
         ActiveAdmin::Comment.find_for_resource_in_namespace(another_post, namespace_name).should == []
       end
     end
+    
+    describe "Commenting on resource with string id" do
+      let(:tag){ Tag.create!(:name => "cooltags") }
+      let(:namespace_name){ "admin" }
+      
+      it "should allow commenting" do
+        comment = ActiveAdmin::Comment.create! :resource => tag, 
+                                                :body => "Another Comment", 
+                                                :namespace => namespace_name
+                                                
+        ActiveAdmin::Comment.find_for_resource_in_namespace(tag, namespace_name).should == [comment]
+      end
+    end
   end
 
   describe ActiveAdmin::Comments::NamespaceHelper do


### PR DESCRIPTION
Pull request addresses issue #34.  There was a rails 3.1. gotcha (weird that it workd in 3.0 and 3.2).  Anyways, let me know if we require any more changes for this. Specs/features were done.
