### PR TITLE
Fixes #1986 - Menu should register child regardless of AA resource load order

### DIFF
--- a/features/menu.feature
+++ b/features/menu.feature
@@ -37,3 +37,17 @@ Feature: Menu
     Then I should see a menu item for "Custom Menu"
     When I follow "Custom Menu"
     Then I should be on the admin dashboard page
+
+  Scenario: Adding a resource as a sub menu item
+    Given a configuration of:
+    """
+      ActiveAdmin.register User
+      ActiveAdmin.register Post do
+        menu :parent => 'User'
+      end
+    """
+    When I am on the dashboard
+    Then I should see a menu item for "Users"
+    When I follow "Users"
+    Then the "Users" tab should be selected
+    And I should see a nested menu item for "Posts"

--- a/features/step_definitions/menu_steps.rb
+++ b/features/step_definitions/menu_steps.rb
@@ -5,3 +5,7 @@ end
 Then /^I should not see a menu item for "([^"]*)"$/ do |name|
   page.should_not have_css('#tabs li a', :text => name)
 end
+
+Then /^I should see a nested menu item for "([^"]*)"$/ do |name|
+  page.should have_css('#tabs > li > ul > li > a', :text => name)
+end

--- a/lib/active_admin/menu_item.rb
+++ b/lib/active_admin/menu_item.rb
@@ -53,15 +53,6 @@ module ActiveAdmin
       !parent.nil?
     end
 
-    def dom_id
-      case id
-      when Proc
-        id
-      else
-        id.to_s.gsub( " ", '_' ).gsub( /[^a-z0-9_]/, '' )
-      end
-    end
-
     # Returns an array of the ancestory of this menu item
     # The first item is the immediate parent fo the item
     def ancestors

--- a/lib/active_admin/views/tabbed_navigation.rb
+++ b/lib/active_admin/views/tabbed_navigation.rb
@@ -40,11 +40,11 @@ module ActiveAdmin
       end
 
       def build_menu_item(item)
-        dom_id = case item.dom_id
+        dom_id = case item.id
         when Proc,Symbol
-          normalize_id call_method_or_proc_on(self, item.dom_id)
+          normalize_id call_method_or_proc_on(self, item.id)
         else
-          item.dom_id
+          item.id
         end
 
         li :id => dom_id do |li_element|

--- a/spec/unit/menu_item_spec.rb
+++ b/spec/unit/menu_item_spec.rb
@@ -67,6 +67,10 @@ module ActiveAdmin
         i
       end
 
+      it "should contain 5 submenu items" do
+        item.items.count.should == 5
+      end
+
       it "should give access to the menu item as an array" do
         item['Blog'].label.should == 'Blog'
       end
@@ -121,7 +125,7 @@ module ActiveAdmin
     end # accessing ancestory
 
 
-    describe ".generate_item_id" do
+    describe "#id" do
 
       it "downcases the id" do
         MenuItem.new(:id => "Identifier").id.should == "identifier"
@@ -131,8 +135,12 @@ module ActiveAdmin
         MenuItem.new(:id => "An Id").id.should == "an_id"
       end
 
-      it "should return a proc if label was a proc" do
-        MenuItem.new(:label => proc{ "Dynamic" }).id.should be_an_instance_of(Proc)
+      it "should render a proc if label was a proc" do
+        MenuItem.new(:label => proc{ "Dynamic Id" }).id.should == "dynamic_id"
+      end
+
+      it "should preserve the ID that was set if the label was a proc" do
+        MenuItem.new(:label => proc{ "Dynamic Id" }, :id => "static_id").id.should == "static_id"
       end
 
     end

--- a/spec/unit/menu_spec.rb
+++ b/spec/unit/menu_spec.rb
@@ -50,6 +50,16 @@ describe ActiveAdmin::Menu do
 
       menu["Admin"]["Projects"].should be_an_instance_of(ActiveAdmin::MenuItem)
     end
+
+    it "should assign children regardless of resource file load order" do
+      menu = Menu.new
+      menu.add :parent => "Users", :label => "Posts"
+      menu.add :label => "Users", :url => '/some/url'
+
+      menu["Users"].url.should == '/some/url'
+      menu["Users"]["Posts"].should be_an_instance_of(ActiveAdmin::MenuItem)
+    end
+
   end
 
 end


### PR DESCRIPTION
Fixes #1986.
- ActiveAdmin::MenuItem#dom_id removed, wasn't needed
- Load order is no longer important in registering menu items
