### PR TITLE
Allow custom title for Index pages

### DIFF
--- a/features/index/page_title.feature
+++ b/features/index/page_title.feature
@@ -1,0 +1,12 @@
+Feature: Index - Page Title
+
+  Modifying the page title on the index screen
+
+  Scenario: Set a string as the title
+    Given an index configuration of:
+    """
+      ActiveAdmin.register Post do
+        index :title => "Awesome Title"
+      end
+    """
+    Then I should see the page title "Awesome Title"

--- a/lib/active_admin/views/pages/index.rb
+++ b/lib/active_admin/views/pages/index.rb
@@ -5,10 +5,7 @@ module ActiveAdmin
       class Index < Base
 
         def title
-          case config[:title]
-          when Symbol, Proc
-            call_method_or_proc_on(resource, config[:title])
-          when String
+          if config[:title].is_a? String
             config[:title]
           else
             active_admin_config.plural_resource_label


### PR DESCRIPTION
Because I wanted to override it for my own uses, and thought someone else might like to do so as well :)

I simply copied-and-pasted this code from the `show` page, as it's the exact functionality I wanted. That way you can do this:

``` ruby
index :title => "Awesome Title" do
  #...
end
```
