### PR TITLE
IndexAsBlog now renders a proc passed to title/body methods in view context

### DIFF
--- a/features/index/index_as_blog.feature
+++ b/features/index/index_as_blog.feature
@@ -48,3 +48,22 @@ Feature: Index as Blog
     Then I should see "Hello World From Block" within "h3"
     And I should see a link to "Hello World From Block"
     And I should see "My great post body From Block" within ".post"
+
+  Scenario: Viewing a blog with a resource as a block configuration should render Abre components
+    Given a post with the title "Hello World" and body "My great post body" exists
+    And an index configuration of:
+      """
+      ActiveAdmin.register Post do
+        index :as => :blog do
+          title do |post|
+            span(:class => :title_span) { post.title + " From Block " }
+          end
+          body do |post|
+            span(:class => :body_span) { post.body + " From Block" }
+          end
+        end
+      end
+      """
+      Then I should see "Hello World From Block" within "span.title_span"
+      And I should see a link to "Hello World From Block"
+      And I should see "My great post body From Block" within ".post span.body_span"

--- a/lib/active_admin/view_helpers/method_or_proc_helper.rb
+++ b/lib/active_admin/view_helpers/method_or_proc_helper.rb
@@ -76,16 +76,16 @@ module MethodOrProcHelper
     end
   end
 
-  # This method is different from the others in that it calls `instance_eval` on the reciever,
+  # This method is different from the others in that it calls `instance_exec` on the reciever,
   # passing it the proc. This evaluates the proc in the context of the reciever, thus changing
   # what `self` means inside the proc.
-  def render_in_context(context, obj)
+  def render_in_context(context, obj, *args)
     context ||= self # default to `self`
     case obj
     when Proc
-      context.instance_exec &obj
+      context.instance_exec *args, &obj
     when Symbol
-      context.send obj
+      context.send obj, *args
     else
       obj
     end

--- a/lib/active_admin/views/index_as_blog.rb
+++ b/lib/active_admin/views/index_as_blog.rb
@@ -117,7 +117,9 @@ module ActiveAdmin
       def build_title(post)
         if @title
           h3 do
-            link_to(call_method_or_proc_on(post, @title), resource_path(post))
+            a(:href => resource_path(post)) do
+             render_method_on_post_or_call_proc post, @title
+            end
           end
         else
           h3 do
@@ -128,7 +130,18 @@ module ActiveAdmin
 
       def build_body(post)
         if @body
-          div(call_method_or_proc_on(post, @body), :class => 'content')
+          div :class => 'content' do
+            render_method_on_post_or_call_proc post, @body
+          end
+        end
+      end
+
+      def render_method_on_post_or_call_proc(post, proc)
+        case proc
+        when String,Symbol
+          post.send proc
+        else
+          instance_exec post, &proc
         end
       end
 


### PR DESCRIPTION
Resolves issue #1890 so that the documentation works for the following scenario:

``` ruby
ActiveAdmin.register Post do
  index as: :blog do |post|
    title do |post|
      span(class: :my_title) { post.title + " From Block" }
    end
    body :body # calls post.body
  end
end
```
