### PR TITLE
Replace ARel "exists?" with "count >= 1" due to ARel bugs against SQL Server

### DIFF
--- a/lib/active_admin/views/pages/index.rb
+++ b/lib/active_admin/views/pages/index.rb
@@ -38,7 +38,7 @@ module ActiveAdmin
           #
           # If we don't reorder, there may be some columns referenced in the order
           # clause that requires the original select.
-          collection.reorder("").limit(1).exists?
+          collection.reorder("").limit(1).count >= 1
         end
 
         # TODO: Refactor to new HTML DSL


### PR DESCRIPTION
ARel generates invalid SQL for SQL Server from the statement:

collection.reorder('').limit(1).exists?

If changed, to the equally performant form:

collection.reorder('').limit(1).count >= 1

The SQL is correct.

While I understand this is a bug in ARel (or the activerecord-sqlserver-connector), this seems so innocuous and helpful, I thought I'd ask.

Thank you!
