### PR TITLE
Fix error `uninitialized constant Namespace`

### DIFF
--- a/spec/unit/belongs_to_spec.rb
+++ b/spec/unit/belongs_to_spec.rb
@@ -4,7 +4,7 @@ describe ActiveAdmin::Resource::BelongsTo do
 
 
   let(:application){ ActiveAdmin::Application.new }
-  let(:namespace){ Namespace.new(application, :admin) }
+  let(:namespace){ ActiveAdmin::Namespace.new(application, :admin) }
   let(:post){ namespace.register(Post) }
   let(:belongs_to){ ActiveAdmin::Resource::BelongsTo.new(post, :user) }
 


### PR DESCRIPTION
This spec was failing on my machine because it could not find `::Namespace`. I wonder why 1) it works fine on Travis-CI, 2) it was working before.

I think that this fix makes sense anyway.
