### PR TITLE
[1773] Fix ExecJS exception

### DIFF
--- a/app/assets/javascripts/active_admin/components/jquery.aa.dropdown-menu.js.coffee
+++ b/app/assets/javascripts/active_admin/components/jquery.aa.dropdown-menu.js.coffee
@@ -20,7 +20,7 @@ window.AA.DropdownMenu = class AA.DropdownMenu
     @_buildMenuList()
     @_bind()
 
-    return @
+    @
 
   open: ->
     @isOpen = true
@@ -29,20 +29,20 @@ window.AA.DropdownMenu = class AA.DropdownMenu
     @_positionMenuList()
     @_positionNipple()
 
-    return @
+    @
 
 
   close: ->
     @isOpen = false
     @$menuList.fadeOut this.options.fadeOutDuration
 
-    return @
+    @
 
   destroy: ->
     @$element.unbind()
     @$element = null
 
-    return @
+    @
 
   isDisabled: ->
     @$menuButton.hasClass("disabled")

--- a/app/assets/javascripts/active_admin/components/jquery.aa.popover.js.coffee
+++ b/app/assets/javascripts/active_admin/components/jquery.aa.popover.js.coffee
@@ -27,7 +27,7 @@ window.AA.Popover = class AA.Popover
     @_buildPopover()
     @_bind()
 
-    return @
+    @
 
 
   open: ->
@@ -37,21 +37,21 @@ window.AA.Popover = class AA.Popover
     @_positionPopover()
     @_positionNipple()
 
-    return @
+    @
 
 
   close: ->
     @isOpen = false;
     @$popover.fadeOut this.options.fadeOutDuration;
 
-    return @
+    @
 
   destroy: ->
     @$element.removeData('popover');
     @$element.unbind();
     @$element = null;
 
-    return @
+    @
 
   option: ->
     # ??


### PR DESCRIPTION
Fixes #1773

Don't ask me why this works. Perhaps someone else could shed some light on it?

According to @bcavileer, the temporary workaround is to backport `coffee-script-source` from 1.5 to 1.4

``` ruby
gem 'coffee-script-source', '~> 1.4.0'
```
