### PR TITLE
Fix styling of Formtastic date elements

### DIFF
--- a/app/assets/stylesheets/active_admin/_forms.css.scss
+++ b/app/assets/stylesheets/active_admin/_forms.css.scss
@@ -107,7 +107,7 @@ form {
     }
 
     /* Date and Time Fields */
-    &.date, &.time, &.datetime {
+    &.date, &.time, &.datetime, &.date_select {
       fieldset ol li {
         float:left; width:auto; margin:0 0.5em 0 0; 
         label { display: none; }


### PR DESCRIPTION
Newer Formtastic apparently uses .date_select class on date field wrapper (instead of .date?) in 2.2.

From their changelog:
- renamed DateInput (:as => :date) to TimeSelectInput (:as => :date_select), aliased and deprecated DateInput

This apparently changed the wrapper class.
