### PR TITLE
Fix for asset pipeline 'base.js has already been required' error

### DIFF
--- a/app/assets/javascripts/active_admin/application.js
+++ b/app/assets/javascripts/active_admin/application.js
@@ -1,4 +1,3 @@
 //= require_tree  ./lib/
 //= require_tree  ./components/
 //= require_tree  ./pages/
-//= require_directory ./


### PR DESCRIPTION
Default app/assets/javascripts/active_admin.js requires active_admin/base . And active_admin/base requires active_admin/application.

So there is no sense in requiring this script again.
