### PR TITLE
Signing out redirects incorrectly when activeadmin route is scoped

### DIFF
--- a/lib/active_admin/devise.rb
+++ b/lib/active_admin/devise.rb
@@ -35,12 +35,21 @@ module ActiveAdmin
 
       # Redirect to the default namespace on logout
       def root_path
-        (Rails.configuration.action_controller[:relative_url_root] || '') +
-        if ActiveAdmin.application.default_namespace
-          "/#{ActiveAdmin.application.default_namespace}"
-        else
-          "/"
-        end
+        namespace = ActiveAdmin.application.default_namespace.presence
+        root_path_method = [*namespace, :root_path].join('_')
+        url_helpers = Rails.application.routes.url_helpers
+
+        path = if url_helpers.respond_to? root_path_method
+                 url_helpers.send root_path_method
+               else
+                 # Guess a root_path when url_helpers not helpful
+                 "/#{namespace}"
+               end
+
+        # NOTE: `relative_url_root` is deprecated by rails.
+        #       Remove prefix here if it is removed completely.
+        prefix = Rails.configuration.action_controller[:relative_url_root] || ''
+        prefix + path
       end
     end
 

--- a/spec/unit/devise_spec.rb
+++ b/spec/unit/devise_spec.rb
@@ -42,6 +42,35 @@ describe ActiveAdmin::Devise::Controller do
     end
     
   end
+
+  context "within a scoped route" do
+
+    SCOPE = '/aa_scoped'
+
+    before do
+      # Remove existing routes
+      routes = Rails.application.routes
+      routes.clear!
+
+      # Add scoped routes
+      routes.draw do
+        scope :path => SCOPE do
+          ActiveAdmin.routes(self)
+          devise_for :admin_users, ActiveAdmin::Devise.config
+        end
+      end
+    end
+
+    after do
+      # Resume default routes
+      reload_routes!
+    end
+
+    it "should include scope path in root_path" do
+      controller.root_path.should == "#{SCOPE}/admin"
+    end
+
+  end
   
   describe "#config" do
     let(:config) { ActiveAdmin::Devise.config }


### PR DESCRIPTION
If active admin route is scoped, like

``` ruby
scope :path => '/foo' do
  ActiveAdmin.routes(self)
end
```

Then devise sign out action will redirect to '/admin', where it should be '/foo/admin'.

This is because in `lib/active_admin/devise.rb`, there are some hardcoded urls:

``` ruby
def root_path
  if ActiveAdmin.application.default_namespace
    "/#{ActiveAdmin.application.default_namespace}"
  else
    "/"
  end
end
```

It may be fixed by change these lines to

``` ruby
def root_path
  root_path_method = [ActiveAdmin.application.default_namespace, :root_path].join('_')
  respond_to?(root_path_method) ? send(root_path_method) : '/'
end
```

I am somehow busy these days. I will write test for this and commit fix later.
