### PR TITLE
Fixed a TODO in resource_spec by wrapping filter addition specs inside a...

### DIFF
--- a/spec/unit/filters/resource_spec.rb
+++ b/spec/unit/filters/resource_spec.rb
@@ -46,30 +46,31 @@ describe ActiveAdmin::Filters::ResourceExtension do
     end
   end
 
-  # TODO: wrap the below in a context like "filter removal" was above
-  it "should add a filter" do
-    resource.add_filter :title
-    resource.filters.should == [{:attribute => :title}]
-  end
+  context "adding a filter" do
+    it "should work" do
+      resource.add_filter :title
+      resource.filters.should == [{:attribute => :title}]
+    end
 
-  it "should add a filter with options" do
-    resource.add_filter :title, :as => :string
-    resource.filters.should == [{:attribute => :title, :as => :string}]
-  end
+    it "should work with specified options" do
+      resource.add_filter :title, :as => :string
+      resource.filters.should == [{:attribute => :title, :as => :string}]
+    end
 
-  it "should preserve default filters" do
-    resource.preserve_default_filters!
-    resource.add_filter :count, :as => :string
-    resource.filters.map{|f| f[:attribute].to_s }.sort.should == %w{
+    it "should preserve default filters" do
+      resource.preserve_default_filters!
+      resource.add_filter :count, :as => :string
+      resource.filters.map { |f| f[:attribute].to_s }.sort.should == %w{
       author body category count created_at published_at starred title updated_at
     }
-  end
+    end
 
-  it "should raise an exception if trying to add a filter when they are disabled" do
-    resource.filters = false
-    expect {
-      resource.add_filter :title
-    }.should raise_error(RuntimeError)
+    it "should raise an exception when filters are disabled" do
+      resource.filters = false
+      expect {
+        resource.add_filter :title
+      }.should raise_error(RuntimeError)
+    end
   end
 
   it "should reset filters" do


### PR DESCRIPTION
Fixed a TODO on line number 49 of resource_spec.rb which talked about wrapping specs testing filter addition to a common 'context'
