### PR TITLE
Partial fix for #474: Use sass' image-url rather than depend on AA routes

### DIFF
--- a/app/assets/stylesheets/active_admin/_forms.css.scss
+++ b/app/assets/stylesheets/active_admin/_forms.css.scss
@@ -252,7 +252,7 @@ form.filter_form {
       }
     
       input[type=text] {
-        background: #fff url(active_admin_image_path('datepicker/datepicker-input-icon.png')) no-repeat 100% 7px;
+        background: #fff image-url('active_admin/datepicker/datepicker-input-icon.png') no-repeat 100% 7px;
         padding-right: $date-range-filter-input-right-padding;
         width: $date-range-filter-input-width;
       }

--- a/app/assets/stylesheets/active_admin/_header.css.scss
+++ b/app/assets/stylesheets/active_admin/_header.css.scss
@@ -68,13 +68,13 @@
       }
 
       &.has_nested > a { 
-        background: url(active_admin_image_path('nested_menu_arrow.gif')) no-repeat 89% 50%; 
+        background: image-url('active_admin/nested_menu_arrow.gif') no-repeat 89% 50%; 
         padding-right: 20px; 
         z-index: 1050;
       }
 
       &.has_nested.current > a { 
-        background: $current-menu-item-background url(active_admin_image_path('nested_menu_arrow_dark.gif')) no-repeat 89% 50%; 
+        background: $current-menu-item-background image-url('active_admin/nested_menu_arrow_dark.gif') no-repeat 89% 50%; 
         padding-right: 20px; 
       }
 
@@ -86,7 +86,7 @@
       &.has_nested:hover > a { 
         @include rounded-top(10px);
         border-bottom: 5px solid $hover-menu-item-background;
-        background: $hover-menu-item-background url(active_admin_image_path('nested_menu_arrow_dark.gif')) no-repeat 89% 50%;
+        background: $hover-menu-item-background image-url('active_admin/nested_menu_arrow_dark.gif') no-repeat 89% 50%;
       }
 
 

--- a/app/assets/stylesheets/active_admin/components/_date_picker.css.scss
+++ b/app/assets/stylesheets/active_admin/components/_date_picker.css.scss
@@ -11,7 +11,7 @@
   text-align: center;
   width: 160px;
   
-  background: url(active_admin_image_path('datepicker/datepicker-nipple.png')) no-repeat 0 -40px;
+  background: image-url('active_admin/datepicker/datepicker-nipple.png') no-repeat 0 -40px;
   
   a { 
     text-decoration: none;
@@ -21,7 +21,7 @@
   }
   
   .ui-datepicker-header {
-    background: url(active_admin_image_path('datepicker/datepicker-header-bg.png')) no-repeat 0px 0px;
+    background: image-url('active_admin/datepicker/datepicker-header-bg.png') no-repeat 0px 0px;
     height: 12px;
     padding: 16px 7px 8px;
     position: relative;
@@ -46,11 +46,11 @@
       
       &.ui-datepicker-prev { 
         float: left;
-        background: url(active_admin_image_path('datepicker/datepicker-prev-link-icon.png')) no-repeat 2px 5px;
+        background: image-url('active_admin/datepicker/datepicker-prev-link-icon.png') no-repeat 2px 5px;
       }
       &.ui-datepicker-next {
         float: right;  
-        background: url(active_admin_image_path('datepicker/datepicker-next-link-icon.png')) no-repeat 12px 5px;
+        background: image-url('active_admin/datepicker/datepicker-next-link-icon.png') no-repeat 12px 5px;
       }
       &:active {
         margin-top: -3px;

--- a/app/assets/stylesheets/active_admin/components/_tables.css.scss
+++ b/app/assets/stylesheets/active_admin/components/_tables.css.scss
@@ -29,7 +29,7 @@ table.index_table {
     }
 
     &.sortable a {
-      background: url(active_admin_image_path('orderable.png')) no-repeat 0 4px; padding-left: 13px;
+      background: image-url('active_admin/orderable.png') no-repeat 0 4px; padding-left: 13px;
     }
 
     &.sorted-asc a { background-position: 0 -27px; }


### PR DESCRIPTION
Changed scss files to use sass' image-url rather than depend on AA routes
- Per http://guides.rubyonrails.org/asset_pipeline.html#css-and-sass
  image-url is recommended in scss over using asset_path helpers
