### PR TITLE
Fix Sprockets::CircularDependencyError 

### DIFF
--- a/app/assets/javascripts/active_admin/application.js
+++ b/app/assets/javascripts/active_admin/application.js
@@ -1,4 +1,3 @@
 //= require_tree  ./lib/
 //= require_tree  ./components/
 //= require_tree  ./pages/
-//= require_directory ./


### PR DESCRIPTION
Fix Sprockets::CircularDependencyError  

``` ruby
bundler/gems/active_admin-1bff73d87a26/app/assets/javascripts/active_admin/application.js has already   been required
```
