### PR TITLE
has_many checks for an option[:name] to go in the h3 tag

### DIFF
--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -56,7 +56,7 @@ module ActiveAdmin
       options = { :for => association }.merge(options)
       options[:class] ||= ""
       options[:class] << "inputs has_many_fields"
-      options[:name] ||= association.to_s.titlecase
+      options[:name] = association.to_s.titlecase if not options.has_key?(:name)
       
       # Add Delete Links
       form_block = proc do |has_many_form|
@@ -70,7 +70,7 @@ module ActiveAdmin
 
       content = with_new_form_buffer do
         template.content_tag :div, :class => "has_many #{association}" do
-          form_buffers.last << template.content_tag(:h3, options[:name]) unless options[:name].blank?
+          form_buffers.last << template.content_tag(:h3, options[:name]) unless options[:name].nil?
           inputs options, &form_block
 
           # Capture the ADD JS


### PR DESCRIPTION
You can now write something like

`f.has_many :name => "Wibble" do |w|`

to get Wibble in the `<h3>` tag. If you do:

`f.has_many :name => "" do |w|`

it omits the `<h3>` tag completely.

NOTE: there don't seem to be any unit tests at all for has_many.  I was unsuccessful in setting any up, so this patch doesn't add any new specs.
