### PR TITLE
Add option to "undecorate" resource for forms

### DIFF
--- a/docs/11-decorators.md
+++ b/docs/11-decorators.md
@@ -53,32 +53,14 @@ Then the following is possible
 
 Note that the resource proveded to form_for also gets decorated.
 
-In most cases this will work as expected. However, it can have some unexpected
-results. Here's an example gotcha:
+In most cases this will work as expected. However, it is possible to disable
+automatic decoration in the form with the `decorate` option:
 
-```ruby
-class UserDecorator < Draper::Base
-  decorates :user
+    ActiveAdmin.register Post do
+      decorate_with PostDecorator
 
-  def self.status_options_for_select
-    User.status_options.map { |s| [s.humanize, s] }
-  end
-
-  def status
-    model.status.titleize
-  end
-end
-
-ActiveAdmin.register User do
-  form do
-    f.inputs do
-      f.input :status, collection: UserDecorator.status_options_for_select
+      form decorate: false do
+        # ...
+      end
     end
-  end
-end
-```
-
-In this example, `f.object.status` now returns "Submitted", which does not match
-the actual status option: "submitted". Because of this, the `<select>` will not
-have the correct status selected.
 

--- a/lib/active_admin/view_helpers/form_helper.rb
+++ b/lib/active_admin/view_helpers/form_helper.rb
@@ -1,10 +1,15 @@
 module ActiveAdmin
   module ViewHelpers
     module FormHelper
-      
+
       def active_admin_form_for(resource, options = {}, &block)
         options = Marshal.load( Marshal.dump(options) )
         options[:builder] ||= ActiveAdmin::FormBuilder
+
+        if ! options.fetch(:decorate, true)
+          resource = resource.model
+        end
+
         semantic_form_for resource, options, &block
       end
 

--- a/spec/unit/view_helpers/form_helper_spec.rb
+++ b/spec/unit/view_helpers/form_helper_spec.rb
@@ -1,11 +1,45 @@
 require 'spec_helper'
 
 describe ActiveAdmin::ViewHelpers::FormHelper do
+
+  describe '.active_admin_form_for' do
+    let(:view) { action_view }
+    let(:resource) { stub('resource') }
+    let(:default_options) { { builder: ActiveAdmin::FormBuilder } }
+
+    it 'calls semantic_form_for with the ActiveAdmin form builder' do
+      view.should_receive(:semantic_form_for).with(resource, builder: ActiveAdmin::FormBuilder)
+      view.active_admin_form_for(resource)
+    end
+
+    it 'allows the form builder to be customized' do
+      # We can't use a stub here because options gets marshalled, and a new
+      # instance built. Any constant will work.
+      custom_builder = Object
+      view.should_receive(:semantic_form_for).with(resource, builder: custom_builder)
+      view.active_admin_form_for(resource, builder: custom_builder)
+    end
+
+    context 'with a decorated resource' do
+      let(:decorated) { stub('decorated_resource', model: resource) }
+
+      it 'can disable automatic decoration' do
+        view.should_receive(:semantic_form_for).with(resource, default_options.merge(decorate: false))
+        view.active_admin_form_for(decorated, decorate: false)
+      end
+
+      it 'can enable automatic decoration' do
+        view.should_receive(:semantic_form_for).with(decorated, default_options.merge(decorate: true))
+        view.active_admin_form_for(decorated, decorate: true)
+      end
+    end
+  end
+
   describe ".hidden_field_tags_for" do
     let(:view) { action_view }
 
     it "should render hidden field tags for params" do
-      view.hidden_field_tags_for(:scope => "All", :filter => "None").should == 
+      view.hidden_field_tags_for(:scope => "All", :filter => "None").should ==
         %{<input id="hidden_active_admin_scope" name="scope" type="hidden" value="All" />\n<input id="hidden_active_admin_filter" name="filter" type="hidden" value="None" />}
     end
 
@@ -14,7 +48,7 @@ describe ActiveAdmin::ViewHelpers::FormHelper do
     end
 
     it "should filter out the field passed via the option :except" do
-      view.hidden_field_tags_for({:scope => "All", :filter => "None"}, :except => :filter).should == 
+      view.hidden_field_tags_for({:scope => "All", :filter => "None"}, :except => :filter).should ==
         %{<input id="hidden_active_admin_scope" name="scope" type="hidden" value="All" />}
     end
   end


### PR DESCRIPTION
This pull-request adds the following option:

``` ruby
ActiveAdmin.register MyModel do
  decorate_with MyModelDecorator

  # Calls `model` on resource before calling semantic_form_for
  form decorate: false do
    # ...
  end

end
```

This also adds more coverage for `ActiveAdmin::ViewHelpers::FormHelper.active_admin_form_for` (specs not specific to this pull-request).

See discussion at #2057.
