### PR TITLE
speed up tests suite by 8 seconds by increasing log level

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -102,3 +102,7 @@ include Warden::Test::Helpers
 After do
   Warden.test_reset!
 end
+
+# improve the performance of the specs suite by not logging anything
+# see http://blog.plataformatec.com.br/2011/12/three-tips-to-improve-the-performance-of-your-test-suite/
+Rails.logger.level = 4

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -160,3 +160,7 @@ RSpec::Matchers.define :have_tag do |*args|
     end
   end
 end
+
+# improve the performance of the specs suite by not logging anything
+# see http://blog.plataformatec.com.br/2011/12/three-tips-to-improve-the-performance-of-your-test-suite/
+Rails.logger.level = 4


### PR DESCRIPTION
Increasing the log level is a low hanging fruit to speed a test suite.

Explanation: Rails by default logs everything that is happening in your test environment to “log/test.log”. By increasing the logger level, you will be able to reduce the IO during your tests. The only downside of this approach is that, if a test is failing, you won’t have anything logged. In such cases, just comment the configuration option above and run your tests again.

Thank you http://blog.plataformatec.com.br/2011/12/three-tips-to-improve-the-performance-of-your-test-suite/

Benchmarks on my machine (macbook 2008): saved 8 seconds for the whole test suite.
## Current, with standard logging
### RSpec

Finished in 38.42 seconds
real        0m55.244s
### Cucumber

1m50.046s    real   2m0.971s
## With increased log level
### RSpec

Finished in 36.8 seconds
real     0m_52.469s_
### Cucumber

1m45.477s    real   1m55.479s
