### PR TITLE
site_title proc should be rendered in Devise page title

### DIFF
--- a/app/views/layouts/active_admin_logged_out.html.erb
+++ b/app/views/layouts/active_admin_logged_out.html.erb
@@ -3,7 +3,7 @@
 <head>
   <meta http-equiv="Content-type" content="text/html; charset=utf-8">
  
-  <title><%= [@page_title, ActiveAdmin.application.site_title].compact.join(" | ") %></title>
+  <title><%= [@page_title, render_or_call_method_or_proc_on(self, ActiveAdmin.application.site_title)].compact.join(" | ") %></title>
 
   <% ActiveAdmin.application.stylesheets.each do |style| %>
     <%= stylesheet_link_tag style.path, style.options %>


### PR DESCRIPTION
Like #1445 and #1456. Adding another missing call to `render_or_call_method_or_proc_on`. (Should be the last one).
