### PR TITLE
Removed camel case formatting from error messages in forms

### DIFF
--- a/app/assets/stylesheets/active_admin/_forms.css.scss
+++ b/app/assets/stylesheets/active_admin/_forms.css.scss
@@ -145,7 +145,6 @@ form {
 
     /* Errors */
     p.inline-errors { 
-      text-transform:capitalize;
       color: $error-color;
       font-weight: bold;
       margin:0.3em 0 0 20%; 


### PR DESCRIPTION
Fixes #1660 - removed "text-transform: capitalize" from error messages shown in forms
