### PR TITLE
fix so config.require_js uses asset pipeline

### DIFF
--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -27,7 +27,7 @@ module ActiveAdmin
             end
             
             active_admin_application.javascripts.each do |path|
-              script :src => javascript_path(path), :type => "text/javascript"
+              text_node(javascript_include_tag(path).html_safe)
             end
             text_node csrf_meta_tag
           end


### PR DESCRIPTION
ActiveAdmin's require_js config option was not utilizing the asset pipeline.  Previously when trying to add a javascript file such via:

   config.register_javascript "foo" 

it would output a script tag with path of "javascripts/foo" instead of "/assets/foo.js" (note the file doesn't even have an extension).

By trying to force the path to be within the assets directory:
  config.register_javascript "/assets/foo.js" 

It would output a script tage with a path of "/javascripts//assets/foo.js"
