### PR TITLE
Add the license identifier to the gemspec

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -4,6 +4,7 @@ require "active_admin/version"
 
 Gem::Specification.new do |s|
   s.name          = %q{activeadmin}
+  s.license       = "MIT"
   s.version       = ActiveAdmin::VERSION
   s.platform      = Gem::Platform::RUBY
   s.homepage      = %q{http://activeadmin.info}


### PR DESCRIPTION
It makes it easier for individuals and automated systems to identify the library's LICENSE without having to guess filenames.
