### PR TITLE
Problem when filtering with a default scope

### DIFF
--- a/lib/active_admin/resource_controller/collection.rb
+++ b/lib/active_admin/resource_controller/collection.rb
@@ -102,8 +102,8 @@ module ActiveAdmin
         include ActiveAdmin::ScopeChain
 
         def current_scope
-          @current_scope ||= if params[:scope]
-            active_admin_config.get_scope_by_id(params[:scope]) if params[:scope]
+          @current_scope ||= if params[:scope].present?
+            active_admin_config.get_scope_by_id(params[:scope])
           else
             active_admin_config.default_scope
           end


### PR DESCRIPTION
I run into a problem when using filters with a default scope. The method _current_scope_ (_lib/active_admin/resource_controller/collection.rb_) checks _params[:scope]_ to see if there is an active scope, but this param may be an empty string (that's the case when the filters are submitted using the default scope). 

The solution is simple: check it with _present?_. I removed also the redudant _if_.
