### PR TITLE
Add ability to add html options to index_as_table

### DIFF
--- a/lib/active_admin/views/index_as_table.rb
+++ b/lib/active_admin/views/index_as_table.rb
@@ -111,10 +111,10 @@ module ActiveAdmin
         table_options = {
           :id => "index_table_#{active_admin_config.resource_name.plural}",
           :sortable => true,
-          :class => "index_table index",
+          :class => ['index_table index', page_presenter[:class]].compact.join(' '),
           :i18n => active_admin_config.resource_class,
           :paginator => page_presenter[:paginator] != false
-        }
+        }.merge(page_presenter[:table_options] || {})
 
         table_for collection, table_options do |t|
           table_config_block = page_presenter.block || default_table


### PR DESCRIPTION
Example: 

``` ruby
index class: 'positionable', html_options: { 'data-sort-uri' => '/resource/sort' } do 
  # ...
end
#=> <table class="index index_table positionable" data-sort-uri="/resource/sort">...</table>
```
