### PR TITLE
[2012] Get `human_attribute_name` working for all inputs

### DIFF
--- a/lib/active_admin.rb
+++ b/lib/active_admin.rb
@@ -11,6 +11,8 @@ require 'active_admin/dependency_checker'
 require 'active_admin/sass/helpers'
 require 'active_admin/engine'
 
+require 'gem_ext'
+
 module ActiveAdmin
 
   autoload :VERSION,                  'active_admin/version'

--- a/lib/active_admin/inputs/filter_base.rb
+++ b/lib/active_admin/inputs/filter_base.rb
@@ -27,16 +27,6 @@ module ActiveAdmin
         end
       end
 
-      # Returns the default label for a given attribute
-      # Will use ActiveModel I18n if possible
-      def humanized_method_name
-        if object.base.respond_to?(:human_attribute_name)
-          object.base.human_attribute_name(method)
-        else
-          method.to_s.send(builder.label_str_method)
-        end
-      end
-
       # Returns the association reflection for the method if it exists
       def reflection_for(method)
         @object.base.reflect_on_association(method) if @object.base.respond_to?(:reflect_on_association)

--- a/lib/gem_ext.rb
+++ b/lib/gem_ext.rb
@@ -1,0 +1,1 @@
+require 'formtastic/inputs/base'

--- a/lib/gem_ext/formtastic/inputs/base.rb
+++ b/lib/gem_ext/formtastic/inputs/base.rb
@@ -1,0 +1,17 @@
+module Formtastic
+  module Inputs
+    module Base
+
+      # Overrides Formtastic's version to accept `.base`
+      def humanized_method_name
+        klass = object.respond_to?(:base) ? object.base : object.class
+        if klass.respond_to? :human_attribute_name
+          klass.human_attribute_name method
+        else
+          method.to_s.send builder.label_str_method
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
For #2012

For AA, Formtastic's method needs to be changed so that it checks `.base`. I noticed that `FilterBase` was already doing this, so I moved it out to directly monkeypatch `Formtastic::Inputs::Base` so that all input types respect `.base`.

Since this is a direct and global change to Formtastic itself, I created a new directory structure: `lib/formtastic/`. I'm welcome to other ideas.

Unfortunately, it doesn't work just like that. I'm getting this error:

```
Formtastic::UnknownInputError - Formtastic::UnknownInputError:
  /home/sean/code/gems/active_admin/lib/active_admin/form_builder.rb:161:in `rescue in input_class_by_trying'
  /home/sean/code/gems/active_admin/lib/active_admin/form_builder.rb:149:in `input_class_by_trying'
  (gem) formtastic-2.2.1/lib/formtastic/helpers/input_helper.rb:323:in `input_class'
  (gem) formtastic-2.2.1/lib/formtastic/helpers/input_helper.rb:238:in `input'
  /home/sean/code/gems/active_admin/lib/active_admin/form_builder.rb:19:in `block in input'
  /home/sean/code/gems/active_admin/lib/active_admin/form_builder.rb:176:in `with_new_form_buffer'
```

My guess is this change affects/prevents the input types from being loaded. Any thoughts on this @macfanatic?
