### PR TITLE
Fix #items_in_collection? for SELECT with DISTINCT.

### DIFF
--- a/lib/active_admin/views/pages/index.rb
+++ b/lib/active_admin/views/pages/index.rb
@@ -43,7 +43,8 @@ module ActiveAdmin
           #
           # If we don't reorder, there may be some columns referenced in the order
           # clause that requires the original select.
-          collection.reorder("").limit(1).exists?
+
+          !!collection.reorder("").first
         end
 
         def build_collection


### PR DESCRIPTION
# items_in_collection? returns false even if there are items on a select with a distinct clause.

For example:

``` ruby
class User
  def posts
    Post.joins(:blogs).where('blog.user_id' => current_user.id).uniq
  end
end

User.first.posts.page(2).all
  # => select distinct "posts".*....

User.first.posts.page(2).exists?
  # => select distinct(1) ....
  # => false
```

Let me know if you think I should write a regression test.
