### PR TITLE
Fixed double rendering of Content-type meta-tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ group :development, :test do
   gem 'yard'
   gem 'rdiscount' # For yard
   gem 'rails-i18n' # Gives us default i18n for many languages
+  gem 'therubyracer'
 end
 
 group :test do

--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -25,7 +25,7 @@ module ActiveAdmin
             active_admin_application.stylesheets.each do |style|
               text_node(stylesheet_link_tag(style.path, style.options).html_safe)
             end
-            link :href => stylesheet_path('active_admin/print.css'), :media => "print", :rel => "stylesheet", :type => "text/css"
+            
             active_admin_application.javascripts.each do |path|
               script :src => javascript_path(path), :type => "text/javascript"
             end

--- a/lib/generators/active_admin/install/templates/active_admin.rb.erb
+++ b/lib/generators/active_admin/install/templates/active_admin.rb.erb
@@ -120,7 +120,8 @@ ActiveAdmin.setup do |config|
   #
   # To load a stylesheet:
   #   config.register_stylesheet 'my_stylesheet.css'
-  #
+  config.register_stylesheet 'active_admin/print.css', :media => :print
+  
   # You can provide an options hash for more control, which is passed along to stylesheet_link_tag():
   #   config.register_stylesheet 'my_print_stylesheet.css', :media => :print
   #


### PR DESCRIPTION
ActiveAdmin renders `Content-type` meta tag twice, you can see it here: http://demo.activeadmin.info/

So I fixed it, I just removed insertion of additional meta tag from `ActiveAdmin::Views::Pages::Base#build_active_admin_head`

Also I think this is a good idea to register built-in active_admin/print.css stylesheet in active_admin.rb initializer.
I moved it out from ActiveAdmin::Views::Pages::Base#build_active_admin_head method.

All tests passed.
