### PR TITLE
Position the dropdown menu relative to the next positioned parent instead of the document.

### DIFF
--- a/app/assets/javascripts/active_admin/components/jquery.aa.dropdown-menu.js.coffee
+++ b/app/assets/javascripts/active_admin/components/jquery.aa.dropdown-menu.js.coffee
@@ -83,14 +83,14 @@ window.AA.DropdownMenu = class AA.DropdownMenu
       false
 
   _positionMenuList: ->
-    centerOfButtonFromLeft = @$menuButton.offset().left + @$menuButton.outerWidth() / 2
+    centerOfButtonFromLeft = @$menuButton.position().left + @$menuButton.outerWidth() / 2
     centerOfmenuListFromLeft = @$menuList.outerWidth() / 2
     menuListLeftPos = centerOfButtonFromLeft - centerOfmenuListFromLeft
     @$menuList.css "left", menuListLeftPos
 
   _positionNipple: ->
     centerOfmenuListFromLeft = @$menuList.outerWidth() / 2
-    bottomOfButtonFromTop = @$menuButton.offset().top + @$menuButton.outerHeight() + 10
+    bottomOfButtonFromTop = @$menuButton.position().top + @$menuButton.outerHeight() + 10
     @$menuList.css "top", bottomOfButtonFromTop
     $nipple = @$menuList.find(".dropdown_menu_nipple")
     centerOfnippleFromLeft = $nipple.outerWidth() / 2


### PR DESCRIPTION
This patch fixes the positioning of the dropdown menu in our (@mrhenry) custom layout. It doesn't affect the default AA layout.
