### PR TITLE
Remove crazy tabbing from breadcrumb view-helper

### DIFF
--- a/lib/active_admin/view_helpers/breadcrumb_helper.rb
+++ b/lib/active_admin/view_helpers/breadcrumb_helper.rb
@@ -2,31 +2,32 @@ module ActiveAdmin
   module ViewHelpers
     module BreadcrumbHelper
 
-			# Returns an array of links to use in a breadcrumb
-			def breadcrumb_links(path = nil)
-				path ||= request.fullpath
-				parts = path.gsub(/^\//, '').split('/')
-				parts.pop unless %w{ create update }.include?(params[:action])
-				crumbs = []
-				parts.each_with_index do |part, index|
-					name = ""
-					if part =~ /^\d/ && parent = parts[index - 1]
-						begin
-							parent_class = parent.singularize.camelcase.constantize
-							obj = parent_class.find(part.to_i)
-							name = obj.display_name if obj.respond_to?(:display_name)
-						rescue
-						end
-					end
-					name = part.titlecase if name == ""
-					begin
-						crumbs << link_to( I18n.translate!("activerecord.models.#{part.singularize}", :count => 2), "/" + parts[0..index].join('/'))
-					rescue I18n::MissingTranslationData
-						crumbs << link_to( name, "/" + parts[0..index].join('/'))
-					end
-				end
-				crumbs
-			end
+      # Returns an array of links to use in a breadcrumb
+      def breadcrumb_links(path = nil)
+        path ||= request.fullpath
+        parts = path.gsub(/^\//, '').split('/')
+        parts.pop unless %w{ create update }.include?(params[:action])
+        crumbs = []
+        parts.each_with_index do |part, index|
+          name = ""
+          if part =~ /^\d/ && parent = parts[index - 1]
+            begin
+              parent_class = parent.singularize.camelcase.constantize
+              obj = parent_class.find(part.to_i)
+              name = obj.display_name if obj.respond_to?(:display_name)
+            rescue
+            end
+          end
+          
+          name = part.titlecase if name == ""
+          begin
+            crumbs << link_to( I18n.translate!("activerecord.models.#{part.singularize}", :count => 2), "/" + parts[0..index].join('/'))
+          rescue I18n::MissingTranslationData
+            crumbs << link_to( name, "/" + parts[0..index].join('/'))
+          end
+        end
+        crumbs
+      end
 
     end
   end


### PR DESCRIPTION
While the diff for this request may look identical, take a look [here](https://github.com/gregbell/active_admin/blob/master/lib/active_admin/view_helpers/breadcrumb_helper.rb) (or [this page](https://github.com/gregbell/active_admin/blob/69be6fb92bea589a91dcf3621b5ea80744241cb0/lib/active_admin/view_helpers/breadcrumb_helper.rb) for those of you viewing this in the future)
