### PR TITLE
Pagination respects Kaminari.config.param_name

### DIFF
--- a/lib/active_admin/resource_controller/collection.rb
+++ b/lib/active_admin/resource_controller/collection.rb
@@ -119,8 +119,11 @@ module ActiveAdmin
         end
 
         def paginate(chain)
-          chain.send(Kaminari.config.page_method_name, params[:page]).per(per_page)
-        end
+          page_method_name = Kaminari.config.page_method_name
+          page = params[Kaminari.config.param_name]
+
+          chain.send(page_method_name, page).per(per_page)
+	end
 
         def per_page
           return max_csv_records if request.format == 'text/csv'


### PR DESCRIPTION
The page variable can thus be named something other than 'page'. Fixes #1371.
