### PR TITLE
[559] Show scopes if no results are found

### DIFF
--- a/features/index/index_scopes.feature
+++ b/features/index/index_scopes.feature
@@ -26,21 +26,17 @@ Feature: Index Scoping
     And I should see the scope "All" with the count 3
     And I should see 3 posts in the table
 
-  Scenario: Viewing resources with one scope and no results
+  Scenario: Viewing resources with a scope and no results
     Given 3 posts exist
     And an index configuration of:
-     """
-     ActiveAdmin.register Post do
-       scope :all, :default => true
-       filter :title
-     end
-     """
-
+      """
+      ActiveAdmin.register Post do
+        scope :all, :default => true
+        filter :title
+      end
+      """
     When I fill in "Search Title" with "Non Existing Post"
     And I press "Filter"
-    And I should not see the scope "All"
-
-    When I am on the index page for posts
     Then I should see the scope "All" selected
 
   Scenario: Viewing resources with a scope but scope_count turned off

--- a/lib/active_admin/views/components/scopes.rb
+++ b/lib/active_admin/views/components/scopes.rb
@@ -21,10 +21,8 @@ module ActiveAdmin
       end
 
       def build(scopes, options = {})
-        unless current_filter_search_empty?
-          scopes.each do |scope|
-            build_scope(scope, options) if call_method_or_proc_on(self, scope.display_if_block)
-          end
+        scopes.each do |scope|
+          build_scope(scope, options) if call_method_or_proc_on(self, scope.display_if_block)
         end
       end
 
@@ -55,10 +53,6 @@ module ActiveAdmin
         else
           active_admin_config.default_scope == scope
         end
-      end
-
-      def current_filter_search_empty?
-        params.include?(:q) && collection_is_empty?
       end
 
       # Return the count for the scope passed in.


### PR DESCRIPTION
This PR reverts #559 and is a half-fix for #995

Since we currently hide/remove scopes when a filter doesn't return results, it's much more difficult for the user to figure out "what went wrong" with their query. If they can see that all available scopes are reporting 0 records for the query, they know with a much higher degree of certainty that there truly is nothing to find. What's worse, since the scopes are currently hidden, there would be no way to know if there were results in other scopes!

This PR is tangentially related to #1532. I intend to implement "minimap" of sorts to explicitly tell the user how their result set has been refined:
![](https://raw.github.com/Daxter/5-gallon-bucket/master/Screenshot%20for%20AA%20%231532.png)
