### PR TITLE
Adds permitted params for admin_user for rails 4

### DIFF
--- a/lib/generators/active_admin/install/templates/admin_user.rb.erb
+++ b/lib/generators/active_admin/install/templates/admin_user.rb.erb
@@ -17,4 +17,11 @@ ActiveAdmin.register <%= @user_class %> do
     end
     f.actions
   end
+<% unless Rails::VERSION::MAJOR < 4 -%>
+  controller do
+    def permitted_params
+      params.permit admin_user: [:email, :password, :password_confirmation]
+    end
+  end
+<% end -%>
 end


### PR DESCRIPTION
Just defaulting the template for > rails 4 to define the permitted_params
