### PR TITLE
cleans up default style for has_many form

### DIFF
--- a/app/assets/stylesheets/active_admin/_forms.css.scss
+++ b/app/assets/stylesheets/active_admin/_forms.css.scss
@@ -29,6 +29,13 @@ form {
       }
     }
 
+    ol > div.has_many {
+      padding: 20px 10px;
+      h3 {
+        font-size: 12px;
+        font-weight: bold;
+      }
+    }
 
     ol > li > li label { 
       line-height:100%; 
@@ -67,7 +74,7 @@ form {
 
         li {
           padding:0; 
-          border:0; 
+          border:0;
         }
       }
     }


### PR DESCRIPTION
Quick fix to make the default output look a little prettier. I imagine the expected usage is outside of the inputs block, but this will cover if it's used within. h3 is pretty awkward and since it's stuck in a div the lack of padding leaves it riding the edge. Might want to reconsider the default output, but wasn't sure and figured the fix would be useful at least to bring it to your attention.

Before:
![Before](http://i39.tinypic.com/28tfl8j.jpg)

After:
![After](http://i44.tinypic.com/28m2zau.jpg)

``` ruby
form do |f|
  f.inputs "Film" do
    f.has_many :film_stills do |film_still_form|
      film_still_form.input :photo, :as => :file
    end
  end
  f.buttons
end
```

``` html
<div class="has_many film_stills">
  <h3>Film Stills</h3>
...
```
