### PR TITLE
Allow procs for Dashboard section names

### DIFF
--- a/lib/active_admin/dashboards/section.rb
+++ b/lib/active_admin/dashboards/section.rb
@@ -4,7 +4,7 @@ module ActiveAdmin
 
       DEFAULT_PRIORITY = 10
 
-      attr_accessor :name, :block
+      attr_accessor :block
       attr_reader :namespace, :options
 
       def initialize(namespace, name, options = {}, &block)
@@ -12,6 +12,10 @@ module ActiveAdmin
         @name = name
         @options = options
         @block = block
+      end
+
+      def name
+        @name.is_a?(Proc) ? @name.call : @name
       end
 
       def priority


### PR DESCRIPTION
This way you can have a dynamic name, as such, and watch the seconds pass by as you refresh the page!

``` ruby
section -> {Time.now} do
  #...
end
```
