### PR TITLE
Default `rake` to `rake test`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,8 +14,7 @@ require File.expand_path('../spec/support/detect_rails_version', __FILE__)
 # Import all our rake tasks
 FileList['tasks/**/*.rake'].each { |task| import task }
 
-# Run the specs & cukes using parallel_tests
-task :default => :parallel_tests
+task :default => :test
 
 begin
   require 'jasmine'


### PR DESCRIPTION
The previous default was `rake parallel_tests`.

Parallel are awesome, but are failing on master right now (could be setup related, I don't know).

In any case, I'm not against parallel_tests, I'm just proposing that they not be the default.
