### PR TITLE
Use display_name to generate the default title on resource show

### DIFF
--- a/features/i18n.feature
+++ b/features/i18n.feature
@@ -11,7 +11,7 @@ Feature: Internationalization
     Then I should see "Hello words"
     When I follow "View"
     Then I should see "Bookstore Details"
-    And I should see "Bookstore #"
+    And I should see "Bookstore: Hello words"
     And I should see a link to "Delete Bookstore"
     When I follow "Edit Bookstore"
     Then I should see "Edit Bookstore"

--- a/features/show/page_title.feature
+++ b/features/show/page_title.feature
@@ -31,3 +31,11 @@ Feature: Show - Page Title
       end
     """
     Then I should see the page title "Title: Hello World"
+
+  Scenario: No configuration
+    Given a show configuration of:
+    """
+      ActiveAdmin.register Post do
+      end
+    """
+    Then I should see the page title "Post: Hello World"

--- a/lib/active_admin/views/pages/show.rb
+++ b/lib/active_admin/views/pages/show.rb
@@ -36,7 +36,7 @@ module ActiveAdmin
         protected
 
         def default_title
-          "#{active_admin_config.resource_label} ##{resource.id}"
+          "#{active_admin_config.resource_label}: #{display_name(resource)}"
         end
 
         module DefaultMainContent


### PR DESCRIPTION
Post #1 is instead displayed as Post: #{display_name(post)}
display_name was used for several of the other resource pages, so this is more consistent.
