### PR TITLE
active_admin_comments table issue. fixes #662

### DIFF
--- a/lib/active_admin/comments/show_page_helper.rb
+++ b/lib/active_admin/comments/show_page_helper.rb
@@ -12,13 +12,18 @@ module ActiveAdmin
         active_admin_comments if active_admin_config.comments?
       end
 
+      def comments_table_exists?
+         @val ||= ActiveRecord::Base.connection.tables.include?("active_admin_comments")
+      end
+
       # Display the comments for the resource. Same as calling
       # #active_admin_comments_for with the current resource
       def active_admin_comments(*args, &block)
-        if ActiveRecord::Base.connection.tables.include?("active_admin_comments")
+        if comments_table_exists?
           active_admin_comments_for(resource, *args, &block)
         end
       end
     end
+
   end
 end


### PR DESCRIPTION
now if you remove the "active_admin_comments" table, it will not raise such errors.
