### PR TITLE
Allow redirection shortcut for inherited_resources actions

### DIFF
--- a/lib/active_admin/resource_controller/actions.rb
+++ b/lib/active_admin/resource_controller/actions.rb
@@ -45,17 +45,25 @@ module ActiveAdmin
     alias :edit! :edit
 
     def create(options={}, &block)
-      super(options) do |success, failure|
-        block.call(success, failure) if block
-        failure.html { render active_admin_template('new') }
+      if block && block.arity == 0
+        super(options, &block)
+      else
+        super(options) do |success, failure|
+          block.call(success, failure) if block
+          failure.html { render active_admin_template('new') }
+        end
       end
     end
     alias :create! :create
 
     def update(options={}, &block)
-      super do |success, failure|
-        block.call(success, failure) if block
-        failure.html { render active_admin_template('edit') }
+      if block && block.arity == 0
+        super(options, &block)
+      else
+        super do |success, failure|
+          block.call(success, failure) if block
+          failure.html { render active_admin_template('edit') }
+        end
       end
     end
     alias :update! :update


### PR DESCRIPTION
This fixes issue #1930 by just passing through any blocks passed to inherited_resources actions such as `create!` when provided with zero arguments. This allows the shortcut to defining redirection locations within the block provided.

Although honestly, I don't get why AA overwrites `create!` and `update!` (or rather, `create` and `update`) anyway. As far as I can see, the behaviour would be the same if it didn't. Can anyone enlighten me?
