### PR TITLE
add skip_filter to config

### DIFF
--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -190,7 +190,7 @@ module ActiveAdmin
     # Example usage:
     #   ActiveAdmin.before_filter :authenticate_admin!
     #
-    %w(before_filter skip_before_filter after_filter around_filter).each do |name|
+    %w(before_filter skip_before_filter after_filter around_filter skip_filter).each do |name|
       define_method name do |*args, &block|
         ActiveAdmin::BaseController.send              name, *args, &block
         ActiveAdmin::Devise::PasswordsController.send name, *args, &block

--- a/lib/active_admin/resource_dsl.rb
+++ b/lib/active_admin/resource_dsl.rb
@@ -117,7 +117,7 @@ module ActiveAdmin
     delegate :before_destroy, :after_destroy, :to => :controller
 
     # Standard rails filters
-    delegate :before_filter, :skip_before_filter, :after_filter, :around_filter, :to => :controller
+    delegate :before_filter, :skip_before_filter, :after_filter, :around_filter, :skip_filter, :to => :controller
 
     # Specify which actions to create in the controller
     #

--- a/spec/unit/controller_filters_spec.rb
+++ b/spec/unit/controller_filters_spec.rb
@@ -24,4 +24,9 @@ describe ActiveAdmin::Application do
     controllers.each{ |c| c.should_receive(:around_filter).and_return(true) }
     application.around_filter :my_filter, :only => :show
   end
+  
+  it 'skip_filter' do
+    controllers.each{ |c| c.should_receive(:skip_filter).and_return(true) }
+    application.skip_filter :my_filter, :only => :show
+  end
 end


### PR DESCRIPTION
Skip before, after or around filters.

Usage: config.skip_filter :before_after_or_around_filter_name
