### PR TITLE
Add custom sorting methods

### DIFF
--- a/lib/active_admin/resource_controller/data_access.rb
+++ b/lib/active_admin/resource_controller/data_access.rb
@@ -217,7 +217,9 @@ module ActiveAdmin
 
       def apply_sorting(chain)
         params[:order] ||= active_admin_config.sort_order
-        if params[:order] && params[:order] =~ /^([\w\_\.]+)_(desc|asc)$/
+        if params[:order] && chain.respond_to?("sort_by_#{params[:order]}")
+          chain.send("sort_by_#{params[:order]}")
+        elsif params[:order] && params[:order] =~ /^([\w\_\.]+)_(desc|asc)$/
           column = $1
           order  = $2
           table  = active_admin_config.resource_column_names.include?(column) ? active_admin_config.resource_table_name : nil

--- a/spec/unit/resource_controller/data_access_spec.rb
+++ b/spec/unit/resource_controller/data_access_spec.rb
@@ -43,6 +43,23 @@ describe ActiveAdmin::ResourceController::DataAccess do
       end
     end
 
+    context "for custom sorting methods" do
+      let(:params){ {:order => "custom_field_asc" }}
+      context "when the methods exist on the model" do
+        it "should call the model's sort methods" do
+          chain = mock("ChainObj", sort_by_custom_field_asc: :sorted)
+          controller.send(:apply_sorting, chain).should == :sorted
+        end
+      end
+
+      context "when the methods do not exist on the model" do
+        it "should call reorder" do
+          chain = mock("ChainObj")
+          chain.should_receive(:reorder).once
+          controller.send :apply_sorting, chain
+        end
+      end
+    end
   end
 
   describe "scoping" do


### PR DESCRIPTION
I was looking for a way to specify a custom search method for a table column, but didn't find anything. I followed the pattern from MetaSearch of defining `sort_by_x_asc` and `sort_by_x_desc` methods that get called if available and return a scope. If you'd prefer a different interface, I can change it to something else.

I made this request on the rails4 branch because that's what I'm using, but I can make a request on master as well.
