### PR TITLE
ActiveAdmin::Resource loads a resource for breadcrumbs

### DIFF
--- a/lib/active_admin/resource.rb
+++ b/lib/active_admin/resource.rb
@@ -135,6 +135,11 @@ module ActiveAdmin
       @csv_builder || default_csv_builder
     end
 
+    def find_resource(id)
+      resource = resource_class.where(resource_class.primary_key => id).first
+      decorator_class ? decorator_class.new(resource) : resource
+    end
+
     # @deprecated
     def resource
       resource_class

--- a/lib/active_admin/view_helpers/breadcrumb_helper.rb
+++ b/lib/active_admin/view_helpers/breadcrumb_helper.rb
@@ -13,8 +13,7 @@ module ActiveAdmin
           # 3. default to calling `titlecase` on the URL fragment
           if part =~ /\A(\d+|[a-f0-9]{24})\z/ && parts[index-1]
             config = active_admin_config.belongs_to_config.try(:target) || active_admin_config
-            obj    = config.resource_class.where( config.resource_class.primary_key => part ).first
-            name   = display_name obj
+            name   = display_name config.find_resource(part)
           end
           name ||= I18n.t "activerecord.models.#{part.singularize}", :count => 1.1, :default => part.titlecase
 

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -208,5 +208,36 @@ module ActiveAdmin
         end
       end
     end
+
+    describe '#find_resource' do
+      let(:resource) { namespace.register(Post) }
+      let(:post) { stub }
+      before do
+        Post.stub(:where).with('id' => '12345').and_return { [post] }
+      end
+
+      it 'can find the resource' do
+        resource.find_resource('12345').should == post
+      end
+
+      context 'with a decorator' do
+        let(:resource) { namespace.register(Post) { decorate_with PostDecorator } }
+        it 'decorates the resource' do
+          resource.find_resource('12345').should == PostDecorator.new(post)
+        end
+      end
+
+      context 'when using a nonstandard primary key' do
+        let(:different_post) { stub }
+        before do
+          Post.stub(:primary_key).and_return 'something_else'
+          Post.stub(:where).with('something_else' => '55555').and_return { [different_post] }
+        end
+
+        it 'can find the post by the custom primary key' do
+          resource.find_resource('55555').should == different_post
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Here is an proof-of-concept attempt at gregbell/active_admin#2266.

A couple of notes/thoughts:
- I think this is better than having the loading logic in the breadcrumbs helper, but it still doesn't seem idea. All of the resource loading logic is already in the controller (through inherited resources, so not easy to refactor out).
- Another possible direction would be to use `ActiveAdmin::Resource#controller` to load the resource. I started trying this, but it gets ugly pretty quick. Here's what it would look like:
  
  ``` ruby
    def resource_from_param(id)
      c = controller.new
      c.params = { id: id }
      c.send(:instance_variable_set, "@_session", session)
      # I didn't actually get this far, so I'm not sure what other hacks we would need...
      c.send(:resource)
    end
  ```
  
  So, yeah, not great, but at least the resource loading logic isn't duplicated.

@Daxter, any thoughts?
