### PR TITLE
Prevent panels from escaping HTML safe titles

### DIFF
--- a/lib/active_admin/views/components/panel.rb
+++ b/lib/active_admin/views/components/panel.rb
@@ -6,7 +6,7 @@ module ActiveAdmin
 
       def build(title, attributes = {})
         icon_name = attributes.delete(:icon)
-        icn = icon_name ? icon(icon_name) : ""
+        icn = icon_name ? icon(icon_name) : "".html_safe
         super(attributes)
         add_class "panel"
         @title = h3(icn + title.to_s)

--- a/spec/unit/views/components/panel_spec.rb
+++ b/spec/unit/views/components/panel_spec.rb
@@ -29,6 +29,14 @@ describe ActiveAdmin::Views::Panel do
     the_panel.find_by_tag("h3").first.content.should include("span class=\"icon")
   end
 
+  it "should allow a html_safe title (without icon)" do
+    title_with_html = %q[Title with <abbr>HTML</abbr>].html_safe
+    the_panel = render_arbre_component do
+      panel(title_with_html)
+    end
+    the_panel.find_by_tag("h3").first.content.should eq(title_with_html)
+  end
+
   describe "#children?" do
 
     it "returns false if no children have been added to the panel" do


### PR DESCRIPTION
Panels concatinate a non-html_safe, empty string with the title provided. The
resulting new string is always considered unsafe and prevents titles with
HTML from being rendered. This fixes the issue by starting with a html_safe
empty string.
