### PR TITLE
Width option for dashboard section

### DIFF
--- a/lib/active_admin/views/pages/dashboard.rb
+++ b/lib/active_admin/views/pages/dashboard.rb
@@ -25,8 +25,10 @@ module ActiveAdmin
             sections.in_groups_of(3, false).each do |row|
               tr do
                 row.each do |section|
-                  td do
-                    render_section(section)
+                  if section.options[:width]
+                    td :width => section.options[:width] { render_section(section) }
+                  else
+                    td { render_section(section) }
                   end
                 end
               end


### PR DESCRIPTION
If `:width` option passed - render `td` with `width` attribute. 

Allows to do this:

``` ruby
section :statistics, :width => 400 do
  div do
    render "pie_chart"
  end
end
```

This will render `<td width="400">%section code%</td>` 
