### PR TITLE
Added support to pages for setting a custom title

### DIFF
--- a/features/registering_pages.feature
+++ b/features/registering_pages.feature
@@ -30,6 +30,32 @@ Feature: Registering Pages
     Then I should see the page title "Status"
     And I should see the Active Admin layout
 
+  Scenario: Registering a page with a custom title as a string
+    Given a configuration of:
+    """
+    ActiveAdmin.register_page "Status" do
+      content :title => "Custom Page Title" do
+        "I love chocolate."
+      end
+    end
+    """
+    When I go to the dashboard
+    And I follow "Status"
+    Then I should see the page title "Custom Page Title"
+
+  Scenario: Registering a page with a custom title as a proc
+    Given a configuration of:
+    """
+    ActiveAdmin.register_page "Status" do
+      content :title => proc{ "Custom Page Title from Proc" } do
+        "I love chocolate."
+      end
+    end
+    """
+    When I go to the dashboard
+    And I follow "Status"
+    Then I should see the page title "Custom Page Title from Proc"
+
   Scenario: Adding a sidebar section to a page
     Given a configuration of:
     """

--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -26,7 +26,7 @@ module ActiveAdmin
             active_admin_application.stylesheets.each do |style|
               text_node(stylesheet_link_tag(style.path, style.options).html_safe)
             end
-            
+
             active_admin_application.javascripts.each do |path|
               script :src => javascript_path(path), :type => "text/javascript"
             end

--- a/lib/active_admin/views/pages/page.rb
+++ b/lib/active_admin/views/pages/page.rb
@@ -4,9 +4,7 @@ module ActiveAdmin
       class Page < Base
 
         def main_content
-          page_presenter = active_admin_config.get_page_presenter(:index)
-
-          if page_presenter && page_presenter.block
+          if page_presenter.block
             instance_exec &page_presenter.block
           else
             nil
@@ -15,8 +13,16 @@ module ActiveAdmin
 
         protected
 
+        def page_presenter
+          active_admin_config.get_page_presenter(:index) || ActiveAdmin::PagePresenter.new
+        end
+
         def title
-          active_admin_config.name
+          if page_presenter[:title]
+            render_or_call_method_or_proc_on self, page_presenter[:title]
+          else
+            active_admin_config.name
+          end
         end
       end
     end

--- a/lib/active_admin/views/pages/show.rb
+++ b/lib/active_admin/views/pages/show.rb
@@ -4,7 +4,7 @@ module ActiveAdmin
       class Show < Base
 
         def config
-          active_admin_config.get_page_presenter(:show) || ::ActiveAdmin::PagePresenter.new
+          active_admin_config.get_page_presenter(:show) || super
         end
 
         def title

--- a/lib/generators/active_admin/install/templates/dashboard.rb
+++ b/lib/generators/active_admin/install/templates/dashboard.rb
@@ -1,7 +1,8 @@
 ActiveAdmin.register_page "Dashboard" do
-  menu :priority => 1
 
-  content do
+  menu :priority => 1, :label => proc{ I18n.t("active_admin.dashboard") }
+
+  content :title => proc{ I18n.t("active_admin.dashboard") } do
     div :class => "blank_slate_container", :id => "dashboard_default_message" do
       span :class => "blank_slate" do
         span "Welcome to Active Admin. This is the default dashboard page."


### PR DESCRIPTION
- To mimic the APIs of the other resources, the page #content DSL method
  now accepts a hash with the "title" key
- `:title` can be set to a string to be rendered, a symbol to be called
  in the context of the view, or a proc to be run at render-time
- Updated the dashboard template to use I18n and procs for the page
  title and menu items
