### PR TITLE
Use const_defined in production to determine input_class

### DIFF
--- a/lib/active_admin/filters/forms.rb
+++ b/lib/active_admin/filters/forms.rb
@@ -37,6 +37,10 @@ module ActiveAdmin
       end
 
       def custom_input_class_name(as)
+        "Filter#{as.to_s.camelize}Input"
+      end
+
+      def active_admin_input_class_name(as)
         "ActiveAdmin::Inputs::Filter#{as.to_s.camelize}Input"
       end
 

--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -125,14 +125,6 @@ module ActiveAdmin
       "ActiveAdmin::Inputs::#{as.to_s.camelize}Input"
     end
 
-    # Copy Formtastic 2.1.1's #input_class in case user has Formtastic 2.2
-    def input_class(as)
-      @input_classes_cache ||= {}
-      @input_classes_cache[as] ||= begin
-        Rails.application.config.cache_classes ? input_class_with_const_defined(as) : input_class_by_trying(as)
-      end
-    end
-
     # prevent exceptions in production environment for better performance
     def input_class_with_const_defined(as)
       input_class_name = custom_input_class_name(as)


### PR DESCRIPTION
See #1442. Instead of overriding Formtastic's #input_class, override its #input_class_with_const_defined and #input_class_by_trying methods.
