### PR TITLE
Fix fields_for_params when Boolean values #1818

### DIFF
--- a/lib/active_admin/view_helpers/fields_for.rb
+++ b/lib/active_admin/view_helpers/fields_for.rb
@@ -38,6 +38,8 @@ module ActiveAdmin
             end
           when nil
           	{ k => '' }
+          when TrueClass,FalseClass
+            { k => v }
           else
             raise "I don't know what to do with #{v.class} params: #{v.inspect}"
           end

--- a/spec/unit/view_helpers/fields_for_spec.rb
+++ b/spec/unit/view_helpers/fields_for_spec.rb
@@ -43,4 +43,8 @@ describe ActiveAdmin::ViewHelpers::FormHelper, ".fields_for" do
     fields_for_params(:filter => :id).
       should == [ { :filter => "id" } ]
   end
+
+  it "should work with booleans" do
+    fields_for_params(:booleantest => false).should == [ { :booleantest => false } ]
+  end
 end


### PR DESCRIPTION
Fixes issue #1818 by adding a case for TrueClass,FalseClass. No modification of the values is needed (I think) because the form tag helpers can handle and convert these.
