### PR TITLE
Register Comment as AdminComment

### DIFF
--- a/features/comments/commenting.feature
+++ b/features/comments/commenting.feature
@@ -95,7 +95,7 @@ Feature: Commenting
         ActiveAdmin.register Post
       """
     When I add a comment "Hello from Comment"
-    When I am on the index page for comments
+    When I am on the index page for admin_comments
     Then I should see a table header with "Body"
     And I should see "Hello from Comment"
 

--- a/features/comments/viewing_index.feature
+++ b/features/comments/viewing_index.feature
@@ -9,7 +9,7 @@ Feature: Viewing Index of Comments
 
   Scenario: Viewing all commments for a namespace
     When I add a comment "Hello from Comment"
-    When I am on the index page for comments
+    When I am on the index page for admin_comments
     Then I should see a table header with "Body"
     And I should see a table header with "Resource"
     And I should see a table header with "Author"

--- a/lib/active_admin/comments.rb
+++ b/lib/active_admin/comments.rb
@@ -20,7 +20,7 @@ ActiveAdmin.application.view_factory.show_page.send :include, ActiveAdmin::Comme
 ActiveAdmin.after_load do |app|
   app.namespaces.values.each do |namespace|
     if namespace.comments?
-      namespace.register ActiveAdmin::Comment, :as => "Comment" do
+      namespace.register ActiveAdmin::Comment, :as => "AdminComment" do
         actions :index, :show, :create
 
         # Ensure filters are turned on
@@ -61,10 +61,10 @@ ActiveAdmin.after_load do |app|
         controller do
           def create
             create! do |success, failure|
-              failure.html do 
-                resource_config = active_admin_config.namespace.resource_for(@comment.resource.class)
+              failure.html do
+                resource_config = active_admin_config.namespace.resource_for(@admin_comment.resource.class)
                 flash[:error] = I18n.t('active_admin.comments.errors.empty_text')
-                redirect_to send(resource_config.route_instance_path, @comment.resource)
+                redirect_to send(resource_config.route_instance_path, @admin_comment.resource)
               end
             end
           end

--- a/lib/active_admin/comments/views/active_admin_comments.rb
+++ b/lib/active_admin/comments/views/active_admin_comments.rb
@@ -59,7 +59,7 @@ module ActiveAdmin
           if active_admin_namespace.root?
             comments_path
           else
-            send(:"#{active_admin_namespace.name}_comments_path")
+            send(:"#{active_admin_namespace.name}_admin_comments_path")
           end
         end
 


### PR DESCRIPTION
Cleaner alternative to #2059; instead of renaming the `ActiveAdmin::Comment` model (as in that PR), just register it as `AdminComment` rather than `Comment`. Allows registration of a Rails app's `Comment` model without the workaround discussed in #301 (registering the app's `Comment` as something else, e.g. `UserComment`).
