### PR TITLE
Performance improvement for active admin forms using has_many

### DIFF
--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -1,6 +1,10 @@
 module ActiveAdmin
   class FormBuilder < ::Formtastic::FormBuilder
 
+    class << self
+      attr_accessor :input_classes_cache
+    end
+
     attr_reader :form_buffers
 
     def initialize(*args)
@@ -131,8 +135,8 @@ module ActiveAdmin
     end
 
     def input_class(as)
-      @input_classes_cache ||= {}
-      @input_classes_cache[as] ||= begin
+      self.class.input_classes_cache ||= {}
+      self.class.input_classes_cache[as] ||= begin
         begin
           begin
             custom_input_class_name(as).constantize


### PR DESCRIPTION
Because of the fact that the custom class cache on ActiveAdmin's form builder is on each individual form builder instance, there are significant performance slowdowns when using f.has_many on an object with a fair amount of children.

On an object with a dozen or so children, this commit eliminates timeouts and makes activeadmin usable (but still not extremely fast).

Is this a reasonable way to go about fixing this problem? 
