### PR TITLE
Document replacing `member` in the controller

### DIFF
--- a/docs/2-resource-customization.md
+++ b/docs/2-resource-customization.md
@@ -90,7 +90,7 @@ This would ensure that the Post menu item, is at the beginning of the menu.
 
 ### Conditionally Showing / Hiding Menu Items
 
-Menu items can be shown or hidden at runtime using the `:if` option. 
+Menu items can be shown or hidden at runtime using the `:if` option.
 
     ActiveAdmin.register Post do
       menu :if => proc{ current_admin_user.can_edit_posts? }
@@ -101,8 +101,8 @@ your helpers and current user session information.
 
 ## Scoping the queries
 
-If your administrators have different access levels, you may sometimes want to 
-scope what they have access to. Assuming your User model has the proper 
+If your administrators have different access levels, you may sometimes want to
+scope what they have access to. Assuming your User model has the proper
 has_many relationships, you can simply scope the listings and finders like so:
 
     ActiveAdmin.register Post do
@@ -114,8 +114,8 @@ has_many relationships, you can simply scope the listings and finders like so:
 
 That approach limits the posts an admin can access to ```current_user.posts```.
 
-If you want to do something fancier, for example override a default scope, you can 
-also use :association_method parameter with a normal method on your User model. 
+If you want to do something fancier, for example override a default scope, you can
+also use :association_method parameter with a normal method on your User model.
 The only requirement is that your method returns an instance of ActiveRecord::Relation.
 
     class Ad < ActiveRecord::Base
@@ -133,7 +133,7 @@ The only requirement is that your method returns an instance of ActiveRecord::Re
       scope_to :current_user, :association_method => :managed_ads
     end
 
-In case you just need to customize the query independently of the current user, you can 
+In case you just need to customize the query independently of the current user, you can
 override the `scoped_collection` method on the controller:
 
     ActiveAdmin.register Post do
@@ -143,3 +143,20 @@ override the `scoped_collection` method on the controller:
         end
       end
     end
+
+## Customizing resource retrieval
+
+If you need to completely replace the record retrieving code (e.g., you have a custom
+`to_param` implementation in your models), override the `resource` method on the controller:
+
+    ActiveAdmin.register Post do
+      controller do
+        def resource
+          Post.where(id: params[:id]).first!
+        end
+      end
+    end
+
+In fact, the controllers use [Inherited Resource](https://github.com/josevalim/inherited_resources),
+so you can use all the
+[customization features in Inherited Resource](https://github.com/josevalim/inherited_resources#overwriting-defaults).


### PR DESCRIPTION
I added an example for replacing `Post.find(params[:id])` on all member controller actions, because I stumbled upon that, and spent a bit of time figuring it out.

I eventually figured it out by reading the documentation for InheritedResources (once I realized that's what the controller uses).
https://github.com/josevalim/inherited_resources#overwriting-defaults

Thanks for `active_admin`! It saved me a ton of time on a project I'm working on!
