### PR TITLE
added attr_accessible to Comment

### DIFF
--- a/lib/active_admin/comments/comment.rb
+++ b/lib/active_admin/comments/comment.rb
@@ -6,6 +6,7 @@ module ActiveAdmin
   ::ActiveRecord::Base.send :include, Kaminari::ActiveRecordExtension
 
   class Comment < ActiveRecord::Base
+    attr_accessible :resource_id, :resource_type, :body
     self.table_name = "active_admin_comments"
 
     belongs_to :resource, :polymorphic => true


### PR DESCRIPTION
Hi Greg,

From ActiveRecord 3.2.3 onward the default value of `config.active_record.whitelist_attributes` is set to true. So when I use Active Admin 0.4.4 with Rails 3.2.5, I get mass assignment error on `Comment` model. So to fix this problem, I added `attr_accessible :resource_id, :resource_type, :body` to `Comment` model. What do you think?

Cheers,
