### PR TITLE
Advanced routing constraints

### DIFF
--- a/docs/1-general-configuration.md
+++ b/docs/1-general-configuration.md
@@ -78,6 +78,47 @@ individually.
 Each setting available in the Active Admin setup block is configurable on a per
 namespace basis.
 
+### Namespace Routing Constraints
+
+If you want to customize the routing behavior even further, you can pass a 
+constraint object to ActiveAdmin to use when generating the routes for the namespace.
+
+For example, to have the namespace "admin" served up at "admin.example.com" instead of
+"example.com/admin", you could use the following constraint class:
+
+    class Constraint::Subdomain
+      def initialize(*subdomains)
+        @subdomains = subdomains
+      end
+
+      def matches?(request)
+        request.subdomain.present? && @subdomains.include? request.subdomain
+      end
+    end
+
+And pair that with the following config for the "admin" namespace:
+
+    ActiveAdmin.setup do |config|
+      config.namespace :admin do |admin|
+        admin.routing_constraint = Constraint::Subdomain.new('admin')
+      end
+    end
+
+Note that according to Rails routing documentation, a proc could also be passed here, as
+we only need an object that responds to the '#matches?' method.  Passing a Hash is also valid.
+
+    ActiveAdmin.setup do |config|
+      config.namespace :admin do |admin|
+
+        # Can pass in a Proc object that accepts the request, returning true/false
+        admin.routing_constraint = proc { |request| request.host == 'myapp.example.com' }
+
+        # Can also pass in a Hash of options that is provided directly to the router
+        admin.routing_constraint = { :subdomain => "admin" }
+        
+      end
+    end
+
 ## Load paths
 
 By default Active Admin files go under '/app/admin'. You can change this

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -44,6 +44,9 @@ module ActiveAdmin
     # Set the site title image displayed in the main layout (has precendence over :site_title)
     inheritable_setting :site_title_image, ""
 
+    # Set an optional Constraint object to be used when creating routes for this namespace
+    inheritable_setting :routing_constraint, nil
+
     # The view factory to use to generate all the view classes. Take
     # a look at ActiveAdmin::ViewFactory
     inheritable_setting :view_factory, ActiveAdmin::ViewFactory.new

--- a/lib/generators/active_admin/install/templates/active_admin.rb.erb
+++ b/lib/generators/active_admin/install/templates/active_admin.rb.erb
@@ -96,6 +96,18 @@ ActiveAdmin.setup do |config|
   # config.root_to = 'dashboard#index'
 
 
+  # == Advanced Namespace Routing
+  #
+  # To provide a class, class instance, proc or hash to the `Routes#constraints`
+  # method in Rails, use this setting.  You can achieve things like "admin.example.com"
+  # trivially with this setting.
+  #
+  # This is configurable per namespace or globally.
+  #
+  # Default:
+  # config.routing_constraint = nil
+
+
   # == Admin Comments
   #
   # This allows your users to comment on any resource registered with Active Admin.

--- a/spec/unit/routing_spec.rb
+++ b/spec/unit/routing_spec.rb
@@ -12,9 +12,6 @@ describe ActiveAdmin, "Routing", :type => :routing do
   include Rails.application.routes.url_helpers
 
   describe "root" do
-    before do
-      pending "Y U NO PASS?"
-    end
     context "when default configuration" do
       context "when in admin namespace" do
         it "should route the admin dashboard" do
@@ -151,6 +148,31 @@ describe ActiveAdmin, "Routing", :type => :routing do
 
         it "should properly route the second verb" do
           {:delete => "/admin/posts/1/do_something"}.should be_routable
+        end
+      end
+
+      context "with routing constraint" do
+        before do
+          ActiveAdmin.setup do |config|
+            config.routing_constraint = { :subdomain => 'admin' }
+          end
+        end
+
+        after do
+          ActiveAdmin.setup do |config|
+            config.routing_constraint = nil
+          end
+        end
+
+        let(:url)     { "http://admin.domain.com"   }
+        let(:bad_url) { "http://bad_url.domain.com" }
+
+        it "does map :admin namespace to the specified subdomain" do
+          get(url).should route_to('admin/dashboard#index')
+        end
+
+        it "should not route unrecongized constraint" do
+          get(bad_url).should_not be_routable
         end
       end
     end


### PR DESCRIPTION
Advanced routing configuration per namespace, or globally, with a new setting.  Inspired when loading engines into my parent application with ActiveAdmin, client wanted each engine to be available at it's own URL.

The old URL "http://www.mygreatapp.com/some_engine" is now served up at "http://engine.mygreatapp.com/" with the following config change:

``` ruby
ActiveAdmin.setup do |config|
  config.namespace :some_engine do |e|
    e.routing_constraint = { subdomain: "engine" }
  end
end
```

The new setting with accept a Proc, Hash, Class or Class instance - any object that responds to `#matches?`.
