### PR TITLE
Force active_admin to honour subURI upon successful logout from admin

### DIFF
--- a/lib/active_admin/devise.rb
+++ b/lib/active_admin/devise.rb
@@ -34,6 +34,7 @@ module ActiveAdmin
 
       # Redirect to the default namespace on logout
       def root_path
+        Rails.configuration.action_controller[:relative_url_root] +
         if ActiveAdmin.application.default_namespace
           "/#{ActiveAdmin.application.default_namespace}"
         else


### PR DESCRIPTION
I have a rails app deployed in a subURI with mod_passenger.

The app resides at http://domain.tld/myapp/
Admin interface is at http://domain.tld/myapp/admin

When clicking the logout button, the process is successful but redirects to http://domain.tld**/admin**
But should be http://domain.tld/**myapp/admin**

The issue is in method **root_path** defined in /lib/active_admin/devise.rb on lines 36-42.
The redirect takes you to the default namespace without honouring the complete URI where the application resides.
