### PR TITLE
[1924] make CSV downloads respect pagination

### DIFF
--- a/lib/active_admin/resource_controller/data_access.rb
+++ b/lib/active_admin/resource_controller/data_access.rb
@@ -267,21 +267,16 @@ module ActiveAdmin
       end
 
       def apply_pagination(chain)
-        page_method_name = Kaminari.config.page_method_name
-        page = params[Kaminari.config.param_name]
+        page_method = Kaminari.config.page_method_name
+        page_param  = params[Kaminari.config.param_name]
 
-        chain.send(page_method_name, page).per(per_page)
+        chain.send(page_method, page_param).per(per_page)
       end
 
       def per_page
-        return max_csv_records if request.format == 'text/csv'
         return max_per_page if active_admin_config.paginate == false
 
         @per_page || active_admin_config.per_page
-      end
-
-      def max_csv_records
-        10_000
       end
 
       def max_per_page


### PR DESCRIPTION
Fixes #1924

The old behavior was: if you're on the first page, export 10,000 records. If you're on any other page, don't export anything.

The problem was that a true export functionality (where every single record is exported) wasn't ever fully implemented. Until such a PR exists, I'm removing the code that caused this, so CSV export respects pagination.
