### PR TITLE
[469 & 1375] JS cleanup, dynamic datepickers, and slim filter queries

### DIFF
--- a/app/assets/javascripts/active_admin/pages/application.js.coffee
+++ b/app/assets/javascripts/active_admin/pages/application.js.coffee
@@ -1,13 +1,16 @@
-#
-# Active Admin JS
-#
-
-
+# Initializers
 $ ->
-  # Date picker
-  $(".datepicker").datepicker dateFormat: "yy-mm-dd"
-  $(".clear_filters_btn").click ->
-    window.location.search = ""
-    false
+  # jQuery datepickers (also evaluates dynamically added HTML)
+  $(document).on 'focus', '.datepicker:not(.hasDatepicker)', ->
+    $(@).datepicker dateFormat: 'yy-mm-dd'
 
-  $(".dropdown_button").popover()
+  # Clear Filters button
+  $('.clear_filters_btn').click ->
+    window.location.search = ''
+
+  # Batch Actions dropdown
+  $('.dropdown_button').popover()
+
+  # Filter form: don't send any inputs that are empty
+  $('#q_search').submit ->
+    $(@).find(':input[value=""]').attr 'disabled', 'disabled'


### PR DESCRIPTION
- evaluate dynamically added datepickers (has_many form) (thanks @saepia)
  - related issues: #469, #1593, #1651, #1813, #1862 => #1865
- Filter form: don't pollute the URL bar with empty input values
  - related issues: #1186, #1375, #1905
- Clear Filters button: remove return value (it's never reached)

Note that ideally these initializers would be moved into our own `app/assets/javascripts/active_admin.js.coffee` file, that way it's easier to override. But for now, let's at least have the right lines of javascript imposed on our applications.
