### PR TITLE
Add OmniAuth provider links to the login page.

### DIFF
--- a/app/views/active_admin/devise/shared/_links.erb
+++ b/app/views/active_admin/devise/shared/_links.erb
@@ -18,3 +18,10 @@
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
   <%= link_to t('active_admin.devise.links.resend_unlock_instructions'), new_unlock_path(resource_name) %><br />
 <% end -%>
+
+<%- if devise_mapping.omniauthable? %>
+  <%- resource_class.omniauth_providers.each do |provider| %>
+    <%= link_to t('active_admin.devise.links.sign_in_with_omniauth_provider', :provider => provider.to_s.titleize),
+          omniauth_authorize_path(resource_name, provider) %><br />
+  <% end -%>
+<% end -%>

--- a/lib/active_admin/locales/bg.yml
+++ b/lib/active_admin/locales/bg.yml
@@ -74,4 +74,5 @@ bg:
       links:
         sign_in: "Влезте в профила си"
         forgot_your_password: "Забравена парола?"
+        sign_in_with_omniauth_provider: "Влезте с %{provider}"
 

--- a/lib/active_admin/locales/ca.yml
+++ b/lib/active_admin/locales/ca.yml
@@ -78,4 +78,5 @@ ca:
       links:
         sign_in: "Registrar"
         forgot_your_password: "Heu perdut la contrasenya?"
+        sign_in_with_omniauth_provider: "Connecta't amb %{provider}"
 

--- a/lib/active_admin/locales/cs.yml
+++ b/lib/active_admin/locales/cs.yml
@@ -81,3 +81,5 @@ cs:
       links:
         sign_in: "Přihlásit se"
         forgot_your_password: "Zapomněli jste heslo?"
+        sign_in_with_omniauth_provider: "Přihlásit se %{provider}"
+        

--- a/lib/active_admin/locales/da.yml
+++ b/lib/active_admin/locales/da.yml
@@ -77,4 +77,5 @@ da:
       links:
         sign_in: "Log ind"
         forgot_your_password: "Glemt din adgangskode?"
-
+        sign_in_with_omniauth_provider: "Log ind med %{provider}"
+        

--- a/lib/active_admin/locales/de-CH.yml
+++ b/lib/active_admin/locales/de-CH.yml
@@ -79,6 +79,7 @@
       links:
         sign_in: "Anmeldung"
         forgot_your_password: "Passwort vergessen?"
+        sign_in_with_omniauth_provider: "Anmeldung mit %{provider}"
   activerecord:
     attributes:
       admin_user:

--- a/lib/active_admin/locales/de.yml
+++ b/lib/active_admin/locales/de.yml
@@ -79,6 +79,7 @@ de:
       links:
         sign_in: "Anmeldung"
         forgot_your_password: "Passwort vergessen?"
+        sign_in_with_omniauth_provider: "Anmeldung mit %{provider}"
   activerecord:
     attributes:
       admin_user:

--- a/lib/active_admin/locales/en-GB.yml
+++ b/lib/active_admin/locales/en-GB.yml
@@ -79,3 +79,5 @@
       links:
         sign_in: "Sign in"
         forgot_your_password: "Forgot your password?"
+        sign_in_with_omniauth_provider: "Sign in with %{provider}"
+        

--- a/lib/active_admin/locales/en.yml
+++ b/lib/active_admin/locales/en.yml
@@ -82,6 +82,7 @@ en:
       links:
         sign_in: "Sign in"
         forgot_your_password: "Forgot your password?"
+        sign_in_with_omniauth_provider: "Sign in with %{provider}"
     access_denied:
       message: "You are not authorized to perform this action."
     index_list:

--- a/lib/active_admin/locales/es.yml
+++ b/lib/active_admin/locales/es.yml
@@ -79,6 +79,7 @@ es:
       links:
         sign_in: "registrarse"
         forgot_your_password: "¿Olvidó su contraseña?"
+        sign_in_with_omniauth_provider: "Conéctate con %{provider}"
   views:
       pagination:
           truncate: "..."

--- a/lib/active_admin/locales/fr.yml
+++ b/lib/active_admin/locales/fr.yml
@@ -79,3 +79,4 @@ fr:
       links:
         sign_in: "Connectez-vous"
         forgot_your_password: "Vous avez oublié votre mot de passe?"
+        sign_in_with_omniauth_provider: "Connectez-vous avec %{provider}"

--- a/lib/active_admin/locales/he.yml
+++ b/lib/active_admin/locales/he.yml
@@ -79,3 +79,4 @@ he:
       links:
         sign_in: "כניסה"
         forgot_your_password: "שכחת את הסיסמא שלך?"
+        sign_in_with_omniauth_provider: "%{provider} היכנס עם"

--- a/lib/active_admin/locales/hr.yml
+++ b/lib/active_admin/locales/hr.yml
@@ -83,3 +83,4 @@ hr:
       links:
         sign_in: "Prijavi se"
         forgot_your_password: "Zaboravljena lozinka?"
+        sign_in_with_omniauth_provider: "Prijavite se za %{provider}"

--- a/lib/active_admin/locales/hu.yml
+++ b/lib/active_admin/locales/hu.yml
@@ -65,3 +65,21 @@ hu:
       title_content: "%{count} hozzászólás"
       errors:
         empty_text: "A hozzászólás nem lett mentve, a törzs nem lehet üres."
+    devise:
+      login:
+        title: "Bejelentkezés"
+        remember_me: "Emlékezz rám"
+        submit: "Belépés"
+      reset_password:
+        title: "Elfelejtette a jelszavát?"
+        submit: "Visszaállítása a jelszót"
+      change_password:
+        title: "A jelszó módosítása"
+        submit: "Jelszó módosítása"
+      unlock:
+        title: "Újraküldés unlock utasítások"
+        submit: "Újraküldés unlock utasítások"
+      links:
+        sign_in: "Bejelentkezés"
+        forgot_your_password: "Elfelejtette a jelszavát?"
+        sign_in_with_omniauth_provider: "Jelentkezzen be a %{provider}"

--- a/lib/active_admin/locales/it.yml
+++ b/lib/active_admin/locales/it.yml
@@ -79,3 +79,4 @@ it:
       links:
         sign_in: "Entra"
         forgot_your_password: "Dimenticato la password?"
+        sign_in_with_omniauth_provider: "Collegati a %{provider}"

--- a/lib/active_admin/locales/ja.yml
+++ b/lib/active_admin/locales/ja.yml
@@ -77,3 +77,4 @@ ja:
       links:
         sign_in: "サインイン"
         forgot_your_password: "パスワードをお忘れですか？"
+        sign_in_with_omniauth_provider: "%{provider}のアカウントを使ってログイン"

--- a/lib/active_admin/locales/ko.yml
+++ b/lib/active_admin/locales/ko.yml
@@ -74,3 +74,4 @@ ko:
       links:
         sign_in: "로그인"
         forgot_your_password: "비밀 번호를 잊으 셨나요?"
+        sign_in_with_omniauth_provider: "%{provider} 으로 로그인"

--- a/lib/active_admin/locales/lt.yml
+++ b/lib/active_admin/locales/lt.yml
@@ -79,3 +79,4 @@ lt:
       links:
         sign_in: 'Prisijungti'
         forgot_your_password: 'Pamiršote slaptažodį?'
+        sign_in_with_omniauth_provider: "Prisijunkite su %{provider}"

--- a/lib/active_admin/locales/lv.yml
+++ b/lib/active_admin/locales/lv.yml
@@ -79,3 +79,4 @@ lv:
       links:
         sign_in: "pierakstīties"
         forgot_your_password: "Aizmirsāt savu paroli?"
+        sign_in_with_omniauth_provider: "Pierakstieties ar %{provider}"

--- a/lib/active_admin/locales/nl.yml
+++ b/lib/active_admin/locales/nl.yml
@@ -79,4 +79,5 @@ nl:
       links:
         sign_in: "Meld u aan"
         forgot_your_password: "Wachtwoord vergeten?"
+        sign_in_with_omniauth_provider: "Log in met %{provider}"
 

--- a/lib/active_admin/locales/no-NB.yml
+++ b/lib/active_admin/locales/no-NB.yml
@@ -74,4 +74,5 @@
       links:
         sign_in: "Logg inn"
         forgot_your_password: "Glemt passord?"
+        sign_in_with_omniauth_provider: "Logg på med %{provider}"
 

--- a/lib/active_admin/locales/pl.yml
+++ b/lib/active_admin/locales/pl.yml
@@ -78,6 +78,7 @@ pl:
       links:
         sign_in: "Zaloguj się"
         forgot_your_password: "Nie pamiętasz hasła?"
+        sign_in_with_omniauth_provider: "Zaloguj się z %{provider}"
   formtastic:
     actions:
       update: "Aktualizuj %{model}"

--- a/lib/active_admin/locales/pt-BR.yml
+++ b/lib/active_admin/locales/pt-BR.yml
@@ -79,3 +79,4 @@
       links:
         sign_in: "Entrar"
         forgot_your_password: "Esqueceu sua senha?"
+        sign_in_with_omniauth_provider: "Entre com o %{provider}"

--- a/lib/active_admin/locales/pt-PT.yml
+++ b/lib/active_admin/locales/pt-PT.yml
@@ -79,3 +79,4 @@
       links:
         sign_in: "Entrar"
         forgot_your_password: "Esqueceu-se da sua senha?"
+        sign_in_with_omniauth_provider: "Entre com o %{provider}"

--- a/lib/active_admin/locales/ro.yml
+++ b/lib/active_admin/locales/ro.yml
@@ -65,4 +65,21 @@ ro:
       title_content: "Comentarii (%{count})"
       errors:
         empty_text: "Comentariul nu a fost salvat, textul lipseste."
-
+    devise:
+      login:
+        title: "Autentificare"
+        remember_me: "Tine-ma minte"
+        submit: "Autentificare"
+      reset_password:
+        title: "Ați uitat parola?"
+        submit: "Reseta parola"
+      change_password:
+        title: "Schimbați parola"
+        submit: "Schimbă parola"
+      unlock:
+        title: "Retrimite instrucțiunile de deblocare"
+        submit: "Retrimite instrucțiunile de deblocare"
+      links:
+        sign_in: "Autentificare"
+        forgot_your_password: "Ați uitat parola?"
+        sign_in_with_omniauth_provider: "Conectați-vă cu %{provider}"

--- a/lib/active_admin/locales/ru.yml
+++ b/lib/active_admin/locales/ru.yml
@@ -79,3 +79,4 @@ ru:
       links:
         sign_in: "Войти"
         forgot_your_password: "Забыли пароль?"
+        sign_in_with_omniauth_provider: "Войти на приложения %{provider}"

--- a/lib/active_admin/locales/sv-SE.yml
+++ b/lib/active_admin/locales/sv-SE.yml
@@ -79,3 +79,4 @@
       links:
         sign_in: "Logga in"
         forgot_your_password: "Glömt ditt lösenord?"
+        sign_in_with_omniauth_provider: "Logga in med %{provider}"

--- a/lib/active_admin/locales/tr.yml
+++ b/lib/active_admin/locales/tr.yml
@@ -79,3 +79,5 @@ tr:
       links:
         sign_in: "Oturum aç"
         forgot_your_password: "Şifreni mi unuttun?"
+        sign_in_with_omniauth_provider: "%{provider} ile giriş yapın"
+        

--- a/lib/active_admin/locales/vi.yml
+++ b/lib/active_admin/locales/vi.yml
@@ -79,3 +79,5 @@ vi:
       links:
         sign_in: "Đăng nhập"
         forgot_your_password: "Quên mật khẩu của bạn?"
+        sign_in_with_omniauth_provider: "Đăng nhập với %{provider}"
+        

--- a/lib/active_admin/locales/zh-CN.yml
+++ b/lib/active_admin/locales/zh-CN.yml
@@ -79,3 +79,5 @@
       links:
         sign_in: "登录"
         forgot_your_password: "忘记密码？"
+        sign_in_with_omniauth_provider: "登入%{provider}"
+        

--- a/lib/active_admin/locales/zh-TW.yml
+++ b/lib/active_admin/locales/zh-TW.yml
@@ -79,3 +79,5 @@
       links:
         sign_in: "登錄"
         forgot_your_password: "忘記密碼？"
+        sign_in_with_omniauth_provider: "登入%{provider}"
+        


### PR DESCRIPTION
Squashed version of https://github.com/gregbell/active_admin/pull/2086

Adds OmniAuth provider links to the login page. Includes translated strings for all locales.
