### PR TITLE
Improve test performance by deferring garbage collection

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -137,3 +137,10 @@ end
 # improve the performance of the specs suite by not logging anything
 # see http://blog.plataformatec.com.br/2011/12/three-tips-to-improve-the-performance-of-your-test-suite/
 Rails.logger.level = 4
+
+# Improves performance by forcing the garbage collector to run less often.
+unless ENV['DEFER_GC'] == '0' || ENV['DEFER_GC'] == 'false'
+  require File.expand_path('../../../spec/support/deferred_garbage_collection', __FILE__)
+  Before { DeferredGarbageCollection.start }
+  After  { DeferredGarbageCollection.reconsider }
+end

--- a/spec/integration/memory_spec.rb
+++ b/spec/integration/memory_spec.rb
@@ -11,13 +11,14 @@ describe "Memory Leak" do
 
   def self.it_should_not_leak(klass)
     it "should not leak #{klass}" do
+      previously_disabled = GC.enable # returns true if the garbage collector was disabled
       GC.start
-
       count = count_instances_of(klass)
 
       load_defaults!
-      GC.start
 
+      GC.start
+      GC.disable if previously_disabled
       count_instances_of(klass).should <= count
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-require File.expand_path("../spec_helper_without_rails", __FILE__)
+require 'spec_helper_without_rails'
 
 module ActiveAdminIntegrationSpecHelper
   extend self
@@ -163,3 +163,13 @@ end
 # improve the performance of the specs suite by not logging anything
 # see http://blog.plataformatec.com.br/2011/12/three-tips-to-improve-the-performance-of-your-test-suite/
 Rails.logger.level = 4
+
+
+# Improves performance by forcing the garbage collector to run less often.
+unless ENV['DEFER_GC'] == '0' || ENV['DEFER_GC'] == 'false'
+  require 'support/deferred_garbage_collection'
+  RSpec.configure do |config|
+    config.before(:all) { DeferredGarbageCollection.start }
+    config.after(:all)  { DeferredGarbageCollection.reconsider }
+  end
+end

--- a/spec/support/deferred_garbage_collection.rb
+++ b/spec/support/deferred_garbage_collection.rb
@@ -1,0 +1,19 @@
+class DeferredGarbageCollection
+
+  DEFERRED_GC_THRESHOLD = (ENV['DEFER_GC'] || 15.0).to_f
+
+  @@last_gc_run = Time.now
+
+  def self.start
+    GC.disable
+  end
+
+  def self.reconsider
+    if Time.now - @@last_gc_run >= DEFERRED_GC_THRESHOLD
+      GC.enable
+      GC.start
+      GC.disable
+      @@last_gc_run = Time.now
+    end
+  end
+end


### PR DESCRIPTION
Our tests run noticeably faster by only running the garbage collector every 15 seconds.
Inspired by: https://ariejan.net/2011/09/24/rspec-speed-up-by-tweaking-ruby-garbage-collection
#### Rspec tests: 20 second, 40% improvement

``` sh
time (DEFER_GC=false rspec spec 1>/dev/null)
real    0m52.368s
user    0m50.189s
sys     0m2.144s

time (rspec spec 1>/dev/null)
real    0m32.329s
user    0m29.206s
sys     0m3.087s
```
#### Cucumber tests: 35 second, 32% improvement

``` sh
time (DEFER_GC=false cucumber features 1>/dev/null)
real    1m51.976s
user    1m40.672s
sys     0m9.517s

time (cucumber features 1>/dev/null)
real    1m16.127s
user    1m2.412s
sys     0m12.184s
```
#### When run together: 55 second, 32% improvement

``` sh
time (DEFER_GC=false rake test 1>/dev/null)
real    2m55.147s
user    2m39.958s
sys     0m13.335s

time (rake test 1>/dev/null)
real    2m0.330s
user    1m42.163s
sys     0m16.593s
```
