### PR TITLE
Added missing fr translations regarding batch actions labels

### DIFF
--- a/lib/active_admin/locales/fr.yml
+++ b/lib/active_admin/locales/fr.yml
@@ -51,6 +51,9 @@ fr:
         other: "%{count} %{plural_model} supprimés"
       selection_toggle_explanation: "(Inverser la sélection)"
       link: "Créer un"
+      action_label: "%{title} les éléments sélectionnés"
+      labels:
+        destroy: "Supprimer"
     comments:    
       body: "Corps"
       author: "Auteur"


### PR DESCRIPTION
French translations elements were missing regarding batch action labels causing ActiveAdmin to display "fr.active_admin.batch_actions.action_label" instead of the correct labels (fixing issue #1785).
