### PR TITLE
Use to_param instead of id method to route to a singular resource.

### DIFF
--- a/lib/active_admin/resource/routes.rb
+++ b/lib/active_admin/resource/routes.rb
@@ -70,9 +70,9 @@ module ActiveAdmin
         # @return params to pass to instance path
         def route_instance_params(instance)
           if nested?
-            [instance.send(belongs_to_name).id, instance.id]
+            [instance.send(belongs_to_name).to_param, instance.to_param]
           else
-            instance.id
+            instance.to_param
           end
         end
 


### PR DESCRIPTION
The routing should use to_param as the default ID resolver for routes. All tests pass. I wasn't sure if I should add another model to test this functionality.
