### PR TITLE
Raise Error when install with ActiveAdminUser as user

### DIFF
--- a/lib/generators/active_admin/devise/devise_generator.rb
+++ b/lib/generators/active_admin/devise/devise_generator.rb
@@ -1,11 +1,16 @@
 module ActiveAdmin
   module Generators
+    class Error < Rails::Generators::Error
+    end
+
     class DeviseGenerator < Rails::Generators::NamedBase
       desc "Creates an admin user and uses Devise for authentication"
       argument :name, :type => :string, :default => "AdminUser"
 
       class_option  :registerable, :type => :boolean, :default => false,
                     :desc => "Should the generated resource be registerable?"
+
+      RESERVED_NAMES = [:active_admin_user]
 
       def install_devise
         require 'devise'
@@ -18,6 +23,9 @@ module ActiveAdmin
       end
 
       def create_admin_user
+        if RESERVED_NAMES.include?(name.underscore)
+          raise Error, "The name #{name} is reserved by Active Admin"
+        end
         invoke "devise", [name]
       end
 


### PR DESCRIPTION
Currently installing active admin with 'ActiveAdminUser' fails with
StackLevelTooDeep after login. This happens due to a collision of the
current_user_method with the internally used current_active_admin_user.
