### PR TITLE
Make the paginator use offset correctly when on the last page.

### DIFF
--- a/features/index/pagination.feature
+++ b/features/index/pagination.feature
@@ -19,6 +19,17 @@ Feature: Index Pagination
     Given 31 posts exist
     When I am on the index page for posts
     Then I should see pagination with 2 pages
+    And I should see "Displaying Posts 1 - 30 of 31 in total"
+
+  Scenario: Viewing last page of index when multiple pages of resources exist
+    Given an index configuration of:
+    """
+      ActiveAdmin.register Post
+    """
+    Given 34 posts exist
+    And I am on the index page for posts
+    When I follow "Last »"
+    Then I should see "Displaying Posts 31 - 34 of 34 in total"
 
   Scenario: Viewing index with a custom per page set
     Given an index configuration of:

--- a/lib/active_admin/views/components/paginated_collection.rb
+++ b/lib/active_admin/views/components/paginated_collection.rb
@@ -112,9 +112,9 @@ module ActiveAdmin
         else
           size = collection.size
           size = size.size if size.kind_of? Hash # when GROUP BY is used, AR returns Hash instead of Fixnum for .size
-          offset = collection.current_page * size
+          offset = collection.current_page * collection.limit_value - collection.limit_value
           total  = collection.total_count
-          I18n.t('active_admin.pagination.multiple', :model => entries_name, :from => (offset - size + 1), :to => offset > total ? total : offset, :total => total)
+          I18n.t('active_admin.pagination.multiple', :model => entries_name, :from => offset + 1, :to => offset + size, :total => total)
         end
       end
 


### PR DESCRIPTION
This makes the last page of paginated collections render correctly. Before, the "Displaying xx-xx of xx" was incorrect when viewing the last page.
