### PR TITLE
dashboard section with localization

### DIFF
--- a/lib/active_admin/views/dashboard_section_renderer.rb
+++ b/lib/active_admin/views/dashboard_section_renderer.rb
@@ -11,7 +11,11 @@ module ActiveAdmin
       protected
 
       def title
-        @section.name.to_s.titleize
+        begin
+          I18n.t!("active_admin.sections.#{@section.name.to_s}")
+        rescue I18n::MissingTranslationData
+          @section.name.to_s.titleize
+        end		  
       end
 
     end


### PR DESCRIPTION
possibility to use I18n to translate name of section with translation from "active_admin.sections.name" where name should by :anything
