### PR TITLE
parameterize name of Sidebar ID html attribute

### DIFF
--- a/lib/active_admin/sidebar_section.rb
+++ b/lib/active_admin/sidebar_section.rb
@@ -12,7 +12,7 @@ module ActiveAdmin
 
     # The id gets used for the div in the view
     def id
-      name.to_s.downcase.underscore + '_sidebar_section'
+      "#{name.to_s.downcase.underscore}_sidebar_section".parameterize
     end
 
     def icon?


### PR DESCRIPTION
parameterize on the name/id of the Sidebar section to give valid html attribute values when spaces or special chars used for the title. EG:

```
sidebar 'Date / Time', :partial => "shared/datetime"
```

Before would produce: date / time_sidebar_section
After: date-time_sidebar_section
