### PR TITLE
fix breadcrumb code for non-ID primary keys

### DIFF
--- a/lib/active_admin/view_helpers/breadcrumb_helper.rb
+++ b/lib/active_admin/view_helpers/breadcrumb_helper.rb
@@ -4,16 +4,17 @@ module ActiveAdmin
 
       # Returns an array of links to use in a breadcrumb
       def breadcrumb_links(path = request.path)
-        parts = path[1..-1].split('/')                        # remove leading "/" and split up URL path
-        parts.pop unless params[:action] =~ /^create|update$/ # remove last if not create/update
+        parts = path[1..-1].split('/') # remove leading "/" and split up the URL
+        parts.pop                      # remove last since it's used as the page title
 
         parts.each_with_index.map do |part, index|
-          # If an object (users/23), look it up via ActiveRecord and capture its name.
-          # If name is nil, look up the model translation, using `titlecase` as the backup.
-          if part =~ /^\d|^[a-f0-9]{24}$/ && parent = parts[index-1]
+          # 1. try using `display_name` if we can locate a DB object
+          # 2. try using the model name translation
+          # 3. default to calling `titlecase` on the URL fragment
+          if part =~ /\A(\d+|[a-f0-9]{24})\z/ && parts[index-1]
             config = active_admin_config.belongs_to_config.try(:target) || active_admin_config
-            obj    = config.resource_class.find_by_id(part) if config
-            name   = display_name(obj)                      if obj
+            obj    = config.resource_class.where( config.resource_class.primary_key => part ).first
+            name   = display_name obj
           end
           name ||= I18n.t "activerecord.models.#{part.singularize}", :count => 1.1, :default => part.titlecase
 

--- a/lib/active_admin/view_helpers/display_helper.rb
+++ b/lib/active_admin/view_helpers/display_helper.rb
@@ -5,7 +5,7 @@ module ActiveAdmin
       # Attempts to call any known display name methods on the resource.
       # See the setting in `application.rb` for the list of methods and their priority.
       def display_name(resource)
-        resource.send display_name_method_for resource
+        resource.send display_name_method_for resource if resource
       end
 
       # Looks up and caches the first available display name method.

--- a/spec/unit/view_helpers/breadcrumbs_spec.rb
+++ b/spec/unit/view_helpers/breadcrumbs_spec.rb
@@ -79,7 +79,7 @@ describe "Breadcrumbs" do
 
       context "when Post.find(1) does exist" do
         before do
-          Post.stub!(:find_by_id).and_return{ mock(:display_name => "Hello World") }
+          Post.stub(:where).with('id' => '1').and_return{ [ mock(:display_name => 'Hello World') ] }
         end
         it "should have a link to /admin/posts/1 using display name" do
           trail[2][:name].should == "Hello World"
@@ -112,10 +112,10 @@ describe "Breadcrumbs" do
 
       context "when Post.find(4e24d6249ccf967313000000) does exist" do
         before do
-          Post.stub!(:find_by_id).with('4e24d6249ccf967313000000').and_return{ mock(:display_name => "Hello World") }
+          Post.stub(:where).with('id' => '4e24d6249ccf967313000000').and_return{ [ mock(:display_name => 'Hello :)') ] }
         end
         it "should have a link to /admin/posts/4e24d6249ccf967313000000 using display name" do
-          trail[2][:name].should == "Hello World"
+          trail[2][:name].should == "Hello :)"
           trail[2][:path].should == "/admin/posts/4e24d6249ccf967313000000"
         end
       end
@@ -142,6 +142,18 @@ describe "Breadcrumbs" do
       it "should have a link to /admin/posts/1/comments" do
         trail[3][:name].should == "Comments"
         trail[3][:path].should == "/admin/posts/1/comments"
+      end
+    end
+
+    context 'when using a nonstandard primary key' do
+      let(:path) { '/admin/posts/55555/comments' }
+      before do
+        Post.stub(:primary_key).and_return 'something_else'
+        Post.stub(:where).with('something_else' => '55555').and_return{ [ mock(:display_name => 'Hello Hello!') ] }
+      end
+      it 'should link to /admin/posts/55555 using display name' do
+        trail[2][:name].should == 'Hello Hello!'
+        trail[2][:path].should == '/admin/posts/55555'
       end
     end
 

--- a/spec/unit/view_helpers/display_name_spec.rb
+++ b/spec/unit/view_helpers/display_name_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "display names" do
+describe "display_name" do
 
   include ActiveAdmin::ViewHelpers
 
@@ -30,6 +30,12 @@ describe "display names" do
     subject.should_not_receive :login
     subject.stub(:email).and_return 'foo@bar.baz'
     display_name(subject).should == 'foo@bar.baz'
+  end
+
+  [nil, false].each do |type|
+    it "should return nil when the passed object is #{type.inspect}" do
+      display_name(type).should eq nil
+    end
   end
 
 end


### PR DESCRIPTION
For #2238
- `display_name` returns nil if the object passed isn't truthy
- updated the `parts.pop` line to be more representative
- the remaining regular expression is more accurate

/cc @rraub, @LeakyBucket, @mindhalt
