### PR TITLE
Inherit from ActiveAdmin::ApplicationController, instead of Main App ApplicationController

### DIFF
--- a/lib/active_admin/base_controller.rb
+++ b/lib/active_admin/base_controller.rb
@@ -2,9 +2,10 @@ require 'inherited_resources'
 require 'active_admin/base_controller/menu'
 
 module ActiveAdmin
-  # BaseController for ActiveAdmin. 
+  # BaseController for ActiveAdmin.
   # It implements ActiveAdmin controllers core features.
-  class BaseController < ::InheritedResources::Base
+  class BaseController < ::Admin::ApplicationController
+    inherit_resources
     helper ::ActiveAdmin::ViewHelpers
 
     layout :determine_active_admin_layout

--- a/lib/active_admin/base_controller/menu.rb
+++ b/lib/active_admin/base_controller/menu.rb
@@ -1,5 +1,7 @@
 module ActiveAdmin
-  class BaseController < ::InheritedResources::Base
+  class BaseController < ::Admin::ApplicationController
+    inherit_resources
+
     module Menu
       extend ActiveSupport::Concern
 

--- a/lib/generators/active_admin/install/install_generator.rb
+++ b/lib/generators/active_admin/install/install_generator.rb
@@ -17,6 +17,11 @@ module ActiveAdmin
         template 'active_admin.rb.erb', 'config/initializers/active_admin.rb'
       end
 
+      def setup_controllers
+        empty_directory "app/controllers/admin"
+        template 'application_controller.rb', 'app/controllers/admin/application_controller.rb'
+      end
+
       def setup_directory
         empty_directory "app/admin"
         template 'dashboard.rb', 'app/admin/dashboard.rb'

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -51,6 +51,8 @@ inject_into_file "config/environment.rb", "\n$LOAD_PATH.unshift('#{File.expand_p
 # Add some translations
 append_file "config/locales/en.yml", File.read(File.expand_path('../templates/en.yml', __FILE__))
 
+generate :'active_admin:install'
+
 # Add predefined admin resources
 directory File.expand_path('../templates/admin', __FILE__), "app/admin"
 
@@ -66,8 +68,6 @@ route <<-EOS
     match '/admin/logout' => 'active_admin/devise/sessions#destroy', :as => :logout
   end
 EOS
-
-generate :'active_admin:install'
 
 # Setup a root path for devise
 route "root :to => 'admin/dashboard#index'"


### PR DESCRIPTION
This allows users to use active_admin without worrying about what's in their existing application_controller.rb. This allows the front end and the back end to remain segregated. This also solves a problem with cancan interfering with admin resources if you don't want it to.

This can also be overridden in the main app by creating an controllers/acitve_admin/application_controller.rb.
