### PR TITLE
Prevent print css to get media value screen on second requests

### DIFF
--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -24,7 +24,7 @@ module ActiveAdmin
           within @head do
             insert_tag Arbre::HTML::Title, [title, render_or_call_method_or_proc_on(self, active_admin_application.site_title)].join(" | ")
             active_admin_application.stylesheets.each do |style|
-              text_node(stylesheet_link_tag(style.path, style.options).html_safe)
+              text_node(stylesheet_link_tag(style.path, style.options.dup).html_safe)
             end
 
             active_admin_application.javascripts.each do |path|


### PR DESCRIPTION
This fixes #1182.

The problem is that the options hash from a `ActiveAdmin::Stylesheet` instance is directly passed into Rails' `stylesheet_link_tag` helper. `stylesheet_link_tag` modifies this hash and clears it. So every other request gets an empty options hash (without media value so it defaults to screen).

A simple dup of the options hash before passing it to `stylesheet_link_tag` fixes this issue.
