### PR TITLE
Allow CSS class for rows in attributes_table

### DIFF
--- a/lib/active_admin/views/components/attributes_table.rb
+++ b/lib/active_admin/views/components/attributes_table.rb
@@ -17,13 +17,16 @@ module ActiveAdmin
         attrs.each {|attr| row(attr) }
       end
 
-      def row(attr, &block)
-        @table << tr do
+      def row(*args, &block)
+        title   = args[0]
+        options = args.extract_options!
+        options[:class] ||= :row
+        @table << tr(options) do
           th do
-            header_content_for(attr)
+            header_content_for(title)
           end
           td do
-            content_for(block || attr)
+            content_for(block || title)
           end
         end
       end

--- a/spec/unit/views/components/attributes_table_spec.rb
+++ b/spec/unit/views/components/attributes_table_spec.rb
@@ -90,6 +90,17 @@ describe ActiveAdmin::Views::AttributesTable do
       end
     end # describe dsl styles
 
+    it "should allow html options for the row itself" do
+      table = render_arbre_component(assigns) {
+        attributes_table_for(post) do
+          row("Wee", :class => "custom_row", :style => "custom_style") { }
+        end
+      }
+      table.find_by_tag("tr").first.to_s.
+        split("\n").first.lstrip.
+          should == '<tr class="custom_row" style="custom_style">'
+    end
+
     it "should allow html content inside the attributes table" do
       table = render_arbre_component(assigns) {
         attributes_table_for(post) do


### PR DESCRIPTION
Code to fix #1381

This way you can include a custom CSS class to identify rows. The default has been set to 'row'.

``` ruby
attributes_table do
  row("Total", :class => :total) {  }
end
```

I'd add unit tests to `attributes_table_spec.rb`, but I'm not entirely sure what all is happening there.
