### PR TITLE
Let i18n decide how to capitalize words

### DIFF
--- a/lib/active_admin/resource/naming.rb
+++ b/lib/active_admin/resource/naming.rb
@@ -20,7 +20,7 @@ module ActiveAdmin
         if @options[:as]
           @options[:as]
         else
-           resource_name.human(:default => resource_name.gsub('::', ' ')).titleize
+           resource_name.human(:default => resource_name.gsub('::', ' ').titleize)
          end
       end
 
@@ -29,7 +29,7 @@ module ActiveAdmin
         if @options[:as]
           @options[:as].pluralize
         else
-          resource_name.human(:count => 1.1, :default => resource_label.pluralize).titleize
+          resource_name.human(:count => 1.1, :default => resource_label.pluralize.titleize)
         end
       end
     end

--- a/lib/active_admin/views/components/attributes_table.rb
+++ b/lib/active_admin/views/components/attributes_table.rb
@@ -35,7 +35,11 @@ module ActiveAdmin
       end
 
       def header_content_for(attr)
-        @record.class.respond_to?(:human_attribute_name) ? @record.class.human_attribute_name(attr).titleize : attr.to_s.titleize
+        if @record.class.respond_to?(:human_attribute_name)
+          @record.class.human_attribute_name(attr, :default => attr.to_s.titleize)
+        else
+          attr.to_s.titleize
+        end
       end
 
       def empty_value

--- a/lib/active_admin/views/components/table_for.rb
+++ b/lib/active_admin/views/components/table_for.rb
@@ -175,11 +175,11 @@ module ActiveAdmin
 
         def pretty_title(raw)
           if raw.is_a?(Symbol)
-            if @options[:i18n] && @options[:i18n].respond_to?(:human_attribute_name) && human_name = @options[:i18n].human_attribute_name(raw)
-              raw = human_name
+            if @options[:i18n] && @options[:i18n].respond_to?(:human_attribute_name)
+              raw = @options[:i18n].human_attribute_name(raw, :default => raw.to_s.titleize)
+            else
+              raw.to_s.titleize
             end
-
-            raw.to_s.titleize
           else
             raw
           end

--- a/spec/unit/resource/naming_spec.rb
+++ b/spec/unit/resource/naming_spec.rb
@@ -63,14 +63,14 @@ module ActiveAdmin
           it "should return the titleized model_name.human" do
             config.resource_name.should_receive(:human).and_return "Da category"
 
-            config.resource_label.should == "Da Category"
+            config.resource_label.should == "Da category"
           end
         end
 
         describe "plural label" do
           it "should return the titleized plural version defined by i18n if available" do
             I18n.should_receive(:translate).at_least(:once).and_return("Da categories")
-            config.plural_resource_label.should == "Da Categories"
+            config.plural_resource_label.should == "Da categories"
           end
         end
 


### PR DESCRIPTION
In some cases ([here](https://github.com/gregbell/active_admin/blob/master/lib/active_admin/views/dashboard_section_renderer.rb#L14) and [here](https://github.com/gregbell/active_admin/blob/master/lib/active_admin/views/pages/layout.rb#L10)), `titleize` is only called if the I18n lookup fails. In other cases, however, it calls `titleize` no matter what. This is not ideal, because if I translate an attribute in my locale file as "Date de début", I want it to be displayed that way. I don't want ActiveAdmin to render it as "Date De Début," which is not the proper capitalization. This pull request fixes those parts of the code that call `titleize` even when the I18n lookup succeeds.
