### PR TITLE
Remove Ruby 1.9.2 from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 script: bundle exec rake test
 rvm:
   - ree
-  - 1.9.2
   - 1.9.3
 before_install:
   - gem update --system


### PR DESCRIPTION
1.9.2 is slow and fails randomly on travis-ci. Does anyone still use 1.9.2?
