### PR TITLE
Fix for inheritable settings in initializer

### DIFF
--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -113,11 +113,17 @@ module ActiveAdmin
     # @returns [Namespace] the new or existing namespace
     def find_or_create_namespace(name)
       name ||= :root
-      return namespaces[name] if namespaces[name]
-      namespace = Namespace.new(self, name)
-      namespaces[name] = namespace
-      ActiveAdmin::Event.dispatch ActiveAdmin::Namespace::RegisterEvent, namespace
+
+      if namespaces[name]
+        namespace = namespaces[name]
+      else
+        namespace = Namespace.new(self, name)
+        namespaces[name] = namespace
+        ActiveAdmin::Event.dispatch ActiveAdmin::Namespace::RegisterEvent, namespace
+      end
+
       yield(namespace) if block_given?
+
       namespace
     end
 

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -93,19 +93,8 @@ describe ActiveAdmin::Application do
     end
   end
 
-  describe "adding an inheritable setting" do
+  describe "#namespace (or #find_or_create_namespace)" do
 
-    it "should add a setting to Application and Namespace" do
-      ActiveAdmin::Application.inheritable_setting :inheritable_setting, "inheritable_setting"
-      app = ActiveAdmin::Application.new
-      app.inheritable_setting.should == "inheritable_setting"
-      ns = ActiveAdmin::Namespace.new(app, :admin)
-      ns.inheritable_setting.should == "inheritable_setting"
-    end
-
-  end
-
-  describe "#namespace" do
     it "should yield a new namespace" do
       application.namespace :new_namespace do |ns|
         ns.name.should == :new_namespace
@@ -114,9 +103,16 @@ describe ActiveAdmin::Application do
 
     it "should return an instantiated namespace" do
       admin = application.find_or_create_namespace :admin
-      application.namespace :admin do |ns|
-        ns.should == admin
-      end
+      admin.should == application.namespaces[:admin]
+    end
+
+    it "should yield an existing namespace" do
+      expect {
+        application.namespace :admin do |ns|
+          ns.should == application.namespaces[:admin]
+          raise "found"
+        end
+      }.to raise_error("found")
     end
   end
 


### PR DESCRIPTION
When trying to set inheritable settings on a namespace that was already
initialized, the block would not be run. In the end, this just meant
that you couldn't update settings on the default namespace.

This fixes the issue and adds specs to ensure it won't happen again.
