### PR TITLE
Refactor breadcrumb helper

### DIFF
--- a/lib/active_admin/view_helpers/breadcrumb_helper.rb
+++ b/lib/active_admin/view_helpers/breadcrumb_helper.rb
@@ -3,28 +3,22 @@ module ActiveAdmin
     module BreadcrumbHelper
 
       # Returns an array of links to use in a breadcrumb
-      def breadcrumb_links(path = nil)
-        path ||= request.fullpath
-        parts = path.gsub(/^\//, '').split('/')
-        parts.pop unless %w{ create update }.include?(params[:action])
-        crumbs = []
-        parts.each_with_index do |part, index|
-          name = nil
-          if part =~ /^\d|^[a-f0-9]{24}$/ && (parent = parts[index - 1])
-            begin
-              parent_class = parent.singularize.camelcase.constantize
-              obj = parent_class.find(part[/^[a-f0-9]{24}$/] ? part : part.to_i)
-              name = display_name(obj)
-            rescue
-              # ignored
-            end
+      def breadcrumb_links(path = request.path)
+        parts = path[1..-1].split('/')                        # remove leading "/" and split up URL path
+        parts.pop unless params[:action] =~ /^create|update$/ # remove last if not create/update
+
+        parts.each_with_index.map do |part, index|
+          # If an object (users/23), look it up via ActiveRecord and capture its name.
+          # If name is nil, look up the model translation, using `titlecase` as the backup.
+          if part =~ /^\d|^[a-f0-9]{24}$/ && parent = parts[index-1]
+            klass = parent.singularize.camelcase.constantize rescue nil
+            obj   = klass.find_by_id(part) if klass
+            name  = display_name(obj)      if obj
           end
+          name ||= I18n.t "activerecord.models.#{part.singularize}", :count => 1.1, :default => part.titlecase
 
-          name ||= I18n.t("activerecord.models.#{part.singularize}", :count => 1.1, :default => part.titlecase)
-
-          crumbs << link_to( name, "/" + parts[0..index].join('/'))
+          link_to name, '/' + parts[0..index].join('/')
         end
-        crumbs
       end
 
     end

--- a/spec/unit/breadcrumbs_spec.rb
+++ b/spec/unit/breadcrumbs_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper' 
+require 'spec_helper'
 
 describe "Breadcrumbs" do
 
@@ -73,7 +73,7 @@ describe "Breadcrumbs" do
 
       context "when Post.find(1) does exist" do
         before do
-          Post.stub!(:find).and_return{ mock(:display_name => "Hello World") }
+          Post.stub!(:find_by_id).and_return{ mock(:display_name => "Hello World") }
         end
         it "should have a link to /admin/posts/1 using display name" do
           trail[2][:name].should == "Hello World"
@@ -106,7 +106,7 @@ describe "Breadcrumbs" do
 
       context "when Post.find(4e24d6249ccf967313000000) does exist" do
         before do
-          Post.stub!(:find).with('4e24d6249ccf967313000000').and_return{ mock(:display_name => "Hello World") }
+          Post.stub!(:find_by_id).with('4e24d6249ccf967313000000').and_return{ mock(:display_name => "Hello World") }
         end
         it "should have a link to /admin/posts/4e24d6249ccf967313000000 using display name" do
           trail[2][:name].should == "Hello World"


### PR DESCRIPTION
- removed unnecessary begin/rescue/end block; used nil-returning method alternatives
- ActiveRecord#find accepts a string (even when searching for a numeric ID)
- use `path` instead of `fullpath` to get rid of query parameters (we already leave them out)
