### PR TITLE
Add 'has_many_delete' class to `li` on new records

### DIFF
--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -57,7 +57,7 @@ module ActiveAdmin
         end
 
         if has_many_form.object.new_record?
-          contents += template.content_tag(:li) do
+          contents += template.content_tag(:li, :class => 'has_many_delete') do
             template.link_to I18n.t('active_admin.has_many_delete'), "#", :onclick => "$(this).closest('.has_many_fields').remove(); return false;", :class => "button"
           end
         end

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -335,7 +335,7 @@ describe ActiveAdmin::FormBuilder do
       end
 
       it "should add a link to remove new nested records" do
-        Capybara.string(body).should have_css(".has_many > fieldset > ol > li > a", :class => "button", :href => "#", :content => "Delete")
+        Capybara.string(body).should have_css(".has_many > fieldset > ol > li.has_many_delete > a", :class => "button", :href => "#", :content => "Delete")
       end
 
       it "should include the nested record's class name in the js" do


### PR DESCRIPTION
References #2024.

This adds the class `has_many_delete` to the `li` wrapper for the delete button on `has_many` form fields. The fact that this is the only `li` in the list without a class makes it harder to grab using CSS selectors.
