### PR TITLE
hebrew locale file

### DIFF
--- a/lib/active_admin/locales/he.yml
+++ b/lib/active_admin/locales/he.yml
@@ -1,4 +1,4 @@
-he_il:
+he:
   active_admin:
     dashboard: פנל ניהול
     dashboard_welcome:


### PR DESCRIPTION
he is more widely used than he_il. See for example in rails-i18n:
https://github.com/svenfuchs/rails-i18n/tree/master/rails/locale
