### PR TITLE
[2023] Fix MenuItem label sorting

### DIFF
--- a/features/menu.feature
+++ b/features/menu.feature
@@ -37,3 +37,17 @@ Feature: Menu
     Then I should see a menu item for "Custom Menu"
     When I follow "Custom Menu"
     Then I should be on the admin dashboard page
+
+  Scenario: Adding a resource as a sub menu item
+    Given a configuration of:
+    """
+      ActiveAdmin.register User
+      ActiveAdmin.register Post do
+        menu :parent => 'User'
+      end
+    """
+    When I am on the dashboard
+    Then I should see a menu item for "Users"
+    When I follow "Users"
+    Then the "Users" tab should be selected
+    And I should see a nested menu item for "Posts"

--- a/features/step_definitions/menu_steps.rb
+++ b/features/step_definitions/menu_steps.rb
@@ -5,3 +5,7 @@ end
 Then /^I should not see a menu item for "([^"]*)"$/ do |name|
   page.should_not have_css('#tabs li a', :text => name)
 end
+
+Then /^I should see a nested menu item for "([^"]*)"$/ do |name|
+  page.should have_css('#tabs > li > ul > li > a', :text => name)
+end

--- a/lib/active_admin/menu.rb
+++ b/lib/active_admin/menu.rb
@@ -5,8 +5,8 @@ module ActiveAdmin
   # To build a new menu:
   #
   #   menu = Menu.new do |m|
-  #     m.add :label => "Dashboard", :url => "/"
-  #     m.add :label => "Admin", :url => "/admin"
+  #     m.add label: 'Dashboard', url: '/'
+  #     m.add label: 'Users',     url: '/users'
   #   end
   #
   # If you're interested in configuring a menu item, take a look at the
@@ -15,80 +15,91 @@ module ActiveAdmin
   class Menu
 
     def initialize
+      super # MenuNode
       yield(self) if block_given?
     end
 
     module MenuNode
-
-      # Add a new MenuItem to the menu
-      #
-      # Example:
-      #   menu = Menu.new
-      #   menu.add :label => "Dashboard" do |dash|
-      #     dash.add :label => "My Child Dashboard"
-      #   end
-      #
-      # @param [Hash] menu_items Add as many menu items as you pass in
-      def add(item_options)
-        parent_label = item_options[:parent]
-
-        if parent_label
-          child_options = item_options.except(:parent)
-          menu_item = add_with_parent(parent_label, child_options)
-        else
-          menu_item = add_without_parent(item_options)
-        end
-
-        yield(menu_item) if block_given?
-
-        menu_item
+      def initialize
+        @children = {}
       end
 
       def [](id)
-        children.fetch(normalize_id(id))
+        @children[normalize_id(id)]
+      end
+      def []=(id, child)
+        @children[normalize_id(id)] = child
       end
 
-      def include?(item)
-        items.include?(item)
-      end
-
-      # @return Sorted [Array] of [MenuItem]
-      def items
-        children.values.sort
-      end
-
-      private
-
-      def add_without_parent(item_options)
-        menu_item = ActiveAdmin::MenuItem.new(item_options, self)
-        children[menu_item.id] = menu_item
-      end
-
-      def add_with_parent(parent, item_options)
-        parent_id = normalize_id(parent)
-        parent = children.fetch(parent_id){ add(:label => parent) }
-
-        parent.add(item_options)
-      end
-
-      def children
-        @children ||= {}
-      end
-
-      def normalize_id(string)
-        case string
-        when Proc
-          string
+      # Recursively builds any given menu items. There are two syntaxes supported,
+      # as shown in the below examples. Both create an identical menu structure.
+      #
+      # Example 1:
+      #   menu = Menu.new
+      #   menu.add label: 'Dashboard' do |dash|
+      #     dash.add label: 'My Child Dashboard'
+      #   end
+      #
+      # Example 2:
+      #   menu = Menu.new
+      #   menu.add label:  'Dashboard'
+      #   menu.add parent: 'Dashboard', label: 'My Child Dashboard'
+      #
+      def add(options)
+        item = if parent = options.delete(:parent)
+          (self[parent] || add(:label => parent)).add options
         else
-          string.to_s.downcase.gsub(" ", "_")
+          _add options.merge :parent => self
+        end
+
+        yield(item) if block_given?
+
+        item
+      end
+
+      # Whether any children match the given item.
+      def include?(item)
+        @children.values.include? item
+      end
+
+      # Used in the UI to visually distinguish which menu item is selected.
+      def current?(item)
+        self == item || include?(item)
+      end
+
+      # Returns sorted array of menu items that should be displayed in this context.
+      # Sorts by priority first, then alphabetically by label if needed.
+      def items(context = nil)
+        @children.values.select{ |i| i.display?(context) }.sort do |a,b|
+          result = a.priority       <=> b.priority
+          result = a.label(context) <=> b.label(context) if result == 0
+          result
         end
       end
 
+      attr_reader :children
+      private
+      attr_writer :children
+
+      # The method that actually adds new menu items. Called by the public method.
+      # If this ID is already taken, transfer the children of the existing item to the new item.
+      def _add(options)
+        item = ActiveAdmin::MenuItem.new(options)
+        item.send :children=, self[item.id].children if self[item.id]
+        self[item.id] = item
+      end
+
+      def normalize_id(id)
+        case id
+        when String, Symbol
+          id.to_s.downcase.gsub ' ', '_'
+        else
+          raise TypeError, "#{id.class} isn't supported as a Menu ID"
+        end
+      end
     end
 
     include MenuNode
 
   end
-
-
 end

--- a/lib/active_admin/resource/menu.rb
+++ b/lib/active_admin/resource/menu.rb
@@ -19,15 +19,15 @@ module ActiveAdmin
         @menu_item_options ||= default_menu_options
       end
 
-      # The default menu options to pass through to MenuItem.new
       def default_menu_options
+        # These local variables are accessible to the procs.
         menu_resource_class = respond_to?(:resource_class) ? resource_class : self
-        the_resource = self # Make it available in the proc
+        resource = self
         {
-          :id     => resource_name.plural,
-          :label  => proc{ plural_resource_label },
-          :url    => proc{ the_resource.route_collection_path(params) },
-          :if     => proc { authorized?(:read, menu_resource_class)  }
+          :id    => resource_name.plural,
+          :label => proc{ resource.plural_resource_label },
+          :url   => proc{ resource.route_collection_path(params) },
+          :if    => proc{ authorized?(:read, menu_resource_class) }
         }
       end
 

--- a/lib/active_admin/view_helpers/method_or_proc_helper.rb
+++ b/lib/active_admin/view_helpers/method_or_proc_helper.rb
@@ -75,4 +75,19 @@ module MethodOrProcHelper
       string_symbol_or_proc
     end
   end
+
+  # This method is different from the others in that it calls `instance_eval` on the reciever,
+  # passing it the proc. This evaluates the proc in the context of the reciever, thus changing
+  # what `self` means inside the proc.
+  def render_in_context(context, obj)
+    context ||= self # default to `self`
+    case obj
+    when Proc
+      context.instance_exec &obj
+    when Symbol
+      context.send obj
+    else
+      obj
+    end
+  end
 end

--- a/lib/active_admin/views/tabbed_navigation.rb
+++ b/lib/active_admin/views/tabbed_navigation.rb
@@ -22,9 +22,9 @@ module ActiveAdmin
         build_menu
       end
 
-      # Returns the first level menu items to display
+      # The top-level menu items that should be displayed.
       def menu_items
-        displayable_items(menu.items)
+        menu.items(self)
       end
 
       def tag_name
@@ -40,63 +40,16 @@ module ActiveAdmin
       end
 
       def build_menu_item(item)
-        dom_id = case item.dom_id
-        when Proc,Symbol
-          normalize_id call_method_or_proc_on(self, item.dom_id)
-        else
-          item.dom_id
-        end
+        li :id => item.id do |li|
+          li.add_class "current" if item.current? assigns[:current_tab]
 
-        li :id => dom_id do |li_element|
-          li_element.add_class "current" if current?(item)
+          text_node link_to item.label(self), item.url(self), item.html_options
 
-          if item.items.any?
-            li_element.add_class "has_nested"
-            actual_item_link item
-            render_nested_menu(item)
-          else
-            actual_item_link item
-          end
-        end
-      end
-
-      def normalize_id(string)
-        string.to_s.downcase.gsub(" ", "_").gsub(/[^a-z0-9_]/, '')
-      end
-
-      def actual_item_link(item)
-
-        label = case item.label
-        when Symbol
-          send item.label
-        when Proc
-          item.label.call rescue instance_exec(&item.label)
-        else
-          item.label.to_s
-        end
-
-        link_path = url_for_menu_item(item)
-        text_node link_to(label, link_path, item.html_options)
-
-      end
-
-      def url_for_menu_item(menu_item)
-        case menu_item.url
-        when Symbol
-          send(menu_item.url)
-        when Proc
-          instance_exec &menu_item.url
-        when nil
-          "#"
-        else
-          menu_item.url
-        end
-      end
-
-      def render_nested_menu(item)
-        ul do
-          displayable_items(item.items).each do |child|
-            build_menu_item child
+          if children = item.items(self).presence
+            li.add_class "has_nested"
+            ul do
+              children.each{ |child| build_menu_item child }
+            end
           end
         end
       end
@@ -104,32 +57,6 @@ module ActiveAdmin
       def default_options
         { :id => "tabs" }
       end
-
-      # Returns true if the menu item name is @current_tab (set in controller)
-      def current?(menu_item)
-        assigns[:current_tab] == menu_item || menu_item.items.include?(assigns[:current_tab])
-      end
-
-      # Returns an Array of items to display
-      def displayable_items(items)
-        items.select do |item|
-          display_item? item
-        end
-      end
-
-      # Returns true if the item should be displayed
-      def display_item?(item)
-        return false unless call_method_or_proc_on(self, item.display_if_block)
-        return true if (item.url.nil? or item.url == '#') && item.items.empty?
-        return false if (item.url.nil? or item.url == '#') && !displayable_children?(item)
-        true
-      end
-
-      # Returns true if the item has any children that should be displayed
-      def displayable_children?(item)
-        !item.items.find{|child| display_item?(child) }.nil?
-      end
     end
-
   end
 end

--- a/spec/unit/menu_spec.rb
+++ b/spec/unit/menu_spec.rb
@@ -7,7 +7,6 @@ include ActiveAdmin
 describe ActiveAdmin::Menu do
 
   context "with no items" do
-
     it "should have an empty item collection" do
       menu = Menu.new
       menu.items.should be_empty
@@ -18,10 +17,9 @@ describe ActiveAdmin::Menu do
       menu.add :label => "Dashboard"
       menu.items.first.label.should == "Dashboard"
     end
-
   end
 
-  context "with many item" do
+  context "with many items" do
     let(:menu) do
       Menu.new do |m|
         m.add :label => "Dashboard"
@@ -35,22 +33,39 @@ describe ActiveAdmin::Menu do
   end
 
   describe "adding items with children" do
-
     it "should add an empty item if the parent does not exist" do
       menu = Menu.new
-      menu.add :parent => "Admin", :label  => "Users"
+      menu.add :parent => "Admin", :label => "Users"
 
       menu["Admin"]["Users"].should be_an_instance_of(ActiveAdmin::MenuItem)
     end
 
     it "should add a child to a parent if it exists" do
       menu = Menu.new
-      menu.add :parent => "Admin", :label  => "Users"
-      menu.add :parent => "Admin", :label  => "Projects"
+      menu.add :parent => "Admin", :label => "Users"
+      menu.add :parent => "Admin", :label => "Projects"
 
       menu["Admin"]["Projects"].should be_an_instance_of(ActiveAdmin::MenuItem)
     end
+
+    it "should assign children regardless of resource file load order" do
+      menu = Menu.new
+      menu.add :parent => "Users", :label => "Posts"
+      menu.add :label  => "Users", :url   => "/some/url"
+
+      menu["Users"].url.should == "/some/url"
+      menu["Users"]["Posts"].should be_a ActiveAdmin::MenuItem
+    end
   end
 
-end
+  describe "sorting items" do
+    it "should sort children by the result of their label proc" do
+      menu = Menu.new
+      menu.add :label => proc{ "G" }, :id => "not related 1"
+      menu.add :label => proc{ "B" }, :id => "not related 2"
+      menu.add :label => proc{ "A" }, :id => "not related 3"
 
+      menu.items.map(&:label).should == %w[A B G]
+    end
+  end
+end

--- a/spec/unit/namespace/register_page_spec.rb
+++ b/spec/unit/namespace/register_page_spec.rb
@@ -67,33 +67,8 @@ describe ActiveAdmin::Namespace, "registering a page" do
         end
       end
       it "should not create a menu item" do
-        expect {
-          menu["Status"]
-        }.to raise_error(KeyError)
+        menu["Status"].should be_nil
       end
     end # describe "disabling the menu"
-    
-    describe "setting menu priority" do
-      before do
-        namespace.register_page "Status" do
-          menu :priority => 2
-        end
-      end
-      it "should have a custom priority of 2" do
-        menu["Status"].priority.should == 2
-      end
-    end # describe "setting menu priority"
-    
-    describe "setting a condition for displaying" do
-      before do
-        namespace.register_page "Status" do
-          menu :if => proc { false }
-        end
-      end
-      it "should have a proc returning false" do
-        menu["Status"].display_if_block.should be_instance_of(Proc)
-        menu["Status"].display_if_block.call.should == false
-      end
-    end # describe "setting a condition for displaying"
   end # describe "adding to the menu"
 end

--- a/spec/unit/namespace/register_resource_spec.rb
+++ b/spec/unit/namespace/register_resource_spec.rb
@@ -22,8 +22,8 @@ describe ActiveAdmin::Namespace, "registering a resource" do
       defined?(Admin::DashboardController).should be_true
     end
     it "should create a menu item" do
-      menu["Categories"].should be_an_instance_of(ActiveAdmin::MenuItem)
-      menu["Categories"].url.should be_an_instance_of(Proc)
+      menu["Categories"].should be_a ActiveAdmin::MenuItem
+      menu["Categories"].instance_variable_get(:@url).should be_a Proc
     end
   end # context "with no configuration"
 
@@ -56,7 +56,6 @@ describe ActiveAdmin::Namespace, "registering a resource" do
     it "should use the resource as the model in the controller" do
       Admin::MockResourcesController.resource_class.should == Mock::Resource
     end
-
   end # context "with a resource that's namespaced"
 
   describe "finding resource instances" do
@@ -81,7 +80,6 @@ describe ActiveAdmin::Namespace, "registering a resource" do
       publisher = namespace.register Publisher
       namespace.resource_for(Publisher).should == publisher
     end
-
   end # describe "finding resource instances"
 
   describe "adding to the menu" do
@@ -115,34 +113,9 @@ describe ActiveAdmin::Namespace, "registering a resource" do
         end
       end
       it "should not create a menu item" do
-        expect {
-          menu["Categories"]
-        }.to raise_error(KeyError)
+        menu["Categories"].should be_nil
       end
     end # describe "disabling the menu"
-    
-    describe "setting menu priority" do
-      before do
-        namespace.register Category do
-          menu :priority => 2
-        end
-      end
-      it "should have a custom priority of 2" do
-        menu["Categories"].priority.should == 2
-      end
-    end # describe "setting menu priority"
-    
-    describe "setting a condition for displaying" do
-      before do
-        namespace.register Category do
-          menu :if => proc { false }
-        end
-      end
-      it "should have a proc returning false" do
-        menu["Categories"].display_if_block.should be_instance_of(Proc)
-        menu["Categories"].display_if_block.call.should == false
-      end
-    end # describe "setting a condition for displaying"
 
     describe "adding as a belongs to" do
       context "when not optional" do
@@ -152,9 +125,7 @@ describe ActiveAdmin::Namespace, "registering a resource" do
           end
         end
         it "should not show up in the menu" do
-          expect {
-            menu["Posts"]
-          }.to raise_error(KeyError)
+          menu["Posts"].should be_nil
         end
       end
       context "when optional" do

--- a/spec/unit/namespace_spec.rb
+++ b/spec/unit/namespace_spec.rb
@@ -23,9 +23,9 @@ describe ActiveAdmin::Namespace do
       if ActiveAdmin::Dashboards.built?
         # DEPRECATED behavior. If a dashboard was built while running this
         # spec, then an item gets added to the menu
-        namespace.fetch_menu(:default).should have(1).item
+        namespace.fetch_menu(:default).children.should_not be_empty
       else
-        namespace.fetch_menu(:default).items.should be_empty
+        namespace.fetch_menu(:default).children.should be_empty
       end
     end
   end # context "when new"

--- a/spec/unit/views/tabbed_navigation_spec.rb
+++ b/spec/unit/views/tabbed_navigation_spec.rb
@@ -25,10 +25,10 @@ describe ActiveAdmin::Views::TabbedNavigation do
     before do
       menu.add :label => "Blog Posts", :url => :admin_posts_path
 
-      menu.add :label => "Reports",	:url => "/admin/reports" do |reports|
+      menu.add :label => "Reports", :url => "/admin/reports" do |reports|
         reports.add :label => "A Sub Reports", :url => "/admin/a-sub-reports"
         reports.add :label => "B Sub Reports", :url => "/admin/b-sub-reports"
-        reports.add :label => proc{ "Label Proc Sub Reports" }, :url => "/admin/label-proc-sub-reports"
+        reports.add :label => proc{ "Label Proc Sub Reports" }, :url => "/admin/label-proc-sub-reports", :id => "Label Proc Sub Reports"
       end
 
       menu.add :label => "Administration", :url => "/admin/administration" do |administration|
@@ -48,8 +48,6 @@ describe ActiveAdmin::Views::TabbedNavigation do
                        :priority => 10, 
                        :if => :admin_logged_in?
       end
-
-
     end
 
     it "should generate a ul" do
@@ -73,7 +71,7 @@ describe ActiveAdmin::Views::TabbedNavigation do
       html.should have_tag("li", :parent => { :tag => "ul" }, :attributes => {:id => "b_sub_reports"})
     end
 
-    it "should generate a valid dom_id from a label proc" do
+    it "should generate a valid id from a label proc" do
       html.should have_tag("li", :parent => { :tag => "ul" }, :attributes => {:id => "label_proc_sub_reports"})
     end
 
@@ -124,19 +122,19 @@ describe ActiveAdmin::Views::TabbedNavigation do
 
     it "should not include menu items with an if block that returns false" do
       menu.add :label => "Don't Show", :url => "/", :priority => 10, :if => proc{ false }
-      tabbed_navigation.menu_items.should == []
+      tabbed_navigation.menu_items.should be_empty
     end
 
     it "should not include menu items with an if block that calls a method that returns false" do
       menu.add :label => "Don't Show", :url => "/", :priority => 10, :if => :admin_logged_in?
-      tabbed_navigation.menu_items.should == []
+      tabbed_navigation.menu_items.should be_empty
     end
 
     it "should not display any items that have no children to display" do
       menu.add :label => "Parent", :url => "#" do |p|
         p.add :label => "Child", :url => "/", :priority => 10, :if => proc{ false }
       end
-      tabbed_navigation.menu_items.should == []
+      tabbed_navigation.menu_items.should be_empty
     end
 
     it "should display a parent that has a child to display" do
@@ -148,5 +146,4 @@ describe ActiveAdmin::Views::TabbedNavigation do
     end
 
   end
-
 end


### PR DESCRIPTION
An alternative approach to #2023.

@macfanatic's `MenuItem` changes in 452956ec updated label procs to be evaluated in the view context, but this broke sorting of proc labels. This PR initially moved the sorting logic up into `TabbedNavigation`, where the view context is accessible. Later, I decided that this was a more elegant solution:

``` ruby
# in the view context, e.g. `TabbedNavigation`
link_to item.label(self), item.url(self), item.html_options

# with this implementation
class MenuItem
  def label(context = nil)
    render_in_context context, @label
  end
end
```

This is the commit history of this PR from before I removed the outdated commits.
## First attempt
- b67d583 - moved sorting logic into `TabbedNavigation` to follow the trend
- bc20972 - renamed a `MethodOrProc` helper method (no longer included)
## Second attempt (adding to the above)
- 293b4d0 - tried a more OO approach, where you can pass in the view context to `MenuItem` to use for Procs
- e11fd6c - moved remaining `MenuItem`-specfic out of `TabbedNavigation` :heart:
- f60ebf7 - integrated fixes from #1988
