### PR TITLE
Duplicate options being passed into stylesheet_link_tag in active_admin_logged_out

### DIFF
--- a/app/views/layouts/active_admin_logged_out.html.erb
+++ b/app/views/layouts/active_admin_logged_out.html.erb
@@ -6,7 +6,7 @@
   <title><%= [@page_title, render_or_call_method_or_proc_on(self, ActiveAdmin.application.site_title)].compact.join(" | ") %></title>
 
   <% ActiveAdmin.application.stylesheets.each do |style| %>
-    <%= stylesheet_link_tag style.path, style.options %>
+    <%= stylesheet_link_tag style.path, style.options.dup %>
   <% end %>
   <% ActiveAdmin.application.javascripts.each do |path| %>
     <%= javascript_include_tag path %>


### PR DESCRIPTION
This solves an issue similar to the one solved in this [pull request](https://github.com/gregbell/active_admin/pull/1631)

Issue here: https://github.com/gregbell/active_admin/issues/1705
