### PR TITLE
speed up cucumber suite by 15 seconds using Warden helper

### DIFF
--- a/features/development_reloading.feature
+++ b/features/development_reloading.feature
@@ -10,7 +10,7 @@ Feature: Development Reloading
     """
       ActiveAdmin.register Post
     """
-    And I am logged in
+    And I am logged in with capybara
     And I create a new post with the title ""
     Then I should see a successful create flash
     Given I add "validates_presence_of :title" to the "post" model

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -5,16 +5,27 @@ Given /^I am logged out$/ do
 end
 
 Given /^I am logged in$/ do
-  step 'an admin user "admin@example.com" exists'
+  create_admin_user_and_logout_if_needed
+  user = AdminUser.find_by_email "admin@example.com"
+  login_as(user)
+end
 
-  if page.all(:css, "a", :text => "Logout").size > 0
-    click_link "Logout"
-  end
+# only for @requires-reloading scenario
+Given /^I am logged in with capybara$/ do
+  create_admin_user_and_logout_if_needed
 
   visit new_admin_user_session_path
   fill_in "Email", :with => "admin@example.com"
   fill_in "Password", :with => "password"
   click_button "Login"
+end
+
+def create_admin_user_and_logout_if_needed
+  step 'an admin user "admin@example.com" exists'
+
+  if page.all(:css, "a", :text => "Logout").size > 0
+    click_link "Logout"
+  end
 end
 
 Given /^an admin user "([^"]*)" exists$/ do |admin_email|

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -94,3 +94,11 @@ Before do
   ActiveAdmin.unload!
   ActiveAdmin.load!
 end
+
+# Warden helpers to speed up login
+# See https://github.com/plataformatec/devise/wiki/How-To:-Test-with-Capybara
+include Warden::Test::Helpers
+
+After do
+  Warden.test_reset!
+end


### PR DESCRIPTION
Using Warden test helper #login_as, I was able to speed up cucumber suite by 15 seconds on my machine (macbook 2008).

On travis CI, gain was 12 min (comparing build Duration).

Benchmark:
## Current

128 scenarios (128 passed)
2m2.550s

real    2m11.979s
user    1m58.863s
sys 0m4.992s
## With Warden login_as

28 scenarios (128 passed)
939 steps (939 passed)
1m46.423s

real    1m55.594s
user    1m42.958s
sys 0m4.608s
