### PR TITLE
extend IndexAsTable default_actions method to use CanCan or default back to the original method

### DIFF
--- a/lib/active_admin/views/index_as_table.rb
+++ b/lib/active_admin/views/index_as_table.rb
@@ -146,22 +146,37 @@ module ActiveAdmin
         # Adds links to View, Edit and Delete
         def default_actions(options = {})
           options = {
-            :name => ""
+            :name => "",
+            :link_class => "member_link"
           }.merge(options)
           column options[:name] do |resource|
-			      links = ''.html_safe
-            if controller.action_methods.include?('show')
-              links += link_to I18n.t('active_admin.view'), resource_path(resource), :class => "member_link view_link"
+            links = ''.html_safe
+            
+            if defined?(CanCan)
+              if controller.action_methods.include?('show') && controller.current_ability.can?(:read, resource)
+                links += link_to I18n.t('active_admin.view'), resource_path(resource), :class => "#{options[:link_class]} view_link"
+              end
+              if controller.action_methods.include?('edit') && controller.current_ability.can?(:edit, resource)
+                links += link_to I18n.t('active_admin.edit'), edit_resource_path(resource), :class => "#{options[:link_class]} edit_link"
+              end
+              if controller.action_methods.include?('destroy') && controller.current_ability.can?(:destroy, resource)
+                links += link_to I18n.t('active_admin.delete'), resource_path(resource), :method => :delete, :confirm => I18n.t('active_admin.delete_confirmation'), :class => "#{options[:link_class]} delete_link"
+              end
+            else
+              if controller.action_methods.include?('show')
+                links += link_to I18n.t('active_admin.view'), resource_path(resource), :class => "#{options[:link_class]} view_link"
+              end
+              if controller.action_methods.include?('edit')
+                links += link_to I18n.t('active_admin.edit'), edit_resource_path(resource), :class => "#{options[:link_class]} edit_link"
+              end
+              if controller.action_methods.include?('destroy')
+                links += link_to I18n.t('active_admin.delete'), resource_path(resource), :method => :delete, :confirm => I18n.t('active_admin.delete_confirmation'), :class => "#{options[:link_class]} delete_link"
+              end
             end
-            if controller.action_methods.include?('edit')
-              links += link_to I18n.t('active_admin.edit'), edit_resource_path(resource), :class => "member_link edit_link"
-            end
-            if controller.action_methods.include?('destroy')
-              links += link_to I18n.t('active_admin.delete'), resource_path(resource), :method => :delete, :confirm => I18n.t('active_admin.delete_confirmation'), :class => "member_link delete_link"
-            end            
             links
           end
         end
+        
 
         # Display A Status Tag Column
         #


### PR DESCRIPTION
If CanCan is being used then add additional check if the user can act upon the resource otherwise default to the normal default_actions.

Also added a `:link_class` option to the options hash so it makes it easier to add more css classes to the links (defaults to 'member_link')

references issue #760
