### PR TITLE
Limit the TableCheckboxToggler to 'top level' tables.

### DIFF
--- a/app/assets/javascripts/active_admin/pages/batch_actions.js.coffee
+++ b/app/assets/javascripts/active_admin/pages/batch_actions.js.coffee
@@ -14,8 +14,8 @@ jQuery ($) ->
 
   if $("#batch_actions_selector").length && $(":checkbox.toggle_all").length
 
-    if $(".paginated_collection").find("table.index_table").length
-      $(".paginated_collection table").tableCheckboxToggler()
+    if $(".paginated_collection table.index_table").length
+      $(".paginated_collection table.index_table").tableCheckboxToggler()
     else
       $(".paginated_collection").checkboxToggler()
 


### PR DESCRIPTION
At @mrhenry we have some custom index views one of which has nested tables (not because we live in 1995 but because it actually makes sense...). This patch fixes the `TableCheckboxToggler` so that it only deals with _top level_ tables.
