### PR TITLE
Better german locale for devise and admin user model.

### DIFF
--- a/lib/active_admin/locales/de.yml
+++ b/lib/active_admin/locales/de.yml
@@ -66,3 +66,31 @@ de:
       links:
         sign_in: "Anmeldung"
         forgot_your_password: "Passwort vergessen?"
+  activerecord:
+    attributes:
+      admin_user: 
+        id: ID
+        email: E-Mail
+        encrypted_Password: Verschlüsseltes Passwort
+        reset_password_token: Passwort Reset Token
+        reset_password_sent_at: Passwort Reset Anweisungen gesendet am
+        remember_created_at: Passwort merken seit
+        sign_in_count: Anzahl Logins
+        current_sign_in_at: Aktuell angemeldet seit
+        last_sign_in_at: Letzter Login am
+        current_sign_in_ip: Aktuelle IP-Adresse
+        last_sign_in_ip: Letzte IP-Adresse
+        created_at: Erstellt am
+        updated_at: Aktualisiert am
+    models:
+      admin_user:
+        one: Administrator
+        other: Administratoren  
+  devise:      
+    failure:
+      admin_user:
+        invalid: Benutzername oder Kennwort nicht korrekt.
+        unauthenticated: Bitte melden Sie sich als Administrator an.
+    sessions:
+      admin_user:
+        signed_in: Erfolgreich als Administrator angemeldet.


### PR DESCRIPTION
Added following stuff to the german locale:

``` yaml
  activerecord:
    attributes:
      admin_user: 
        id: ID
        email: E-Mail
        encrypted_Password: Verschlüsseltes Passwort
        reset_password_token: Passwort Reset Token
        reset_password_sent_at: Passwort Reset Anweisungen gesendet am
        remember_created_at: Passwort merken seit
        sign_in_count: Anzahl Logins
        current_sign_in_at: Aktuell angemeldet seit
        last_sign_in_at: Letzter Login am
        current_sign_in_ip: Aktuelle IP-Adresse
        last_sign_in_ip: Letzte IP-Adresse
        created_at: Erstellt am
        updated_at: Aktualisiert am
    models:
      admin_user:
        one: Administrator
        other: Administratoren  
  devise:      
    failure:
      admin_user:
        invalid: Benutzername oder Kennwort nicht korrekt.
        unauthenticated: Bitte melden Sie sich als Administrator an.
    sessions:
      admin_user:
        signed_in: Erfolgreich als Administrator angemeldet.
```
