### PR TITLE
Fix for Issue #1604: ActiveAdmin DeviseCreateAdminUsers migration attempts to create AdminUser on down (migrating to previous version)

### DIFF
--- a/lib/generators/active_admin/devise/devise_generator.rb
+++ b/lib/generators/active_admin/devise/devise_generator.rb
@@ -38,7 +38,7 @@ module ActiveAdmin
         devise_migrations = Dir["db/migrate/*_devise_create_#{table_name}.rb"]
         if devise_migrations.size > 0
           inject_into_file  Dir["db/migrate/*_devise_create_#{table_name}.rb"].first, 
-                            "# Create a default user\n    #{class_name}.create!(:email => 'admin@example.com', :password => 'password', :password_confirmation => 'password')\n\n    ",
+                            "def migrate(direction)\n      super\n      # Create a default user\n      AdminUser.create!(:email => 'admin@example.com', :password => 'password', :password_confirmation => 'password') if direction == :up\n   end\n\n    ",
                             :before => "add_index :#{table_name}, :email"
         end
       end


### PR DESCRIPTION
This is a patch to check migration direction before attempting to create an AdminUser in the migration. Without this, you can't migrate to a version before the ActiveAdmin install and related migration.
