### PR TITLE
Allow a blacklist listing filters

### DIFF
--- a/lib/active_admin/filters/dsl.rb
+++ b/lib/active_admin/filters/dsl.rb
@@ -7,6 +7,10 @@ module ActiveAdmin
         config.add_filter(attribute, options)
       end
 
+      # For docs, please see ActiveAdmin::Filters::ResourceExtension#delete_filter
+      def remove_filter(attribute)
+        config.remove_filter(attribute)
+      end
     end
   end
 end

--- a/lib/active_admin/filters/resource_extension.rb
+++ b/lib/active_admin/filters/resource_extension.rb
@@ -30,11 +30,25 @@ module ActiveAdmin
         @filters_enabled.nil? ? namespace.filters : @filters_enabled
       end
 
+      # Remove a filter for this resource. If filters are not enabled, this method
+      # will raise a RuntimeError
+      #
+      # @param [Symbol] attribute The attribute to not filter on
+      def remove_filter(attribute)
+        unless filters_enabled?
+          raise RuntimeError, "Can't remove a filter when filters are disabled. Enable filters with 'config.filters = true'"
+        end
+
+        @filters ||= default_filters
+
+        @filters.delete_if { |f| f.fetch(:attribute) == attribute }
+      end
+
       # Add a filter for this resource. If filters are not enabled, this method
       # will raise a RuntimeError
       #
       # @param [Symbol] attribute The attribute to filter on
-      # @param [Hash] options The set of options that are passed through to 
+      # @param [Hash] options The set of options that are passed through to
       #                       metasearch for the field definition.
       def add_filter(attribute, options = {})
         unless filters_enabled?

--- a/spec/unit/filters/resource_spec.rb
+++ b/spec/unit/filters/resource_spec.rb
@@ -28,6 +28,12 @@ describe ActiveAdmin::Filters::ResourceExtension do
     resource.filters.should be_empty
   end
 
+  it "should remove a filter" do
+    resource.filters.should include({:attribute => :author})
+    resource.remove_filter :author
+    resource.filters.should_not include({:attribute => :author})
+  end
+
   it "should add a filter" do
     resource.add_filter :title
     resource.filters.should == [{:attribute => :title}]


### PR DESCRIPTION
We want to preserve active generation of filters, while
opting out of certain filters, for example associations.

Sometimes associations can be prohibitively large, for
example when there are 100,000 users and several models
which belong_to :user.  That filter would have too many 
items for the list to display correctly, and was causing 
serious performance issues.

Example:

``` ruby

class User < ActiveRecord::Base
  has_many :posts
end

class Post < ActiveRecord::Base
  belongs_to :user 
end

ActiveAdmin.register Post do
  unfilter :user
end
```
