### PR TITLE
Add AuthorizationAdapter documentation to initializer

### DIFF
--- a/lib/generators/active_admin/install/templates/active_admin.rb.erb
+++ b/lib/generators/active_admin/install/templates/active_admin.rb.erb
@@ -57,6 +57,23 @@ ActiveAdmin.setup do |config|
   # within the controller.
   config.authentication_method = :authenticate_<%= @underscored_user_name %>!
 
+  # == User Authorization
+  #
+  # Active Admin will automatically call an authorization
+  # method in a before filter of all controller actions to
+  # ensure that there is a user with proper rights. You can use
+  # CanCanAdapter or make your own. Please refer to documentation.
+  # config.authorization_adapter = ActiveAdmin::CanCanAdapter
+
+  # You can customize your CanCan Ability class name here.
+  # config.cancan_ability_class = "Ability"
+
+  # You can specify a method to be called on unauthorized access.
+  # This is necessary in order to prevent a redirect loop which happens
+  # because, by default, user gets redirected to Dashboard. If user
+  # doesn't have access to Dashboard, he'll end up in a redirect loop.
+  # Method provided here should be defined in application_controller.rb.
+  # config.on_unauthorized_access = :access_denied
 
   # == Current User
   #


### PR DESCRIPTION
I noticed couple of days ago, @monfresh submitted docs update about redirect loop, and since I didn't see anything in initializer file, I decided to add some documentation with examples there as well.
