### PR TITLE
call the inputs block the same way Formtastic does

### DIFF
--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -60,7 +60,7 @@ module ActiveAdmin
         else
           index = parent_child_index(options[:parent]) if options[:parent]
           block.call(has_many_form, index)
-        end.to_s
+        end
 
         if has_many_form.object.new_record?
           contents += template.content_tag(:li) do

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -17,7 +17,7 @@ generate :model, "user type:string first_name:string last_name:string username:s
 inject_into_file 'app/models/user.rb', "  has_many :posts, :foreign_key => 'author_id'\n", :after => "class User < ActiveRecord::Base\n"
 generate :model, "publisher --migration=false --parent=User"
 generate :model, 'category name:string description:text'
-inject_into_file 'app/models/category.rb', "  has_many :posts\n", :after => "class Category < ActiveRecord::Base\n"
+inject_into_file 'app/models/category.rb', "  has_many :posts\n  accepts_nested_attributes_for :posts\n", :after => "class Category < ActiveRecord::Base\n"
 generate :model, 'store name:string'
 
 # Generate a model with string ids


### PR DESCRIPTION
Formtastic lets you get the current index of the child record inside an `inputs_for_nested_attributes` block. [See example](https://github.com/justinfrench/formtastic#usage) in its documentation.

This pull request fixes AA's `has_many` helper to preserve this functionality.

While you're at it, please merge #967 and #1391 (which also would close #1422).
