### PR TITLE
adding title for forms

### DIFF
--- a/lib/active_admin/views/pages/form.rb
+++ b/lib/active_admin/views/pages/form.rb
@@ -5,8 +5,14 @@ module ActiveAdmin
       class Form < Base
 
         def title
-          I18n.t("active_admin.#{params[:action]}_model",
+          form_options = form_presenter.options
+          
+          if form_options[:title]
+            form_options[:title].is_a?(Hash) ? form_options[:title][params[:action].to_sym] : form_options[:title]
+          else
+            I18n.t("active_admin.#{params[:action]}_model",
                  :model => active_admin_config.resource_label)
+          end
         end
 
         def form_presenter


### PR DESCRIPTION
For #2195

Usage : 
Example 1:

``` ruby
ActiveAdmin.register Category do
  form do |f|
    f.inputs do
      f.input :name
      f.input :description
    end
    f.actions
  end
end
```

Edit and New Forms shows Default Titles (Edit Category and New Category)

Example 2:

``` ruby
ActiveAdmin.register Category do
  form :title => "A new title" do |f|
    f.inputs do
      f.input :name
      f.input :description
    end
    f.actions do
      f.action :submit
      f.action :cancel, :label => 'Cancel', :input_html => {:class => 'cancel_subscription'}
    end
  end
end
```

Edit and New Forms shows the new Title ("A new title")

Example 3:

``` ruby
ActiveAdmin.register Category do
  form :title => { :new => "New Category", :edit => "Renew  Category"} do |f|
    f.inputs do
      f.input :name
      f.input :description
    end
    f.actions do
      f.action :submit
      f.action :cancel, :label => 'Cancel', :input_html => {:class => 'cancel_subscription'}
    end
  end
end
```

Edit and New Forms shows the new titles ("Renew Category" and "New Category" respectively)
