### PR TITLE
Use custom page name for cancan abitlity config

### DIFF
--- a/lib/active_admin/cancan_adapter.rb
+++ b/lib/active_admin/cancan_adapter.rb
@@ -8,6 +8,7 @@ module ActiveAdmin
   class CanCanAdapter < AuthorizationAdapter
 
     def authorized?(action, subject = nil)
+      subject = subject.name if subject.is_a?(::ActiveAdmin::Page)
       cancan_ability.can?(action, subject)
     end
 


### PR DESCRIPTION
At the moment custom pages get checked against the page instance.

With this code you can use the custom page name instead.

f.e. (ability.rb)

```
can :manage, 'Dashboard'
```
