### PR TITLE
Add support for f.actions / f.action in forms. ( issue #1085 )

### DIFF
--- a/app/assets/stylesheets/active_admin/_forms.css.scss
+++ b/app/assets/stylesheets/active_admin/_forms.css.scss
@@ -165,12 +165,12 @@ form {
     
   }
   
-  .buttons { 
+  .buttons, .actions {
     margin-top: 15px; 
     input[type=submit] { margin-right: 10px; }
   }
   
-  fieldset.buttons li { 
+  fieldset.buttons li, fieldset.actions li {
     float:left; 
     padding: 0;
 

--- a/app/views/active_admin/devise/passwords/new.html.erb
+++ b/app/views/active_admin/devise/passwords/new.html.erb
@@ -5,8 +5,8 @@
     f.inputs do
       f.input :email
     end
-    f.buttons do
-      f.commit_button "Reset My Password"
+    f.actions do
+      f.action :submit, :label => "Reset My Password", :button_html => { :value => "Reset My Password" }
     end
   end %>
 

--- a/app/views/active_admin/devise/sessions/new.html.erb
+++ b/app/views/active_admin/devise/sessions/new.html.erb
@@ -8,8 +8,8 @@
       f.input :password
       f.input :remember_me, :as => :boolean, :if =>  false  #devise_mapping.rememberable? }
     end
-    f.buttons do
-      f.commit_button "Login"
+    f.actions do
+      f.action :submit, :label => "Login", :button_html => { :value => "Login" }
     end
   end
   %>

--- a/lib/active_admin/comments/views/active_admin_comments.rb
+++ b/lib/active_admin/comments/views/active_admin_comments.rb
@@ -70,8 +70,8 @@ module ActiveAdmin
               form.input :resource_id, :value => @record.id, :as => :hidden
               form.input :body, :input_html => {:size => "80x8"}, :label => false
             end
-            form.buttons do
-              form.commit_button I18n.t('active_admin.comments.add')
+            form.actions do
+              form.action :submit, :label => I18n.t('active_admin.comments.add'), :button_html => { :value => I18n.t('active_admin.comments.add') }
             end
           end
         end

--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -48,6 +48,23 @@ module ActiveAdmin
       content << cancel_link
     end
 
+    def actions(*args, &block)
+      content = with_new_form_buffer do
+        block_given? ? super : super { commit_action_with_cancel_link }
+      end
+      form_buffers.last << content.html_safe
+    end
+
+    def action(*args)
+      content = with_new_form_buffer { super }
+      form_buffers.last << content.html_safe
+    end
+
+    def commit_action_with_cancel_link
+      content = action(:submit)
+      content << cancel_link
+    end
+
     def has_many(association, options = {}, &block)
       options = { :for => association }.merge(options)
       options[:class] ||= ""

--- a/lib/active_admin/views/pages/form.rb
+++ b/lib/active_admin/views/pages/form.rb
@@ -41,7 +41,7 @@ module ActiveAdmin
         def default_form_config
           ActiveAdmin::PagePresenter.new do |f|
             f.inputs
-            f.buttons
+            f.actions
           end
         end
       end

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -36,7 +36,7 @@ describe ActiveAdmin::FormBuilder do
     active_admin_form_for Post.new, options, &block
   end
 
-  context "in general" do
+  context "in general with buttons" do
     let :body do
       build_form do |f|
         f.inputs do
@@ -46,6 +46,38 @@ describe ActiveAdmin::FormBuilder do
         f.buttons do
           f.commit_button "Submit Me"
           f.commit_button "Another Button"
+        end
+      end
+    end
+
+   it "should generate a text input" do
+      body.should have_tag("input", :attributes => { :type => "text",
+                                                     :name => "post[title]" })
+    end
+    it "should generate a textarea" do
+      body.should have_tag("textarea", :attributes => { :name => "post[body]" })
+    end
+    it "should only generate the form once" do
+      body.scan(/Title/).size.should == 1
+    end
+    it "should generate buttons" do
+      body.should have_tag("input", :attributes => {  :type => "submit",
+                                                          :value => "Submit Me" })
+      body.should have_tag("input", :attributes => {  :type => "submit",
+                                                          :value => "Another Button" })
+    end
+  end
+
+  context "in general with actions" do
+    let :body do
+      build_form do |f|
+        f.inputs do
+          f.input :title
+          f.input :body
+        end
+        f.actions do
+          f.action :submit, :button_html => { :value => "Submit Me" }
+          f.action :submit, :button_html => { :value => "Another Button" }
         end
       end
     end
@@ -79,7 +111,7 @@ describe ActiveAdmin::FormBuilder do
     end
   end
 
-  describe "passing in options" do
+  describe "passing in options with buttons" do
     let :body do
       build_form :html => { :multipart => true } do |f|
         f.inputs :title
@@ -90,6 +122,19 @@ describe ActiveAdmin::FormBuilder do
       body.should have_tag("form", :attributes => { :enctype => "multipart/form-data" })
     end
   end
+
+  describe "passing in options with actions" do
+    let :body do
+      build_form :html => { :multipart => true } do |f|
+        f.inputs :title
+        f.actions
+      end
+    end
+    it "should pass the options on to the form" do
+      body.should have_tag("form", :attributes => { :enctype => "multipart/form-data" })
+    end
+  end
+
 
   context "with buttons" do
     it "should generate the form once" do
@@ -119,6 +164,35 @@ describe ActiveAdmin::FormBuilder do
       body.scan(/class=\"cancel\"/).size.should == 0
     end
 
+  end
+
+  context "with actons" do
+    it "should generate the form once" do
+      body = build_form do |f|
+        f.inputs do
+          f.input :title
+        end
+        f.actions
+      end
+      body.scan(/id=\"post_title\"/).size.should == 1
+    end
+    it "should generate one button and a cancel link" do
+      body = build_form do |f|
+        f.actions
+      end
+      body.scan(/type=\"submit\"/).size.should == 1
+      body.scan(/class=\"cancel\"/).size.should == 1
+    end
+    it "should generate multiple actions" do
+      body = build_form do |f|
+        f.actions do
+          f.action :submit, :label => "Create & Continue"
+          f.action :submit, :label => "Create & Edit"
+        end
+      end
+      body.scan(/type=\"submit\"/).size.should == 2
+      body.scan(/class=\"cancel\"/).size.should == 0
+    end
   end
 
   context "without passing a block to inputs" do


### PR DESCRIPTION
- add new form helpers
- add css styling (thanks @Daxter )
- add new specs / rename a few existing specs

Fixes the deprecation warnings in mentioned in issue #1085 except for when running specs.
