### PR TITLE
Fix html escaping for numeeric filter drop down

### DIFF
--- a/lib/active_admin/inputs/filter_numeric_input.rb
+++ b/lib/active_admin/inputs/filter_numeric_input.rb
@@ -22,7 +22,7 @@ module ActiveAdmin
       end
 
       def select_html
-        template.select_tag '', select_options, select_html_options
+        template.select_tag '', select_options, select_html_options.html_safe
       end
 
       def select_options


### PR DESCRIPTION
In rails 3.2 I was getting escaped HTML for the dropdown
