### PR TITLE
Inherit from Admin::ApplicationController, instead of Main App ApplicationController

### DIFF
--- a/lib/active_admin/base_controller.rb
+++ b/lib/active_admin/base_controller.rb
@@ -6,7 +6,7 @@ require 'active_admin/base_controller/menu'
 module ActiveAdmin
   # BaseController for ActiveAdmin.
   # It implements ActiveAdmin controllers core features.
-  class BaseController < ::Admin::ApplicationController
+  class BaseController < ::ActiveAdmin::ApplicationController
     inherit_resources
     helper ::ActiveAdmin::ViewHelpers
 

--- a/lib/active_admin/base_controller/authorization.rb
+++ b/lib/active_admin/base_controller/authorization.rb
@@ -18,8 +18,9 @@ module ActiveAdmin
   end
 
 
-  class BaseController < ::Admin::ApplicationController
+  class BaseController < ::ActiveAdmin::ApplicationController
     inherit_resources
+
     module Authorization
       include MethodOrProcHelper
       extend ActiveSupport::Concern

--- a/lib/active_admin/base_controller/menu.rb
+++ b/lib/active_admin/base_controller/menu.rb
@@ -1,5 +1,5 @@
 module ActiveAdmin
-  class BaseController < ::Admin::ApplicationController
+  class BaseController < ::ActiveAdmin::ApplicationController
     inherit_resources
 
     module Menu

--- a/lib/generators/active_admin/install/install_generator.rb
+++ b/lib/generators/active_admin/install/install_generator.rb
@@ -18,8 +18,8 @@ module ActiveAdmin
       end
 
       def setup_controllers
-        empty_directory "app/controllers/admin"
-        template 'application_controller.rb', 'app/controllers/admin/application_controller.rb'
+        empty_directory "app/controllers/active_admin"
+        template 'application_controller.rb', 'app/controllers/active_admin/application_controller.rb'
       end
 
       def setup_directory

--- a/lib/generators/active_admin/install/templates/application_controller.rb
+++ b/lib/generators/active_admin/install/templates/application_controller.rb
@@ -1,4 +1,4 @@
-module Admin
+module ActiveAdmin
   class ApplicationController < ActionController::Base
     protect_from_forgery
   end

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -8,20 +8,6 @@ gsub_file 'config/database.yml', /^test:.*\n/, "test: &test\n"
 gsub_file 'config/database.yml', /\z/, "\ncucumber:\n  <<: *test\n  database: db/cucumber.sqlite3"
 gsub_file 'config/database.yml', /\z/, "\ncucumber_with_reloading:\n  <<: *test\n  database: db/cucumber.sqlite3"
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
-
-# we need this routing path, named "logout_path", for testing
-route %q{
-  devise_scope :user do
-    match '/admin/logout' => 'active_admin/devise/sessions#destroy', :as => :logout
-  end
-}
-
-generate :'active_admin:install'
-
-# Setup a root path for devise
-route "root :to => 'admin/dashboard#index'"
-
 generate :model, "post title:string body:text published_at:datetime author_id:integer category_id:integer starred:boolean"
 inject_into_file 'app/models/post.rb', %q{
   belongs_to :category
@@ -64,6 +50,20 @@ if Rails::VERSION::MAJOR == 3 && Rails::VERSION::MINOR == 1 #Rails 3.1 Gotcha
   gsub_file 'app/models/tag.rb', /self\.primary_key.*$/, "define_attr_method :primary_key, :id"
 end
 
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+
+# we need this routing path, named "logout_path", for testing
+route %q{
+  devise_scope :user do
+    match '/admin/logout' => 'active_admin/devise/sessions#destroy', :as => :logout
+  end
+}
+
+# Setup a root path for devise
+route "root :to => 'admin/dashboard#index'"
+
+generate :'active_admin:install'
+
 # Configure default_url_options in test environment
 inject_into_file "config/environments/test.rb", "  config.action_mailer.default_url_options = { :host => 'example.com' }\n", :after => "config.cache_classes = true\n"
 
@@ -75,6 +75,10 @@ append_file "config/locales/en.yml", File.read(File.expand_path('../templates/en
 
 # Add predefined admin resources
 directory File.expand_path('../templates/admin', __FILE__), "app/admin"
+
+run "rm Gemfile"
+run "rm -r test"
+run "rm -r spec"
 
 rake "db:migrate"
 rake "db:test:prepare"


### PR DESCRIPTION
Continuation from the original pull request - https://github.com/gregbell/active_admin/pull/1934

Tests should now be passing, BaseController now inherits from Admin::ApplicationController, and admin/application_controller.rb added to install generator.
