### PR TITLE
Nested routes with namespace appears to be broken in 0.6

### DIFF
--- a/lib/active_admin/view_helpers/breadcrumb_helper.rb
+++ b/lib/active_admin/view_helpers/breadcrumb_helper.rb
@@ -11,8 +11,7 @@ module ActiveAdmin
           # If an object (users/23), look it up via ActiveRecord and capture its name.
           # If name is nil, look up the model translation, using `titlecase` as the backup.
           if part =~ /^\d|^[a-f0-9]{24}$/ && parent = parts[index-1]
-            klass = active_admin_config.namespace.resources.find_by_key(parent.singularize.camelcase).
-                resource_class_name.constantize rescue nil
+            klass = active_admin_config.belongs_to_config.target.resource_class
             obj   = klass.find_by_id(part) if klass
             name  = display_name(obj)      if obj
           end

--- a/spec/unit/breadcrumbs_spec.rb
+++ b/spec/unit/breadcrumbs_spec.rb
@@ -6,6 +6,12 @@ describe "Breadcrumbs" do
 
   describe "generating a trail from paths" do
 
+    let :active_admin_config do
+      m = mock
+      m.stub_chain(:belongs_to_config, :target, :resource_class).and_return Post
+      m
+    end
+
     # Mock our params
     def params; {}; end
     # Mock link to and return a hash


### PR DESCRIPTION
I have an admin page that looks like the following

``` ruby
ActiveAdmin.register CloudAccount::Base, as: 'Cloud Account' do
```

I have a child admin page that that defines the parent as follows

``` ruby
belongs_to :cloud_account, parent_class: CloudAccount::Base, instance_name: :fileable, optional: :true
```

Nested routes worked in 0.5.x for this model (ie. /admin/cloud_accounts/:id/file_actions), however in 0.6 I get

undefined method `find_by_id' for CloudAccount:Module

Looks like for some reason it's using the module and not recognizing the "parent_class" specifier.
