### PR TITLE
fix form block evaluation context

### DIFF
--- a/lib/active_admin/view_helpers/form_helper.rb
+++ b/lib/active_admin/view_helpers/form_helper.rb
@@ -5,6 +5,7 @@ module ActiveAdmin
       def active_admin_form_for(resource, options = {}, &block)
         options = Marshal.load( Marshal.dump(options) )
         options[:builder] ||= ActiveAdmin::FormBuilder
+        block = block.bind(self) # make sure block is evaluated inside view context
         semantic_form_for resource, options, &block
       end
 

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -218,6 +218,15 @@ describe ActiveAdmin::FormBuilder do
     end
   end
 
+  context "block evaluation context" do
+    it "should evaluate form block in the view context" do
+      build_form do |f|
+        $form_eval_context = self
+      end
+      $form_eval_context.should be_kind_of(ActionView::Base)
+    end
+  end
+
 
   { 
     "input :title, :as => :string"        => /id\=\"post_title\"/,
@@ -236,6 +245,7 @@ describe ActiveAdmin::FormBuilder do
      body.scan(regex).size.should == 2
    end
   end
+
 
   describe "datepicker input" do
     let :body do


### PR DESCRIPTION
So currentlny when you try something like:

```
form do |f|
  f.input :foo, :collection => Moo.some_scope(current_admin_user)
end
```

it will fail with

```
undefined local variable or method `current_admin_user' for #<ActiveAdmin::ResourceDSL:0x000000037aca30>
```

that is because this block binding. This "form do" block should be evaluated in the view context, then this method will be found. 

Fix proposal included
