### PR TITLE
Added missing batch actions translations leading to no labels (see PR #1788)

### DIFF
--- a/lib/active_admin/locales/lv.yml
+++ b/lib/active_admin/locales/lv.yml
@@ -44,6 +44,17 @@ lv:
     blank_slate:
       content: "Sadaļā '%{resource_name}' nav neviena ieraksta."
       link: "Izveidot jaunu"
+    batch_actions:
+      button_label: "Batch Actions"
+      delete_confirmation: "Are you sure you want to delete these %{plural_model}? You won't be able to undo this."
+      succesfully_destroyed:
+        one: "Successfully destroyed 1 %{model}"
+        other: "Successfully destroyed %{count} %{plural_model}"
+      selection_toggle_explanation: "(Toggle Selection)"
+      link: "Create one"
+      action_label: "%{title} Selected"
+      labels:
+        destroy: "Delete"
     comments:
       body: "Saturs"
       author: "Autors"

--- a/lib/active_admin/locales/no-NB.yml
+++ b/lib/active_admin/locales/no-NB.yml
@@ -39,6 +39,27 @@
     blank_slate:
       content: "Her er det ingen %{resource_name} enda."
       link: "Opprett en"
+    batch_actions:
+      button_label: "Batch Actions"
+      delete_confirmation: "Are you sure you want to delete these %{plural_model}? You won't be able to undo this."
+      succesfully_destroyed:
+        one: "Successfully destroyed 1 %{model}"
+        other: "Successfully destroyed %{count} %{plural_model}"
+      selection_toggle_explanation: "(Toggle Selection)"
+      link: "Create one"
+      action_label: "%{title} Selected"
+      labels:
+        destroy: "Delete"
+    comments:
+      body: "Body"
+      author: "Author"
+      title: "Comment"
+      add: "Add Comment"
+      resource: "Resource"
+      no_comments_yet: "No comments yet."
+      title_content: "Comments (%{count})"
+      errors:
+        empty_text: "Comment wasn't saved, text was empty."
     devise:
       login:
         title: "Logg inn"


### PR DESCRIPTION
This fix is following the PR #1788 as "lv" and "no-NB" i18N files were also missing some translations regarding batch actions.

NB: I only copy-pasted the missing elements for the en localization file as I don't speak both of those langages :s
