### PR TITLE
Refactor Comments UI

### DIFF
--- a/features/comments/commenting.feature
+++ b/features/comments/commenting.feature
@@ -34,7 +34,7 @@ Feature: Commenting
         config.comments = false
       end
     """
-    Then I should not see "Comments"
+    Then I should not see the element "div.comments.panel"
 
   Scenario: View a resource in a namespace that doesn't have comments
     Given a configuration of:
@@ -95,7 +95,7 @@ Feature: Commenting
         ActiveAdmin.register Post
       """
     When I add a comment "Hello from Comment"
-    When I am on the index page for admin_comments
+    When I am on the index page for comments
     Then I should see a table header with "Body"
     And I should see "Hello from Comment"
 

--- a/features/comments/viewing_index.feature
+++ b/features/comments/viewing_index.feature
@@ -9,7 +9,7 @@ Feature: Viewing Index of Comments
 
   Scenario: Viewing all commments for a namespace
     When I add a comment "Hello from Comment"
-    When I am on the index page for admin_comments
+    When I am on the index page for comments
     Then I should see a table header with "Body"
     And I should see a table header with "Resource"
     And I should see a table header with "Author"

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -51,8 +51,10 @@ When /^(?:I )attach the file "([^"]*)" to "([^"]*)"$/ do |path, field|
   attach_file(field, File.expand_path(path))
 end
 
-Then /^(?:I )should( not)? see "([^"]*)"$/ do |negate, text|
-  page.should negate ? have_no_content(text) : have_content(text)
+Then /^(?:I )should( not)? see( the element)? "([^"]*)"$/ do |negate, is_css, text|
+  should = negate ? :should_not    : :should
+  have   = is_css ? have_css(text) : have_content(text)
+  page.send should, have
 end
 
 Then /^the "([^"]*)" field(?: within (.*))? should( not)? contain "([^"]*)"$/ do |field, parent, negate, value|

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -102,10 +102,6 @@ module ActiveAdmin
     # @deprecated The default sort order for index pages
     deprecated_setting :default_sort_order, 'id_desc'
 
-    # DEPRECATED: This option is deprecated and will be removed. Use
-    # the #allow_comments_in option instead
-    attr_accessor :admin_notes
-
     include AssetRegistration
 
     # Event that gets triggered on load of Active Admin

--- a/lib/active_admin/comments/comment.rb
+++ b/lib/active_admin/comments/comment.rb
@@ -7,13 +7,11 @@ module ActiveAdmin
 
   class Comment < ActiveRecord::Base
     belongs_to :resource, :polymorphic => true
-    belongs_to :author, :polymorphic => true
+    belongs_to :author,   :polymorphic => true
 
     attr_accessible :resource, :resource_id, :resource_type, :body, :namespace
 
-    validates_presence_of :resource
-    validates_presence_of :body
-    validates_presence_of :namespace
+    validates_presence_of :body, :namespace, :resource
 
     # @returns [String] The name of the record to use for the polymorphic relationship
     def self.resource_type(record)
@@ -30,13 +28,13 @@ module ActiveAdmin
     end
 
     def self.find_for_resource_in_namespace(resource, namespace)
-      where(:resource_type => resource_type(resource),
-            :resource_id => resource_id_cast(resource),
-            :namespace => namespace.to_s)
+      where :resource_type => resource_type(resource),
+            :resource_id   => resource_id_cast(resource),
+            :namespace     => namespace.to_s
     end
 
     def self.resource_id_type
-      columns.select { |i| i.name == "resource_id" }.first.type
+      columns.detect{ |i| i.name == "resource_id" }.type
     end
 
     def self.table_name

--- a/lib/active_admin/comments/views/active_admin_comments.rb
+++ b/lib/active_admin/comments/views/active_admin_comments.rb
@@ -56,11 +56,11 @@ module ActiveAdmin
         end
 
         def comment_form_url
-          if active_admin_namespace.root?
-            comments_path
-          else
-            send(:"#{active_admin_namespace.name}_admin_comments_path")
-          end
+          parts = []
+          parts << active_admin_namespace.name unless active_admin_namespace.root?
+          parts << active_admin_namespace.comments_registration_name.underscore.pluralize
+          parts << 'path'
+          send parts.join '_'
         end
 
         def build_comment_form

--- a/lib/active_admin/locales/en.yml
+++ b/lib/active_admin/locales/en.yml
@@ -57,6 +57,8 @@ en:
       labels:
         destroy: "Delete"
     comments:
+      resource_type: "Resource Type"
+      author_type: "Author Type"
       body: "Body"
       author: "Author"
       title: "Comment"

--- a/lib/active_admin/resource.rb
+++ b/lib/active_admin/resource.rb
@@ -115,11 +115,6 @@ module ActiveAdmin
       controller.instance_methods.map { |m| m.to_sym } & ResourceController::ACTIVE_ADMIN_ACTIONS
     end
 
-    # Are admin notes turned on for this resource
-    def admin_notes?
-      admin_notes.nil? ? ActiveAdmin.admin_notes : admin_notes
-    end
-
     def belongs_to(target, options = {})
       @belongs_to = Resource::BelongsTo.new(self, target, options)
       self.menu_item_menu_name = target unless @belongs_to.optional?

--- a/lib/generators/active_admin/install/templates/active_admin.rb.erb
+++ b/lib/generators/active_admin/install/templates/active_admin.rb.erb
@@ -86,6 +86,7 @@ ActiveAdmin.setup do |config|
   # Default:
   # config.logout_link_method = :get
 
+
   # == Root
   #
   # Set the action to call for the root path. You can set different
@@ -94,21 +95,19 @@ ActiveAdmin.setup do |config|
   # Default:
   # config.root_to = 'dashboard#index'
 
+
   # == Admin Comments
   #
-  # Admin comments allow you to add comments to any model for admin use.
-  # Admin comments are enabled by default.
+  # This allows your users to comment on any resource registered with Active Admin.
   #
-  # Default:
-  # config.allow_comments = true
+  # You can completely disable comments:
+  # config.allow_comments = false
   #
-  # You can turn them on and off for any given namespace by using a
-  # namespace config block.
+  # You can disable the menu item for the comments index page:
+  # config.show_comments_in_menu = false
   #
-  # Eg:
-  #   config.namespace :without_comments do |without_comments|
-  #     without_comments.allow_comments = false
-  #   end
+  # You can change the name under which comments are registered:
+  # config.comments_registration_name = 'AdminComment'
 
 
   # == Batch Actions
@@ -134,7 +133,7 @@ ActiveAdmin.setup do |config|
   #
   # To load a stylesheet:
   #   config.register_stylesheet 'my_stylesheet.css'
-
+  #
   # You can provide an options hash for more control, which is passed along to stylesheet_link_tag():
   #   config.register_stylesheet 'my_print_stylesheet.css', :media => :print
   #
@@ -144,7 +143,7 @@ ActiveAdmin.setup do |config|
 
   # == CSV options
   #
-  # Set the CSV builder separator (default is ",")
+  # Set the CSV builder separator (default is ',')
   # config.csv_column_separator = ','
   #
   # Set the CSV builder options (default is {})
@@ -171,6 +170,7 @@ ActiveAdmin.setup do |config|
   #       menu.add label: "My Great Website", url: "http://www.mygreatwebsite.com", html_options: { target: :blank }
   #     end
   #   end
+
 
   # == Download Links
   #
@@ -205,6 +205,5 @@ ActiveAdmin.setup do |config|
   # You can enable or disable them for all resources here.
   #
   # config.filters = true
-
 
 end

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -53,10 +53,6 @@ describe ActiveAdmin::Application do
     application.view_factory.should be_an_instance_of(ActiveAdmin::ViewFactory)
   end
 
-  it "should have deprecated admin notes by default" do
-    application.admin_notes.should be_nil
-  end
-
   it "should allow comments by default" do
     application.allow_comments.should == true
   end


### PR DESCRIPTION
While working on #1979, I noticed that we happen to register an index page for Comments, but it's hidden by default. This PR updates that UI so it's worthy of being shown by default.
##### Changes
- new configuration options:
  - menu item visibility (defaults to true)
  - `:as` registration name. For #301; replaces #2060 (defaults to Comment)
- index page:
  - added a scope for every AA namespace, with the current namespace as the default
  - updated `resource_type` and `author_type` filters to be select fields (for Rails >= 3.2)
  - updated table to show every attribute
- show page:
  - instead of redirecting to the associated resource, we now have a proper show page  
