### PR TITLE
coffeescript constructors should not call return

### DIFF
--- a/app/assets/javascripts/active_admin/components/jquery.aa.dropdown-menu.js.coffee
+++ b/app/assets/javascripts/active_admin/components/jquery.aa.dropdown-menu.js.coffee
@@ -20,8 +20,6 @@ window.AA.DropdownMenu = class AA.DropdownMenu
     @_buildMenuList()
     @_bind()
 
-    return @
-
   open: ->
     @isOpen = true
     @$menuList.fadeIn @options.fadeInDuration

--- a/app/assets/javascripts/active_admin/components/jquery.aa.popover.js.coffee
+++ b/app/assets/javascripts/active_admin/components/jquery.aa.popover.js.coffee
@@ -27,9 +27,6 @@ window.AA.Popover = class AA.Popover
     @_buildPopover()
     @_bind()
 
-    return @
-
-
   open: ->
     @isOpen = true
     @$popover.fadeIn @options.fadeInDuration


### PR DESCRIPTION
[coffeescript release 1.5.0](http://coffeescript.org/#changelog) forbids explicit return statements in constructors.  When used with the latest coffeescript, these two files now get compilation errors.

But the return statements in these two files were simply returning @, which is superfluous anyway.  Deleted them and all seems good.
