### PR TITLE
Allow DB-specific scopes & filters by delaying until HTTP request

### DIFF
--- a/lib/active_admin/base_controller.rb
+++ b/lib/active_admin/base_controller.rb
@@ -13,6 +13,11 @@ module ActiveAdmin
 
     before_filter :only_render_implemented_actions
     before_filter :authenticate_active_admin_user
+    before_filter :run_delayed_code, :only => :index
+
+    def run_delayed_code
+      active_admin_config.dsl.delayed_run!
+    end
 
     class << self
       # Ensure that this method is available for the DSL


### PR DESCRIPTION
Resolves #2213

You can use this like so:

``` ruby
ActiveAdmin.register Post do
  delay do
    Post.uniq.pluck(:category).each do |cat|
      scope(cat) { Post.where category: cat }
    end
  end
end
```

TODO:
- add tests
- move the code into a module to `include` into ResourceDSL
- this is broken because it will add scopes and filters multiple times,
  once per HTTP request
