### PR TITLE
site_title proc should be rendered on Devise login page

### DIFF
--- a/app/views/active_admin/devise/sessions/new.html.erb
+++ b/app/views/active_admin/devise/sessions/new.html.erb
@@ -1,5 +1,5 @@
 <div id="login">
-  <h2><%= title "#{active_admin_application.site_title} #{t('active_admin.devise.login.title')}" %></h2>
+  <h2><%= title "#{render_or_call_method_or_proc_on(self, active_admin_application.site_title)} #{t('active_admin.devise.login.title')}" %></h2>
 
   <% scope = Devise::Mapping.find_scope!(resource_name) %>
   <%= active_admin_form_for(resource, :as => resource_name, :url => send(:"#{scope}_session_path"), :html => { :id => "session_new" }) do |f|


### PR DESCRIPTION
Adding another missing call to `render_or_call_method_or_proc_on` (like in the merged #1445).
