### PR TITLE
Fix call to action (dashboards -> dashboard)

### DIFF
--- a/lib/active_admin/locales/bg.yml
+++ b/lib/active_admin/locales/bg.yml
@@ -3,7 +3,7 @@ bg:
     dashboard: Табло
     dashboard_welcome:
       welcome: "Добре дошли в Active Admin. Това е таблото по подразбиране."
-      call_to_action: "За да добавите секции, проверете 'app/admin/dashboards.rb'"
+      call_to_action: "За да добавите секции, проверете 'app/admin/dashboard.rb'"
     view: "Преглед"
     edit: "Редакция"
     delete: "Изтриване"

--- a/lib/active_admin/locales/ca.yml
+++ b/lib/active_admin/locales/ca.yml
@@ -4,7 +4,7 @@ ca:
     dashboard: Tauler
     dashboard_welcome:
       welcome: "Benvingut a Active Admin. Aquest és el tauler per defecte."
-      call_to_action: "Mira l'arxiu 'app/admin/dashboards.rb' per afegir seccions al tauler"
+      call_to_action: "Mira l'arxiu 'app/admin/dashboard.rb' per afegir seccions al tauler"
     view: "Mostra"
     edit: "Edita"
     delete: "Elimina"

--- a/lib/active_admin/locales/cs.yml
+++ b/lib/active_admin/locales/cs.yml
@@ -3,7 +3,7 @@ cs:
     dashboard: Úvod
     dashboard_welcome:
       welcome: "Vítejte v Active Admin. Toto je nástěnka."
-      call_to_action: "Pro přidání sekcí nástěnky se podívejte do 'app/admin/dashboards.rb'"
+      call_to_action: "Pro přidání sekcí nástěnky se podívejte do 'app/admin/dashboard.rb'"
     view: "Zobrazit"
     edit: "Upravit"
     delete: "Smazat"

--- a/lib/active_admin/locales/da.yml
+++ b/lib/active_admin/locales/da.yml
@@ -3,7 +3,7 @@ da:
     dashboard_welcome:
       dashboard: "Kontrolpanel"
       welcome: "Velkommen til Active Admin. Dette er standardoversigtssiden."
-      call_to_action: "Rediger 'app/admin/dashboards.rb' for at tilføje nye elementer til oversigtssiden."
+      call_to_action: "Rediger 'app/admin/dashboard.rb' for at tilføje nye elementer til oversigtssiden."
     view: "Vis"
     edit: "Rediger"
     delete: "Slet"

--- a/lib/active_admin/locales/de.yml
+++ b/lib/active_admin/locales/de.yml
@@ -3,7 +3,7 @@ de:
     dashboard: Übersicht
     dashboard_welcome:
       welcome: "Willkommen in Active Admin. Dies ist die Standard-Übersichtsseite."
-      call_to_action: "Siehe 'app/admin/dashboards.rb', um Übersichts-Bereiche hinzuzufügen."
+      call_to_action: "Siehe 'app/admin/dashboard.rb', um Übersichts-Bereiche hinzuzufügen."
     view: "Anzeigen"
     edit: "Bearbeiten"
     delete: "Löschen"

--- a/lib/active_admin/locales/en.yml
+++ b/lib/active_admin/locales/en.yml
@@ -3,7 +3,7 @@ en:
     dashboard: Dashboard
     dashboard_welcome:
       welcome: "Welcome to Active Admin. This is the default dashboard page."
-      call_to_action: "To add dashboard sections, checkout 'app/admin/dashboards.rb'"
+      call_to_action: "To add dashboard sections, checkout 'app/admin/dashboard.rb'"
     view: "View"
     edit: "Edit"
     delete: "Delete"

--- a/lib/active_admin/locales/es.yml
+++ b/lib/active_admin/locales/es.yml
@@ -3,7 +3,7 @@ es:
     dashboard: Inicio
     dashboard_welcome:
       welcome: "Bienvenido a Active Admin. Esta es la página de inicio predeterminada."
-      call_to_action: "Para agregar secciones edite 'app/admin/dashboards.rb'"
+      call_to_action: "Para agregar secciones edite 'app/admin/dashboard.rb'"
     view: "Ver"
     edit: "Editar"
     delete: "Eliminar"

--- a/lib/active_admin/locales/fr.yml
+++ b/lib/active_admin/locales/fr.yml
@@ -3,7 +3,7 @@ fr:
     dashboard: "Tableau de Bord"
     dashboard_welcome:
       welcome: "Bienvenue dans Active Admin. Ceci est la page par défaut."
-      call_to_action: "Pour ajouter des sections au tableau de bord, consultez 'app/admin/dashboards.rb'"
+      call_to_action: "Pour ajouter des sections au tableau de bord, consultez 'app/admin/dashboard.rb'"
     view: "Voir"
     edit: "Modifier"
     delete: "Supprimer"

--- a/lib/active_admin/locales/he.yml
+++ b/lib/active_admin/locales/he.yml
@@ -3,7 +3,7 @@ he:
     dashboard: פנל ניהול
     dashboard_welcome:
       welcome: "ברוכים הבאים לאקטיב אדמין. זהו פנל הניהול"
-      call_to_action: "כדי להוסיף אזורים בפנל הניהול, אנא בדוק את,  'app/admin/dashboards.rb'"
+      call_to_action: "כדי להוסיף אזורים בפנל הניהול, אנא בדוק את,  'app/admin/dashboard.rb'"
     view: "צפייה"
     edit: "עריכה"
     delete: "מחיקה"

--- a/lib/active_admin/locales/hr.yml
+++ b/lib/active_admin/locales/hr.yml
@@ -3,7 +3,7 @@ hr:
     dashboard: "Upravljačka ploča"
     dashboard_welcome:
       welcome: "Dobrodošli u Active Admin. Ovo je početna upravljačka ploča."
-      call_to_action: "Da bi ste dodali nove odjeljke na upravljačku ploču, pogledajte 'app/admin/dashboards.rb'"
+      call_to_action: "Da bi ste dodali nove odjeljke na upravljačku ploču, pogledajte 'app/admin/dashboard.rb'"
     view: "Pregledaj"
     edit: "Uredi"
     delete: "Obriši"

--- a/lib/active_admin/locales/hu.yml
+++ b/lib/active_admin/locales/hu.yml
@@ -3,7 +3,7 @@ hu:
     dashboard: Vezérlőpult
     dashboard_welcome:
       welcome: "Üdvözöljük az Active Admin felületén. Ez a vezérlőpult kezdőlapja"
-      call_to_action: "Elemek hozzáadásához nézze meg a 'app/admin/dashboards.rb' fájlt"
+      call_to_action: "Elemek hozzáadásához nézze meg a 'app/admin/dashboard.rb' fájlt"
     view: "Megtekintés"
     edit: "Szerkesztés"
     delete: "Törlés"

--- a/lib/active_admin/locales/it.yml
+++ b/lib/active_admin/locales/it.yml
@@ -3,7 +3,7 @@ it:
     dashboard: Dashboard
     dashboard_welcome:
       welcome: "Benvenuti in Active Admin. Questa è la pagina dashboard di default."
-      call_to_action: "Per aggiungere sezioni alla dashboard controlla il file 'app/admin/dashboards.rb'"
+      call_to_action: "Per aggiungere sezioni alla dashboard controlla il file 'app/admin/dashboard.rb'"
     view: "Mostra"
     edit: "Modifica"
     delete: "Rimuovi"

--- a/lib/active_admin/locales/ja.yml
+++ b/lib/active_admin/locales/ja.yml
@@ -3,7 +3,7 @@ ja:
     dashboard: "ダッシュボード"
     dashboard_welcome:
       welcome: "Active Admin へようこそ。ダッシュボードの初期ページを表示しています。"
-      call_to_action: "ダッシュボードに項目を追加するために 'app/admin/dashboards.rb' を編集してください。"
+      call_to_action: "ダッシュボードに項目を追加するために 'app/admin/dashboard.rb' を編集してください。"
     view: "閲覧"
     edit: "編集"
     delete: "削除"

--- a/lib/active_admin/locales/ko.yml
+++ b/lib/active_admin/locales/ko.yml
@@ -3,7 +3,7 @@ ko:
     dashboard: "대시보드"
     dashboard_welcome:
       welcome: "Active Admin 에 오신 것을 환영합니다. 이것은 디폴트 대시보드 페이지 입니다."
-      call_to_action: "대시보드에 섹션을 추가하시려면 'app/admin/dashboards.rb' 소스를 확인해 주세요."
+      call_to_action: "대시보드에 섹션을 추가하시려면 'app/admin/dashboard.rb' 소스를 확인해 주세요."
     view: "보기"
     edit: "수정"
     delete: "삭제"

--- a/lib/active_admin/locales/lt.yml
+++ b/lib/active_admin/locales/lt.yml
@@ -3,7 +3,7 @@ lt:
     dashboard: Valdymo skydelis
     dashboard_welcome:
       welcome: "Sveiki atvykę į Active Admin. Tai yra numatytasis valdymo skydelis."
-      call_to_action: 'Norėdami pridėti skydelyje skyrius, žiūrėkite app/admin/dashboards.rb'
+      call_to_action: 'Norėdami pridėti skydelyje skyrius, žiūrėkite app/admin/dashboard.rb'
     view: 'Žiūrėti'
     edit: 'Redaguoti'
     delete: 'Šalinti'

--- a/lib/active_admin/locales/lv.yml
+++ b/lib/active_admin/locales/lv.yml
@@ -3,7 +3,7 @@ lv:
     dashboard: Panelis
     dashboard_welcome:
       welcome: "Laipni lūgti Active Admin."
-      call_to_action: "Izmantojiet 'app/admin/dashboards.rb', lai pievienotu sadaļas panelim."
+      call_to_action: "Izmantojiet 'app/admin/dashboard.rb', lai pievienotu sadaļas panelim."
     view: "Apskatīt"
     edit: "Labot"
     delete: "Dzēst"

--- a/lib/active_admin/locales/nl.yml
+++ b/lib/active_admin/locales/nl.yml
@@ -3,7 +3,7 @@ nl:
     dashboard: Dashboard
     dashboard_welcome:
       welcome: "Welkom bij Active Admin. Dit is de standaard dashboard pagina"
-      call_to_action: "Pas je eigen dashboard aan in het bestand 'app/admin/dashboards.rb'"
+      call_to_action: "Pas je eigen dashboard aan in het bestand 'app/admin/dashboard.rb'"
     view: "Bekijk"
     edit: "Wijzig"
     delete: "Verwijder"

--- a/lib/active_admin/locales/no-NB.yml
+++ b/lib/active_admin/locales/no-NB.yml
@@ -3,7 +3,7 @@
     dashboard: Oversikt
     dashboard_welcome:
       welcome: "Velkommen til Active Admin. Dette er standardoversiktssiden."
-      call_to_action: "Rediger 'app/admin/dashboards.rb' for at legge til elementer i oversikten."
+      call_to_action: "Rediger 'app/admin/dashboard.rb' for at legge til elementer i oversikten."
     view: "Vis"
     edit: "Rediger"
     delete: "Slett"

--- a/lib/active_admin/locales/pl.yml
+++ b/lib/active_admin/locales/pl.yml
@@ -3,7 +3,7 @@ pl:
     dashboard: Pulpit
     dashboard_welcome:
       welcome: "Witaj w Active Adminie. To jest domyślny pulpit."
-      call_to_action: "Aby dodać sekcje do pulpitu, sprawdź 'app/admin/dashboards.rb'"
+      call_to_action: "Aby dodać sekcje do pulpitu, sprawdź 'app/admin/dashboard.rb'"
     view: "Podgląd"
     edit: "Edytuj"
     delete: "Usuń"

--- a/lib/active_admin/locales/pt-BR.yml
+++ b/lib/active_admin/locales/pt-BR.yml
@@ -3,7 +3,7 @@
     dashboard: "Painel Administrativo"
     dashboard_welcome:
       welcome: "Bem vindo ao Active Admin. Esta é a página de painéis padrão."
-      call_to_action: "Para adicionar seções ao painel, verifique 'app/admin/dashboards.rb'"
+      call_to_action: "Para adicionar seções ao painel, verifique 'app/admin/dashboard.rb'"
     view: "Visualizar"
     edit: "Editar"
     delete: "Remover"

--- a/lib/active_admin/locales/ro.yml
+++ b/lib/active_admin/locales/ro.yml
@@ -3,7 +3,7 @@ ro:
     dashboard: "Pagina Principala"
     dashboard_welcome:
       welcome: "Bine ati venit pe Active Admin. Aceasta este pagina principala."
-      call_to_action: "Pentru a adauga sectiuni, vedeti 'app/admin/dashboards.rb'"
+      call_to_action: "Pentru a adauga sectiuni, vedeti 'app/admin/dashboard.rb'"
     view: "Vizualizati"
     edit: "Modificati"
     delete: "Stergeti"

--- a/lib/active_admin/locales/ru.yml
+++ b/lib/active_admin/locales/ru.yml
@@ -3,7 +3,7 @@ ru:
     dashboard: Dashboard
     dashboard_welcome:
       welcome: "Добро пожаловать в Active Admin. Это стандартная страница управления сайтом."
-      call_to_action: "Чтобы добавить сюда что-нибудь загляните в 'app/admin/dashboards.rb'"
+      call_to_action: "Чтобы добавить сюда что-нибудь загляните в 'app/admin/dashboard.rb'"
     view: "Открыть"
     edit: "Изменить"
     delete: "Удалить"

--- a/lib/active_admin/locales/sv-SE.yml
+++ b/lib/active_admin/locales/sv-SE.yml
@@ -3,7 +3,7 @@
     dashboard: Skrivbord
     dashboard_welcome:
       welcome: "Välkommen till Active Admin. Detta är ditt standardskrivbord."
-      call_to_action: "För att lägga till sektioner, gör en checkout på 'app/admin/dashboards.rb'"
+      call_to_action: "För att lägga till sektioner, gör en checkout på 'app/admin/dashboard.rb'"
     view: "Visa"
     edit: "Editera"
     delete: "Ta bort"

--- a/lib/active_admin/locales/tr.yml
+++ b/lib/active_admin/locales/tr.yml
@@ -3,7 +3,7 @@ tr:
     dashboard: "Kontrol Paneli"
     dashboard_welcome:
       welcome: "Active Admin'e Hoşgeldiniz. Burası öntanımlı Kontrol Paneli sayfasıdır."
-      call_to_action: "Kontrol Paneline bölümler eklemek için 'app/admin/dashboards.rb' dosyasına bakabilirsin."
+      call_to_action: "Kontrol Paneline bölümler eklemek için 'app/admin/dashboard.rb' dosyasına bakabilirsin."
     view: "Görüntüle"
     edit: "Değiştir"
     delete: "Sil"

--- a/lib/active_admin/locales/vi.yml
+++ b/lib/active_admin/locales/vi.yml
@@ -3,7 +3,7 @@ vi:
     dashboard: Dashboard
     dashboard_welcome:
       welcome: "Chào mừng bạn đến với Active Admin. Đây là trang Dashboard mặc định."
-      call_to_action: "Để thêm phần phần cho trang Dashboar hãy chỉnh sửa 'app/admin/dashboards.rb'"
+      call_to_action: "Để thêm phần phần cho trang Dashboar hãy chỉnh sửa 'app/admin/dashboard.rb'"
     view: "Xem"
     edit: "Chỉnh sửa"
     delete: "Xóa"

--- a/lib/active_admin/locales/zh-CN.yml
+++ b/lib/active_admin/locales/zh-CN.yml
@@ -3,7 +3,7 @@
     dashboard: "控制面板"
     dashboard_welcome:
       welcome: "欢迎使用Active Admin. 这是默认的控制面板页."
-      call_to_action: "若要添加新的面板内容, 请修改 'app/admin/dashboards.rb'"
+      call_to_action: "若要添加新的面板内容, 请修改 'app/admin/dashboard.rb'"
     view: "查看"
     edit: "编辑"
     delete: "删除"

--- a/lib/active_admin/locales/zh-TW.yml
+++ b/lib/active_admin/locales/zh-TW.yml
@@ -3,7 +3,7 @@
     dashboard: 儀表板
     dashboard_welcome:
       welcome: "歡迎來到 Active Admin 這是預設的儀表板頁面。"
-      call_to_action: "要新增儀表板內容，請查看 'app/admin/dashboards.rb'"
+      call_to_action: "要新增儀表板內容，請查看 'app/admin/dashboard.rb'"
     view: "檢視"
     edit: "編輯"
     delete: "刪除"


### PR DESCRIPTION
The file app/admin/dashboards.rb doesn't exist after running the generator on a new install of activeadmin.  It does, however, create a file named app/admin/dashboard.rb.  I've updated the I18n files to remove the trailing s.
