### PR TITLE
Move ActiveAdmin Route Generation Into Engine

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,0 +1,3 @@
+ActiveAdmin::Engine.routes.draw do
+  ActiveAdmin.routes(self)
+end

--- a/docs/0-installation.md
+++ b/docs/0-installation.md
@@ -17,11 +17,6 @@ To create a user model with a different name, pass it as the last parameter:
 
     $> rails generate active_admin:install User
 
-You could also skip the creation of this user model. But note that in this case, you
- need to make additional changes in `config/intializers/active_admin.rb`.
-
-    $> rails generate active_admin:install --skip-users
-
 After the generator finishes, you need to migrate the database:
 
     $> rake db:migrate

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -69,7 +69,7 @@ module ActiveAdmin
     inheritable_setting :filters, true
 
     # The namespace root.
-    inheritable_setting :root_to, 'dashboard#index'
+    inheritable_setting :root_to, "admin/dashboard#index"
 
     # Default CSV options
     inheritable_setting :csv_options, {}

--- a/lib/active_admin/devise.rb
+++ b/lib/active_admin/devise.rb
@@ -38,7 +38,7 @@ module ActiveAdmin
         namespace = ActiveAdmin.application.default_namespace.presence
         root_path_method = [namespace, :root_path].compact.join('_')
 
-        url_helpers = Rails.application.routes.url_helpers
+        url_helpers = ActiveAdmin::Engine.routes.url_helpers
 
         path = if url_helpers.respond_to? root_path_method
                  url_helpers.send root_path_method

--- a/lib/active_admin/resource/routes.rb
+++ b/lib/active_admin/resource/routes.rb
@@ -91,7 +91,7 @@ module ActiveAdmin
         end
 
         def routes
-          Rails.application.routes.url_helpers
+          ActiveAdmin::Engine.routes.url_helpers
         end
       end
     end

--- a/lib/active_admin/router.rb
+++ b/lib/active_admin/router.rb
@@ -5,13 +5,6 @@ module ActiveAdmin
     end
 
     # Creates all the necessary routes for the ActiveAdmin configurations
-    #
-    # Use this within the routes.rb file:
-    #
-    #   Application.routes.draw do |map|
-    #     ActiveAdmin.routes(self)
-    #   end
-    #
     def apply(router)
       define_basic_routes router
       define_resource_routes router
@@ -34,9 +27,10 @@ module ActiveAdmin
 
     def root_and_dashboard_routes(namespace)
       Proc.new do
-        root :to => (namespace.root_to || "dashboard#index")
+        get '/', :to => namespace.root_to
+
         if ActiveAdmin::Dashboards.built?
-          match '/dashboard' => 'dashboard#index', :as => 'dashboard'
+          get 'dashboard' => 'admin/dashboard#index', :as => 'dashboard'
         end
       end
     end

--- a/lib/generators/active_admin/install/install_generator.rb
+++ b/lib/generators/active_admin/install/install_generator.rb
@@ -26,14 +26,6 @@ module ActiveAdmin
         end
       end
 
-      def setup_routes
-        if ARGV.include? "--skip-users"
-          route "ActiveAdmin.routes(self)"
-        else # Ensure Active Admin routes occur after Devise routes so that Devise has higher priority
-          inject_into_file "config/routes.rb", "\n  ActiveAdmin.routes(self)", :after => /devise_for.*/
-        end
-      end
-
       def create_assets
         generate "active_admin:assets"
       end

--- a/spec/integration/default_namespace_spec.rb
+++ b/spec/integration/default_namespace_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe ActiveAdmin::Application do
 
-  include Rails.application.routes.url_helpers
+  include ActiveAdmin::Engine.routes.url_helpers
 
   [false, nil].each do |value|
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,7 +71,7 @@ module ActiveAdminIntegrationSpecHelper
     controller = ActionView::TestCase::TestController.new
     ActionView::Base.send :include, ActionView::Helpers
     ActionView::Base.send :include, ActiveAdmin::ViewHelpers
-    ActionView::Base.send :include, Rails.application.routes.url_helpers
+    ActionView::Base.send :include, ActiveAdmin::Engine.routes.url_helpers
     ActionView::Base.new(ActionController::Base.view_paths, assigns, controller)
   end
   alias_method :action_view, :mock_action_view

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -71,7 +71,7 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 # we need this routing path, named "logout_path", for testing
 route %q{
   devise_scope :user do
-    match '/admin/logout' => 'active_admin/devise/sessions#destroy', :as => :logout
+    delete '/admin/logout' => 'active_admin/devise/sessions#destroy', :as => :logout
   end
 }
 

--- a/spec/unit/action_builder_spec.rb
+++ b/spec/unit/action_builder_spec.rb
@@ -24,13 +24,13 @@ describe 'defining new actions from registration blocks' do
       end
 
       it "should create a new public instance method" do
-        controller.public_instance_methods.collect(&:to_s).should include("comment")
+        controller.public_instance_methods.should include(:comment)
       end
       it "should add itself to the member actions config" do
         controller.active_admin_config.member_actions.size.should == 1
       end
       it "should create a new named route" do
-        Rails.application.routes.url_helpers.methods.collect(&:to_s).should include("comment_admin_post_path")
+        ActiveAdmin::Engine.routes.set.named_routes.keys.should include("comment_admin_post")
       end
     end
 
@@ -82,7 +82,7 @@ describe 'defining new actions from registration blocks' do
         controller.active_admin_config.collection_actions.size.should == 1
       end
       it "should create a new named route" do
-        Rails.application.routes.url_helpers.methods.collect(&:to_s).should include("comments_admin_posts_path")
+        ActiveAdmin::Engine.routes.set.named_routes.keys.should include("comments_admin_posts")
       end
     end
     context "without a block" do

--- a/spec/unit/authorization/controller_authorization_spec.rb
+++ b/spec/unit/authorization/controller_authorization_spec.rb
@@ -13,13 +13,13 @@ describe Admin::PostsController, "Controller Authorization", :type => :controlle
 
   it "should authorize the index action" do
     authorization.should_receive(:authorized?).with(Auth::READ, Post).and_return true
-    get :index
+    get :index, :use_route => :active_admin
     response.should be_success
   end
 
   it "should authorize the new action" do
     authorization.should_receive(:authorized?).with(Auth::CREATE, an_instance_of(Post)).and_return true
-    get :new
+    get :new, :use_route => :active_admin
     response.should be_success
   end
 
@@ -36,7 +36,7 @@ describe Admin::PostsController, "Controller Authorization", :type => :controlle
 
   it "should redirect when the user isn't authorized" do
     authorization.should_receive(:authorized?).with(Auth::READ, Post).and_return false
-    get :index
+    get :index, :use_route => :active_admin
     response.body.should eq '<html><body>You are being <a href="http://test.host/">redirected</a>.</body></html>'
     response.should redirect_to '/'
   end

--- a/spec/unit/devise_spec.rb
+++ b/spec/unit/devise_spec.rb
@@ -43,35 +43,6 @@ describe ActiveAdmin::Devise::Controller do
 
   end
 
-  context "within a scoped route" do
-
-    SCOPE = '/aa_scoped'
-
-    before do
-      # Remove existing routes
-      routes = Rails.application.routes
-      routes.clear!
-
-      # Add scoped routes
-      routes.draw do
-        scope :path => SCOPE do
-          ActiveAdmin.routes(self)
-          devise_for :admin_users, ActiveAdmin::Devise.config
-        end
-      end
-    end
-
-    after do
-      # Resume default routes
-      reload_routes!
-    end
-
-    it "should include scope path in root_path" do
-      controller.root_path.should == "#{SCOPE}/admin"
-    end
-
-  end
-
   describe "#config" do
     let(:config) { ActiveAdmin::Devise.config }
 

--- a/spec/unit/routing_spec.rb
+++ b/spec/unit/routing_spec.rb
@@ -9,67 +9,7 @@ describe ActiveAdmin, "Routing", :type => :routing do
     reload_routes!
   end
 
-  include Rails.application.routes.url_helpers
-
-  describe "root" do
-    before do
-      pending "Y U NO PASS?"
-    end
-    context "when default configuration" do
-      context "when in admin namespace" do
-        it "should route the admin dashboard" do
-          get('/admin').should route_to('admin/dashboard#index')
-        end
-      end
-
-      context "when in root namespace" do
-        before(:each) do
-          load_resources { ActiveAdmin.register(Post, :namespace => false) }
-          reload_routes!
-        end
-
-        it "should route the root dashboard" do
-          pending "Y U NO PASS?"
-
-          get('/').should route_to('dashboard#index')
-        end
-      end
-    end
-
-    context "when customized configuration to root to post#index" do
-      before do
-        @original_root = ActiveAdmin.application.root_to
-        ActiveAdmin.application.root_to = "posts#index"
-      end
-
-      after do
-        ActiveAdmin.application.root_to = @original_root
-        reload_routes!
-      end
-
-      context "when in admin namespace" do
-        before do
-          load_resources { ActiveAdmin.register(Post) }
-        end
-
-        it "should route to admin/posts#index" do
-          get('/admin').should route_to('admin/posts#index')
-        end
-      end
-
-      context "when in root namespace" do
-        before do
-          load_resources { ActiveAdmin.register(Post, :namespace => false) }
-        end
-
-        it "should route to posts#index" do
-          pending "Y U NO PASS?"
-
-          get('/').should route_to('posts#index')
-        end
-      end
-    end
-  end
+  include ActiveAdmin::Engine.routes.url_helpers
 
   describe "standard resources" do
     context "when in admin namespace" do


### PR DESCRIPTION
ActiveAdmin now internalizes all its route handling. This means you no longer need to manually hook ActiveAdmin into your routes.

This allows for cleaner integration between ActiveAdmin and your application, and also allows you to exclude it on a per-environment basis by including it only in certain groups. Example:

``` ruby
# Gemfile
group :admin
  gem 'active_admin'
end

# config/application.rb
groups = {
  assets: %w[development test],
  admin: %w[production staging],
}

if defined?(Bundler)
  Bundler.require *Rails.groups(groups)
end
```

Resolves #2126
