### PR TITLE
Page renaming fix

### DIFF
--- a/lib/active_admin/page.rb
+++ b/lib/active_admin/page.rb
@@ -21,9 +21,11 @@ module ActiveAdmin
     module Base
       def initialize(namespace, name, options)
         @namespace = namespace
-        @name = name
+        @internal_name = name
         @options = options
         @page_actions = []
+        
+        @name = @options[:as] ? @options[:as] : name
       end
     end
 
@@ -37,11 +39,11 @@ module ActiveAdmin
 
     # label is singular
     def plural_resource_label
-      name
+      @internal_name || name
     end
 
     def resource_name
-      @resource_name ||= Resource::Name.new(nil, name)
+      @resource_name ||= Resource::Name.new(nil, @internal_name || name)
     end
 
     def default_menu_options


### PR DESCRIPTION
This fixes `:as` option for page registrtion hen using string instead of model class. This is only effective if you want to have non-latin name of page (i.e. when using activeadmin in russian language).

This is required because when you try to use cyrilic (for example) string as page name, Ruby tries to create `<YourCyrilicText>Controller` class, and it fails.
Example:

``` ruby
# encoding: utf-8
ActiveAdmin.register_page "Контакты" do
  menu :label => "Контакты"
end
```

With this fix I can localize controller name properly:

``` ruby
# encoding: utf-8
ActiveAdmin.register_page "Contacts", :as => "Контакты" do
  menu :label => "Контакты"
end
```
