### PR TITLE
#1652 - Added support of Proc object at menu :parent option

### DIFF
--- a/lib/active_admin/menu_item.rb
+++ b/lib/active_admin/menu_item.rb
@@ -28,12 +28,18 @@ module ActiveAdmin
     # @option options [Proc] :if
     #         A block for the view to call to decide if this menu item should be displayed.
     #         The block should return true of false
+    #
+    # @option options [Proc] :parent
+    #         The parent label to display for this menu item. Menu item will be nested
+    #         under that label. It can either be a String or a Proc. If the option is Proc,
+    #         it is called each time the label is requested.
     def initialize(options = {})
       @label    = options[:label]
       @id       = MenuItem.generate_item_id(options[:id] || label)
       @url      = options[:url]
       @priority = options[:priority] || 10
       @children = Menu::ItemCollection.new
+      @parent   = options[:parent]
 
       @display_if_block = options[:if]
 

--- a/lib/active_admin/resource/menu.rb
+++ b/lib/active_admin/resource/menu.rb
@@ -9,7 +9,7 @@ module ActiveAdmin
           @display_menu = false
         else
           options = default_menu_options.merge(options)
-          @parent_menu_item = options.delete(:parent)
+          @parent_menu_item = value_or_proc(options.delete(:parent))
           @menu_item = MenuItem.new(default_menu_options.merge(options))
         end
       end
@@ -37,6 +37,13 @@ module ActiveAdmin
         @display_menu != false
       end
 
+      private
+
+      # Evaluates value if this is proc or return value if else
+      def value_or_proc(value)
+        return value.call if value.is_a? Proc
+        value
+      end
     end
   end
 end

--- a/spec/unit/config_shared_examples.rb
+++ b/spec/unit/config_shared_examples.rb
@@ -33,16 +33,20 @@ shared_examples_for "ActiveAdmin::Config" do
   describe "Menu" do
     describe "menu item" do
 
-	  it "initializes a new menu item with defaults" do
+    it "initializes a new menu item with defaults" do
         config.menu_item.label.should == config.plural_resource_label
-	  end
-
-      it "initialize a new menu item with custom options" do
-		config.menu :label => "Hello"
-        config.menu_item.label.should == "Hello"
-      end
-
     end
+
+    it "initialize a new menu item with custom options" do
+      config.menu :label => "Hello"
+      config.menu_item.label.should == "Hello"
+    end
+
+    it "initialize a new menu item with label as Proc object" do
+      config.menu :label => proc { "Hello" }
+      config.menu_item.label.should == "Hello"
+    end
+  end
 
     describe "#include_in_menu?" do
       it "should be included in menu by default" do
@@ -62,10 +66,14 @@ shared_examples_for "ActiveAdmin::Config" do
       end
 
       it "should return the name if set" do
-		config.menu :parent => "Blog"
+        config.menu :parent => "Blog"
         config.parent_menu_item_name.should == "Blog"
       end
 
+      it "initialize a new parent menu item with label as Proc object" do
+        config.menu :parent => proc{ "Blog" }
+        config.parent_menu_item_name.should == "Blog"
+      end
     end
 
   end


### PR DESCRIPTION
I hadn't expirienced error mentioned at #1652. But to be sure I have added support of Proc object in menu :parent. Same as menu :label. Tests are passing now
