### PR TITLE
[2275] link to user profile in the navbar

### DIFF
--- a/features/comments/commenting.feature
+++ b/features/comments/commenting.feature
@@ -39,8 +39,9 @@ Feature: Commenting
   Scenario: View a resource in a namespace that doesn't have comments
     Given a configuration of:
     """
-      post_config = ActiveAdmin.register Post, :namespace => :new_namespace
-      post_config.namespace.allow_comments = false
+      ActiveAdmin.application.namespace(:new_namespace).allow_comments = false
+      ActiveAdmin.register Post,      :namespace => :new_namespace
+      ActiveAdmin.register AdminUser, :namespace => :new_namespace
     """
     Given I am logged in
     When I am on the index page for posts in the new_namespace namespace
@@ -51,7 +52,8 @@ Feature: Commenting
     Given a show configuration of:
     """
       ActiveAdmin.register Post
-      ActiveAdmin.register Post, :namespace => :public
+      ActiveAdmin.register Post,      :namespace => :public
+      ActiveAdmin.register AdminUser, :namespace => :public
     """
     When I add a comment "Hello world in admin namespace"
     Then I should see "Hello world in admin namespace"

--- a/features/global_navigation.feature
+++ b/features/global_navigation.feature
@@ -1,6 +1,5 @@
 Feature: Global Navigation
 
-
   Background:
     Given a configuration of:
     """

--- a/features/index/index_parameters.feature
+++ b/features/index/index_parameters.feature
@@ -34,11 +34,8 @@ Feature: Index Parameters
   Scenario: Viewing index when download_links disabled only in one namespace
     Given a configuration of:
       """
-      ActiveAdmin.setup do |config|
-        config.namespace :superadmin do |namespace|
-          namespace.download_links = false
-        end
-      end
+      ActiveAdmin.application.namespace(:superadmin).download_links = false
+      ActiveAdmin.register AdminUser, :namespace => :superadmin
       """
     Given an index configuration of:
       """
@@ -60,11 +57,8 @@ Feature: Index Parameters
   Scenario: Viewing index when download_links enabled only for a resource
     Given a configuration of:
       """
-      ActiveAdmin.setup do |config|
-        config.namespace :superadmin do |namespace|
-          namespace.download_links = false
-        end
-      end
+      ActiveAdmin.application.namespace(:superadmin).download_links = false
+      ActiveAdmin.register AdminUser, :namespace => :superadmin
       """
     Given an index configuration of:
       """

--- a/features/users/logging_in.feature
+++ b/features/users/logging_in.feature
@@ -16,8 +16,8 @@ Feature: User Logging In
     And I fill in "Password" with "password"
     And I press "Login"
     Then I should be on the the dashboard
-    And I should see "Logout"
-    And I should see "admin@example.com"
+    And I should see the element "a[href='/admin/logout'       ]:contains('Logout')"
+    And I should see the element "a[href='/admin/admin_users/1']:contains('admin@example.com')"
 
   Scenario: Attempting to log in with an incorrect email address
     When I fill in "Email" with "not-an-admin@example.com"

--- a/lib/active_admin/base_controller.rb
+++ b/lib/active_admin/base_controller.rb
@@ -46,7 +46,7 @@ module ActiveAdmin
     helper_method :current_active_admin_user
 
     def current_active_admin_user?
-      !current_active_admin_user.nil?
+      !!current_active_admin_user
     end
     helper_method :current_active_admin_user?
 

--- a/lib/active_admin/namespace.rb
+++ b/lib/active_admin/namespace.rb
@@ -159,7 +159,7 @@ module ActiveAdmin
       return if @menus.exists? :utility_navigation
       @menus.menu :utility_navigation do |menu|
         menu.add  :label  => proc{ display_name current_active_admin_user },
-                  :url    => '#',
+                  :url    => proc{ url_for [active_admin_namespace.name, current_active_admin_user] },
                   :id     => 'current_user',
                   :if     => proc{ current_active_admin_user? }
 


### PR DESCRIPTION
Some of our tests create a new namespace, but don't register a page for
admin users. This commit updates them so they don't fail.

Resolves #2275.
