### PR TITLE
Allow custom page title on pages (for i18n)

### DIFF
--- a/lib/active_admin/views/pages/page.rb
+++ b/lib/active_admin/views/pages/page.rb
@@ -19,7 +19,7 @@ module ActiveAdmin
 
         def title
           if config[:title]
-            instance_exec resource, &config.block
+            render_or_call_method_or_proc_on self, config[:title]
           else
             active_admin_config.name
           end


### PR DESCRIPTION
in `lib/active_admin/views/pages/page.rb`:

```
def title
  active_admin_config.name
end
```

is not configurable, so it is not translatable / internationalizable.

This patch fixes that, so that on a page you can do

```
content :title => proc{ I18n.t :dashboard } do
  # ...
end
```
