### PR TITLE
Fixes #1845 - Default assets registered twice by ActiveAdmin.setup

### DIFF
--- a/lib/active_admin/asset_registration.rb
+++ b/lib/active_admin/asset_registration.rb
@@ -4,7 +4,8 @@ module ActiveAdmin
     # Stylesheets
 
     def register_stylesheet(*args)
-      stylesheets << ActiveAdmin::Stylesheet.new(*args)
+      tmp = ActiveAdmin::Stylesheet.new(*args)
+      stylesheets << tmp unless stylesheets.include? tmp
     end
 
     def stylesheets
@@ -19,7 +20,7 @@ module ActiveAdmin
     # Javascripts
 
     def register_javascript(name)
-      javascripts << name
+      javascripts << name unless javascripts.include? name
     end
 
     def javascripts


### PR DESCRIPTION
Implements changes suggested in issue #1845 comments
