### PR TITLE
#1920 - Download links option supports an array of formats

### DIFF
--- a/docs/3-index-pages.md
+++ b/docs/3-index-pages.md
@@ -112,21 +112,30 @@ You can remove links to download CSV, XML and JSON exports:
     index :download_links => false do
     end
 
-## Disable Download Links
+## Customizing Download Links
 
-You can remove links to download CSV, XML and JSON exports:
+There are multiple ways to either remove the download links per resource listing, or customize the formats that are shown.  Customize the formats by passing an array of symbols, or pass false to hide entirely.
 
-    index :download_links => false do
-    end
-
-You can also remove the links for the resource via the config object.  This can be overwritten by a local index setting as shown above.
+Customizing the download links per resource:
 
     ActiveAdmin.register Post do
-      config.download_links = false
+
+      # hide the links entirely
+      index :download_links => false
+
+      # only show a PDF export
+      index :download_links => [:pdf]
+
     end
 
-If you want to disable download links for every resource throughout the application, configure that in the `active_admin` initializer.
+If you want to customize download links for every resource throughout the application, configure that in the `active_admin` initializer.
 
     ActiveAdmin.setup do |config|
+
+      # Disable entirely
       config.download_links = false
+
+      # Want PDF added to default download links
+      config.download_links = [:csv, :xml, :json, :pdf]
+
     end

--- a/features/index/formats.feature
+++ b/features/index/formats.feature
@@ -10,3 +10,30 @@ Feature: Index Formats
     Then I should see a link to download "CSV"
     And I should see a link to download "XML"
     And I should see a link to download "JSON"
+
+  Scenario: View index with download_links set to false
+    Given an index configuration of:
+    """
+      ActiveAdmin.register Post do
+        index :download_links => false
+      end
+    """
+    And 1 post exists
+    When I am on the index page for posts
+    Then I should not see a link to download "CSV"
+    And I should not see a link to download "XML"
+    And I should not see a link to download "JSON"
+
+  Scenario: View index with pdf download link set
+    Given an index configuration of:
+    """
+      ActiveAdmin.register Post do
+        index :download_links => [:pdf]
+      end
+    """
+    And 1 post exists
+    When I am on the index page for posts
+    Then I should not see a link to download "CSV"
+    And I should not see a link to download "XML"
+    And I should not see a link to download "JSON"
+    And I should see a link to download "PDF"

--- a/lib/active_admin/views/components/paginated_collection.rb
+++ b/lib/active_admin/views/components/paginated_collection.rb
@@ -29,13 +29,12 @@ module ActiveAdmin
 
       # Builds a new paginated collection component
       #
-      # @param [Array] collection  A "paginated" collection from kaminari
-      # @param [Hash]  options     These options will be passed on to the page_entries_info
-      #                            method.
-      #                            Useful keys:
-      #                              :entry_name - The name to display for this resource collection
-      #                              :param_name - Parameter name for page number in the links (:page by default)
-      #                              :download_links - Set to false to skip download format links
+      # collection => A paginated collection from kaminari
+      # options    => These options will be passed to `page_entries_info`
+      #   entry_name     => The name to display for this resource collection
+      #   param_name     => Parameter name for page number in the links (:page by default)
+      #   download_links => Download links override (false or [:csv, :pdf])
+      #
       def build(collection, options = {})
         @collection = collection
         @param_name     = options.delete(:param_name)
@@ -45,7 +44,6 @@ module ActiveAdmin
           raise(StandardError, "Collection is not a paginated scope. Set collection.page(params[:page]).per(10) before calling :paginated_collection.")
         end
         
-      
         @contents = div(:class => "paginated_collection_contents")
         build_pagination_with_formats(options)
         @built = true
@@ -66,7 +64,13 @@ module ActiveAdmin
         div :id => "index_footer" do
           build_pagination
           div(page_entries_info(options).html_safe, :class => "pagination_information")
-          build_download_format_links unless @download_links == false
+
+          if @download_links.is_a?(Array) && !@download_links.empty?
+            build_download_format_links @download_links
+          else
+            build_download_format_links unless @download_links == false
+          end
+
         end
       end
 

--- a/lib/generators/active_admin/install/templates/active_admin.rb.erb
+++ b/lib/generators/active_admin/install/templates/active_admin.rb.erb
@@ -172,4 +172,21 @@ ActiveAdmin.setup do |config|
   #     end
   #   end
 
+  # == Download Links
+  #
+  # You can disable download links on resource listing pages,
+  # or customize the formats shown per namespace/globally
+  #
+  # To disable/customize for the :admin namespace:
+  #
+  #   config.namespace :admin do |admin|
+  #
+  #     # Disable the links entirely
+  #     admin.download_links = false
+  #
+  #     # Only show XML & PDF options
+  #     admin.download_links = [:xml, :pdf]
+  #
+  #   end
+
 end


### PR DESCRIPTION
You have many options for customizing:

`config/initializers/active_admin.rb`

``` ruby
ActiveAdmin.setup do |config|
  config.namespace :admin do |admin|
    admin.download_links = false
  end
end
```

`app/admin/admin_users.rb`

``` ruby
ActiveAdmin.register AdminUser do
  index download_links: [:xml, :pdf]
end
```

This configuration would hide all download links, except at `/admin/admin_users`, which would show only the XML & PDF format options.
