### PR TITLE
Separate destroy and batch destroy action auth

### DIFF
--- a/lib/active_admin/authorization_adapter.rb
+++ b/lib/active_admin/authorization_adapter.rb
@@ -6,6 +6,8 @@ module ActiveAdmin
     CREATE  = :create
     UPDATE  = :update
     DESTROY = :destroy
+
+    BATCH_DESTROY = :batch_destroy
   end
 
   Auth = Authorization

--- a/lib/active_admin/batch_actions/resource_extension.rb
+++ b/lib/active_admin/batch_actions/resource_extension.rb
@@ -62,7 +62,7 @@ module ActiveAdmin
         destroy_options = {
           :priority => 100,
           :confirm => proc { I18n.t('active_admin.batch_actions.delete_confirmation', :plural_model => active_admin_config.plural_resource_label.downcase) },
-          :if => proc{ controller.action_methods.include?('destroy') && authorized?(ActiveAdmin::Auth::DESTROY, active_admin_config.resource_class) }
+          :if => proc{ controller.action_methods.include?('destroy') && authorized?(ActiveAdmin::Auth::BATCH_DESTROY, active_admin_config.resource_class) }
         }
 
         add_batch_action :destroy, proc { I18n.t('active_admin.delete') }, destroy_options do |selected_ids|


### PR DESCRIPTION
ActiveAdmin default batch action (batch destroy) has an `:if` condition, which now is described by a proc:

```
proc{ controller.action_methods.include?('destroy') && authorized?(ActiveAdmin::Auth::DESTROY, active_admin_config.resource_class) }
```

This kind of auth check doesn't really help when you use block syntax to describe CanCan abilities. It is designed only for a basic use, like: `can :destroy, ModelName`, but not for a block.

We have a real need to allow access to the destroy and the batch destroy actions by different rules. So my decision now is to change the name of the rule in that default `:if` condition, and as I see, it is the only right way to do it. Fix me if I am wrong (I should be). 
