### PR TITLE
Hide if comment author overflows

### DIFF
--- a/app/assets/stylesheets/active_admin/components/_comments.css.scss
+++ b/app/assets/stylesheets/active_admin/components/_comments.css.scss
@@ -10,6 +10,7 @@
     .active_admin_comment_meta {
       width: 130px;
       float: left;
+      overflow: hidden;
       font-size: 0.9em;
       color: lighten($primary-color, 10%);
       .active_admin_comment_author {


### PR DESCRIPTION
This change hides the overflowing portion of a comment author text, which does happen with long emails. See below.

![before](http://f.cl.ly/items/3D0P1V0v2A1l2O1s0Z0y/Screen%20Shot%202012-10-17%20at%2001.34.34.png)
![after](http://f.cl.ly/items/1H1F0N1x1o352C033c2Z/Screen%20Shot%202012-10-17%20at%2001.49.06.png)
