### PR TITLE
Custom action would call a method that does not exists on Arbre anymore.

### DIFF
--- a/features/specifying_actions.feature
+++ b/features/specifying_actions.feature
@@ -14,7 +14,7 @@ Feature: Specifying Actions
           end
         end
       """
-	And I am logged in
+    And I am logged in
     And a post with the title "Hello World" exists
     When I am on the index page for posts
     Then an "AbstractController::ActionNotFound" exception should be raised when I follow "View"
@@ -30,9 +30,9 @@ Feature: Specifying Actions
           collection_action :import
         end
       """
-    Given "app/views/admin/posts/import.html.erb" contains:
+    Given "app/views/admin/posts/import.html.arb" contains:
       """
-        <p>We are currently working on this feature...</p>
+        para "We are currently working on this feature..."
       """
     And I am logged in
     When I am on the index page for posts
@@ -46,7 +46,7 @@ Feature: Specifying Actions
           action_item(:only => :show) do
             link_to('Review', review_admin_post_path)
           end
-
+  
           member_action :review do
             @post = Post.find(params[:id])
           end
@@ -90,3 +90,4 @@ Feature: Specifying Actions
     Then I should see "Review: Hello World"
     And I should see the page title "Review"
     And I should see the Active Admin layout
+

--- a/features/step_definitions/configuration_steps.rb
+++ b/features/step_definitions/configuration_steps.rb
@@ -27,10 +27,22 @@ module ActiveAdminContentsRollback
   def self.rollback!
     recorded_files.each do |filename, contents|
       # contents will be nil if the file didin't exist
-      if contents
-        File.open(filename, "w+") {|f| f << contents }
+      if contents.present?
+        File.open(filename, "w") {|f| f << contents }
       else
         File.delete(filename)
+
+        # Delete parent directories
+        begin
+          dir = File.dirname(filename)
+          until dir == Rails.root
+            Dir.rmdir(dir)
+            dir = dir.split('/')[0..-2].join('/')
+          end
+        rescue Errno::ENOTEMPTY
+          # Directory not empty
+        end
+
       end
     end
 

--- a/lib/active_admin/views/pages/layout.rb
+++ b/lib/active_admin/views/pages/layout.rb
@@ -14,7 +14,7 @@ module ActiveAdmin
         def main_content
           content_for_layout = content_for(:layout)
           if content_for_layout.is_a?(Arbre::Element)
-            current_dom_context.add_child content_for_layout.children
+            current_arbre_element.add_child content_for_layout.children
           else
             text_node content_for_layout
           end


### PR DESCRIPTION
Fix #1517.
