### PR TITLE
#micro #bugfix Replaced `active_admin_application` with `ActiveAdmin.application`

### DIFF
--- a/app/views/layouts/active_admin_logged_out.html.erb
+++ b/app/views/layouts/active_admin_logged_out.html.erb
@@ -3,7 +3,7 @@
 <head>
   <meta http-equiv="Content-type" content="text/html; charset=utf-8">
  
-  <title><%= [@page_title, active_admin_application.site_title].compact.join(" | ") %></title>
+  <title><%= [@page_title, ActiveAdmin.application.site_title].compact.join(" | ") %></title>
 
   <% ActiveAdmin.application.stylesheets.each do |style| %>
     <%= stylesheet_link_tag style.path, style.options %>


### PR DESCRIPTION
Till this little change a try to use the layout in an controller outside of active admin resulted with error:

undefined local variable or method `active_admin_application' for #<#Class:0x00000003de4038:0x00000004b7ab20>
