### PR TITLE
[887] Respect the form buffer!

### DIFF
--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -154,6 +154,14 @@ module ActiveAdmin
       raise Formtastic::UnknownInputError
     end
 
+    # This method calls the block it's passed (in our case, the `f.inputs` block)
+    # and wraps the resulting HTML in a fieldset. If your block happens to return
+    # nil (but it otherwise built the form correctly), the below override passes
+    # the most recent part of the Active Admin form buffer.
+    def field_set_and_list_wrapping(*args, &block)
+      block_given? ? super{ yield || form_buffers.last } : super
+    end
+
     private
 
     def with_new_form_buffer

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -408,4 +408,19 @@ describe ActiveAdmin::FormBuilder do
     end
   end
 
+  describe "inputs block with nil return value" do
+    let :body do
+      build_form do |f|
+        f.inputs do
+          f.input :title
+          nil
+        end
+      end
+    end
+
+    it "should generate a single input field" do
+      body.should have_tag("input", :attributes => { :type => "text", :name => "post[title]" })
+    end
+  end
+
 end


### PR DESCRIPTION
resolves #887

All it took:

``` ruby
# This method calls the block it's passed (in our case, the `f.inputs` block)
# and wraps the resulting HTML in a fieldset. If your block happens to return
# nil (but it otherwise built the form correctly), the below override passes
# the most recent part of the Active Admin form buffer.
def field_set_and_list_wrapping(*args, &block)
  block_given? ? super{ yield || form_buffers.last } : super
end
```
