### PR TITLE
Hide new record link for has_many form

### DIFF
--- a/docs/5-forms.md
+++ b/docs/5-forms.md
@@ -53,7 +53,7 @@ You can create forms with nested models using the `has_many` method:
           f.input :body
         end
         f.inputs do
-          f.has_many :categories, :allow_destroy => true do |cf|
+          f.has_many :categories, :allow_destroy => true, :heading => 'Themes', :new_record => false do |cf|
             cf.input :title
           end
         end
@@ -65,4 +65,8 @@ You can create forms with nested models using the `has_many` method:
 The `:allow_destroy` option will add a checkbox to the end of the nested form allowing
 removal of the child object upon submission. Be sure to set `:allow_destroy => true`
 on the association to use this option.
+
+The `:heading` option will add a custom heading to has_many form. You can hide a heading by setting `:heading => false`.
+
+The `:new_record` option will show or hide new record link at the bottom of has_many form. It is set as true by default.
 

--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -42,7 +42,7 @@ module ActiveAdmin
     end
 
     def has_many(association, options = {}, &block)
-      options = { :for => association }.merge(options)
+      options = { :for => association, :new_record => true }.merge(options)
       options[:class] ||= ""
       options[:class] << "inputs has_many_fields"
 
@@ -80,7 +80,8 @@ module ActiveAdmin
 
           inputs options, &form_block
 
-          form_buffers.last << js_for_has_many(association, form_block, template)
+          js = options[:new_record] ? js_for_has_many(association, form_block, template) : ""
+          form_buffers.last << js.html_safe
         end
       end
     end

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -167,7 +167,7 @@ describe ActiveAdmin::FormBuilder do
 
   end
 
-  context "with actons" do
+  context "with actions" do
     it "should generate the form once" do
       body = build_form do |f|
         f.inputs do
@@ -360,7 +360,48 @@ describe ActiveAdmin::FormBuilder do
       it "should accept a block with a second argument" do
         body.should have_tag("label", "Title 1")
       end
+
+      it "should add a custom header" do
+        body.should have_tag('h3', 'Post')
+      end 
+
     end
+
+    describe "without heading and new record link" do
+      let :body do
+        build_form({:url => '/categories'}, Category.new) do |f|
+          f.object.posts.build
+          f.has_many :posts, :heading => false, :new_record => false do |p|
+            p.input :title
+          end
+        end
+      end
+
+      it "should not add a header" do
+        body.should_not have_tag('h3', 'Post')
+      end 
+
+      it "should not add link to new nested records" do
+        body.should_not have_tag('a', 'Add New Post')
+      end 
+
+    end  
+
+    describe "with custom heading" do
+      let :body do
+        build_form({:url => '/categories'}, Category.new) do |f|
+          f.object.posts.build
+          f.has_many :posts, :heading => "Test heading" do |p|
+            p.input :title
+          end
+        end
+      end
+
+      it "should add a custom header" do
+        body.should have_tag('h3', 'Test heading')
+      end       
+
+    end  
 
     describe "with allow destroy" do
       context "with an existing post" do


### PR DESCRIPTION
This changes will do:
1) add option 'new_record' for has_many form to hide 'new item link'
2) add missed specs for 'heading' option that discussed in [#1945](https://github.com/gregbell/active_admin/pull/1945)
3) add changes to documentation to docs/5-forms.md

Screenshots to illustrate changes:

Showing Add button
![before2](https://f.cloud.github.com/assets/583275/204449/66f1de62-8179-11e2-9846-a6afc0084001.png)

not showing Add button
![after2](https://f.cloud.github.com/assets/583275/204446/66c091ea-8179-11e2-9de3-92e265d62c4a.png)
