### PR TITLE
Fix breadcrumb links for namespaced parent models

### DIFF
--- a/lib/active_admin/view_helpers/breadcrumb_helper.rb
+++ b/lib/active_admin/view_helpers/breadcrumb_helper.rb
@@ -11,9 +11,9 @@ module ActiveAdmin
           # If an object (users/23), look it up via ActiveRecord and capture its name.
           # If name is nil, look up the model translation, using `titlecase` as the backup.
           if part =~ /^\d|^[a-f0-9]{24}$/ && parent = parts[index-1]
-            klass = parent.singularize.camelcase.constantize rescue nil
-            obj   = klass.find_by_id(part) if klass
-            name  = display_name(obj)      if obj
+            config = active_admin_config.belongs_to_config
+            obj    = config.target.resource_class.find_by_id(part) if config
+            name   = display_name(obj)                             if obj
           end
           name ||= I18n.t "activerecord.models.#{part.singularize}", :count => 1.1, :default => part.titlecase
 

--- a/spec/unit/breadcrumbs_spec.rb
+++ b/spec/unit/breadcrumbs_spec.rb
@@ -11,6 +11,12 @@ describe "Breadcrumbs" do
     # Mock link to and return a hash
     def link_to(name, url); {:name => name, :path => url}; end
 
+    let :active_admin_config do
+      m = mock
+      m.stub_chain(:belongs_to_config, :target, :resource_class).and_return Post
+      m
+    end
+
     let(:trail) { breadcrumb_links(path) }
 
     context "when request '/admin'" do


### PR DESCRIPTION
The previous code broke nested resource (e.g. /users/1/stories) had a
parent class that was namespaced inside a module.

``` ruby
# Given these models
class Foo::Users   # has_many stories
class Foo::Stories # belongs_to user

# and this AA routing for stories
ActiveAdmin.register Foo::Stories do
  belongs_to :user, parent_class: Foo::User
end

# you'd get this error
"undefined method `find_by_id' for Foo:Module"
```

This commit resolves the problem by directly asking the AA config
what the parent class is, instead of trying to guess based on the URL.

Fixes #2051
