### PR TITLE
Fixed polish translation

### DIFF
--- a/lib/active_admin/locales/pl.yml
+++ b/lib/active_admin/locales/pl.yml
@@ -80,4 +80,5 @@ pl:
   formtastic:
     actions:
       update: "Aktualizuj %{model}"
+      create: "Utwórz %{model}"
 


### PR DESCRIPTION
Hi,
I've just improved some translations for active admin:
I've translated "Login" word, and attached translations for formtastic's "Update Model" buttons. 
