### PR TITLE
allow using an html table inside a "index :as => :block"

### DIFF
--- a/app/assets/javascripts/active_admin/pages/batch_actions.js.coffee
+++ b/app/assets/javascripts/active_admin/pages/batch_actions.js.coffee
@@ -14,7 +14,7 @@ jQuery ($) ->
 
   if $("#batch_actions_selector").length && $(":checkbox.toggle_all").length
 
-    if $(".paginated_collection").find("table").length
+    if $(".paginated_collection").find("table").not(".table_in_block").length
       $(".paginated_collection table").tableCheckboxToggler()
     else
       $(".paginated_collection").checkboxToggler()


### PR DESCRIPTION
I'm using the block layout for my index page, but I also want to use an HTML Table inside the div.  The current batch actions javascript detects the table and sets up the batch actions for the table layout.
