### PR TITLE
Allow utility_navigation to be set to a unique component for rendering

### DIFF
--- a/lib/active_admin/view_factory.rb
+++ b/lib/active_admin/view_factory.rb
@@ -5,6 +5,7 @@ module ActiveAdmin
 
     # Register Helper Renderers
     register  :global_navigation    => ActiveAdmin::Views::TabbedNavigation,
+              :utility_navigation   => ActiveAdmin::Views::TabbedNavigation,
               :site_title           => ActiveAdmin::Views::SiteTitle,
               :action_items         => ActiveAdmin::Views::ActionItems,
               :title_bar            => ActiveAdmin::Views::TitleBar,

--- a/lib/active_admin/views/header.rb
+++ b/lib/active_admin/views/header.rb
@@ -24,7 +24,7 @@ module ActiveAdmin
       end
 
       def build_utility_navigation
-        insert_tag view_factory.global_navigation, @utility_menu, :id => "utility_nav", :class => 'header-item tabs'
+        insert_tag view_factory.utility_navigation, @utility_menu, :id => "utility_nav", :class => 'header-item tabs'
       end
 
     end

--- a/spec/unit/view_factory_spec.rb
+++ b/spec/unit/view_factory_spec.rb
@@ -9,6 +9,7 @@ end
 describe ActiveAdmin::ViewFactory do
 
   it_should_have_view :global_navigation,    ActiveAdmin::Views::TabbedNavigation
+  it_should_have_view :utility_navigation,   ActiveAdmin::Views::TabbedNavigation
   it_should_have_view :site_title,           ActiveAdmin::Views::SiteTitle
   it_should_have_view :action_items,         ActiveAdmin::Views::ActionItems
   it_should_have_view :header,               ActiveAdmin::Views::Header


### PR DESCRIPTION
Allow user to be able to provide a custom component for rendering the utility navigation.
