### PR TITLE
Temporary fix for memory leak #170

### DIFF
--- a/lib/active_admin/resource.rb
+++ b/lib/active_admin/resource.rb
@@ -47,6 +47,9 @@ module ActiveAdmin
     # Set the configuration for the CSV
     attr_writer :csv_builder
 
+    # Workaround for memory leak.
+    attr_accessor :dsl
+
     module Base
       def initialize(namespace, resource_class, options = {})
         @namespace = namespace

--- a/lib/active_admin/resource_controller.rb
+++ b/lib/active_admin/resource_controller.rb
@@ -30,9 +30,11 @@ module ActiveAdmin
       def active_admin_config=(config)
         @active_admin_config = config
 
-        defaults  :resource_class => config.resource_class,
-                  :route_prefix => config.route_prefix,
-                  :instance_name => config.resource_name.singular
+        unless config.nil?
+          defaults  :resource_class => config.resource_class,
+                    :route_prefix => config.route_prefix,
+                    :instance_name => config.resource_name.singular
+        end
       end
 
       # Inherited Resources uses the inherited(base) hook method to 

--- a/spec/integration/memory_spec.rb
+++ b/spec/integration/memory_spec.rb
@@ -6,20 +6,12 @@ require 'spec_helper'
 describe "Memory Leak" do
 
   def count_instances_of(klass)
-    count = 0
-
-    ObjectSpace.each_object do |o|
-      if o.class == klass
-        count += 1
-      end
-    end
-
-    count
+    ObjectSpace.each_object(klass) { }
   end
 
   def self.it_should_not_leak(klass)
     it "should not leak #{klass}" do
-      pending
+      #pending
 
       GC.start
 


### PR DESCRIPTION
Hello.

I've been trying to figure the memory leak in issue #170 out for recent few days and I think I know what may cause it. 

First, a small disclaimer. Since I'm just learning Rails I have not been testing it in a real application environment, but instead used memory_spec test.
I would appreciate it if someone could test it in a real Rails application's production environment.

Now, to the point. There are two resource dependencies that somehow cause GC not to sweep the Resource objects after their respective Controllers are unregistered:
1. Circular dependency between controller and its resource.
2. The ResourceDSL config instance variable when registering resource with a block (e.g. Comments). I think this might be caused by the closure nature of Ruby blocks.

To fix the first issue I had to reset the circular dependency in the controller after its constant is unregistered.
Unfortunately to fix the second issue I had to introduce another circular dependency between Resource and ResourceDSL instances in order to remove it later.  
Both of these are implemented in private clear_resource_bindings method in Namespace class.

These fixes are far from perfect to say the least - they break encapsulation and introduce another unneeded dependency.
(Un)Fortunately I am leaving for vacation soon, so this is all the work I can do on it for now.

Hopefully someone with deeper AA understanding will have some better ideas on how to fix these two situations :)
