### PR TITLE
update string filter UI

### DIFF
--- a/app/assets/javascripts/active_admin/pages/application.js.coffee
+++ b/app/assets/javascripts/active_admin/pages/application.js.coffee
@@ -14,3 +14,8 @@ $ ->
   # Filter form: don't send any inputs that are empty
   $('#q_search').submit ->
     $(@).find(':input').filter(-> @value is '').prop 'disabled', true
+
+  # Filter form: for filters that let you choose the query method from
+  # a dropdown, apply that choice to the filter input field.
+  $('.filter_form_field.select_and_search select').change ->
+    $(@).siblings('input').prop name: "q[#{@value}]"

--- a/app/assets/stylesheets/active_admin/_forms.css.scss
+++ b/app/assets/stylesheets/active_admin/_forms.css.scss
@@ -241,7 +241,7 @@ form.filter_form {
     margin-bottom: 10px;
     clear: both;
 
-    &.filter_numeric {
+    &.select_and_search {
       input[type=text] {
         margin-left: $filter-field-seperator-width + 4;
         width: $side-by-side-filter-input-width;

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -24,7 +24,6 @@ bg:
     has_many_remove: "Премахване"
     filter: "Филтриране"
     clear_filters: "Изчистване"
-    search_field: "Търсене по %{field}"
     contains: "съдържа"
     starts_with: "Започва с"
     ends_with: "Завършва с"

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -23,7 +23,6 @@ ca:
     has_many_remove: "Treure"
     filter: "Filtrar"
     clear_filters: "Treure filtres"
-    search_field: "Cercar %{field}"
     contains: "Conté"
     starts_with: "Comença amb"
     ends_with: "Acaba amb"

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -24,7 +24,6 @@ cs:
     has_many_remove: "Odstranit"
     filter: "Filtrovat"
     clear_filters: "Vyčistit filtry"
-    search_field: "Prohledat %{field}"
     contains: "Obsahuje"
     starts_with: "Začíná se"
     ends_with: "Končí"

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -24,7 +24,6 @@ da:
     has_many_remove: "Fjern"
     filter: "Filtrer"
     clear_filters: "Ryd filtre"
-    search_field: "Søg %{field}"
     contains: "Indeholder"
     starts_with: "Begynder med"
     ends_with: "Slutter med"

--- a/config/locales/de-CH.yml
+++ b/config/locales/de-CH.yml
@@ -24,7 +24,6 @@
     has_many_remove: "Entfernen"
     filter: "Filtern"
     clear_filters: "Filter entfernen"
-    search_field: "Durchsuche %{field}"
     contains: "Enthält"
     starts_with: "Beginnt mit"
     ends_with: "Endet mit"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -24,7 +24,6 @@ de:
     has_many_remove: "Entfernen"
     filter: "Filtern"
     clear_filters: "Filter entfernen"
-    search_field: "Durchsuche %{field}"
     contains: "Enthält"
     starts_with: "Beginnt mit"
     ends_with: "Endet mit"

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -24,7 +24,6 @@
     has_many_remove: "Remove"
     filter: "Filter"
     clear_filters: "Clear Filters"
-    search_field: "Search %{field}"
     contains: "Contains"
     starts_with: "Starts with"
     ends_with: "Ends with"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,7 +24,6 @@ en:
     has_many_remove: "Remove"
     filter: "Filter"
     clear_filters: "Clear Filters"
-    search_field: "Search %{field}"
     contains: "Contains"
     starts_with: "Starts with"
     ends_with: "Ends with"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -24,7 +24,6 @@ es:
     has_many_remove: "Quitar"
     filter: "Filtrar"
     clear_filters: "Quitar Filtros"
-    search_field: "Buscar %{field}"
     contains: "Contiene"
     starts_with: "Empieza con"
     ends_with: "Termina con"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -24,7 +24,6 @@ fr:
     has_many_remove: "Enlever"
     filter: "Filtrer"
     clear_filters: "Supprimer les filtres"
-    search_field: "Rechercher %{field}"
     contains: "Contient"
     starts_with: "Commence par"
     ends_with: "Se termine par"

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -24,7 +24,6 @@ he:
     has_many_remove: "להסיר"
     filter: "סינון"
     clear_filters: "איפוס שדות"
-    search_field: "חיפוש %{field}"
     contains: "מכיל"
     starts_with: "מתחיל עם"
     ends_with: "מסתיים ב"

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -24,7 +24,6 @@ hr:
     has_many_remove: "Ukloniti"
     filter: "Filtriraj"
     clear_filters: "Očisti filtere"
-    search_field: "Pretraži po %{field}"
     contains: "Sadrži"
     starts_with: "počinje s"
     ends_with: "Završava sa"

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -24,7 +24,6 @@ hu:
     has_many_remove: "Eltávolít"
     filter: "Szűrés"
     clear_filters: "Feltételek törlése"
-    search_field: "Keresés %{field} alapján"
     equal_to: "Pontosan"
     greater_than: "Nagyobb, mint"
     less_than: "Kisebb, mint"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -24,7 +24,6 @@ it:
     has_many_remove: "Rimuovi"
     filter: "Filtra"
     clear_filters: "Rimuovi filtri"
-    search_field: "Cerca %{field}"
     contains: "Contiene"
     starts_with: "Inizia con"
     ends_with: "Finisce con"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -24,7 +24,6 @@ ja:
     has_many_remove: "削除する"
     filter: "絞り込む"
     clear_filters: "条件を削除する"
-    search_field: "%{field} で絞り込む"
     contains: "含まれています"
     starts_with: "で始まる"
     ends_with: "で終わる"

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -22,7 +22,6 @@ ko:
     has_many_remove: "삭제"
     filter: "필터"
     clear_filters: "필터 초기화"
-    search_field: "%{field} 검색"
     contains: "포함"
     starts_with: "로 시작"
     ends_with: "로 종료"

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -24,7 +24,6 @@ lt:
     has_many_remove: 'Pašalinti'
     filter: 'Filtras'
     clear_filters: 'Išvalyti filtrus'
-    search_field: 'Paieškos %{field}'
     contains: "Sudėtyje yra"
     starts_with: "Prasideda nuo"
     ends_with: "Baigiasi"

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -24,7 +24,6 @@ lv:
     has_many_remove: "Noņemt"
     filter: "Filtrēt"
     clear_filters: "Novākt filtrus"
-    search_field: "Meklēt '%{field}' laukā"
     contains: "Satur"
     starts_with: "Sākas ar"
     ends_with: "Beidzas ar"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -24,7 +24,6 @@ nl:
     has_many_remove: "Verwijderen"
     filter: "Filter"
     clear_filters: "Maak Filters Ongedaan"
-    search_field: "Zoek %{field}"
     contains: "Bevat"
     starts_with: "Begint met"
     ends_with: "Eindigt op"

--- a/config/locales/no-NB.yml
+++ b/config/locales/no-NB.yml
@@ -22,7 +22,6 @@
     has_many_remove: "Fjern"
     filter: "Filter"
     clear_filters: "Fjern filter"
-    search_field: "Søk %{field}"
     contains: "Inneholder"
     starts_with: "Starter med"
     ends_with: "Slutter med"

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -24,7 +24,6 @@ pl:
     has_many_remove: "Usuń"
     filter: "Filtruj"
     clear_filters: "Wyczyść Filtry"
-    search_field: "Szukaj %{field}"
     contains: "Zawiera"
     starts_with: "Zaczyna się"
     ends_with: "Kończy się"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -24,7 +24,6 @@
     has_many_remove: "Remover"
     filter: "Filtrar"
     clear_filters: "Limpar Filtros"
-    search_field: "Pesquisar %{field}"
     contains: "Contém"
     starts_with: "Começa com"
     ends_with: "Termina com"

--- a/config/locales/pt-PT.yml
+++ b/config/locales/pt-PT.yml
@@ -24,7 +24,6 @@
     has_many_remove: "Remover"
     filter: "Filtrar"
     clear_filters: "Limpar Filtros"
-    search_field: "Pesquisar %{field}"
     contains: "Contém"
     starts_with: "Começa com"
     ends_with: "Termina com"

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -24,7 +24,6 @@ ro:
     has_many_remove: "Scoate"
     filter: "Cautati"
     clear_filters: "Stergeti filtrele"
-    search_field: "Cautati dupa %{field}"
     contains: "Conține"
     starts_with: "începe cu"
     ends_with: "se termină cu"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -24,7 +24,6 @@ ru:
     has_many_remove: "Удалить"
     filter: "Фильтровать"
     clear_filters: "Очистить"
-    search_field: "Искать по %{field}"
     contains: "Содержит"
     starts_with: "Начинается с"
     ends_with: "Заканчивается"

--- a/config/locales/sv-SE.yml
+++ b/config/locales/sv-SE.yml
@@ -24,7 +24,6 @@
     has_many_remove: "Ta bort"
     filter: "Filter"
     clear_filters: "Töm dina filters"
-    search_field: "Sök %{field}"
     contains: "Innehåller"
     starts_with: "Börjar med"
     ends_with: "Slutar med"

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -24,7 +24,6 @@ tr:
     has_many_remove: "Çıkarmak"
     filter: "Filtrele"
     clear_filters: "Filtreleri Temizle"
-    search_field: "%{field} alanında ara"
     contains: "içerir"
     starts_with: "ile başlar"
     ends_with: "ile biter"

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -24,7 +24,6 @@ vi:
     has_many_remove: "Hủy bỏ"
     filter: "Lọc"
     clear_filters: "Xóa dữ liệu lọc"
-    search_field: "Tìm kiếm %{field}"
     contains: "Thông tin"
     starts_with: "Bắt đầu với"
     ends_with: "Kết thúc với việc"

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -24,7 +24,6 @@
     has_many_remove: "清除"
     filter: "过滤"
     clear_filters: "清除条件"
-    search_field: "查找%{field}"
     contains: "包含"
     starts_with: "开头"
     ends_with: "完与"

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -24,7 +24,6 @@
     has_many_remove: "清除"
     filter: "篩選"
     clear_filters: "清除篩選條件"
-    search_field: "搜尋 %{field}"
     contains: "包含"
     starts_with: "开头"
     ends_with: "完与"

--- a/features/index/filters.feature
+++ b/features/index/filters.feature
@@ -17,7 +17,7 @@ Feature: Index Filtering
      | Created at   | date range |
      | Updated at   | date range |
 
-    When I fill in "Search Title" with "Hello World 2"
+    When I fill in "Title" with "Hello World 2"
     And I press "Filter"
     And I should see 1 posts in the table
     And I should see "Hello World 2" within ".index_table"
@@ -31,7 +31,7 @@ Feature: Index Filtering
     When I am on the index page for posts
     Then I should see "Displaying all 3 Posts"
 
-    When I fill in "Search Title" with "THIS IS NOT AN EXISTING TITLE!!"
+    When I fill in "Title" with "THIS IS NOT AN EXISTING TITLE!!"
     And I press "Filter"
     Then I should not see ".index_table"
     And I should not see a sortable table header
@@ -49,7 +49,7 @@ Feature: Index Filtering
     When I follow "2"
     Then I should see "Displaying Posts 6 - 9 of 9 in total"
 
-    When I fill in "Search Title" with "Hello World 2"
+    When I fill in "Title" with "Hello World 2"
     And I press "Filter"
     And I should see 1 posts in the table
     And I should see "Hello World 2" within ".index_table"

--- a/features/index/index_scopes.feature
+++ b/features/index/index_scopes.feature
@@ -47,7 +47,7 @@ Feature: Index Scoping
         filter :title
       end
       """
-    When I fill in "Search Title" with "Non Existing Post"
+    When I fill in "Title" with "Non Existing Post"
     And I press "Filter"
     Then I should see the scope "All" selected
 
@@ -199,7 +199,7 @@ Feature: Index Scoping
       """
     Then I should see the scope "All" selected
     And I should see the scope "All" with the count 2
-    When I fill in "Search Title" with "Monkey"
+    When I fill in "Title" with "Monkey"
     And I press "Filter"
     Then I should see the scope "All" selected
     And I should see the scope "All" with the count 1

--- a/features/step_definitions/filter_steps.rb
+++ b/features/step_definitions/filter_steps.rb
@@ -3,7 +3,7 @@ Then /^I should see a select filter for "([^"]*)"$/ do |label|
 end
 
 Then /^I should see a string filter for "([^"]*)"$/ do |label|
-  page.should have_css(".filter_string label", :text => "Search #{label}")
+  page.should have_css(".filter_string label", :text => label)
 end
 
 Then /^I should see a date range filter for "([^"]*)"$/ do |label|

--- a/lib/active_admin/inputs/filter_base/search_method_select.rb
+++ b/lib/active_admin/inputs/filter_base/search_method_select.rb
@@ -24,11 +24,10 @@ module ActiveAdmin
     module FilterBase
       module SearchMethodSelect
 
-        # Active Admin filters are normally named like this: FilterSelectInput.
-        # Formtastic normally removes "Input" off of the end, but it doesn't remove
-        # "Filter". We remove it here so the data type (select/numeric/string) is usable.
-        def type
-          as.sub /\Afilter_/, ''
+        def wrapper_html_options
+          opts = super
+          (opts[:class] ||= '') << ' select_and_search'
+          opts
         end
 
         def to_html
@@ -43,20 +42,12 @@ module ActiveAdmin
           builder.text_field current_filter, input_html_options
         end
 
-        def input_html_options
-          { :size => 10, :id => "#{method}_#{type}" }
-        end
-
         def select_html
-          template.select_tag '', select_options, select_html_options
+          template.select_tag '', select_options
         end
 
         def select_options
           template.options_for_select filters, current_filter
-        end
-
-        def select_html_options
-          { :onchange => "document.getElementById('#{method}_#{type}').name = 'q[' + this.value + ']';" }
         end
 
         # Returns the filter currently in use, or the first one available

--- a/lib/active_admin/inputs/filter_string_input.rb
+++ b/lib/active_admin/inputs/filter_string_input.rb
@@ -21,10 +21,6 @@ module ActiveAdmin
         /_(contains|starts_with|ends_with)\z/
       end
 
-      def label_text
-        I18n.t('active_admin.search_field', :field => super)
-      end
-
       def default_filters
         [ [I18n.t('active_admin.contains'),    'contains'],
           [I18n.t('active_admin.starts_with'), 'starts_with'],

--- a/spec/unit/filters/filter_form_builder_spec.rb
+++ b/spec/unit/filters/filter_form_builder_spec.rb
@@ -75,14 +75,14 @@ describe ActiveAdmin::Filters::ViewHelper do
                                           :name => /q\[(title_starts_with|title_ends_with|title_contains)\]/ })
     end
     
-    it "should label a text field with search" do
-      body.should have_tag('label', 'Search Title')
+    it "should have a proper label" do
+      body.should have_tag('label', 'Title')
     end
 
     it "should translate the label for text field" do
       begin
         I18n.backend.store_translations(:en, :activerecord => { :attributes => { :post => { :title => "Name" } } })
-        body.should have_tag('label', 'Search Name')
+        body.should have_tag('label', 'Name')
       ensure
         I18n.backend.reload!
       end
@@ -92,11 +92,12 @@ describe ActiveAdmin::Filters::ViewHelper do
 
   end
 
-  describe "string attribute with sub filters", :subfilters => true do
-    let(:body) { filter :title_contains, :as => :string }
+  describe "string attribute with sub filters" do
+    let(:body) { filter :title_contains }
     
     it "should generate a search field for a string attribute with query contains" do
       body.should have_tag("input", :attributes => { :name => "q[title_contains]"})
+      body.should have_tag('label', 'Title contains')
     end
 
     it "should NOT generate a select option for contains" do
@@ -104,7 +105,7 @@ describe ActiveAdmin::Filters::ViewHelper do
     end
 
     context "using starts_with and as" do
-      let(:body) { filter :title_starts_with, :as => :string }
+      let(:body) { filter :title_starts_with }
 
       it "should generate a search field for a string attribute with query starts_with" do
         body.should have_tag("input", :attributes => { :name => "q[title_starts_with]" })
@@ -112,7 +113,7 @@ describe ActiveAdmin::Filters::ViewHelper do
     end
 
     context "using ends_with and as" do
-      let(:body) { filter :title_ends_with, :as => :string }
+      let(:body) { filter :title_ends_with }
 
       it "should generate a search field for a string attribute with query starts_with" do
         body.should have_tag("input", :attributes => { :name => "q[title_ends_with]" })
@@ -135,8 +136,8 @@ describe ActiveAdmin::Filters::ViewHelper do
       body.should have_tag("input", :attributes => { :name => "q[body_contains]"})
     end
 
-    it "should label a text field with search" do
-      body.should have_tag('label', 'Search Body')
+    it "should have a proper label" do
+      body.should have_tag('label', 'Body')
     end
   end
 
@@ -214,8 +215,9 @@ describe ActiveAdmin::Filters::ViewHelper do
       let(:body) { filter :author_id }
 
       it "should generate a numeric filter" do
-        body.should have_tag "label",              :attributes => { :for => "author_id_numeric" }
-        body.should have_tag "input",              :attributes => { :id  => "author_id_numeric" }
+        body.should have_tag 'label', 'Author' # really this should be Author ID :/
+        body.should have_tag 'option', :attributes => { :value => 'author_id_lt' }
+        body.should have_tag 'input',  :attributes => { :id => 'q_author_id', :name => 'q[author_id_eq]'}
       end
     end
 


### PR DESCRIPTION
- removes "Search %{field}" translations since as of #2096 you get to choose the search method
- updates string filter UI so the method select is side-by-side with the input field
- moves related JS out of the HTML
## Before

![string_filter_before](https://f.cloud.github.com/assets/688886/564761/57cd979e-c5a0-11e2-8c20-5cc646df4acb.png)
## After

![string_filter_after](https://f.cloud.github.com/assets/688886/564762/5fc6937e-c5a0-11e2-9645-aad00ed7eb54.png)
