### PR TITLE
Pr 1092 - Add specs for show page title

### DIFF
--- a/features/i18n.feature
+++ b/features/i18n.feature
@@ -11,7 +11,7 @@ Feature: Internationalization
     Then I should see "Hello words"
     When I follow "View"
     Then I should see "Bookstore Details"
-    And I should see "Bookstore: Hello words"
+    And I should see "Hello words"
     And I should see a link to "Delete Bookstore"
     When I follow "Edit Bookstore"
     Then I should see "Edit Bookstore"

--- a/features/show/default_content.feature
+++ b/features/show/default_content.feature
@@ -20,8 +20,8 @@ Feature: Show - Default Content
   Scenario: Attributes should link when linked resource is registered
     Given a show configuration of:
       """
-        ActiveAdmin.register User
         ActiveAdmin.register Post
+        ActiveAdmin.register User
       """
     Then I should see the attribute "Author" with "jane_doe"
     And I should see a link to "jane_doe"

--- a/features/show/page_title.feature
+++ b/features/show/page_title.feature
@@ -32,10 +32,16 @@ Feature: Show - Page Title
     """
     Then I should see the page title "Title: Hello World"
 
-  Scenario: No configuration
+  Scenario: Default title
     Given a show configuration of:
     """
-      ActiveAdmin.register Post do
-      end
+      ActiveAdmin.register Post
     """
-    Then I should see the page title "Post: Hello World"
+    Then I should see the page title "Hello World"
+
+  Scenario: Default title with no display name method candidate
+    Given a show configuration of:
+    """
+      ActiveAdmin.register Tag
+    """
+    Then I should see the page title "Tag #"

--- a/features/step_definitions/additional_web_steps.rb
+++ b/features/step_definitions/additional_web_steps.rb
@@ -64,7 +64,9 @@ Then /^I should wait and see "([^"]*)"(?: within "([^"]*)")?$/ do |text, selecto
 end
 
 Then /^I should see the page title "([^"]*)"$/ do |title|
-  page.should have_css('h2#page_title', :text => title)
+  within('h2#page_title') do
+    page.should have_content(title)
+  end
 end
 
 Then /^I should see a fieldset titled "([^"]*)"$/ do |title|

--- a/features/step_definitions/configuration_steps.rb
+++ b/features/step_definitions/configuration_steps.rb
@@ -57,11 +57,21 @@ Given /^an index configuration of:$/ do |configuration_content|
 end
 
 Given /^a show configuration of:$/ do |configuration_content|
+  resource = configuration_content.match(/ActiveAdmin\.register (\w+)/)[1]
   load_active_admin_configuration(configuration_content)
 
-  step 'I am logged in'
-  step "I am on the index page for posts"
-  step 'I follow "View"'
+  case resource
+  when "Post"
+    step 'I am logged in'
+    step "I am on the index page for posts"
+    step 'I follow "View"'
+  when "Tag"
+    step 'I am logged in'
+    Tag.create!
+    visit admin_tag_path(Tag.last)
+  else
+    raise "#{resource} is not supported"
+  end
 end
 
 Given /^"([^"]*)" contains:$/ do |filename, contents|

--- a/lib/active_admin/views/pages/show.rb
+++ b/lib/active_admin/views/pages/show.rb
@@ -36,11 +36,13 @@ module ActiveAdmin
         protected
 
         def default_title
-          if display_name_method_for(resource) == :to_s
-            "#{active_admin_config.resource_label} ##{resource.id}"
-          else
-            display_name(resource)
+          title = display_name(resource)
+
+          if title.in? [nil, "", resource.to_s]
+            title = "#{active_admin_config.resource_label} ##{resource.id}"
           end
+
+          title
         end
 
         module DefaultMainContent


### PR DESCRIPTION
And also fallback on default title when title is nil, blank or == to :to_s. In the feature, Tag was responding to #name and returning nil. Weird isn'it?
