### PR TITLE
Update some gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ group :test do
   gem 'cucumber-rails', '1.3.0', :require => false
   gem 'capybara',       '1.1.2'
   gem 'database_cleaner'
-  gem 'shoulda-matchers', '1.3.0'
+  gem 'shoulda-matchers'
   gem 'launchy'
   gem 'jslint_on_rails',    '~> 1.1.1'
   gem 'guard-rspec'


### PR DESCRIPTION
Hey there! Happy 24pullrequests!

I saw your gems were a bit out of date, so I updated two of them. All tests pass.

I was going to upgrade `capybara` and `rspec-rails` as well, but they'd take a bit more work, and I have to hop on a plane soon. But I figured I'd share what I found:

Upgrading to rspec-rails 2.12.0 causes two things to happen:

A bunch of deprecation warnings:
- `expect { }.should_not` is deprecated.
- please use `expect { }.to_not` instead.

I would have just fixed this, but it also causes one test to break:

```
Failing Scenarios:
cucumber features/edit_page.feature:28 # Scenario: Generating a custom form
```

I didn't investigate further. As for Capybara 2.0, if/when you want to update, you'll need to do this: http://alindeman.github.com/2012/11/11/rspec-rails-and-capybara-2.0-what-you-need-to-know.html

But for now, here's these two little updates. :heart:
