### PR TITLE
Correcting a syntax error in the pt_BR translation

### DIFF
--- a/lib/active_admin/locales/pt-BR.yml
+++ b/lib/active_admin/locales/pt-BR.yml
@@ -60,7 +60,7 @@
       title: "Comentário"
       add: "Adicionar Comentário"
       resource: "Objeto"
-      no_comments_yet: "Nenum comentário."
+      no_comments_yet: "Nenhum comentário."
       title_content: "Comentários: %{count}"
       errors:
         empty_text: "O comentário não foi salvo porque o texto estava vazio."


### PR DESCRIPTION
There's a syntax error in the Pt_BR translation where the word "nenhum" is misspelled as "nenum"
