### PR TITLE
Rollback mocha / shoulda-matchers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,6 @@ group :test do
   gem 'launchy'
   gem 'parallel_tests'
   gem 'rspec-rails',     '~> 2.9.0'
-  gem 'shoulda-matchers'
+  gem 'shoulda-matchers', '1.5.0' # See active_admin#2004
   gem 'sqlite3'
 end


### PR DESCRIPTION
As @quark-zju [observed](https://github.com/gregbell/active_admin/pull/1791#issuecomment-15128011):

>  `mocha` is required by `bourne`, which is in turn required by `shoulda-matchers`. After explicitly specifing `shoulda-matchers` to `1.5.0`, all tests passed.

The problem is caused by `shoulda-matchers` 0.5.1 and `mocha` 0.13.3 This can be locally reproduced simply by running `bundle update`. See [this gist](https://gist.github.com/Daxter/5199322) for a backtrace and gem versions.
- [Travis build before this PR](https://travis-ci.org/gregbell/active_admin/builds/5633564)
