### PR TITLE
Make Devise a soft dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ require File.expand_path('../spec/support/detect_rails_version', __FILE__)
 rails_version = detect_rails_version
 gem 'rails',          rails_version
 gem 'bourbon'
+gem 'devise', '>= 1.1.2'
 
 case rails_version
 when /^3\.0/

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.add_dependency("jquery-rails", ">= 1.0.0")
   s.add_dependency("bourbon", ">= 1.0.0")
   s.add_dependency("meta_search", ">= 0.9.2")
-  s.add_dependency("devise", ">= 1.1.2")
   s.add_dependency("formtastic", ">= 2.0.0")
   s.add_dependency("inherited_resources", "<= 1.3.0")
   s.add_dependency("kaminari", ">= 0.13.0")

--- a/lib/active_admin.rb
+++ b/lib/active_admin.rb
@@ -1,6 +1,5 @@
 require 'meta_search'
 require 'bourbon'
-require 'devise'
 require 'kaminari'
 require 'formtastic'
 require 'sass'

--- a/lib/active_admin/devise.rb
+++ b/lib/active_admin/devise.rb
@@ -1,4 +1,12 @@
-require 'devise'
+begin
+  require 'devise'
+rescue LoadError => e
+  $stderr.puts ["You don't have Devise installed in your application. Please add it to your",
+    "Gemfile and run bundle install. If you do not require Devise run the generator with",
+    "--skip-users option"].join(' ')
+  raise e
+end
+
 
 module ActiveAdmin
   module Devise

--- a/lib/generators/active_admin/devise/devise_generator.rb
+++ b/lib/generators/active_admin/devise/devise_generator.rb
@@ -8,7 +8,24 @@ module ActiveAdmin
                     :desc => "Should the generated resource be registerable?"
 
       def install_devise
-        require 'devise'
+        begin
+          require 'devise'
+        rescue LoadError => e
+          $stderr.puts ["You don't have Devise installed in your application. Please add it to your",
+            "Gemfile and run bundle install. If you do not require Devise run the generator with",
+            "--skip-users option"].join(' ')
+          exit
+        end
+        run_devise_generator
+        create_admin_user
+        remove_registerable_from_model
+        set_namespace_for_path
+        add_default_user_to_migration
+      end
+
+      private
+
+      def run_devise_generator
         if File.exists?(File.join(destination_root, "config", "initializers", "devise.rb"))
           log :generate, "No need to install devise, already done."
         else


### PR DESCRIPTION
Fixes #542. Devise has been removed from gemspec and the integration will not be enabled by default when the generator is run. Default behaviour will be the equivalent of --skip-users 

To use devise integration, the user will have to add it to Gemfile and then run the generator with the --devise option. 

I didn't find any tests for --skip-users. I was not very sure of how to add tests for without devise integration. So I have modified the test template to enable devise integration by default. 
