### PR TITLE
Make sure assets are precompiled on Heroku

### DIFF
--- a/lib/active_admin/engine.rb
+++ b/lib/active_admin/engine.rb
@@ -1,7 +1,7 @@
 module ActiveAdmin
   class Engine < Rails::Engine
     if Rails.version > "3.1"
-      initializer "ActiveAdmin precompile hook" do |app|
+      initializer "ActiveAdmin precompile hook", :group => :all do |app|
         app.config.assets.precompile += %w(active_admin.js active_admin.css active_admin/print.css)
       end
     end


### PR DESCRIPTION
Heroku recommends that `config.assets.initialize_on_precompile = false`,
which means that this initializer will not be invoked by
`rake assets:precompile`, which forces developers deploying to Heroku
to duplicate this initializer in their apps' configs.
