### PR TITLE
site_title proc should be rendered in HTML title tag

### DIFF
--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -22,7 +22,7 @@ module ActiveAdmin
 
         def build_active_admin_head
           within @head do
-            insert_tag Arbre::HTML::Title, [title, active_admin_application.site_title].join(" | ")
+            insert_tag Arbre::HTML::Title, [title, render_or_call_method_or_proc_on(self, active_admin_application.site_title)].join(" | ")
             active_admin_application.stylesheets.each do |style|
               text_node(stylesheet_link_tag(style.path, style.options).html_safe)
             end


### PR DESCRIPTION
If `ActiveAdmin.site_title` is a proc, it will not render properly in the HTML title tag (it will instead be the result of calling `to_s` on a `Proc` which is garbage).

This patch calls `render_or_call_method_or_proc_on` on the `site_title` before outputting it in the HTML title tag.
