### PR TITLE
Menu::ItemCollection.sort returns an Array on Ruby 1.9.3.

### DIFF
--- a/lib/active_admin/menu.rb
+++ b/lib/active_admin/menu.rb
@@ -48,6 +48,7 @@ module ActiveAdmin
       @children.find_by_id(id)
     end
 
+    # @return Sorted [Array] of [MenuItem]
     def items
       @children.sort
     end

--- a/spec/unit/menu_item_spec.rb
+++ b/spec/unit/menu_item_spec.rb
@@ -35,7 +35,6 @@ module ActiveAdmin
     context "with no children" do
       it "should be empty" do
         item = MenuItem.new
-        item.children.should be_an_instance_of(Menu::ItemCollection)
         item.children.should == []
       end
 

--- a/spec/unit/menu_spec.rb
+++ b/spec/unit/menu_spec.rb
@@ -10,7 +10,6 @@ describe ActiveAdmin::Menu do
 
     it "should have an empty item collection" do
       menu = Menu.new
-      menu.items.should be_an_instance_of(Menu::ItemCollection)
       menu.items.should be_empty
     end
 


### PR DESCRIPTION
It returns a Menu::ItemCollection with previous version of Ruby.

I got the specs to by removing the expectation on the type of
collection returned by #children.

@gregbell: Do we need the 'find_by_id' method on children?
