### PR TITLE
[1845] prevent assets from being registered multiple times

### DIFF
--- a/app/views/layouts/active_admin_logged_out.html.erb
+++ b/app/views/layouts/active_admin_logged_out.html.erb
@@ -5,8 +5,8 @@
 
   <title><%= [@page_title, render_or_call_method_or_proc_on(self, ActiveAdmin.application.site_title)].compact.join(" | ") %></title>
 
-  <% ActiveAdmin.application.stylesheets.each do |style| %>
-    <%= stylesheet_link_tag style.path, style.options.dup %>
+  <% ActiveAdmin.application.stylesheets.each do |style, options| %>
+    <%= stylesheet_link_tag style, options %>
   <% end %>
   <% ActiveAdmin.application.javascripts.each do |path| %>
     <%= javascript_include_tag path %>

--- a/lib/active_admin/asset_registration.rb
+++ b/lib/active_admin/asset_registration.rb
@@ -1,47 +1,29 @@
 module ActiveAdmin
   module AssetRegistration
 
-    # Stylesheets
-
-    def register_stylesheet(*args)
-      stylesheets << ActiveAdmin::Stylesheet.new(*args)
+    def register_stylesheet(path, options = {})
+      stylesheets[path] = options
     end
 
     def stylesheets
-      @stylesheets ||= []
+      @stylesheets ||= {}
     end
 
     def clear_stylesheets!
-      @stylesheets = []
+      @stylesheets = {}
     end
 
-
-    # Javascripts
-
     def register_javascript(name)
-      javascripts << name
+      javascripts.add name
     end
 
     def javascripts
-      @javascripts ||= []
+      @javascripts ||= Set.new
     end
 
     def clear_javascripts!
-      @javascripts = []
+      @javascripts = Set.new
     end
 
   end
-
-  # Wrapper class for stylesheet registration
-  class Stylesheet
-
-    attr_reader :options, :path
-
-    def initialize(*args)
-      @options = args.extract_options!
-      @path = args.first if args.first
-    end
-
-  end
-
 end

--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -23,8 +23,8 @@ module ActiveAdmin
         def build_active_admin_head
           within @head do
             insert_tag Arbre::HTML::Title, [title, render_or_call_method_or_proc_on(self, active_admin_application.site_title)].join(" | ")
-            active_admin_application.stylesheets.each do |style|
-              text_node(stylesheet_link_tag(style.path, style.options.dup).html_safe)
+            active_admin_application.stylesheets.each do |style, options|
+              text_node stylesheet_link_tag(style, options).html_safe
             end
 
             active_admin_application.javascripts.each do |path|

--- a/spec/unit/asset_registration_spec.rb
+++ b/spec/unit/asset_registration_spec.rb
@@ -14,30 +14,43 @@ describe ActiveAdmin::AssetRegistration do
   it "should register a stylesheet file" do
     MockRegistration.register_stylesheet "active_admin.css"
     MockRegistration.stylesheets.length.should == 1
-    MockRegistration.stylesheets.first.path.should == "active_admin.css"
+    MockRegistration.stylesheets.keys.first.should == "active_admin.css"
   end
 
   it "should clear all existing stylesheets" do
     MockRegistration.register_stylesheet "active_admin.css"
     MockRegistration.stylesheets.length.should == 1
     MockRegistration.clear_stylesheets!
-    MockRegistration.stylesheets.length.should == 0
+    MockRegistration.stylesheets.should be_empty
   end
 
   it "should allow media option when registering stylesheet" do
     MockRegistration.register_stylesheet "active_admin.css", :media => :print
-    MockRegistration.stylesheets.first.options[:media].should == :print
+    MockRegistration.stylesheets.values.first[:media].should == :print
   end
+
+  it "shouldn't register a stylesheet twice" do
+    MockRegistration.register_stylesheet "active_admin.css"
+    MockRegistration.register_stylesheet "active_admin.css"
+    MockRegistration.stylesheets.length.should == 1
+  end
+
 
   it "should register a javascript file" do
     MockRegistration.register_javascript "active_admin.js"
-    MockRegistration.javascripts.should == ["active_admin.js"]
+    MockRegistration.javascripts.should == ["active_admin.js"].to_set
   end
 
   it "should clear all existing javascripts" do
     MockRegistration.register_javascript "active_admin.js"
-    MockRegistration.javascripts.should == ["active_admin.js"]
+    MockRegistration.javascripts.should == ["active_admin.js"].to_set
     MockRegistration.clear_javascripts!
-    MockRegistration.javascripts.should == []
+    MockRegistration.javascripts.should be_empty
+  end
+
+  it "shouldn't register a javascript twice" do
+    MockRegistration.register_javascript "active_admin.js"
+    MockRegistration.register_javascript "active_admin.js"
+    MockRegistration.javascripts.length.should == 1
   end
 end


### PR DESCRIPTION
JavaScript and CSS registrations are now stored inside a Set and a
Hash, respectively, to ensure that no duplicates are created.

For #1845
