### PR TITLE
Fixes table_for printing <tbody>[]</tbody> when collection is empty

### DIFF
--- a/lib/active_admin/views/components/table_for.rb
+++ b/lib/active_admin/views/components/table_for.rb
@@ -85,7 +85,9 @@ module ActiveAdmin
       def build_table_body
         @tbody = tbody do
           # Build enough rows for our collection
-          @collection.each{|_| tr(:class => cycle('odd', 'even'), :id => dom_id(_)) }
+          unless @collection.empty?
+            @collection.each{|_| tr(:class => cycle('odd', 'even'), :id => dom_id(_)) }
+          end
         end
       end
 

--- a/spec/unit/views/components/table_for_spec.rb
+++ b/spec/unit/views/components/table_for_spec.rb
@@ -90,6 +90,16 @@ describe ActiveAdmin::Views::TableFor do
         end
       end
     end
+    
+    context "when creating a table with an empty collection" do
+      let(:collection) { Post.page(nil).per(5) }
+      let(:table)      { table_for(collection) { column :title } }
+      
+      it "should have an empty body" do
+        collection.should be_empty
+        table.find_by_tag("tbody").first.content.should be_blank
+      end
+    end
   end
 
   describe "column sorting" do


### PR DESCRIPTION
I was seeing a weird "[]" artifact output to the page whenever I displayed table_for with an empty collection. It was very frustrating so here's a fix.

Extra interesting is what safari does with it, illustrated by this inspector screenshot.

![weirdness](http://f.cl.ly/items/1s1C2V24413U0o441f1I/Screen%20Shot%202012-03-01%20at%204.36.08%20PM.png)
