### PR TITLE
Doc: Remove instruction of adding sass-rails to Rails 3.1 projects.

### DIFF
--- a/docs/0-installation.md
+++ b/docs/0-installation.md
@@ -6,13 +6,6 @@ your Gemfile:
     # Gemfile
     gem 'activeadmin'
 
-If you are using Rails >= 3.1, you must also include a beta version of
-MetaSearch and sass-rails:
-
-    # Gemfile in Rails >= 3.1
-    gem 'activeadmin'
-    gem 'sass-rails'
-
 ## Running the Generator
 
 Once you have added the gem to your Gemfile (and any other dependencies), you


### PR DESCRIPTION
It is a Rails 3.1 thing. [ci-skip]
