### PR TITLE
Include JS in layout with rails helper

### DIFF
--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -28,7 +28,7 @@ module ActiveAdmin
             end
 
             active_admin_application.javascripts.each do |path|
-              script :src => javascript_path(path), :type => "text/javascript"
+              text_node(javascript_include_tag(path))
             end
             text_node csrf_meta_tag
           end


### PR DESCRIPTION
Use Rails helper to include javascript. Assets pipeline divides manifest into separate files if assets.debug is true
