### PR TITLE
fix Rails 4 problem with form builder ("undefined method `upcase'")

### DIFF
--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -183,7 +183,7 @@ module ActiveAdmin
     def js_for_has_many(association, form_block, template)
       assoc_reflection = object.class.reflect_on_association(association)
       assoc_name       = assoc_reflection.klass.model_name
-      placeholder      = "NEW_#{assoc_name.upcase.split(' ').join('_')}_RECORD"
+      placeholder      = "NEW_#{assoc_name.to_s.upcase.split(' ').join('_')}_RECORD"
       opts = {
         :for         => [association, assoc_reflection.klass.new],
         :class       => "inputs has_many_fields",


### PR DESCRIPTION
In Rails 4, ActiveRecord::Base#model_name no longer returns a string, but an ActiveModel::Name object, see https://gist.github.com/brupm/4544950. Calling #to_s on this object is a Rails3-compatible workaround for this change.
