### PR TITLE
#1670 - :default now expects proc for index scopes

### DIFF
--- a/features/index/index_scopes.feature
+++ b/features/index/index_scopes.feature
@@ -26,6 +26,18 @@ Feature: Index Scoping
     And I should see the scope "All" with the count 3
     And I should see 3 posts in the table
 
+  Scenario: Viewing resources with one scope that is set as not default
+    Given 3 posts exist
+    And an index configuration of:
+      """
+      ActiveAdmin.register Post do
+        scope :all, :default => proc{ false }
+      end
+      """
+    Then I should see the scope "All" not selected
+    And I should see the scope "All" with the count 3
+    And I should see 3 posts in the table
+
   Scenario: Viewing resources with a scope and no results
     Given 3 posts exist
     And an index configuration of:

--- a/lib/active_admin/resource.rb
+++ b/lib/active_admin/resource.rb
@@ -68,6 +68,8 @@ module ActiveAdmin
       end
     end
 
+    include MethodOrProcHelper
+
     include Base
     include ActionItems
     include Authorization

--- a/lib/active_admin/resource/scopes.rb
+++ b/lib/active_admin/resource/scopes.rb
@@ -13,8 +13,14 @@ module ActiveAdmin
         scopes.find{|s| s.id == id }
       end
 
-      def default_scope
-        @default_scope
+      def default_scope(context = nil)
+        scopes.detect do |scope| 
+          if scope.default_block.is_a?(Proc)
+            render_in_context(context, scope.default_block)
+          else
+            scope.default_block
+          end
+        end
       end
 
       # Create a new scope object for this resource.
@@ -35,8 +41,6 @@ module ActiveAdmin
         else
           self.scopes << scope
         end
-
-        @default_scope = scope if options[:default]
 
         scope
       end

--- a/lib/active_admin/resource_controller/data_access.rb
+++ b/lib/active_admin/resource_controller/data_access.rb
@@ -260,7 +260,7 @@ module ActiveAdmin
         @current_scope ||= if params[:scope]
           active_admin_config.get_scope_by_id(params[:scope]) if params[:scope]
         else
-          active_admin_config.default_scope
+          active_admin_config.default_scope(self)
         end
       end
 

--- a/lib/active_admin/scope.rb
+++ b/lib/active_admin/scope.rb
@@ -1,7 +1,7 @@
 module ActiveAdmin
   class Scope
 
-    attr_reader :scope_method, :id, :scope_block, :display_if_block, :show_count
+    attr_reader :scope_method, :id, :scope_block, :display_if_block, :show_count, :default_block
 
     # Create a Scope
     #
@@ -39,7 +39,9 @@ module ActiveAdmin
       @scope_method, @scope_block = nil, block if block_given?
 
       @show_count       = options[:show_count].nil? ? true : options[:show_count]
-      @display_if_block = options[:if] || proc{ true }
+      @display_if_block = options[:if]      || proc{ true }
+      @default_block    = options[:default] || proc{ false }
+      
     end
 
     def name

--- a/lib/active_admin/views/components/scopes.rb
+++ b/lib/active_admin/views/components/scopes.rb
@@ -1,4 +1,5 @@
 require 'active_admin/helpers/collection'
+require 'active_admin/view_helpers/method_or_proc_helper'
 
 module ActiveAdmin
   module Views
@@ -51,7 +52,7 @@ module ActiveAdmin
         if params[:scope]
           params[:scope] == scope.id
         else
-          active_admin_config.default_scope == scope
+          active_admin_config.default_scope(self) == scope
         end
       end
 

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -229,6 +229,13 @@ module ActiveAdmin
         config.scope :published
         config.get_scope_by_id(:published).name.should == "Published"
       end
+
+      it "should retrieve the default scope by proc" do
+        config.scope :published, :default => proc{ true }
+        config.scope :all
+        config.default_scope.name.should == "Published"
+      end
+
     end
 
     describe "#csv_builder" do

--- a/spec/unit/scope_spec.rb
+++ b/spec/unit/scope_spec.rb
@@ -72,6 +72,25 @@ describe ActiveAdmin::Scope do
 
   end
 
+  describe "#default" do
+
+    it "should accept a boolean" do
+      scope = ActiveAdmin::Scope.new(:method, nil, :default => true)
+      scope.default_block.should == true
+    end
+
+    it "should default to a false #default_block" do
+      scope = ActiveAdmin::Scope.new(:method, nil)
+      scope.default_block.call.should == false
+    end
+
+    it "should store the :default proc" do
+      scope = ActiveAdmin::Scope.new(:with_block, nil, :default => proc{ true })
+      scope.default_block.call.should == true
+    end
+
+  end
+
   describe "show_count" do
 
     it "should allow setting of show_count to prevent showing counts" do


### PR DESCRIPTION
Resolves #1670, allows you to pass a proc to the `:default` option for a proc.  For code cleanliness, method now expects a proc (much like Rails 4 does with scopes anyway).

The only thing I'm thinking of is finding a way to execute the proc in a view context, so that you can use CanCan for instance, which doesn't work right now and is what most people will want to use this for I imagine.

Thoughts @Daxter?
