### PR TITLE
Add formating ability to the Dashboard main table.

### DIFF
--- a/lib/active_admin/views/pages/dashboard.rb
+++ b/lib/active_admin/views/pages/dashboard.rb
@@ -21,13 +21,18 @@ module ActiveAdmin
         end
 
         def render_sections(sections)
+          cloned_sections = sections.clone
           table :class => "dashboard" do
-            sections.in_groups_of(3, false).each do |row|
+            while !cloned_sections.empty?
+              current_cols_number = 0
               tr do
-                row.each do |section|
-                  td do
-                    render_section(section)
+                while current_cols_number < 12 && !cloned_sections.empty?
+                  s       = cloned_sections.shift
+                  colspan = s.options[:colspan].nil? ? 4 : s.options[:colspan]
+                  td colspan: colspan do
+                    render_section(s)
                   end
+                  current_cols_number += colspan
                 end
               end
             end


### PR DESCRIPTION
A table is used to display the sections on the dashboard.
This table has 3 columns (hard-coded).

This is an over-ride on the render_sections method
in the ActiveAdmin::Views::Pages::Dashboard class.

The new method does two things:
- add the 'colspan' attribute if it was definde as
  an option of the section
- format the table to be 12-column wide

By default, the colspan is set to 4 to keep the
previous layout of three columns.
# 

my Ruby skills are pretty basic and 
my coding style may not  fit yours. 
Please don't hesitate to tell me if so.
