### PR TITLE
removing the cucumber 1.1.4 dependency, 1.1.5 issues were fixed in 1.1.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,6 @@ end
 
 group :test do
   gem 'rspec-rails',    '~> 2.9.0'
-  gem 'cucumber', '1.1.4'
   gem 'cucumber-rails', '1.2.1', :require => false
   gem 'capybara',       '1.1.2'
   gem 'database_cleaner'


### PR DESCRIPTION
Cucumber 1.1.5 introduced issues that kept us from running cuke suite.  This conflict no longer exists on the latest versions of cuke.
