### PR TITLE
Fix pagination last page counts

### DIFF
--- a/features/index/pagination.feature
+++ b/features/index/pagination.feature
@@ -42,13 +42,3 @@ Feature: Index Pagination
     Given 31 posts exist
     When I am on the index page for posts
     Then I should not see pagination
-
-  Scenario: Viewing last page of a multi-page index
-    Given an index configuration of:
-      """
-        ActiveAdmin.register Post
-      """
-      Given 81 posts exist
-      When I am on page 3 of the index pages for posts
-      Then I should see that the current page is 3
-      And I should see "Displaying Posts 61 - 81 of 81 in total"

--- a/features/step_definitions/pagination_steps.rb
+++ b/features/step_definitions/pagination_steps.rb
@@ -6,7 +6,3 @@ Then /^I should see pagination with (\d+) pages$/ do |count|
   step %{I should see "#{count}" within ".pagination a"}
   step %{I should not see "#{count.to_i + 1}" within ".pagination a"}
 end
-
-Then /^I should see that the current page is (\d+)$/ do |count|
-  step %{I should see "#{count}" within ".pagination .current"}
-end

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -28,9 +28,6 @@ module NavigationHelpers
     when /^the index page for (.*)$/
       send(:"admin_#{$1}_path")
 
-    when /^page (.*) of the index pages for (.*)$/
-      send(:"admin_#{$2}_path") + "?page=#{$1}"
-
     when /^the last author's posts$/
       admin_user_posts_path(User.last)
 


### PR DESCRIPTION
Another pull request for fixing  gregbell/active_admin#1411 - correcting the calculations used to render the pagination's "Displaying X of Y" to fix error in math on the last page of a multi-page index.  

The corrections which were [suggested as comments to the previous pull request](https://github.com/gregbell/active_admin/pull/1412#issuecomment-6607115) have been made.
