### PR TITLE
Refactored the fix for #2043: nil/false namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Add missing batch actions translations. [#1788][] by [@EtienneDepaulis][]
 * Fix for [#1960][], pluralize the example `admin_users` model to be consistent [#1961][] by [@rmw][]
 * JS fix for batch actions checkbox toggling [#1947][] by [@ai][]
+* Fixed routing bug when using `config.default_namespace = false` in initializer [#2043][]
+  by [@Daxter][] and [@gregbell][]
 
 ### Enhancements
 
@@ -20,8 +22,6 @@
 * Allow options to be passed to the Abre element for rows in `attributes_table` [#1439][] by [@Daxter][]
 * Gender neutral Spanish translations [#1973][] by [@laffinkippah][]
 * Adds the ability to use `starts_with` and `ends_with` in string filters [#1962][] by [@rmw][]
-* Added support for `config.default_namespace = false` in initializer [#2043][]
-  by [@Daxter][] and [@gregbell][]
 
 ### New Features
 

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -124,7 +124,8 @@ module ActiveAdmin
 
     # Registers a brand new configuration for the given resource.
     def register(resource, options = {}, &block)
-      namespace(options[:namespace]).register resource, options, &block
+      ns_name = namespace_name(options)
+      namespace(ns_name).register resource, options, &block
     end
 
     # Creates a namespace for the given name
@@ -133,7 +134,7 @@ module ActiveAdmin
     #
     # @returns [Namespace] the new or existing namespace
     def namespace(name)
-      name = normalize_namespace_name(name)
+      name ||= :root
 
       if namespaces[name]
         namespace = namespaces[name]
@@ -154,7 +155,8 @@ module ActiveAdmin
     # @&block The registration block.
     #
     def register_page(name, options = {}, &block)
-      namespace(options[:namespace]).register_page name, options, &block
+      ns_name = namespace_name(options)
+      namespace(ns_name).register_page name, options, &block
     end
 
     # Whether all configuration files have been loaded
@@ -213,21 +215,9 @@ module ActiveAdmin
 
     private
 
-    # Normalizes the namespace name.
-    #
-    # `normalize_namespace_name(nil)` results in the default_namesapce or :root
-    # `normalize_namespace_name(:admin)` results in :admin
-    # `normalize_namespace_name(false)` results in :root
-    #
-    # @params [Symbil, nil, false] name The name of the namespace
-    #
-    # @returns [Symbol] The normalized name of the namespace. Will always return
-    #                   a symbol. Ie: nil and false will not be returned.
-    def normalize_namespace_name(name)
-      return name if name
-      return :root if name == false
-
-      default_namespace || :root
+    # Return either the passed in namespace or the default
+    def namespace_name(options)
+      options.fetch(:namespace){ default_namespace }
     end
 
     def register_default_assets


### PR DESCRIPTION
This is a refactored version of the commit 9326cb35ba9ebcdcc512548b73f56c73a5968556 that fixes the issue presented in #2043. 

Both nil and false are treated the same when passed in to `#register`
