### PR TITLE
Added coffee-script dependency to gemspec.

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |s|
   s.add_dependency("sass", ">= 3.1.0")
   s.add_dependency("fastercsv", ">= 0")
   s.add_dependency("arbre", ">= 1.0.1")
+  s.add_dependency("coffee-script", ">= 2.2.0")
 end


### PR DESCRIPTION
ActiveAdmin relies on CoffeeScript, but it doesn't have the dependency listed in the gemspec.

For any Rails app that is already using CoffeeScript and has the gem installed, it doesn't matter, but when you don't already have the `coffee-script` gem installed, when you try to visit an ActiveAdmin page, you'll get this error:

```
cannot load such file -- coffee_script
  (in [your-gem-path]/activeadmin-0.6.0/app/assets/javascripts/active_admin/lib/namespace.js.coffee)
```

This fixes that.
