### PR TITLE
Extracted duplicated download_format_links methods into helper

### DIFF
--- a/lib/active_admin/resource_controller/collection.rb
+++ b/lib/active_admin/resource_controller/collection.rb
@@ -126,7 +126,7 @@ module ActiveAdmin
           page = params[Kaminari.config.param_name]
 
           chain.send(page_method_name, page).per(per_page)
-	end
+        end
 
         def per_page
           return max_csv_records if request.format == 'text/csv'

--- a/lib/active_admin/view_helpers/download_format_links_helper.rb
+++ b/lib/active_admin/view_helpers/download_format_links_helper.rb
@@ -1,0 +1,50 @@
+module ActiveAdmin
+  module ViewHelpers
+    module DownloadFormatLinksHelper
+
+      module ClassMethods
+
+        # A ready only of formats to make available in index/paginated
+        # collection view.
+        # @return [Array]
+        # @see add_format for information on adding custom download link
+        # formats
+        def formats
+          @formats ||= [:csv, :xml, :json]
+          @formats.clone
+        end
+        
+        # Adds a mime type extension to the list of available formats.
+        # You must register the extension prior to adding it to the list
+        # of avilable formats. This should be used by plugins that want 
+        # to add additional formats to the download format links.
+        # @param [Symbol] extension the mime extension to add
+        # @return [Array] A copy of the updated formats array.
+        def add_format extension
+          unless formats.include?(extension)
+            if Mime::Type.lookup_by_extension(extension).nil?
+              raise ArgumentError, "The mime extension you defined: #{extension} is not registered. Please register it via Mime::Type.register before adding it to the available formats."
+            end
+          @formats << extension
+          end
+          formats
+        end
+      end
+
+      # TODO: Refactor to new HTML DSL
+      def build_download_format_links(formats = self.class.formats)
+        links = formats.collect do |format|
+          link_to format.to_s.upcase, { :format => format}.merge(request.query_parameters.except(:commit, :format))
+        end
+        div :class => "download_links" do
+          text_node [I18n.t('active_admin.download'), links].flatten.join("&nbsp;").html_safe
+        end
+      end
+
+      def self.included base
+        base.extend ClassMethods
+      end
+    end
+  end
+end
+

--- a/lib/active_admin/views/components/paginated_collection.rb
+++ b/lib/active_admin/views/components/paginated_collection.rb
@@ -77,18 +77,9 @@ module ActiveAdmin
         text_node paginate(collection, options.symbolize_keys)
       end
 
-      # TODO: Refactor to new HTML DSL
-      def build_download_format_links(formats = [:csv, :xml, :json])
-        links = formats.collect do |format|
-          link_to format.to_s.upcase, { :format => format}.merge(request.query_parameters.except(:commit, :format))
-        end
-        div :class => "download_links" do
-          text_node [I18n.t('active_admin.download'), links].flatten.join("&nbsp;").html_safe
-        end
-      end
-
       include ::ActiveAdmin::Helpers::Collection
-
+      include ::ActiveAdmin::ViewHelpers::DownloadFormatLinksHelper
+        
       # modified from will_paginate
       def page_entries_info(options = {})
         if options[:entry_name]

--- a/lib/active_admin/views/pages/index.rb
+++ b/lib/active_admin/views/pages/index.rb
@@ -55,13 +55,7 @@ module ActiveAdmin
           end
         end
 
-        # TODO: Refactor to new HTML DSL
-        def build_download_format_links(formats = [:csv, :xml, :json])
-          links = formats.collect do |format|
-            link_to format.to_s.upcase, { :format => format}.merge(request.query_parameters.except(:commit, :format))
-          end
-          text_node [I18n.t('active_admin.download'), links].flatten.join("&nbsp;").html_safe
-        end
+        include ::ActiveAdmin::ViewHelpers::DownloadFormatLinksHelper
 
         def build_table_tools
           div :class => "table_tools" do

--- a/spec/unit/view_helpers/download_format_links_helper_spec.rb
+++ b/spec/unit/view_helpers/download_format_links_helper_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe ActiveAdmin::ViewHelpers::DownloadFormatLinksHelper do
+
+  describe "class methods" do
+    before :each do
+
+      begin
+        # The mime type to be used in respond_to |format| style web-services in rails
+        Mime::Type.register "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", :xlsx
+      rescue NameError
+        puts "Mime module not defined. Skipping registration of xlsx"
+      end
+
+      class Foo
+        include ActiveAdmin::ViewHelpers::DownloadFormatLinksHelper
+      end
+    end
+
+    it "extends the class to add a formats class method that returns the default formats." do
+      Foo.formats.should == [:csv, :xml, :json]
+    end
+
+    it "does not let you alter the formats array directly" do
+      Foo.formats << :xlsx
+      Foo.formats.should == [:csv, :xml, :json]
+    end
+
+    it "allows us to add new formats" do
+      Foo.add_format :xlsx
+      Foo.formats.should == [:csv, :xml, :json, :xlsx]
+    end
+
+    it "raises an exception if you provide an unregisterd mime type extension" do
+      expect{ Foo.add_format :hoge }.to raise_error
+    end
+
+  end
+end


### PR DESCRIPTION
This serves two purposes. The first is to remove the duplicated code,
and the second is to stop using a hard coded list of default formats.
With this change, plugins can specify additional download formats so
long as the Mime type is registered.

Once this has been merged, I will release a gem that can be used to add xlsx downloads for collections.
