### PR TITLE
Removed body.active_admin encapsulation for global-reset.

### DIFF
--- a/app/assets/stylesheets/active_admin/_base.css.scss
+++ b/app/assets/stylesheets/active_admin/_base.css.scss
@@ -1,8 +1,6 @@
 /* Active Admin CSS */
 // Reset Away!
-body.active_admin {
-  @include global-reset;
-}
+@include global-reset;
 
 // Partials
 body.active_admin {


### PR DESCRIPTION
Moves the active-admin global reset out of the body.active_admin encapsulation to make the reset more general and therefore not override styles defined by various third-party libraries (e.g. ckeditor). 

This is a potential fix for #1852.  
