### PR TITLE
[2342] only build AA routes when necessary

### DIFF
--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -1,10 +1,12 @@
 require 'active_admin/router'
 require 'active_admin/helpers/settings'
+require 'active_admin/helpers/environment_checker'
 
 module ActiveAdmin
   class Application
     include Settings
     include Settings::Inheritance
+    include EnvironmentChecker
 
     settings_inherited_by Namespace
 
@@ -182,8 +184,10 @@ module ActiveAdmin
 
     # One-liner called by user's config/routes.rb file
     def routes(rails_router)
-      load!
-      router.apply(rails_router)
+      if should_build_routes?
+        load!
+        router.apply(rails_router)
+      end
     end
 
     # Adds before, around and after filters to all controllers.

--- a/lib/active_admin/helpers/environment_checker.rb
+++ b/lib/active_admin/helpers/environment_checker.rb
@@ -1,0 +1,30 @@
+module ActiveAdmin
+  module EnvironmentChecker
+
+    def should_build_routes?
+      if ENV['ACTIVE_ADMIN_ROUTING'].present? then routes_from_env
+      else
+        running_server? || running_console? || running_rake_routes?
+      end
+    end
+
+    private
+
+    def routes_from_env
+      ActiveRecord::ConnectionAdapters::Column.value_to_boolean ENV['ACTIVE_ADMIN_ROUTING']
+    end
+
+    def running_server?
+      !!defined? ::Rails::Server
+    end
+
+    def running_console?
+      !!defined? ::Rails::Console
+    end
+
+    def running_rake_routes?
+      File.basename($0) == "rake" && ARGV.grep(/routes/).any?
+    end
+
+  end
+end


### PR DESCRIPTION
A possible solution for #2342. With this PR, Active Admin routes are only ever loaded when one of these commands run:

``` sh
rails server
rails console
rake routes
```

If for some reason you want custom control, I've added the `ACTIVE_ADMIN_ROUTING` environment variable.
