### PR TITLE
Fixes error on Ruby 2.0.0/Rails 4.0.0.beta1

### DIFF
--- a/lib/active_admin/reloader.rb
+++ b/lib/active_admin/reloader.rb
@@ -75,7 +75,7 @@ module ActiveAdmin
         end
 
         # Over-ride the default #updated_at to support the deletion of files
-        def updated_at
+        def updated_at(paths)
           paths.map { |path| File.mtime(path) rescue Time.now }.max
         end
 


### PR DESCRIPTION
Fixes error on Ruby 2.0.0/Rails 4.0.0.beta1:

```
/Users/lupinglade/.rvm/gems/ruby-2.0.0-p0@rails-4.0.0.beta1/bundler/gems/active_admin-d2b9840832f4/lib/active_admin/reloader.rb:78:in `updated_at': wrong number of arguments (1 for 0) (ArgumentError)
```
