### PR TITLE
Fix sorting of menu items whose labels are procs

### DIFF
--- a/lib/active_admin/menu_item.rb
+++ b/lib/active_admin/menu_item.rb
@@ -69,9 +69,10 @@ module ActiveAdmin
       [parent, parent.ancestors].flatten
     end
 
+    # Sort menu items first by their priority attribute, then by their labels.
     def <=>(other)
       result = priority <=> other.priority
-      result = label.to_s <=> other.label.to_s if result == 0
+      result = label_value <=> other.label_value if result == 0
       result
     end
 
@@ -79,6 +80,13 @@ module ActiveAdmin
     # a default block always returning true will be returned.
     def display_if_block
       @display_if_block || lambda { |_| true }
+    end
+
+    def label_value
+      case label
+      when String then label
+      when Proc then label.call.to_s
+      end
     end
 
   end

--- a/spec/unit/menu_spec.rb
+++ b/spec/unit/menu_spec.rb
@@ -52,5 +52,19 @@ describe ActiveAdmin::Menu do
     end
   end
 
+  describe "sorting items" do
+    def build_label_proc(label)
+      proc {|label| label }
+    end
+
+    it "should sort children by the result of their label proc" do
+      menu = Menu.new
+      blog_post_menu = menu.add :label => build_label_proc("Blog posts")
+      user_menu = menu.add :label => build_label_proc("Users")
+      projects_menu = menu.add :label => build_label_proc("Projects")
+
+      menu.items.should == [blog_post_menu, user_menu, projects_menu]
+    end
+  end
 end
 


### PR DESCRIPTION
Commit 452956eccf77ea368b05902a3d0d8020152a7aaa introduced a bug in `MenuItem#<=>`: even if the label was a proc, it would not compare `label.call <=> other.label.call`, but instead `label.to_s <=> other.label.to_s`, and `Proc#to_s` returns some irrelevant metadata about the Proc object.

This bug would show when the menu items got randomly rearranged on every refresh of the admin area.
