### PR TITLE
713 Fix wrapping in navigation

### DIFF
--- a/app/assets/stylesheets/active_admin/_header.css.scss
+++ b/app/assets/stylesheets/active_admin/_header.css.scss
@@ -1,32 +1,34 @@
-// ----------------------------------- Header 
-#header { 
+// ----------------------------------- Header
+#header {
   @include primary-gradient;
   @include shadow;
   @include text-shadow(#000);
+  display: table;
   height: 20px;
+  width: 100%;
   overflow: visible;
   position: inherit;
-  padding: 9px $horizontal-page-margin;
+  padding: 9px 0;
   z-index: 900;
 
-  h1 { 
-    display: inline-block; 
+  h1 {
+    display: table-cell;
     color: #cdcdcd;
-    float: left;
-    margin-right: 20px; 
+    margin-right: 20px;
     margin-bottom: 0px;
-    padding-top: 3px;
-    font-size: 1.3em; 
+    padding: 3px $horizontal-page-margin 0 $horizontal-page-margin;
+    font-size: 1.3em;
     font-weight: normal;
-    
+    line-height: 1.2;
+
     a {
       text-decoration: none;
-      
+
       &:hover {
         color: #fff;
       }
-    } 
-    
+    }
+
     img {
       position: relative;
       top: -2px;
@@ -36,27 +38,27 @@
   a, a:link { color: #cdcdcd; }
 
   .header-item {
-    float: left;
     top: 2px;
     position: relative;
     height: 20px
   }
 
   ul.tabs {
-    display: inline-block; 
+    display: table-cell;
     height: 100%;
-    margin: 0; 
+    margin: 0;
     padding: 0;
 
-    & > li { 
-      display: inline-block; 
-      margin-right: 4px; 
-      font-size: 1.0em; 
-      position: relative; 
+    & > li {
+      display: inline-block;
+      margin-right: 4px;
+      margin-bottom: 10px;
+      font-size: 1.0em;
+      position: relative;
 
-      a { 
-        text-decoration: none; 
-        padding: 6px 10px 4px 10px; 
+      a {
+        text-decoration: none;
+        padding: 6px 10px 4px 10px;
         position: relative;
         @include rounded(10px);
       }
@@ -66,23 +68,23 @@
         color: #fff;
       }
 
-      &.has_nested > a { 
-        background: url(active_admin_image_path('nested_menu_arrow.gif')) no-repeat 89% 50%; 
-        padding-right: 20px; 
+      &.has_nested > a {
+        background: url(active_admin_image_path('nested_menu_arrow.gif')) no-repeat 89% 50%;
+        padding-right: 20px;
         z-index: 1050;
       }
 
-      &.has_nested.current > a { 
-        background: $current-menu-item-background url(active_admin_image_path('nested_menu_arrow_dark.gif')) no-repeat 89% 50%; 
-        padding-right: 20px; 
+      &.has_nested.current > a {
+        background: $current-menu-item-background url(active_admin_image_path('nested_menu_arrow_dark.gif')) no-repeat 89% 50%;
+        padding-right: 20px;
       }
 
-      &:hover > a { 
+      &:hover > a {
         background: $hover-menu-item-background;
         color: #fff;
       }
 
-      &.has_nested:hover > a { 
+      &.has_nested:hover > a {
         @include rounded-top(10px);
         border-bottom: 5px solid $hover-menu-item-background;
         background: $hover-menu-item-background url(active_admin_image_path('nested_menu_arrow_dark.gif')) no-repeat 89% 50%;
@@ -92,24 +94,24 @@
       /* Hover on li, display the ul */
       &:hover ul { display: block;}
       /* Drop down menus */
-      ul { 
+      ul {
         background: $hover-menu-item-background;
         @include rounded-all(0,10px,10px,10px);
         @include shadow(0, 1px, 3px, #444);
-        position: absolute; 
-        width: 175px; 
+        position: absolute;
+        width: 175px;
         margin-top: 5px;
         float: left;
-        display: none; 
+        display: none;
         padding: 3px 0px 5px 0;
         list-style: none;
         z-index: 1010;
 
-        li { 
-          margin: 0px; 
-          a { 
+        li {
+          margin: 0px;
+          a {
             background: none;
-            display: block; 
+            display: block;
             &:hover { color: #fff; background: none; }
           }
 
@@ -122,10 +124,9 @@
 
   }
 
-  #utility_nav { 
+  #utility_nav {
     color: #aaa;
-    float: right;
-    display: inline-block;
+    display: table-cell;
     margin: 0;
     padding: 0;
 


### PR DESCRIPTION
Prevents the navigation from breaking the layout for smaller window sizes (https://github.com/gregbell/active_admin/issues/713). The navigation entries now wrap properly without overlapping each other (and the h1 and utility-nav):

![navigation](https://f.cloud.github.com/assets/563038/333059/fdf12bc0-9c44-11e2-90f5-2f7373b2960c.png)
