### PR TITLE
Fix plural resource label for default :destroy batch action

### DIFF
--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -52,6 +52,8 @@ he:
       delete_confirmation: "האם הנך בטוח שאתה רוצה למרוח את %{plural_model}? לא תוכל לבטל את המחיקה."
       succesfully_destroyed:
         one: "1 %{model} נמחק בהצלחה"
+        few: "%{count} %{plural_model} נמחק בהצלחה"
+        many: "%{count} %{plural_model} נמחק בהצלחה"
         other: "%{count} %{plural_model} נמחק בהצלחה"
       selection_toggle_explanation: "(שינוי בחירה)"
       link: "צור"

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -52,6 +52,7 @@ lt:
       delete_confirmation: 'Ar jūs tikrai norite pašalinti šiuos %{plural_model}? Pašalinus negalėsite atstatyti?'
       succesfully_destroyed:
         one: 'Sėkmingai pašalintas 1 %{model}'
+        few: 'Sėkmingai pašalinti %{count} %{plural_model}'
         other: 'Sėkmingai pašalinti %{count} %{plural_model}'
       selection_toggle_explanation: '(Žymėti)'
       link: 'Sukurti'

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -52,6 +52,7 @@ ro:
       delete_confirmation: "Sunteti sigur ca doriti sa stergeti aceste %{plural_model}?"
       succesfully_destroyed:
         one: "1 %{model} sters"
+        few: "%{count} %{plural_model} sterse"
         other: "%{count} %{plural_model} sterse"
       selection_toggle_explanation: "(Modifica Selectia)"
       link: "Creati unul"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -52,6 +52,8 @@ ru:
       delete_confirmation: "Вы уверены, что хотите удалить %{plural_model}? Вы не сможете это отменить."
       succesfully_destroyed:
         one: "Успешно удалено: 1 %{model}"
+        few: "Успешно удалено: %{count} %{plural_model}"
+        many: "Успешно удалено: %{count} %{plural_model}"
         other: "Успешно удалено: %{count} %{plural_model}"
       selection_toggle_explanation: "(Отметить всё / Снять выделение)"
       link: "Создать"

--- a/lib/active_admin/batch_actions/resource_extension.rb
+++ b/lib/active_admin/batch_actions/resource_extension.rb
@@ -72,7 +72,7 @@ module ActiveAdmin
                       :notice => I18n.t("active_admin.batch_actions.succesfully_destroyed",
                                         :count => selected_ids.count,
                                         :model => active_admin_config.resource_label.downcase,
-                                        :plural_model => active_admin_config.plural_resource_label.downcase)
+                                        :plural_model => active_admin_config.plural_resource_label(:count => selected_ids.count).downcase)
         end
       end
 


### PR DESCRIPTION
Same that was with Index pages and was fixed in:
https://github.com/gregbell/active_admin/pull/2135

P.S. + added some missing translations for plural forms
