### PR TITLE
Fix scope counts with filters

### DIFF
--- a/features/index/index_scopes.feature
+++ b/features/index/index_scopes.feature
@@ -88,6 +88,40 @@ Feature: Index Scoping
     Then I should see the scope "Published" selected
     And I should see 3 posts in the table
 
+  Scenario: Viewing resources when scoping and filtering
+    Given 2 posts written by "Daft Punk" exist
+    Given 1 published posts written by "Daft Punk" exist
+
+    Given 1 posts written by "Alfred" exist
+    Given 2 published posts written by "Alfred" exist
+
+    And an index configuration of:
+      """
+      ActiveAdmin.register Post do
+        scope :all, :default => true
+        scope :published do |posts|
+          posts.where("published_at IS NOT NULL")
+        end
+      end
+      """
+    Then I should see the scope "All" with the count 6
+    And I should see the scope "Published" with the count 3
+    And I should see 6 posts in the table
+
+    When I follow "Published"
+    Then I should see the scope "Published" selected
+    And I should see the scope "All" with the count 6
+    And I should see the scope "Published" with the count 3
+    And I should see 3 posts in the table
+
+    When I select "daft_punk" from "Author"
+    And I press "Filter"
+
+    Then I should see the scope "Published" selected
+    And I should see the scope "All" with the count 3
+    And I should see the scope "Published" with the count 1
+    And I should see 1 posts in the table
+
   Scenario: Viewing resources with optional scopes
     Given 3 posts exist
     And an index configuration of:
@@ -136,7 +170,7 @@ Feature: Index Scoping
     And I should see the scope "Today" not selected
     And I should see a link to "Today"
     
-  Scenario: Viewing resources with scopes when a filter is applied
+  Scenario: Viewing resources with scopes when scoping to user
     Given 2 posts written by "Daft Punk" exist
     And a post with the title "Monkey Wrench" written by "Foo Fighters" exists
     And a post with the title "Everlong" written by "Foo Fighters" exists

--- a/features/step_definitions/factory_steps.rb
+++ b/features/step_definitions/factory_steps.rb
@@ -13,11 +13,11 @@ Given /^a (published )?post with the title "([^"]*)" written by "([^"]*)" exists
   Post.create! :title => title, :author => author, :published_at => published_at
 end
 
-Given /^(\d+) posts? written by "([^"]*)" exist$/ do |count, author_name|
+Given /^(\d+)( published)? posts? written by "([^"]*)" exist$/ do |count, published, author_name|
   first, last = author_name.split(' ')
   author = User.find_or_create_by_first_name_and_last_name(first, last, :username => author_name.gsub(' ', '').underscore)
   (0...count.to_i).each do |i|
-    Post.create! :title => "Hello World #{i}", :author => author
+    Post.create! :title => "Hello World #{i}", :author => author, :published_at => (published ? Time.now : nil)
   end
 end
 

--- a/lib/active_admin/resource_controller/collection.rb
+++ b/lib/active_admin/resource_controller/collection.rb
@@ -88,16 +88,19 @@ module ActiveAdmin
         end
 
         def scope_current_collection(chain)
+          @collection_before_scope = chain
+
           if current_scope
-            @before_scope_collection = chain
             scope_chain(current_scope, chain)
-          elsif active_admin_config.scope_to
-            @before_scope_collection = scoped_collection
-            chain
           else
             chain
           end
         end
+
+        def collection_before_scope
+          @collection_before_scope
+        end
+
 
         include ActiveAdmin::ScopeChain
 

--- a/lib/active_admin/views/components/scopes.rb
+++ b/lib/active_admin/views/components/scopes.rb
@@ -59,17 +59,8 @@ module ActiveAdmin
 
       # Return the count for the scope passed in.
       def get_scope_count(scope)
-        if params[:q]
-          search(scope_chain(scope, scoping_class)).relation.count
-        else 
-          scope_chain(scope, scoping_class).count
-        end
+        scope_chain(scope, collection_before_scope).count
       end
-
-      def scoping_class
-        assigns[:before_scope_collection] || active_admin_config.resource_class
-      end
-
     end
   end
 end

--- a/spec/unit/resource_controller/collection_spec.rb
+++ b/spec/unit/resource_controller/collection_spec.rb
@@ -31,17 +31,26 @@ describe ActiveAdmin::ResourceController::Collection do
     end
   end
   
-  describe ActiveAdmin::ResourceController::Collection::Scoping do
-    it "should assign @before_scope_collection if a scope_to is registered" do
-      chain = mock("ChainObj")
-      scoped_collection = mock('scoped_collection')
-      controller.stub(:current_scope).and_return(false)
-      controller.stub(:scoped_collection).and_return(scoped_collection)
-      controller.stub_chain(:active_admin_config, :scope_to).and_return(true)
-      
-      controller.send :scope_current_collection, chain
-      controller.instance_variable_get('@before_scope_collection').should == scoped_collection
+  describe ActiveAdmin::ResourceController::Collection::Scoping, "#scope_current_collection" do
+    context "when no current scope" do
+      it "should set collection_before_scope to the chain and return the chain" do
+        chain = mock("ChainObj")
+        controller.send(:scope_current_collection, chain).should == chain
+        controller.send(:collection_before_scope).should == chain
+      end
+    end
+
+    context "when current scope" do
+      it "should set collection_before_scope to the chain and return the scoped chain" do
+        chain = mock("ChainObj")
+        scoped_chain = mock("ScopedChain")
+        current_scope = mock("CurrentScope")
+        controller.stub!(:current_scope) { current_scope }
+
+        controller.should_receive(:scope_chain).with(current_scope, chain) { scoped_chain }
+        controller.send(:scope_current_collection, chain).should == scoped_chain
+        controller.send(:collection_before_scope).should == chain
+      end
     end
   end
-
 end


### PR DESCRIPTION
Scope counts were wrong when applying filters. They would all display count of the "All" filter. This pull request fixes this.

The scopes scenarios creates 3 (instead of 10!) entries to test scopes.
