### PR TITLE
fix_duplicating_css_ids_bug: generate id with prefix

### DIFF
--- a/lib/active_admin/view_helpers/form_helper.rb
+++ b/lib/active_admin/view_helpers/form_helper.rb
@@ -11,7 +11,7 @@ module ActiveAdmin
       def hidden_field_tags_for(params, options={})
         fields_for_params(params, options).map do |kv|
           k, v = kv.first
-          hidden_field_tag k, v
+          hidden_field_tag k, v, :id => sanitize_to_id("hidden_active_admin_#{k}")
         end.join("\n").html_safe
       end
     end

--- a/spec/unit/view_helpers/form_helper_spec.rb
+++ b/spec/unit/view_helpers/form_helper_spec.rb
@@ -6,12 +6,16 @@ describe ActiveAdmin::ViewHelpers::FormHelper do
 
     it "should render hidden field tags for params" do
       view.hidden_field_tags_for(:scope => "All", :filter => "None").should == 
-        %{<input id="scope" name="scope" type="hidden" value="All" />\n<input id="filter" name="filter" type="hidden" value="None" />}
+        %{<input id="hidden_active_admin_scope" name="scope" type="hidden" value="All" />\n<input id="hidden_active_admin_filter" name="filter" type="hidden" value="None" />}
+    end
+
+    it "should generate not default id for hidden input" do
+      view.hidden_field_tags_for(:scope => "All")[/id="([^"]+)"/, 1].should_not == "scope"
     end
 
     it "should filter out the field passed via the option :except" do
       view.hidden_field_tags_for({:scope => "All", :filter => "None"}, :except => :filter).should == 
-        %{<input id="scope" name="scope" type="hidden" value="All" />}
+        %{<input id="hidden_active_admin_scope" name="scope" type="hidden" value="All" />}
     end
   end
 end


### PR DESCRIPTION
I had troubles with datepicker on the sidebar on index page because of duplicating css id. The duplicate element was a hidden field on the filters' sidebar. So I think that changing id from default makes sence
