### PR TITLE
Don't need to use pre version of meta_search

### DIFF
--- a/docs/0-installation.md
+++ b/docs/0-installation.md
@@ -12,7 +12,6 @@ MetaSearch and sass-rails:
     # Gemfile in Rails >= 3.1
     gem 'activeadmin'
     gem 'sass-rails'
-    gem "meta_search",    '>= 1.1.0.pre'
 
 ## Running the Generator
 


### PR DESCRIPTION
The latest version works fine and is already a dependency of `active_admin`.
