### PR TITLE
Add .actions method for index as table

### DIFF
--- a/docs/3-index-pages/index-as-table.md
+++ b/docs/3-index-pages/index-as-table.md
@@ -44,18 +44,27 @@ within the context of the view for each of the objects in the collection.
 The block gets called once for each resource in the collection. The resource gets passed into
 the block as an argument.
 
-To setup links to View, Edit and Delete a resource, use the default_actions method:
+To setup links to View, Edit and Delete a resource, use the actions method:
 
     index do
       column :title
-      default_actions
+      actions
     end
 
-Alternatively, you can create a column with custom links:
+You can also append custom links to the default links:
 
     index do
       column :title
-      column "Actions" do |post|
+      actions do |post|
+        link_to "Preview", admin_preview_post_path(post)
+      end
+    end
+
+Or forego the default links entirely:
+
+    index do
+      column :title
+      actions :defaults => false do |post|
         link_to "View", admin_post_path(post)
       end
     end

--- a/features/index/index_as_table.feature
+++ b/features/index/index_as_table.feature
@@ -92,6 +92,46 @@ Feature: Index as Table
     And I should see a member link to "Edit"
     And I should not see a member link to "Delete"
 
+  Scenario: Actions with defaults and custom actions
+    Given a post with the title "Hello World" and body "From the body" exists
+    And an index configuration of:
+      """
+      ActiveAdmin.register Post do
+        actions :index, :show, :edit, :update
+
+        index do
+          column :category
+          actions do |resource|
+            link_to 'Custom Action', edit_admin_post_path(resource), :class => 'member_link'
+          end
+        end
+      end
+      """
+    Then I should see a member link to "View"
+    And I should see a member link to "Edit"
+    And I should not see a member link to "Delete"
+    And I should see a member link to "Custom Action"
+
+  Scenario: Actions without default actions
+    Given a post with the title "Hello World" and body "From the body" exists
+    And an index configuration of:
+      """
+      ActiveAdmin.register Post do
+        actions :index, :show, :edit, :update
+
+        index do
+          column :category
+          actions :defaults => false do |resource|
+            link_to 'Custom Action', edit_admin_post_path(resource), :class => 'member_link'
+          end
+        end
+      end
+      """
+    Then I should not see a member link to "View"
+    And I should not see a member link to "Edit"
+    And I should not see a member link to "Delete"
+    And I should see a member link to "Custom Action"
+
   Scenario: Associations are not sortable
     Given 1 post exists
     And an index configuration of:

--- a/lib/active_admin/views/index_as_table.rb
+++ b/lib/active_admin/views/index_as_table.rb
@@ -155,12 +155,33 @@ module ActiveAdmin
           end
         end
 
-        # Adds links to View, Edit and Delete
-        def default_actions(options = {})
+        # Add links to perform actions.
+        #
+        #   # Add default links.
+        #   actions
+        #
+        #   # Append some actions onto the end of the default actions.
+        #   actions do |admin_user|
+        #     link_to 'Grant Admin', grant_admin_admin_user_path(admin_user)
+        #   end
+        #
+        #   # Custom actions without the defaults.
+        #   actions :defaults => false do |admin_user|
+        #     link_to 'Grant Admin', grant_admin_admin_user_path(admin_user)
+        #   end
+        def actions(options = {}, &block)
           options = {
-            :name => ""
+            :name => "",
+            :defaults => true
           }.merge(options)
           column options[:name] do |resource|
+            text_node default_actions(resource) if options[:defaults]
+            text_node instance_exec(resource, &block) if block_given?
+          end
+        end
+
+        def default_actions(*args)
+          links = proc do |resource|
             links = ''.html_safe
             if controller.action_methods.include?('show')
               links << link_to(I18n.t('active_admin.view'), resource_path(resource), :class => "member_link view_link")
@@ -172,6 +193,13 @@ module ActiveAdmin
               links << link_to(I18n.t('active_admin.delete'), resource_path(resource), :method => :delete, :data => {:confirm => I18n.t('active_admin.delete_confirmation')}, :class => "member_link delete_link")
             end
             links
+          end
+
+          options = args.extract_options!
+          if options.present? || args.empty?
+            actions options
+          else
+            links.call(args.first)
           end
         end
 


### PR DESCRIPTION
I've always wanted to be able to easily extend the default actions. This adds an `actions` method when using index as table.

Some examples:

``` ruby
# Works just like before
default_actions

# Same as above
actions

# Append some actions onto the end of the default actions
actions do |resource|
  auto_link resource
end

# Custom actions without the defaults.
actions :defaults => false do |resource|
  auto_link resource
end
```

Would love some feedback/suggestions.
