### PR TITLE
Fixes missing translations on default batch action

### DIFF
--- a/lib/active_admin/batch_actions/resource_extension.rb
+++ b/lib/active_admin/batch_actions/resource_extension.rb
@@ -61,11 +61,11 @@ module ActiveAdmin
       def add_default_batch_actions
         destroy_options = {
           :priority => 100,
-          :confirm => I18n.t('active_admin.batch_actions.delete_confirmation', :plural_model => plural_resource_label.downcase),
+          :confirm => proc { I18n.t('active_admin.batch_actions.delete_confirmation', :plural_model => active_admin_config.plural_resource_label.downcase) },
           :if => proc{ controller.action_methods.include?('destroy') }
         }
 
-        add_batch_action :destroy, I18n.t('active_admin.delete'), destroy_options do |selected_ids|
+        add_batch_action :destroy, proc { I18n.t('active_admin.delete') }, destroy_options do |selected_ids|
           active_admin_config.resource_class.find(selected_ids).each { |r| r.destroy }
 
           redirect_to collection_path, :notice => I18n.t("active_admin.batch_actions.succesfully_destroyed",

--- a/lib/active_admin/batch_actions/views/batch_action_selector.rb
+++ b/lib/active_admin/batch_actions/views/batch_action_selector.rb
@@ -27,13 +27,16 @@ module ActiveAdmin
                       :id => "batch_actions_selector",
                       :button => { :class => "disabled" } do
           batch_actions_to_display.each do |batch_action|
+            confirmation_text = render_or_call_method_or_proc_on(self, batch_action.confirm)
+
             options = {
               :class => "batch_action",
               "data-action" => batch_action.sym,
-              "data-confirm" => batch_action.confirm
+              "data-confirm" => confirmation_text
             }
 
-            title = I18n.t("active_admin.batch_actions.labels.#{batch_action.sym}", :default => batch_action.title)
+            default_title = render_or_call_method_or_proc_on(self, batch_action.title)
+            title = I18n.t("active_admin.batch_actions.labels.#{batch_action.sym}", default_title)
             label = I18n.t("active_admin.batch_actions.action_label", :title => title)
 
             item label, "#", options


### PR DESCRIPTION
The confirmation translation was running before the Active Admin
translations have been loaded. Instead of calling directly to get the
translation, it is now wrapped in a proc.
