### PR TITLE
Add option for customizing has_many heading text

### DIFF
--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -67,7 +67,13 @@ module ActiveAdmin
 
       form_buffers.last << with_new_form_buffer do
         template.content_tag :div, :class => "has_many #{association}" do
-          form_buffers.last << template.content_tag(:h3, object.class.reflect_on_association(association).klass.model_name.human(:count => 1.1))
+          # Allow customization of the nested form heading
+          unless options.key?(:heading) && !options[:heading]
+            form_heading = options[:heading] ||
+              object.class.reflect_on_association(association).klass.model_name.human(:count => 1.1)
+            form_buffers.last << template.content_tag(:h3, form_heading)
+          end
+
           inputs options, &form_block
 
           form_buffers.last << js_for_has_many(association, form_block, template)


### PR DESCRIPTION
This adds additional functionality to the `heading` option for `has_many`. Strings will be used directly, and falsy values disable the heading altogether. Default behavior (generating a heading automatically based on class name) remains the same.
