### PR TITLE
Using sass ie-hex-str for colors in IE filters

### DIFF
--- a/app/assets/stylesheets/active_admin/mixins/_gradients.css.scss
+++ b/app/assets/stylesheets/active_admin/mixins/_gradients.css.scss
@@ -6,9 +6,9 @@ $secondary-gradient-stop: #dfe1e2 !default;
   background: -webkit-gradient(linear, left top, left bottom, from($start), to($end)); 
   background: -moz-linear-gradient(-90deg, $start, $end); 
   // IE 6 & 7
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#{$start}', endColorstr='#{$end}');
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#{ie-hex-str($start)}', endColorstr='#{ie-hex-str($end)}');
   // IE 8
-  -ms-filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#{$start}', endColorstr='#{$end}');
+  -ms-filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#{ie-hex-str($start)}', endColorstr='#{ie-hex-str($end)}');
 }
 
 @mixin primary-gradient { 


### PR DESCRIPTION
This fixes blue buttons (#1252) issue in IE, tested in IE9.

I've used SASS' [ie_hex_str](http://sass-lang.com/docs/yardoc/Sass/Script/Functions.html#ie_hex_str-instance_method) to expand color values.
