### PR TITLE
changed breadcrumb helper to find models by their primary key instead of find_by_id

### DIFF
--- a/lib/active_admin/view_helpers/breadcrumb_helper.rb
+++ b/lib/active_admin/view_helpers/breadcrumb_helper.rb
@@ -12,8 +12,8 @@ module ActiveAdmin
           # If name is nil, look up the model translation, using `titlecase` as the backup.
           if part =~ /^\d|^[a-f0-9]{24}$/ && parent = parts[index-1]
             config = active_admin_config.belongs_to_config.try(:target) || active_admin_config
-            obj    = config.resource_class.find_by_id(part) if config
-            name   = display_name(obj)                      if obj
+            obj    = config.resource_class.where(config.resource_class.primary_key => part).first if config
+            name   = display_name(obj)  if obj
           end
           name ||= I18n.t "activerecord.models.#{part.singularize}", :count => 1.1, :default => part.titlecase
 

--- a/spec/unit/view_helpers/breadcrumbs_spec.rb
+++ b/spec/unit/view_helpers/breadcrumbs_spec.rb
@@ -79,7 +79,7 @@ describe "Breadcrumbs" do
 
       context "when Post.find(1) does exist" do
         before do
-          Post.stub!(:find_by_id).and_return{ mock(:display_name => "Hello World") }
+          Post.stub!(:where).and_return{ [mock(:display_name => "Hello World")] }
         end
         it "should have a link to /admin/posts/1 using display name" do
           trail[2][:name].should == "Hello World"
@@ -112,7 +112,7 @@ describe "Breadcrumbs" do
 
       context "when Post.find(4e24d6249ccf967313000000) does exist" do
         before do
-          Post.stub!(:find_by_id).with('4e24d6249ccf967313000000').and_return{ mock(:display_name => "Hello World") }
+          Post.stub!(:where).with('id' => '4e24d6249ccf967313000000').and_return{ [mock(:display_name => "Hello World")] }
         end
         it "should have a link to /admin/posts/4e24d6249ccf967313000000 using display name" do
           trail[2][:name].should == "Hello World"


### PR DESCRIPTION
For #2238

find_by_id was being used for all models and in the case of a model using a different primary key this fails.

activeadmin-0.6.0/lib/active_admin/view_helpers/breadcrumb_helper.rb:15

```
obj = config.resource_class.where(config.resource_class.primary_key => part).first if config
```

This as concise as I can come up with, however it still is a bit long..
