### PR TITLE
forcing to use formstatic 2.1.1 instead of lastest version

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency("bourbon", ">= 1.0.0")
   s.add_dependency("meta_search", ">= 0.9.2")
   s.add_dependency("devise", ">= 1.1.2")
-  s.add_dependency("formtastic", ">= 2.0.0")
+  s.add_dependency("formtastic", "~> 2.1.1")
   s.add_dependency("inherited_resources", "<= 1.3.0")
   s.add_dependency("kaminari", ">= 0.13.0")
   s.add_dependency("sass", ">= 3.1.0")


### PR DESCRIPTION
for now this is a solution to [#1224](https://github.com/gregbell/active_admin/issues/1224)
