### PR TITLE
Only show empty_value for attributes_table row if the row is actually empty

### DIFF
--- a/lib/active_admin/views/components/attributes_table.rb
+++ b/lib/active_admin/views/components/attributes_table.rb
@@ -43,14 +43,15 @@ module ActiveAdmin
       end
 
       def content_for(attr_or_proc)
+        previous = current_arbre_element.to_s
         value = case attr_or_proc
                 when Proc
-                  attr_or_proc.call(@record) || content
+                  attr_or_proc.call(@record)
                 else
                   content_for_attribute(attr_or_proc)
                 end
         value = pretty_format(value)
-        value == "" || value == nil ? empty_value : value
+        (value == "" || value == nil) && previous == current_arbre_element.to_s ? empty_value : value
       end
 
       def content_for_attribute(attr)

--- a/spec/unit/views/components/attributes_table_spec.rb
+++ b/spec/unit/views/components/attributes_table_spec.rb
@@ -46,8 +46,16 @@ describe ActiveAdmin::Views::AttributesTable do
             row("Body") { post.body }
           end
         }
-      }
-
+      },
+      "when you create each row with a custom block that returns nil" => proc {
+        render_arbre_component(assigns) {
+          attributes_table_for post do
+            row("Id")   { text_node post.id; nil }
+            row("Title"){ text_node post.title; nil }
+            row("Body") { text_node post.body; nil }
+          end
+        }
+      },
     }.each do |context_title, table_decleration|
       context context_title do
         let(:table) { instance_eval &table_decleration }
@@ -68,15 +76,15 @@ describe ActiveAdmin::Views::AttributesTable do
 
         describe "rendering the rows" do
           [
-            ["Id" , "2"],
+            ["Id" , "1"],
             ["Title" , "Hello World"],
             ["Body" , "<span class=\"empty\">Empty</span>"]
           ].each_with_index do |set, i|
-            let(:title){ set[0] }
-            let(:content){ set[1] }
-            let(:current_row){ table.find_by_tag("tr")[i] }
-
             describe "for #{set[0]}" do
+              let(:title){ set[0] }
+              let(:content){ set[1] }
+              let(:current_row){ table.find_by_tag("tr")[i] }
+
               it "should have the title '#{set[0]}'" do
                 current_row.find_by_tag("th").first.content.should == title
               end


### PR DESCRIPTION
If you do:

``` ruby
ActiveAdmin.register ClassName do
  show do
    attributes_table do
      row :attribute_name do |x|
        div "some content"
        if some_condition
          div "other content"
        end
      end
    end
  end
end
```

and if `some_condition` evaluates to false, then [empty_value](https://github.com/gregbell/active_admin/blob/master/lib/active_admin/views/components/attributes_table.rb#L41) will be rendered after "some_content", even though the row is not empty! You can get around this by doing:

``` ruby
row :attribute_name do |x|
  div "some content"
  if some_condition
    div "other content"
  end
  "foobar"
end
```

because "foobar" won't be rendered, but that seems like a cludgy workaround. This pull request fixes this, so that an `attributes_table` `row` can return nil. The new code checks whether any content was created by the block passed to `row`, instead of checking the block's return value.

Specs included.
