### PR TITLE
Don't let wrapping tabs break the design (fix #713)

### DIFF
--- a/app/assets/stylesheets/active_admin/_header.css.scss
+++ b/app/assets/stylesheets/active_admin/_header.css.scss
@@ -125,7 +125,7 @@
     color: #aaa;
     float: right;
     display: inline-block;
-    margin: 0;
+    margin: 9px 0;
     padding: 0;
     span, a { margin-left: 10px; }
 


### PR DESCRIPTION
The quickest and easiest fix for the wrapping tabs problem (#713).

![After the fix](http://f.cl.ly/items/3E0J0Q411c0b212J0i13/Screen%20Shot%202012-07-02%20at%2010.06.12%20AM.png)

A more robust solution would better but maybe that's something to look for in more responsive design.

If `overflow: hidden;` is not a viable option then I'd suggest we just the micro clearfix instead:

``` css
#header {
  &:after {
    clear: both;
    content: "";
    display: table;
  }
}
```
