### PR TITLE
fix a bug in AA::Inputs::FilterSelectInput#method

### DIFF
--- a/lib/active_admin/inputs/filter_select_input.rb
+++ b/lib/active_admin/inputs/filter_select_input.rb
@@ -12,7 +12,7 @@ module ActiveAdmin
       end
 
       def method
-        super.to_s.gsub('_id','').to_sym
+        super.to_s.sub(/_id$/,'').to_sym
       end
 
       def extra_input_html_options


### PR DESCRIPTION
This method takes something like "author_id" and returns "author". It
was failing for the edge case "external_identity_id" because of the
extra "_id" in the middle of the string - i.e. it was returning
"externalentity".

Change the way the substitution is done so that it only matches at the
end of the string.

---

All specs are still passing.
