### PR TITLE
Replaced "%{singular_model} with %{plural_model} in tr.yml in order to fix Turkish translation.

### DIFF
--- a/lib/active_admin/locales/tr.yml
+++ b/lib/active_admin/locales/tr.yml
@@ -45,10 +45,10 @@ tr:
       link: "Bir tane oluşturun"
     batch_actions:
       button_label: "Toplu işlemler"
-      delete_confirmation: "%{singular_model} kayıtlarını silmek istediğinize emin misiniz? Dikkat bu işlemin geri dönüşü yoktur!"
+      delete_confirmation: "%{plural_model} kayıtlarını silmek istediğinize emin misiniz? Dikkat bu işlemin geri dönüşü yoktur!"
       succesfully_destroyed:
         one: "1 %{model} kaydı başarıyla silindi."
-        other: "Toplam %{count} kayıt %{singular_model} modelinden silindi"
+        other: "Toplam %{count} kayıt %{plural_model} modelinden silindi"
       selection_toggle_explanation: "Seçimi Değiştir"
       link: "Ekle"
       action_label: "%{title} Seçildi"


### PR DESCRIPTION
Replaced "%{singular_model} with %{plural_model} in tr.yml in order to fix Turkish translation.

Backtrace:

I18n::MissingInterpolationArgument in Admin/admin_users#index
missing interpolation argument in "%{singular_model} kayıtlarını silmek istediğinize emin misiniz? Dikkat bu işlemin geri dönüşü yoktur!" ({:plural_model=>"yönetici"} given)

Extracted source (around line #1):

1: insert_tag renderer_for(:index)
