### PR TITLE
Croatian pluralizations fix

### DIFF
--- a/lib/active_admin/locales/hr.yml
+++ b/lib/active_admin/locales/hr.yml
@@ -21,8 +21,8 @@ hr:
     download: "Spremi na računalo:"
     has_many_new: "Dodaj novi %{model}"
     has_many_delete: "Obriši"
-    filter: "Filter"
-    clear_filters: "Očisti Filtere"
+    filter: "Filtriraj"
+    clear_filters: "Očisti filtere"
     search_field: "Pretraži po %{field}"
     equal_to: "Jednako"
     greater_than: "Veće Od"
@@ -30,7 +30,7 @@ hr:
     main_content: "Molim Vas, implementirajte %{model}#main_content da bi ste prikazali sadržaj."
     logout: "Odjavi se"
     sidebars:
-      filters: "Filteri"
+      filters: "Filtriranje"
     pagination:
       empty: "Nije pronađen niti jedan %{model}."
       one: "Prikazan <b>1</b> %{model}"


### PR DESCRIPTION
The fix prevents errors when using native pluralizations (one, few, many, other). Rails-i18n gem provides those native pluralization. For comparison see: https://github.com/svenfuchs/rails-i18n/blob/master/rails/locale/hr.yml
