### PR TITLE
Show correct display_name in breadcrumbs

### DIFF
--- a/lib/active_admin/view_helpers/breadcrumb_helper.rb
+++ b/lib/active_admin/view_helpers/breadcrumb_helper.rb
@@ -10,13 +10,17 @@ module ActiveAdmin
 				crumbs = []
 				parts.each_with_index do |part, index|
 					name = ""
-					if part =~ /^\d/ && parent = parts[index - 1]
-						begin
-							parent_class = parent.singularize.camelcase.constantize
-							obj = parent_class.find(part.to_i)
-							name = obj.display_name if obj.respond_to?(:display_name)
-						rescue
-						end
+					if parent = parts[index - 1]
+				            begin
+				              parent_class = parent.singularize.camelcase.constantize
+				              if parent_class.respond_to?(:default_finder)
+				                obj = parent_class.try(parent_class.default_finder, part)
+				              else
+				                obj = parent_class.find(part.to_i)
+				              end
+				              name = obj.display_name if obj.respond_to?(:display_name)
+				            rescue
+				            end					  
 					end
 					name = part.titlecase if name == ""
 					begin


### PR DESCRIPTION
If resource has finder other than id, uncorrect name is displayed in breadcrumbs.

Example:

``` ruby
ActiveAdmin.register Customer do
  controller do
    defaults :finder => :find_by_uuid
  end
end

class Customer < ActiveRecord::Base
  def display_name
    some_model_attribute
  end

  def to_param
    uuid
  end
end
```

In this example, breadcrumb in edit will be something like 'admin/customers/d7b98c74-7f0b-11e1-9e6d-001cc097f0b7', even if in customer model is display_name method.

So I created quick fix for this - it requires additional class method in model - default_finder. This method have to returns symbol for finder method:

``` ruby
class Customer < ActiveRecord::Base
  def self.default_finder
    :find_by_uuid
  end
end
```

After that, breadcrumbs will be 'admin/customer/some_model_attribute', where some_model_attribute is value returned by display_name.
