### PR TITLE
Can now set page title for member and collection actions.

### DIFF
--- a/lib/active_admin/resource_dsl.rb
+++ b/lib/active_admin/resource_dsl.rb
@@ -93,14 +93,20 @@ module ActiveAdmin
     # 
     def member_action(name, options = {}, &block)
       config.member_actions << ControllerAction.new(name, options)
+      title = options.delete(:title)
+
       controller do
+        before_filter :only => [name] { @page_title = title } if title
         define_method(name, &block || Proc.new{})
       end
     end
 
     def collection_action(name, options = {}, &block)
       config.collection_actions << ControllerAction.new(name, options)
+      title = options.delete(:title)
+
       controller do
+        before_filter :only => [name] { @page_title = title } if title
         define_method(name, &block || Proc.new{})
       end
     end


### PR DESCRIPTION
With this commit, setting the page title for collection and member actions is consistent with how it is done with the standard actions:

``` ruby
ActiveAdmin.register Post do
  collection_action :comments, :title => "My Awesome Comments" do
    # do stuff
  end
end
```
