### PR TITLE
[1927] Get Travis CI working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
 script: bundle exec rake test
 rvm:
-  - ree
-  - 1.9.2
   - 1.9.3
+  - 2.0.0
 before_install:
   - gem update --system
   - gem --version
+  - gem install bundler
 env:
-  - RAILS=3.0.12
-  - RAILS=3.1.4
-  - RAILS=3.2.3
+  - RAILS=3.0.20
+  - RAILS=3.1.11
+  - RAILS=3.2.12
+matrix:
+  allow_failures:
+    - rvm: 2.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ ACTIVE_ADMIN_PATH = File.dirname(__FILE__) unless defined?(ACTIVE_ADMIN_PATH)
 require File.expand_path('spec/support/detect_rails_version', ACTIVE_ADMIN_PATH)
 
 rails_version = detect_rails_version
-gem 'rails',          rails_version
+gem 'rails', rails_version
 gem 'bourbon'
 
 case rails_version
@@ -22,27 +22,26 @@ else
 end
 
 group :development, :test do
-  gem 'sqlite3'
-
-  gem 'rake',           '~> 10.0.2', :require => false
-  gem 'haml',           '~> 3.1.7', :require => false
+  gem 'haml', '~> 3.1.7',  :require => false
+  gem 'rake', '~> 10.0.2', :require => false
+  gem 'rails-i18n' # Provides default i18n for many languages
+  gem 'rdiscount'  # Markdown implementation (for yard)
+  gem 'sprockets'
   gem 'yard'
-  gem 'rdiscount' # For yard
-  gem "sprockets"
-  gem 'rails-i18n' # Gives us default i18n for many languages
-  gem 'parallel_tests'
 end
 
 group :test do
-  gem 'rspec-rails',    '~> 2.9.0'
-  gem 'cucumber-rails', '1.3.0', :require => false
-  gem 'capybara',       '1.1.2'
-  gem 'database_cleaner'
-  gem 'shoulda-matchers'
-  gem 'launchy'
-  gem 'jslint_on_rails',    '~> 1.1.1'
-  gem 'guard-rspec'
-  gem "guard-coffeescript"
-  gem 'jasmine'
   gem 'cancan'
+  gem 'capybara',        '1.1.2'
+  gem 'cucumber-rails',  '1.3.0', :require => false
+  gem 'database_cleaner'
+  gem 'guard-coffeescript'
+  gem 'guard-rspec'
+  gem 'jasmine'
+  gem 'jslint_on_rails', '~> 1.1.1'
+  gem 'launchy'
+  gem 'parallel_tests'
+  gem 'rspec-rails',     '~> 2.9.0'
+  gem 'shoulda-matchers'
+  gem 'sqlite3'
 end

--- a/features/step_definitions/index_scope_steps.rb
+++ b/features/step_definitions/index_scope_steps.rb
@@ -26,11 +26,11 @@ end
 
 Then /^I should see (\d+) ([\w]*) in the table$/ do |count, resource_type|
   begin
-    page.should have_css("table##{resource_type} tr > td:first", :count => count.to_i)
+    page.should have_css("table#index_table_#{resource_type} tr > td:first", :count => count.to_i)
   rescue
     current_count = 0
-    
-    all("table##{resource_type} tr > td:first").each { current_count += 1 }
+
+    all("table#index_table_#{resource_type} tr > td:first").each { current_count += 1 }
 
     raise "There were #{current_count} rows in the table not #{count}"
   end

--- a/lib/active_admin/namespace.rb
+++ b/lib/active_admin/namespace.rb
@@ -146,11 +146,12 @@ module ActiveAdmin
     def add_logout_button_to_menu(menu, priority=100, html_options={})
       if logout_link_path
         logout_method = logout_link_method || :get
-        menu.add  :priority     => priority,
-                  :label        => I18n.t('active_admin.logout'),
-                  :html_options => html_options.reverse_merge(:method => logout_method),
-                  :url          => proc{ render_or_call_method_or_proc_on self, active_admin_namespace.logout_link_path },
-                  :if           => proc{ current_active_admin_user? }
+        menu.add :id           => 'logout',
+                 :priority     => priority,
+                 :label        => proc{ I18n.t('active_admin.logout') },
+                 :html_options => html_options.reverse_merge(:method => logout_method),
+                 :url          => proc{ render_or_call_method_or_proc_on self, active_admin_namespace.logout_link_path },
+                 :if           => proc{ current_active_admin_user? }
       end
     end
 

--- a/lib/active_admin/resource_controller/data_access.rb
+++ b/lib/active_admin/resource_controller/data_access.rb
@@ -288,7 +288,7 @@ module ActiveAdmin
 
       def apply_decorator(chain)
         if decorator?
-          decorator_class.decorate(chain)
+          decorator_class.decorate_collection(chain)
         else
           chain
         end

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -16,7 +16,7 @@ inject_into_file 'app/models/post.rb', "  belongs_to :author, :class_name => 'Us
 copy_file File.expand_path('../templates/post_decorator.rb', __FILE__), "app/models/post_decorator.rb"
 
 # Rails 3.2.3 model generator declare attr_accessible
-inject_into_file 'app/models/post.rb', "  attr_accessible :author\n", :before => "end" if Rails::VERSION::STRING >= '3.2.3'
+inject_into_file 'app/models/post.rb', "  attr_accessible :author\n", :before => "end" if Rails::VERSION::STRING >= '3.2'
 generate :model, "user type:string first_name:string last_name:string username:string age:integer"
 inject_into_file 'app/models/user.rb', "  has_many :posts, :foreign_key => 'author_id'\n", :after => "class User < ActiveRecord::Base\n"
 generate :model, "publisher --migration=false --parent=User"

--- a/spec/unit/menu_item_spec.rb
+++ b/spec/unit/menu_item_spec.rb
@@ -38,7 +38,7 @@ module ActiveAdmin
     end
 
     it "should accept an options hash for link_to" do
-      item = MenuItem.new html_options: { :target => :blank }
+      item = MenuItem.new :html_options => { :target => :blank }
       item.html_options.should include(:target => :blank)
     end
 


### PR DESCRIPTION
For #1927
## Changes
### Misc
- reordered Gemfile -- shouldn't change functionality
- fix test env builder to support Rails versions properly
### Issues
- #1966
  - fix missing `decorator_method` for Draper
- #1967
  - remove 1.9 hash syntax
  - fix I18n dynamic re-translation feature
### Travis
- use latest Rails maintainence releases
- use latest Bundler version
- remove REE & 1.9.2
- add 2.0.0
## Travis build history from before commit squash
- 04dc755 [before Bundler update](https://travis-ci.org/gregbell/active_admin/builds/5298607)
- f49d884 [after Bundler update](https://travis-ci.org/gregbell/active_admin/builds/5299819)
- 6f77525 [after fixing cukes for #1966](https://travis-ci.org/gregbell/active_admin/builds/5330322)
- 227c07c [after removing 1.9 hash syntax that snuck in from #1967](https://travis-ci.org/gregbell/active_admin/builds/5334575)
- e86e648 [after fixing REE KeyError issue](https://travis-ci.org/gregbell/active_admin/builds/5393192)
- b3b2c4e [after resolving dynamic i18n re-translation issue caused by #1967](https://travis-ci.org/gregbell/active_admin/builds/5457187)
- 5f8e024 [after fixing Rails 3.2 mass assignment error](https://travis-ci.org/gregbell/active_admin/builds/5477321) Note: Bundler updated to 1.3.3 and broke REE
- 476f8e4 [after removing REE and 1.9.2, and adding 2.0.0 to Travis](https://travis-ci.org/gregbell/active_admin/builds/5478222)
