### PR TITLE
updated form_builder to adhere to the new formtastic spec (Issue #1085)

### DIFF
--- a/app/assets/stylesheets/active_admin/_forms.css.scss
+++ b/app/assets/stylesheets/active_admin/_forms.css.scss
@@ -165,12 +165,12 @@ form {
     
   }
   
-  .buttons { 
+  .buttons, .actions { 
     margin-top: 15px; 
     input[type=submit] { margin-right: 10px; }
   }
   
-  fieldset.buttons li { 
+  fieldset.buttons li, fieldset.actions li { 
     float:left; 
     padding: 0;
 

--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -26,15 +26,19 @@ module ActiveAdmin
 
     # The buttons method always needs to be wrapped in a new buffer
     def buttons(*args, &block)
-      content = with_new_form_buffer do
-        block_given? ? super : super { commit_button_with_cancel_link }
-      end
-      form_buffers.last << content.html_safe
+      # Formtastic has depreciated #buttons in favor of #actions
+      ::ActiveSupport::Deprecation.warn("f.buttons is deprecated in favour of f.actions")
+      actions args, &block
     end
 
     def commit_button(*args)
-      content = with_new_form_buffer{ super }
-      form_buffers.last << content.html_safe
+      # Formtastic has depreciated #commit_button in favor of #action(:submit)
+      ::ActiveSupport::Deprecation.warn("f.commit_button is deprecated in favour of f.action(:submit)")
+      options = args.extract_options!
+      if String === args.first
+        options[:label] = args.first unless options.has_key?(:label)
+      end
+      action(:submit, options)
     end
 
     def cancel_link(url = nil, html_options = {}, li_attributes = {})
@@ -44,7 +48,26 @@ module ActiveAdmin
     end
 
     def commit_button_with_cancel_link
-      content = commit_button
+      # Formtastic has depreciated #buttons in favor of #actions
+      ::ActiveSupport::Deprecation.warn("f.commit_button_with_cancel_link is deprecated in favour of f.commit_action_with_cancel_link")
+      commit_action_with_cancel_link
+    end
+
+    # The action methods always need to be wrapped in a new buffer
+    def actions(*args, &block)
+      content = with_new_form_buffer do
+        block_given? ? super : super { commit_action_with_cancel_link }
+      end
+      form_buffers.last << content.html_safe
+    end
+
+    def action(*args)
+      content = with_new_form_buffer { super }
+      form_buffers.last << content.html_safe
+    end
+
+    def commit_action_with_cancel_link
+      content = action(:submit)
       content << cancel_link
     end
 

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -120,6 +120,64 @@ describe ActiveAdmin::FormBuilder do
     end
 
   end
+  
+  context "while transitioning from buttons to actions" do
+    it "should forward #buttons to #actions" do
+      body = build_form do |f|
+        f.should_receive(:actions).once
+        f.buttons
+      end
+    end
+    it "should forward #commit_button to #action(:submit)" do
+      body = build_form do |f|
+        f.should_receive(:action) do |arg1,arg2|
+          arg1.should == :submit
+          arg2[:label].should == "Create & Continue"
+        end
+        f.actions do
+          f.commit_button "Create & Continue"
+        end
+      end
+    end
+    it "should preserve a label over a string" do
+      body = build_form do |f|
+        f.actions do
+          f.commit_button "Not Valid", :label => "Valid"
+        end
+      end
+      body.should have_tag("input", :attributes => {  :type => "submit",
+                                                          :value => "Valid" })
+    end
+  end
+  
+  context "with actions instead of buttons" do
+    it "should generate the form once" do
+      body = build_form do |f|
+        f.inputs do
+          f.input :title
+        end
+        f.actions
+      end
+      body.scan(/id=\"post_title\"/).size.should == 1
+    end
+    it "should generate one button and a cancel link" do
+      body = build_form do |f|
+        f.actions
+      end
+      body.scan(/type=\"submit\"/).size.should == 1
+      body.scan(/class=\"cancel\"/).size.should == 1
+    end
+    it "should generate multiple buttons" do
+      body = build_form do |f|
+        f.actions do
+          f.action :submit, :label => "Create & Continue"
+          f.action :submit, :label => "Create & Edit"
+        end
+      end
+      body.scan(/type=\"submit\"/).size.should == 2
+      body.scan(/class=\"cancel\"/).size.should == 0
+    end
+  end
 
   context "without passing a block to inputs" do
     let :body do


### PR DESCRIPTION
This relates to issue #1085. Updates the code so that:
1. New methods (#actions, #action, #commit_action_with_cancel_link
2. All calls to #buttons, #commit_button, and #commit_button_with_cancel_link will receive a depreciation warning and then call their new corresponding method as an action. In the case of #commit_button, some parsing is done to translate the string that can be passed to #commit_button as part of the option has passed to #action(:submit).
3. Small update to CSS that makes `.action` equivalent to `.button`

This does assume that active_admin eventually wants to change the syntax to f.actions etc together with formtastic, and depreciate the f.buttons syntax. Something that might need some more discussion?
