### PR TITLE
Modularize the search method dropdown for the filter form

### DIFF
--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -130,7 +130,7 @@ module ActiveAdmin
       "ActiveAdmin::Inputs::#{as.to_s.camelize}Input"
     end
 
-    # prevent exceptions in production environment for better performance
+    # Overrides Formtastic's version to include ActiveAdmin::Inputs::*
     def input_class_with_const_defined(as)
       input_class_name = custom_input_class_name(as)
 
@@ -141,7 +141,7 @@ module ActiveAdmin
       elsif Formtastic::Inputs.const_defined?(input_class_name)
         standard_input_class_name(as).constantize
       else
-        raise Formtastic::UnknownInputError
+        raise Formtastic::UnknownInputError, "Unable to find input class #{input_class_name}"
       end
     end
 

--- a/lib/active_admin/inputs/filter_base.rb
+++ b/lib/active_admin/inputs/filter_base.rb
@@ -3,11 +3,13 @@ module ActiveAdmin
     module FilterBase
       include ::Formtastic::Inputs::Base
 
+      extend ::ActiveSupport::Autoload
+      autoload :SearchMethodSelect
+
       def input_wrapping(&block)
-        template.content_tag(:div,
+        template.content_tag :div,
           template.capture(&block),
           wrapper_html_options
-        )
       end
 
       def required?

--- a/lib/active_admin/inputs/filter_base/search_method_select.rb
+++ b/lib/active_admin/inputs/filter_base/search_method_select.rb
@@ -1,0 +1,77 @@
+# This is a common set of Formtastic overrides needed to build a filter form
+# that lets you select from a set of search methods for a given attribute.
+#
+# For example, FilterNumericInput uses this to let users choose from ==, >, and <.
+#
+# The `default_filters` method must be defined in your input class for this module to work.
+# This method must return a nested array, with each child array's first element being a
+# translation and the second being a search method that Metasearch recognizes.
+# For example:
+#
+#   class FilterNumericInput < ::Formtastic::Inputs::NumberInput
+#     include FilterBase
+#     include FilterBase::SearchMethodSelect
+#
+#     def default_filters
+#       [ [I18n.t('active_admin.equal_to'),     'eq'],
+#         [I18n.t('active_admin.greater_than'), 'gt'],
+#         [I18n.t('active_admin.less_than'),    'lt'] ]
+#     end
+#   end
+#
+module ActiveAdmin
+  module Inputs
+    module FilterBase
+      module SearchMethodSelect
+
+        # Active Admin filters are normally named like this: FilterSelectInput.
+        # Formtastic normally removes "Input" off of the end, but it doesn't remove
+        # "Filter". We remove it here so the data type (select/numeric/string) is usable.
+        def type
+          as.sub /\Afilter_/, ''
+        end
+
+        def to_html
+          input_wrapping do
+            label_html  << # your label
+            select_html << # the dropdown that holds the available search methods
+            input_html     # your input field
+          end
+        end
+
+        def input_html
+          builder.text_field current_filter, input_html_options
+        end
+
+        def input_html_options
+          { :size => 10, :id => "#{method}_#{type}" }
+        end
+
+        def select_html
+          template.select_tag '', select_options, select_html_options
+        end
+
+        def select_options
+          template.options_for_select filters, current_filter
+        end
+
+        def select_html_options
+          { :onchange => "document.getElementById('#{method}_#{type}').name = 'q[' + this.value + ']';" }
+        end
+
+        # Returns the filter currently in use, or the first one available
+        def current_filter
+          ( filters.detect{ |(_,query)| @object.send query } || filters.first )[1]
+        end
+
+        # TODO: document what can be done with `options[:filters]`
+        def filters
+          (options[:filters] || default_filters).collect do |(translation,scope)|
+            [translation, "#{method}_#{scope}"]
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/lib/active_admin/inputs/filter_numeric_input.rb
+++ b/lib/active_admin/inputs/filter_numeric_input.rb
@@ -2,47 +2,7 @@ module ActiveAdmin
   module Inputs
     class FilterNumericInput < ::Formtastic::Inputs::NumberInput
       include FilterBase
-
-      def to_html
-        input_wrapping do
-          [ label_html,
-            select_html,
-            " ",
-            input_html
-          ].join("\n").html_safe
-        end
-      end
-
-      def input_html
-        builder.text_field current_filter, input_html_options
-      end
-
-      def input_html_options
-        { :size => 10, :id => "#{method}_numeric" }
-      end
-
-      def select_html
-        template.select_tag '', select_options, select_html_options
-      end
-
-      def select_options
-        template.options_for_select filters, current_filter
-      end
-
-      def select_html_options
-        { :onchange => "document.getElementById('#{method}_numeric').name = 'q[' + this.value + ']';" }
-      end
-
-      # Returns the filter currently in use, or the first one available
-      def current_filter
-        ( filters.detect{ |(_,query)| @object.send query } || filters.first )[1]
-      end
-
-      def filters
-        (options[:filters] || default_filters).collect do |(translation,scope)|
-          [translation, "#{method}_#{scope}"]
-        end
-      end
+      include FilterBase::SearchMethodSelect
 
       def default_filters
         [ [I18n.t('active_admin.equal_to'),     'eq'],


### PR DESCRIPTION
This way any new filter type can simply include this module and define `default_filters`, and have it just work.
