### PR TITLE
add test task to specify any version of rails

### DIFF
--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -34,6 +34,11 @@ namespace :test do
 
   desc "Alias for major_supported_rails"
   task :all => :major_supported_rails
+  
+  desc "Run test suite against specified version of rails (version=3.1.3)"
+  task :version do 
+    run_tests_against ENV['version']
+  end
 
 end
 


### PR DESCRIPTION
Not sure if anyone wanted this, but it came in handy when I was troubleshooting an issue for a specific version of rails.  Maybe there's another way to do this already? 
