### PR TITLE
Adds localization support to re-named resources

### DIFF
--- a/lib/active_admin/resource/naming.rb
+++ b/lib/active_admin/resource/naming.rb
@@ -18,7 +18,7 @@ module ActiveAdmin
       # Returns the name to call this resource such as "Bank Account"
       def resource_label
         if @options[:as]
-          @options[:as]
+          I18n.t resource_name.i18n_key, :scope => [:activerecord, :models], :default => @options[:as], :count => 1
         else
            resource_name.human(:default => resource_name.gsub('::', ' ').titleize)
          end
@@ -27,7 +27,7 @@ module ActiveAdmin
       # Returns the plural version of this resource such as "Bank Accounts"
       def plural_resource_label
         if @options[:as]
-          @options[:as].pluralize
+          I18n.t resource_name.i18n_key, :scope => [:activerecord, :models], :default => @options[:as].pluralize, :count => 1.1
         else
           resource_name.human(:count => 1.1, :default => resource_label.pluralize.titleize)
         end

--- a/spec/unit/resource/naming_spec.rb
+++ b/spec/unit/resource/naming_spec.rb
@@ -74,6 +74,28 @@ module ActiveAdmin
           end
         end
 
+        context "when the :as option is given" do
+          describe "singular label" do
+            it "should return the translated custom name" do
+              as_option = 'My Category'
+              custom_config = config(:as => as_option)
+
+              I18n.should_receive(:t).with(custom_config.resource_name.i18n_key, :scope => [ :activerecord, :models ], :default => as_option, :count => 1).and_return("Translated category")
+              config(:as => as_option).resource_label.should == "Translated category"
+            end
+          end
+
+          describe "plural label" do
+            it "should return the translated custom pluralized name if available" do
+              as_option = 'My Category'
+              custom_config = config(:as => as_option)
+
+              I18n.should_receive(:t).with(custom_config.resource_name.i18n_key, :scope => [ :activerecord, :models ], :default => as_option.pluralize, :count => 1.1).and_return("Translated categories")
+              config(:as => as_option).plural_resource_label.should == "Translated categories"
+            end
+          end
+        end
+
       end
     end
 


### PR DESCRIPTION
Fixes an issue I opened a few minutes before ( #1884 )

I made a new localization scope; I'm not sure if this is appropriate or not, but it works.
