### PR TITLE
Properly translate renamed resources

### DIFF
--- a/lib/active_admin/resource/naming.rb
+++ b/lib/active_admin/resource/naming.rb
@@ -17,20 +17,12 @@ module ActiveAdmin
 
       # Returns the name to call this resource such as "Bank Account"
       def resource_label
-        if @options[:as]
-          @options[:as]
-        else
-           resource_name.human(:default => resource_name.gsub('::', ' ').titleize)
-         end
+        resource_name.translate :count => 1,  :default => resource_name.gsub('::', ' ').titleize
       end
 
       # Returns the plural version of this resource such as "Bank Accounts"
       def plural_resource_label
-        if @options[:as]
-          @options[:as].pluralize
-        else
-          resource_name.human(:count => 1.1, :default => resource_label.pluralize.titleize)
-        end
+        resource_name.translate :count => 1.1, :default => resource_label.pluralize.titleize
       end
     end
 
@@ -44,6 +36,10 @@ module ActiveAdmin
         else
           super(klass, nil, name)
         end
+      end
+
+      def translate(options = {})
+        I18n.t i18n_key, {:scope => [:activerecord, :models]}.merge(options)
       end
 
       def proxy_for_initializer(klass, name)

--- a/spec/unit/resource/naming_spec.rb
+++ b/spec/unit/resource/naming_spec.rb
@@ -61,7 +61,7 @@ module ActiveAdmin
       describe "I18n integration" do
         describe "singular label" do
           it "should return the titleized model_name.human" do
-            config.resource_name.should_receive(:human).and_return "Da category"
+            config.resource_name.should_receive(:translate).and_return "Da category"
 
             config.resource_label.should == "Da category"
           end
@@ -69,8 +69,26 @@ module ActiveAdmin
 
         describe "plural label" do
           it "should return the titleized plural version defined by i18n if available" do
-            I18n.should_receive(:translate).at_least(:once).and_return("Da categories")
+            config.resource_name.should_receive(:translate).at_least(:once).and_return "Da categories"
             config.plural_resource_label.should == "Da categories"
+          end
+        end
+
+        context "when the :as option is given" do
+          describe "singular label" do
+            it "should translate the custom name" do
+              config = config(:as => 'My Category')
+              config.resource_name.should_receive(:translate).and_return "Translated category"
+              config.resource_label.should == "Translated category"
+            end
+          end
+
+          describe "plural label" do
+            it "should translate the custom name" do
+              config = config(:as => 'My Category')
+              config.resource_name.should_receive(:translate).at_least(:once).and_return "Translated categories"
+              config.plural_resource_label.should == "Translated categories"
+            end
           end
         end
 


### PR DESCRIPTION
This is for #1884, and is a re-wiring of #1885.

The initial problem that #1885 solved was that if you used the `:as` option, translation just didn't happen:

``` ruby
def resource_label
  if @options[:as]
    # just return the string
  else
    # actually do translation
  end
end
```

Unfortunately, to do so #1885 added a lot of duplicated code. This PR is an attempt to find a middle ground.

I had to create my own `translate` method, because for some reason `String#human` wasn't properly respecting `i18n_key` and the `activerecord.models` I18n scope.

But the result is that now you can rename a resource:

``` ruby
ActiveAdmin.register Foo, as: 'Bar'
```

and can have custom translations for `Bar`

``` yaml
en:
  activerecord:
    models:
      bar:
        one: "Baz"
        other: "A great deal of Bazs"
```
