### PR TITLE
Use normal variable name over _ when block variable is used

### DIFF
--- a/lib/active_admin/views/components/table_for.rb
+++ b/lib/active_admin/views/components/table_for.rb
@@ -79,7 +79,7 @@ module ActiveAdmin
       def build_table_body
         @tbody = tbody do
           # Build enough rows for our collection
-          @collection.each{|_| tr(:class => cycle('odd', 'even'), :id => dom_id(_)) }
+          @collection.each{|elem| tr(:class => cycle('odd', 'even'), :id => dom_id(elem)) }
         end
       end
 


### PR DESCRIPTION
_ is generally used and intented for ignoring options. It allows for
having multiple _ parameters for example. The behavior of this is also
not consistent across at least Ruby 1.8 and 1.9, where on 1.8 it is the
value nil, on 1.9 it works somewhat like a regular name.

To avoid all this confusion, this commit changes it to use a regular
name. This also fixes a bug running in Rubinius 1.9 mode (this behavior needs to be fixed there as well).
