### PR TITLE
[2342] Prevent DB access during rake tasks

### DIFF
--- a/lib/active_admin/resource.rb
+++ b/lib/active_admin/resource.rb
@@ -38,7 +38,10 @@ module ActiveAdmin
     attr_reader :collection_actions
 
     # The default sort order to use in the controller
-    attr_accessor :sort_order
+    attr_writer :sort_order
+    def sort_order
+      @sort_order ||= (resource_class.respond_to?(:primary_key) ? resource_class.primary_key.to_s : 'id') + '_desc'
+    end
 
     # Set the configuration for the CSV
     attr_writer :csv_builder
@@ -57,8 +60,8 @@ module ActiveAdmin
       def initialize(namespace, resource_class, options = {})
         @namespace = namespace
         @resource_class_name = "::#{resource_class.name}"
-        @options = default_options.merge(options)
-        @sort_order = @options[:sort_order]
+        @options    = options
+        @sort_order = options[:sort_order]
         @member_actions, @collection_actions = [], []
       end
     end
@@ -148,12 +151,6 @@ module ActiveAdmin
       "ActiveAdmin::Resource#resource is deprecated. Please use #resource_class instead."
 
     private
-
-    def default_options
-      {
-        :sort_order => (resource_class.respond_to?(:primary_key) ? resource_class.primary_key.to_s : 'id') + '_desc'
-      }
-    end
 
     def default_csv_builder
       @default_csv_builder ||= CSVBuilder.default_for_resource(resource_class)


### PR DESCRIPTION
Fixes #2342 by lazy-loading the sort order, which depends on DB access. Since when using Heroku the asset precompile task doesn't have access to the DB, this was an issue for many users.

Note that prior to Rails 4 the DB was needed just to load the app, so this change wasn't necessary until now.
