### PR TITLE
Only show empty_value for attributes_table row if the row is actually empty

### DIFF
--- a/lib/active_admin/views/components/attributes_table.rb
+++ b/lib/active_admin/views/components/attributes_table.rb
@@ -45,7 +45,7 @@ module ActiveAdmin
       def content_for(attr_or_proc)
         value = case attr_or_proc
                 when Proc
-                  attr_or_proc.call(@record)
+                  attr_or_proc.call(@record) || content
                 else
                   content_for_attribute(attr_or_proc)
                 end


### PR DESCRIPTION
If you do:

``` ruby
ActiveAdmin.register ClassName do
  show do
    attributes_table do
      row :attribute_name do |x|
        div "some content"
        if some_condition
          div "other content"
        end
      end
    end
  end
end
```

and if `some_condition` evaluates to false, then [empty_value](https://github.com/gregbell/active_admin/blob/master/lib/active_admin/views/components/attributes_table.rb#L41) will be rendered after "some_content", even though the row is not empty! You can get around this by doing:

``` ruby
row :attribute_name do |x|
  div "some content"
  if some_condition
    div "other content"
  end
  "sigh..."
end
```

because "sigh..." won't be rendered, but that seems like a cludgy workaround. This pull request fixes this, so that an `attributes_table` `row` can return nil. The new code checks whether any content was created by the block passed to `row`, instead of checking the block's return value.
