### PR TITLE
[2507] Preserve default filters!

### DIFF
--- a/lib/active_admin/filters/forms.rb
+++ b/lib/active_admin/filters/forms.rb
@@ -64,8 +64,7 @@ module ActiveAdmin
         options  = defaults.deep_merge(options).deep_merge(required)
 
         form_for search, options do |f|
-          filters.group_by{ |o| o[:attribute] }.each do |attribute, array|
-            opts     = array.last # grab last-defined `filter` call from DSL
+          filters.each do |attribute, opts|
             should   = opts.delete(:if)     || proc{ true }
             shouldnt = opts.delete(:unless) || proc{ false }
 

--- a/lib/active_admin/filters/resource_extension.rb
+++ b/lib/active_admin/filters/resource_extension.rb
@@ -50,7 +50,7 @@ module ActiveAdmin
       def remove_filter(attribute)
         raise Disabled unless filters_enabled?
 
-        (@filters_to_remove ||= []) << attribute
+        (@filters_to_remove ||= []) << attribute.to_sym
       end
 
       # Add a filter for this resource. If filters are not enabled, this method
@@ -62,7 +62,7 @@ module ActiveAdmin
       def add_filter(attribute, options = {})
         raise Disabled unless filters_enabled?
 
-        (@filters ||= []) << options.merge(attribute: attribute)
+        (@filters ||= {})[attribute.to_sym] = options
       end
 
       # Reset the filters to use defaults
@@ -71,18 +71,21 @@ module ActiveAdmin
         @filters_to_remove = nil
       end
 
-      private
+    private
 
       # Collapses the waveform, if you will, of which filters should be displayed.
       # Removes filters and adds in default filters as desired.
       def filter_lookup
-        filters = @filters.try(:dup) || []
-        filters.push *default_filters if filters.empty? || preserve_default_filters?
+        filters = @filters.try(:dup) || {}
+
+        if filters.empty? || preserve_default_filters?
+          default_filters.each do |f|
+            filters[f] ||= {}
+          end
+        end
 
         if @filters_to_remove
-          @filters_to_remove.each do |attr|
-            filters.delete_if{ |f| f.fetch(:attribute) == attr }
-          end
+          @filters_to_remove.each &filters.method(:delete)
         end
 
         filters
@@ -98,7 +101,7 @@ module ActiveAdmin
         if resource_class.respond_to?(:reflections)
           poly, not_poly = resource_class.reflections.partition{ |_,r| r.macro == :belongs_to && r.options[:polymorphic] }
           filters        = poly.map{ |_,r| r.foreign_type } + not_poly.map(&:first)
-          filters.collect{ |name| { :attribute => name.to_sym } }
+          filters.map &:to_sym
         else
           []
         end
@@ -106,8 +109,8 @@ module ActiveAdmin
 
       # Returns a default set of filters for the content columns
       def default_content_filters
-        if resource_class.respond_to?(:content_columns)
-          resource_class.content_columns.collect{ |c| { :attribute => c.name.to_sym } }
+        if resource_class.respond_to? :content_columns
+          resource_class.content_columns.map{ |c| c.name.to_sym }
         else
           []
         end
@@ -118,7 +121,7 @@ module ActiveAdmin
       end
 
       def filters_sidebar_section
-        ActiveAdmin::SidebarSection.new(:filters, :only => :index, :if => proc{ active_admin_config.filters.any? } ) do
+        ActiveAdmin::SidebarSection.new :filters, only: :index, if: ->{ active_admin_config.filters.any? } do
           active_admin_filters_form_for assigns[:search], active_admin_config.filters
         end
       end

--- a/spec/unit/filters/resource_spec.rb
+++ b/spec/unit/filters/resource_spec.rb
@@ -8,9 +8,9 @@ describe ActiveAdmin::Filters::ResourceExtension do
   end
 
   it "should return the defaults if no filters are set" do
-    resource.filters.map{|f| f[:attribute].to_s }.sort.should == %w{
-      author body category created_at published_at starred title updated_at
-    }
+    resource.filters.keys.sort.should == [
+      :author, :body, :category, :created_at, :published_at, :starred, :title, :updated_at
+    ]
   end
 
   it "should not have defaults when filters are disabled on the resource" do
@@ -30,9 +30,15 @@ describe ActiveAdmin::Filters::ResourceExtension do
 
   describe "removing a filter" do
     it "should work" do
-      resource.filters.should include :attribute => :author
+      resource.filters.keys.should include :author
       resource.remove_filter :author
-      resource.filters.should_not include :attribute => :author
+      resource.filters.keys.should_not include :author
+    end
+
+    it "should work as a string" do
+      resource.filters.keys.should include :author
+      resource.remove_filter 'author'
+      resource.filters.keys.should_not include :author
     end
 
     it "should be lazy" do
@@ -54,20 +60,33 @@ describe ActiveAdmin::Filters::ResourceExtension do
   describe "adding a filter" do
     it "should work" do
       resource.add_filter :title
-      resource.filters.should == [{:attribute => :title}]
+      resource.filters.should eq title: {}
+    end
+
+    it "should work as a string" do
+      resource.add_filter 'title'
+      resource.filters.should eq title: {}
     end
 
     it "should work with specified options" do
-      resource.add_filter :title, :as => :string
-      resource.filters.should == [{:attribute => :title, :as => :string}]
+      resource.add_filter :title, as: :string
+      resource.filters.should eq title: {as: :string}
+    end
+
+    it "should override an existing filter" do
+      resource.add_filter :title, one: :two
+      resource.add_filter :title, three: :four
+
+      resource.filters.should eq title: {three: :four}
     end
 
     it "should preserve default filters" do
       resource.preserve_default_filters!
-      resource.add_filter :count, :as => :string
-      resource.filters.map { |f| f[:attribute].to_s }.sort.should == %w{
-      author body category count created_at published_at starred title updated_at
-    }
+      resource.add_filter :count, as: :string
+
+      resource.filters.keys.sort.should == [
+        :author, :body, :category, :count, :created_at, :published_at, :starred, :title, :updated_at
+      ]
     end
 
     it "should raise an exception when filters are disabled" do


### PR DESCRIPTION
This fixes #2507 and adds tests to ensure that's the case.

When using a hash it's simple to write over an existing filter, and it's easy to avoid that when adding the default filters in.

Before this PR there was a array of filters that we'd just append, and later only use the last of for each filter name.
