### PR TITLE
Adding a final chance to create custom filters in production

### DIFF
--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -135,6 +135,9 @@ module ActiveAdmin
         active_admin_input_class_name(as).constantize
       elsif Formtastic::Inputs.const_defined?(input_class_name)
         standard_input_class_name(as).constantize
+      elsif Rails.application.config.cache_classes == true and input_class_name.include?("Filter")
+        # in production this is needed or custom filters like autocomplete filters will crash
+        input_class_by_trying(as)
       else
         raise Formtastic::UnknownInputError
       end


### PR DESCRIPTION
When classes are cached (usually in production), custom filters working in development
were not being found. I try to load them as if classes were not cached.
