### PR TITLE
Fixes scope behaviour when method is :all and name is set to something else

### DIFF
--- a/lib/active_admin/scope.rb
+++ b/lib/active_admin/scope.rb
@@ -24,6 +24,7 @@ module ActiveAdmin
       @scope_method = method
       # Scope ':all' means no scoping
       @scope_method ||= name.to_sym unless name.to_sym == :all
+      @scope_method = nil if method && method.to_s == 'all'
       @id = @name.gsub(' ', '').underscore
       if block_given?
         @scope_method = nil

--- a/spec/unit/scope_spec.rb
+++ b/spec/unit/scope_spec.rb
@@ -22,6 +22,13 @@ describe ActiveAdmin::Scope do
       its(:scope_block)  { should == nil }
     end
 
+    context 'when a name and scope method is :all' do
+      let(:scope)        { ActiveAdmin::Scope.new 'Tous', :all }
+      its(:name)         { should eq 'Tous' }
+      its(:scope_method) { should be_nil }
+      its(:scope_block)  { should be_nil }
+    end
+
     context "when a name and scope method" do
       let(:scope)        { ActiveAdmin::Scope.new "With API Access", :with_api_access }
       its(:name)         { should == "With API Access"}


### PR DESCRIPTION
Typically when using I18n to translate the displayed scope and specifying the method.
