### PR TITLE
Fix routing for Devise on root namespace

### DIFF
--- a/lib/generators/active_admin/install/install_generator.rb
+++ b/lib/generators/active_admin/install/install_generator.rb
@@ -27,7 +27,11 @@ module ActiveAdmin
       end
 
       def setup_routes
-        route "ActiveAdmin.routes(self)"
+        if ARGV.include? "--skip-users"
+          route "ActiveAdmin.routes(self)"
+        else # Ensure Active Admin routes occur after Devise routes so that Devise has higher priority
+          inject_into_file "config/routes.rb", "\n  ActiveAdmin.routes(self)", :after => /devise_for.*/
+        end
       end
 
       def create_assets


### PR DESCRIPTION
This PR fixes session logout routing by ensuring that Devise routes have higher priority than Active Admin routes. Before, I would have to manually reorder my routes file, or users would be greeted with `RecordNotFound : Couldn't find User with id=logout` when trying to log out.

If you're curious, the problem originally stemmed from the `route` function. It only ever inserts routes at the top of the file. Devise runs first, using `route` which puts it at the top, then we use the very same function to put _ours_ at the top.

If there is a real way to write tests for this, please let me know.
