### PR TITLE
Use display_name helper in breadcrumb

### DIFF
--- a/lib/active_admin/view_helpers/breadcrumb_helper.rb
+++ b/lib/active_admin/view_helpers/breadcrumb_helper.rb
@@ -14,7 +14,7 @@ module ActiveAdmin
             begin
               parent_class = parent.singularize.camelcase.constantize
               obj = parent_class.find(part.to_i)
-              name = obj.display_name if obj.respond_to?(:display_name)
+              name = display_name(obj)
             rescue
             end
           end


### PR DESCRIPTION
Right now, the `BreadcrumbHelper` calls the object's `display_name` method if it is defined.

`DisplayHelper` has a `display_name` helper that uses the `display_name_methods` settings to find alternative methods to call on the object in order to find an appropriate name. 

`BreadcrumbHelper` should call that helper method instead.
