### PR TITLE
Don't run 'active_support/i18n' too early in Rails initialization

### DIFF
--- a/lib/active_admin.rb
+++ b/lib/active_admin.rb
@@ -50,9 +50,11 @@ module ActiveAdmin
   autoload :Views,                    'active_admin/views'
 
   class Railtie < ::Rails::Railtie
-    # Add load paths straight to I18n, so engines and application can overwrite it.
-    require 'active_support/i18n'
-    I18n.load_path += Dir[File.expand_path('../active_admin/locales/*.yml', __FILE__)]
+    config.after_initialize do
+      # Add load paths straight to I18n, so engines and application can overwrite it.
+      require 'active_support/i18n'
+      I18n.load_path += Dir[File.expand_path('../active_admin/locales/*.yml', __FILE__)]
+    end
   end
 
   class << self


### PR DESCRIPTION
Alternative to #1448
