### PR TITLE
Use complex names for pages #1481

### DIFF
--- a/features/registering_pages.feature
+++ b/features/registering_pages.feature
@@ -20,6 +20,21 @@ Feature: Registering Pages
     And I should see the Active Admin layout
     And I should see the content "I love chocolate."
 
+  Scenario: Registering a page with a complex name
+    Given a configuration of:
+    """
+    ActiveAdmin.register_page "Chocolate I lØve You!" do
+      content do
+        "I love chocolate."
+      end
+    end
+    """
+    When I go to the dashboard
+    And I follow "Chocolate I lØve You!"
+    Then I should see the page title "Chocolate I lØve You!"
+    And I should see the Active Admin layout
+    And I should see the content "I love chocolate."
+
   Scenario: Registering an empty page
     Given a configuration of:
     """

--- a/lib/active_admin/page.rb
+++ b/lib/active_admin/page.rb
@@ -44,12 +44,20 @@ module ActiveAdmin
       @resource_name ||= Resource::Name.new(nil, name)
     end
 
+    def underscored_resource_name
+      resource_name.parameterize.underscore
+    end
+
+    def camelized_resource_name
+      underscored_resource_name.camelize
+    end
+
     def default_menu_options
       super.merge(:id => resource_name)
     end
 
     def controller_name
-      [namespace.module_name, resource_name + "Controller"].compact.join('::')
+      [namespace.module_name, camelized_resource_name + "Controller"].compact.join('::')
     end
 
     def belongs_to?

--- a/lib/active_admin/router.rb
+++ b/lib/active_admin/router.rb
@@ -63,9 +63,9 @@ module ActiveAdmin
               end
             when Page
 
-              match "/#{config.resource_name.singular}" => "#{config.resource_name.singular}#index"
+              match "/#{config.underscored_resource_name}" => "#{config.underscored_resource_name}#index"
               config.page_actions.each do |action|
-                match "/#{config.resource_name.singular}/#{action.name}" => "#{config.resource_name.singular}##{action.name}", :via => action.http_verb
+                match "/#{config.underscored_resource_name}/#{action.name}" => "#{config.underscored_resource_name}##{action.name}", :via => action.http_verb
               end
             else
               raise "Unsupported config class: #{config.class}"

--- a/spec/unit/page_spec.rb
+++ b/spec/unit/page_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'spec_helper' 
 require File.expand_path('config_shared_examples', File.dirname(__FILE__))
 
@@ -11,34 +13,46 @@ module ActiveAdmin
     let(:namespace){ Namespace.new(application, :admin) }
 
     def config(options = {})
-      @config ||= namespace.register_page("Status", options)
+      @config ||= namespace.register_page("Chocolate I lØve You!", options)
     end
 
     describe "controller name" do
       it "should return a namespaced controller name" do
-        config.controller_name.should == "Admin::StatusController"
+        config.controller_name.should == "Admin::ChocolateILoveYouController"
       end
       context "when non namespaced controller" do
         let(:namespace){ ActiveAdmin::Namespace.new(application, :root) }
         it "should return a non namespaced controller name" do
-          config.controller_name.should == "StatusController"
+          config.controller_name.should == "ChocolateILoveYouController"
         end
       end
     end
 
     describe "#resource_name" do
       it "returns the name" do
-        config.resource_name.should == "Status"
+        config.resource_name.should == "Chocolate I lØve You!"
       end
 
-      it "returns the underscored name" do
-        config.resource_name.singular.should == "status"
+      it "returns the singular, lowercase name" do
+        config.resource_name.singular.should == "chocolate i lØve you!"
       end
     end
 
     describe "#plural_resource_label" do
       it "returns the singular name" do
-        config.plural_resource_label.should == "Status"
+        config.plural_resource_label.should == "Chocolate I lØve You!"
+      end
+    end
+
+    describe "#underscored_resource_name" do
+      it "returns the resource name underscored" do
+        config.underscored_resource_name.should == "chocolate_i_love_you"
+      end
+    end
+
+    describe "#camelized_resource_name" do
+      it "returns the resource name camel case" do
+        config.camelized_resource_name.should == "ChocolateILoveYou"
       end
     end
 

--- a/spec/unit/routing_spec.rb
+++ b/spec/unit/routing_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'spec_helper'
 
 describe ActiveAdmin, "Routing", :type => :routing do
@@ -150,20 +152,20 @@ describe ActiveAdmin, "Routing", :type => :routing do
   describe "page" do
     context "when default namespace" do
       before(:each) do
-        load_resources { ActiveAdmin.register_page("Status") }
+        load_resources { ActiveAdmin.register_page("Chocolate I lØve You!") }
       end
 
       it "should route to the page under /admin" do
-        admin_status_path.should == "/admin/status"
+        admin_chocolate_i_love_you_path.should == "/admin/chocolate_i_love_you"
       end
 
       context "when in the root namespace" do
         before(:each) do
-          load_resources { ActiveAdmin.register_page("Status", :namespace => false) }
+          load_resources { ActiveAdmin.register_page("Chocolate I lØve You!", :namespace => false) }
         end
 
         it "should route to page under /" do
-          status_path.should == "/status"
+          chocolate_i_love_you_path.should == "/chocolate_i_love_you"
         end
       end
 


### PR DESCRIPTION
This is a fix for issue #1481 (which was discussed in https://github.com/gregbell/active_admin/pull/1463)

Previously, only the simplest page names would work. Now, any page name should work, including with spaces and special characters.

This code relies on ActiveSupport's #parameterize method, which includes a transliteration process to handle complex characters.
