### PR TITLE
Resolves #587 adding :if & :unless proc arguments to scope_to() method

### DIFF
--- a/docs/2-resource-customization.md
+++ b/docs/2-resource-customization.md
@@ -158,6 +158,21 @@ has_many relationships, you can simply scope the listings and finders like so:
 
 That approach limits the posts an admin can access to ```current_user.posts```.
 
+If you want to conditionally apply the scope, then there are options for that as well:
+
+    ActiveAdmin.register Post do
+      # Only scope the query if there is a user to scope to, helper provided via Devise
+      scope_to :current_user, :if => proc{ admin_user_signed_in? }
+
+      # Don't scope the query if the user is an admin
+      scope_to :current_user, :unless => proc{ current_admin_user.admin? }
+
+      # Get fancy and can combine with block syntax
+      scope_to :if => proc{ admin_user_signed_in? } do
+        User.most_popular
+      end
+    end
+
 If you want to do something fancier, for example override a default scope, you can
 also use :association_method parameter with a normal method on your User model.
 The only requirement is that your method returns an instance of ActiveRecord::Relation.

--- a/features/index/index_scope_to.feature
+++ b/features/index/index_scope_to.feature
@@ -30,3 +30,27 @@ Feature: Index Scope To
 
     When I follow "Published"
     Then I should see 1 posts in the table
+
+  Scenario: Viewing the index with conditional scope :if
+    Given an index configuration of:
+      """
+      ActiveAdmin.register Post do
+        scope_to :if => proc{ false } do
+          User.find_by_first_name_and_last_name("John", "Doe")
+        end
+      end
+      """
+    When I am on the index page for posts
+    Then I should see 12 posts in the table
+
+  Scenario: Viewing the index with conditional scope :unless
+    Given an index configuration of:
+      """
+      ActiveAdmin.register Post do
+        scope_to :unless => proc{ true } do
+          User.find_by_first_name_and_last_name("John", "Doe")
+        end
+      end
+      """
+    When I am on the index page for posts
+    Then I should see 12 posts in the table

--- a/lib/active_admin/resource.rb
+++ b/lib/active_admin/resource.rb
@@ -6,6 +6,7 @@ require 'active_admin/resource/pagination'
 require 'active_admin/resource/routes'
 require 'active_admin/resource/naming'
 require 'active_admin/resource/scopes'
+require 'active_admin/resource/scope_to'
 require 'active_admin/resource/sidebars'
 require 'active_admin/resource/belongs_to'
 
@@ -38,12 +39,6 @@ module ActiveAdmin
 
     # The default sort order to use in the controller
     attr_accessor :sort_order
-
-    # Scope this resource to an association in the controller
-    attr_accessor :scope_to
-
-    # If we're scoping resources, use this method on the parent to return the collection
-    attr_accessor :scope_to_association_method
 
     # Set the configuration for the CSV
     attr_writer :csv_builder
@@ -79,6 +74,7 @@ module ActiveAdmin
     include PagePresenters
     include Pagination
     include Scopes
+    include ScopeTo
     include Sidebars
     include Menu
     include Routes

--- a/lib/active_admin/resource/scope_to.rb
+++ b/lib/active_admin/resource/scope_to.rb
@@ -1,0 +1,74 @@
+module ActiveAdmin
+  class Resource
+    module ScopeTo
+
+      # Scope this controller to some object which has a relation
+      # to the resource. Can either accept a block or a symbol 
+      # of a method to call.
+      #
+      # Eg:
+      #
+      #   ActiveAdmin.register Post do
+      #     scope_to :current_user
+      #   end
+      #
+      # Then every time we instantiate and object, it would call
+      #
+      #   current_user.posts.build
+      #
+      # By default Active Admin will use the resource name to build a
+      # method to call as the association. If its different, you can 
+      # pass in the association_method as an option.
+      #
+      #   scope_to :current_user, :association_method => :blog_posts
+      #
+      # will result in the following
+      #
+      #   current_user.blog_posts.build
+      #
+      # To conditionally use this scope, you can use conditional procs
+      # 
+      #   scope_to :current_user, :if => proc{ admin_user_signed_in? } 
+      #
+      # or
+      #
+      #   scope_to :current_user, :unless => proc{ current_user.admin? }
+      #
+      def scope_to(*args, &block)
+        options = args.extract_options!
+        method = args.first
+
+        scope_to_config[:method]              = block || method
+        scope_to_config[:association_method]  = options[:association_method]
+        scope_to_config[:if]                  = options[:if]
+        scope_to_config[:unless]              = options[:unless]
+
+      end
+
+      def scope_to_association_method
+        scope_to_config[:association_method]
+      end
+
+      def scope_to_method
+        scope_to_config[:method]
+      end
+
+      def scope_to_config
+        @scope_to_config ||= { 
+          :method               => nil, 
+          :association_method   => nil, 
+          :if                   => nil,
+          :unless               => nil
+        }
+      end
+
+      def scope_to?(context = nil)
+        return false if scope_to_method.nil?
+        return render_in_context(context, scope_to_config[:if]) unless scope_to_config[:if].nil?
+        return !render_in_context(context, scope_to_config[:unless]) unless scope_to_config[:unless].nil?
+        true
+      end
+
+    end
+  end
+end

--- a/lib/active_admin/resource_controller/scoping.rb
+++ b/lib/active_admin/resource_controller/scoping.rb
@@ -11,16 +11,11 @@ module ActiveAdmin
       # the scope to be defined in the active admin configuration.
       #
       # If scope_to is a proc, we eval it, otherwise we call the method on the controller.
+      #
+      # Collection can be scoped conditionally with an :if or :unless proc.
       def begin_of_association_chain
-        return nil unless active_admin_config.scope_to
-        case active_admin_config.scope_to
-        when Proc
-          instance_eval &active_admin_config.scope_to
-        when Symbol
-          send active_admin_config.scope_to
-        else
-          raise ArgumentError, "#scope_to accepts a symbol or a block"
-        end
+        return nil unless active_admin_config.scope_to?(self)
+        render_in_context(self, active_admin_config.scope_to_method)
       end
 
       # Overriding from InheritedResources::BaseHelpers

--- a/lib/active_admin/resource_dsl.rb
+++ b/lib/active_admin/resource_dsl.rb
@@ -7,36 +7,9 @@ module ActiveAdmin
       config.belongs_to(target, options)
     end
 
-    # Scope this controller to some object which has a relation
-    # to the resource. Can either accept a block or a symbol 
-    # of a method to call.
-    #
-    # Eg:
-    #
-    #   ActiveAdmin.register Post do
-    #     scope_to :current_user
-    #   end
-    #
-    # Then every time we instantiate and object, it would call
-    #
-    #   current_user.posts.build
-    #
-    # By default Active Admin will use the resource name to build a
-    # method to call as the association. If its different, you can 
-    # pass in the association_method as an option.
-    #
-    #   scope_to :current_user, :association_method => :blog_posts
-    #
-    # will result in the following
-    #
-    #   current_user.blog_posts.build
-    #
+    # Scope collection to a relation
     def scope_to(*args, &block)
-      options = args.extract_options!
-      method = args.first
-
-      config.scope_to = block_given? ? block : method
-      config.scope_to_association_method = options[:association_method]
+      config.scope_to(*args, &block)
     end
 
     # Create a scope

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -155,19 +155,6 @@ module ActiveAdmin
         end
       end
 
-      context "when not using a block or symbol" do
-        before do
-          @resource = application.register Category do
-            scope_to "Some string"
-          end
-        end
-        it "should raise and exception" do
-          lambda {
-            @resource.controller.new.send(:begin_of_association_chain)
-          }.should raise_error(ArgumentError)
-        end
-      end
-
       describe "getting the method for the association chain" do
         context "when a simple registration" do
           before do


### PR DESCRIPTION
Provides the following DSL for conditionally scoping resources:

``` ruby
ActiveAdmin.register Post do

    # Only scope the query if there is a user to scope to, helper provided via Devise
    scope_to :current_user, :if => proc{ admin_user_signed_in? }

    # Don't scope the query if the user is an admin
    scope_to :current_user, :unless => proc{ current_admin_user.admin? }

    # Get fancy and can combine with block syntax
    scope_to :if => proc{ admin_user_signed_in? } do
      User.most_popular
    end

end
```

Resolves issue #587.
