### PR TITLE
Automatically load the CanCanAdapter if CanCan is given

### DIFF
--- a/lib/active_admin.rb
+++ b/lib/active_admin.rb
@@ -19,7 +19,6 @@ module ActiveAdmin
   autoload :Authorization,            'active_admin/authorization_adapter'
   autoload :AuthorizationAdapter,     'active_admin/authorization_adapter'
   autoload :Breadcrumbs,              'active_admin/breadcrumbs'
-  autoload :CanCanAdapter,            'active_admin/cancan_adapter'
   autoload :Callbacks,                'active_admin/callbacks'
   autoload :Component,                'active_admin/component'
   autoload :BaseController,           'active_admin/base_controller'
@@ -124,3 +123,6 @@ ActiveAdmin::DependencyChecker.check!
 require 'active_admin/comments'
 require 'active_admin/batch_actions'
 require 'active_admin/filters'
+
+# Load gem-specific code only if that gem is being used
+require 'active_admin/cancan_adapter' if ActiveAdmin::DependencyChecker.cancan?

--- a/lib/active_admin/dependency_checker.rb
+++ b/lib/active_admin/dependency_checker.rb
@@ -37,6 +37,10 @@ module ActiveAdmin
           false
         end
       end
+
+      def cancan?
+        !!Gem.loaded_specs['cancan']
+      end
     end
   end
 end


### PR DESCRIPTION
This resolves #2473 by discretely loading the adapter instead of waiting on class autoloading.
