### PR TITLE
use inherited resources >= 1.3.1

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency("meta_search", ">= 0.9.2")
   s.add_dependency("devise", ">= 1.1.2")
   s.add_dependency("formtastic", "~> 2.1.1")
-  s.add_dependency("inherited_resources", "<= 1.3.0")
+  s.add_dependency("inherited_resources", ">= 1.3.1")
   s.add_dependency("kaminari", ">= 0.13.0")
   s.add_dependency("sass", ">= 3.1.0")
   s.add_dependency("fastercsv", ">= 0")


### PR DESCRIPTION
This moves active_admin to use 1.3.1 or greater of inherited resource to move past a bug in 1.3.0
