### PR TITLE
Fix i18n for boolean filter (updates the fix for #2170)

### DIFF
--- a/lib/active_admin/inputs/filter_boolean_input.rb
+++ b/lib/active_admin/inputs/filter_boolean_input.rb
@@ -11,12 +11,16 @@ module ActiveAdmin
         end
       end
 
-      def label_text
-        super.sub(/_eq\z/, '') + '?'
+      def search_method
+        method.to_s.match(search_conditions) ? method : "#{method}_eq"
       end
 
-      def method
-        super.to_s =~ search_conditions ? super : "#{super}_eq"
+      def checked?
+        object && boolean_checked?(object.send(search_method), checked_value)
+      end
+
+      def input_html_options
+        { :name => "q[#{ search_method }]" }
       end
 
       def search_conditions

--- a/spec/unit/filters/filter_form_builder_spec.rb
+++ b/spec/unit/filters/filter_form_builder_spec.rb
@@ -146,6 +146,15 @@ describe ActiveAdmin::Filters::ViewHelper do
                                             :name => "q[starred_eq]",
                                             :type => "checkbox" })
       end
+
+      it "should translate the label for boolean field" do
+        begin
+          I18n.backend.store_translations(:en, :activerecord => { :attributes => { :post => { :starred => "Faved" } } })
+          body.should have_tag('label', 'Faved')
+        ensure
+          I18n.backend.reload!
+        end
+      end
     end
 
     context "non-boolean data types" do


### PR DESCRIPTION
Same as PR #2206 but squashes commits into a single commit. Updates 47fe4c5f483399c0efda0d3cf275d5d12b0283d3 that initially fixed #2170 but introduced a regression.
