### PR TITLE
Dynamic scope names

### DIFF
--- a/spec/unit/scope_spec.rb
+++ b/spec/unit/scope_spec.rb
@@ -43,6 +43,19 @@ describe ActiveAdmin::Scope do
       its(:scope_method) { should == nil }
       its(:scope_block)  { should be_a(Proc)}
     end
+
+    context "with a proc as the label" do
+      it "should raise an exception if a second argument isn't provided" do
+        expect{ ActiveAdmin::Scope.new proc{ Date.today.strftime '%A' }
+        }.to raise_error
+      end
+
+      it "should properly render the proc" do
+        scope = ActiveAdmin::Scope.new proc{ Date.today.strftime '%A' }, :foobar
+        scope.name.should eq Date.today.strftime '%A'
+      end
+    end
+
   end # describe "creating a scope"
 
   describe "#display_if_block" do


### PR DESCRIPTION
With these changes you can specify a proc for the name shown on index pages for scopes.

Using this syntax:

``` ruby
# Assuming you've got a `published_today` scope defined in your model
scope ->{ Date.today.strftime '%A' }, :published_today
```

You can get something like this:
![dynamic_scopes](https://f.cloud.github.com/assets/688886/299493/a1d9a66a-957c-11e2-8e8b-5b34f21e1bf3.png)
(Friday and Thursday are dynamically named)
