### PR TITLE
30b36e9 implemented incorrectly, this should resolve the issue

### DIFF
--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -77,7 +77,7 @@ module ActiveAdmin
           inputs options, &form_block
 
           # Capture the ADD JS
-          placeholder = "NEW_#{object.class.reflect_on_association(association).klass.model_name.human.upcase}_RECORD"
+          placeholder = "NEW_#{object.class.reflect_on_association(association).klass.model_name.human.upcase.split(' ').join('_')}_RECORD"
           js = with_new_form_buffer do
             inputs_for_nested_attributes  :for => [association, object.class.reflect_on_association(association).klass.new],
                                           :class => "inputs has_many_fields",


### PR DESCRIPTION
Commit 30b36e9 makes a change the effectively creates input fields with unique names. The problem is that the `placeholder` string has spaces in it. Thus, when a JS replace is called on the newly inserted field, the ID is not updated correctly. As a result, multiple input fields have the same ID. 

This commit simply splits the string by spaces and replaces them with underscores. There may be a better solution for this though.
