### PR TITLE
Make Travis CI test with multiple Rails versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-script: bundle exec rake
+script: bundle exec rake test:all
 rvm:
   - ree
   - 1.9.2


### PR DESCRIPTION
I noticed that `.travis.yml` currently runs `bundle exec rake`, which just runs the default task, `test`, which runs rspec and cucumber on one rails version. If it ran `bundle exec rake test:all` it would attempt to run on all three versions of rails, which would be more thorough and therefore could detect more issues. I'm unsure if this will work well, but it seems it might.
