### PR TITLE
Prevent addition of duplicate resources in Rails 4

### DIFF
--- a/lib/active_admin/resource/naming.rb
+++ b/lib/active_admin/resource/naming.rb
@@ -30,6 +30,8 @@ module ActiveAdmin
     # in Rails < 3.1 and > 3.1.
     class Name < ActiveModel::Name
 
+      delegate :hash, :to => :to_str
+
       def initialize(klass, name = nil)
         if ActiveModel::Name.instance_method(:initialize).arity == 1
           super(proxy_for_initializer(klass, name))
@@ -51,6 +53,10 @@ module ActiveAdmin
 
       def route_key
         plural
+      end
+
+      def eql?(other)
+        to_str.eql?(other.to_str)
       end
 
       class StringProxy

--- a/spec/unit/resource/naming_spec.rb
+++ b/spec/unit/resource/naming_spec.rb
@@ -104,5 +104,19 @@ module ActiveAdmin
       end
     end
 
+    describe "duplicate resource names" do
+      let(:resource_name) { config.resource_name }
+      let(:duplicate_resource_name) { Resource.new(namespace, Category).resource_name }
+
+      [:==, :===, :eql?].each do |method|
+        it "are equivalent when compared with #{method}" do
+          resource_name.public_send(method, duplicate_resource_name).should be_true
+        end
+      end
+
+      it "have identical hash values" do
+        resource_name.hash.should == duplicate_resource_name.hash
+      end
+    end
   end
 end

--- a/spec/unit/resource_collection_spec.rb
+++ b/spec/unit/resource_collection_spec.rb
@@ -148,6 +148,19 @@ describe ActiveAdmin::ResourceCollection do
         collection.values.should include(resource, resource_renamed)
       end
     end
+
+    context "when a duplicate resource is added" do
+      let(:resource_duplicate) { Resource.new(namespace, Category) }
+
+      before do
+        collection.add(resource)
+        collection.add(resource_duplicate)
+      end
+
+      it "the collection contains one instance of that resource" do
+        collection.values.should eq([resource])
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Rails 4's ActiveModel::Name class no longer inherits from String and
breaks the expected comparison behavior when searching for existing
resources.
