### PR TITLE
Add sub navigation menu for nested resources

### DIFF
--- a/app/assets/stylesheets/active_admin/_header.css.scss
+++ b/app/assets/stylesheets/active_admin/_header.css.scss
@@ -132,6 +132,28 @@
 
   }
 
+  div.navigation {
+    margin-bottom: 5px;
+  }
+
+  div.subnav {
+    background-color: lighten(#53595D, 20%);
+    padding: 5px 20px 2px;
+    margin-bottom: -5px;
+
+    ul.tabs {
+      & > li {
+        &.has_nested > a {
+          z-index: 1009;
+        }
+        ul {
+          z-index: 1008;
+        }
+      }
+    }
+  }
+
+
   #tabs {
     width: 100%;
   }

--- a/app/assets/stylesheets/active_admin/_header.css.scss
+++ b/app/assets/stylesheets/active_admin/_header.css.scss
@@ -132,14 +132,14 @@
 
   }
 
-  div.navigation {
+  div.navigation.has_subnav {
     margin-bottom: 5px;
   }
 
   div.subnav {
     background-color: lighten(#53595D, 20%);
     padding: 5px 20px 2px;
-    margin-bottom: -5px;
+    margin-bottom: -6px;
 
     ul.tabs {
       & > li {

--- a/features/belongs_to.feature
+++ b/features/belongs_to.feature
@@ -16,8 +16,8 @@ Feature: Belongs To
       end
     """
     When I go to the last author's posts
-    Then the "Posts" tab should be selected
-    And I should not see a menu item for "Users"
+    Then the "Users" tab should be selected
+    Then the "Posts" secondary navigation tab should be selected
     And I should see "Displaying 1 Post"
     And I should see a link to "Users" in the breadcrumb
     And I should see a link to "Jane Doe" in the breadcrumb
@@ -35,7 +35,8 @@ Feature: Belongs To
     When I go to the last author's posts
     And I follow "View"
     Then I should be on the last author's last post page
-    And the "Posts" tab should be selected
+    And the "Users" tab should be selected
+    And the "Posts" secondary navigation tab should be selected
 
   Scenario: When the belongs to is optional
     Given a configuration of:
@@ -47,7 +48,7 @@ Feature: Belongs To
     """
     When I go to the last author's posts
     Then the "Users" tab should be selected
-    And I should see a menu item for "Posts"
+    And I should see a secondary menu item for "Posts"
 
     When I follow "Posts"
     Then the "Posts" tab should be selected
@@ -64,3 +65,16 @@ Feature: Belongs To
     When I go to the last author's posts
     And I follow "View"
     Then the "Posts" tab should be selected
+
+  Scenario: Displaying belongs to resources in secondary menu
+    Given a configuration of:
+    """
+      ActiveAdmin.register User
+      ActiveAdmin.register Post do
+        belongs_to :user
+      end
+    """
+    When I go to the last author's posts
+    And I follow "View"
+    Then the "Users" tab should be selected
+    And the "Posts" secondary navigation tab should be selected

--- a/features/step_definitions/menu_steps.rb
+++ b/features/step_definitions/menu_steps.rb
@@ -2,6 +2,10 @@ Then /^I should see a menu item for "([^"]*)"$/ do |name|
   expect(page).to have_css '#tabs li a', text: name
 end
 
+Then /^I should see a secondary menu item for "([^"]*)"$/ do |name|
+  expect(page).to_not have_css '.subnav ul#tabs li a', text: name
+end
+
 Then /^I should not see a menu item for "([^"]*)"$/ do |name|
   expect(page).to_not have_css '#tabs li a', text: name
 end

--- a/features/step_definitions/tab_steps.rb
+++ b/features/step_definitions/tab_steps.rb
@@ -1,3 +1,7 @@
 Then /^the "([^"]*)" tab should be selected$/ do |name|
-  step %{I should see "#{name}" within "ul#tabs li.current"}
+  step %{I should see "#{name}" within ".navigation ul#tabs li.current"}
+end
+
+Then /^the "([^"]*)" secondary navigation tab should be selected$/ do |name|
+  step %{I should see "#{name}" within ".subnav ul#tabs li.current"}
 end

--- a/lib/active_admin/base_controller/menu.rb
+++ b/lib/active_admin/base_controller/menu.rb
@@ -6,12 +6,17 @@ module ActiveAdmin
       included do
         before_filter :set_current_tab
         helper_method :current_menu
+        helper_method :sub_menu
       end
 
       protected
 
       def current_menu
         active_admin_config.navigation_menu
+      end
+
+      def sub_menu
+        active_admin_config.sub_navigation_menu
       end
 
       # Set's @current_tab to be name of the tab to mark as current

--- a/lib/active_admin/base_controller/menu.rb
+++ b/lib/active_admin/base_controller/menu.rb
@@ -19,7 +19,10 @@ module ActiveAdmin
         active_admin_config.sub_navigation_menu
       end
 
-      # Set's @current_tab to be name of the tab to mark as current
+      # Sets @current_tab to be name of the tab to mark as current.
+      # Also sets @current_sub_tab to be name of the sub menu tab to mark as
+      # current.
+      #
       # Get's called through a before filter
       def set_current_tab
         @current_tab = if current_menu && active_admin_config.belongs_to? && parent?
@@ -32,6 +35,11 @@ module ActiveAdmin
         else
           active_admin_config.menu_item
         end
+
+        @current_sub_tab =
+          if active_admin_config.show_sub_menu?(params[:action])
+            active_admin_config.menu_item
+          end
       end
 
     end

--- a/lib/active_admin/namespace.rb
+++ b/lib/active_admin/namespace.rb
@@ -165,10 +165,16 @@ module ActiveAdmin
         resources.each do |resource|
           resource.add_to_menu(@menus)
         end
+
+        @sub_menus.send :build_menus!
       end
 
       @sub_menus.on_build do |menus|
         resources.each do |resource|
+          if resource.belongs_to?
+            resource.belongs_to_config.target.nested_resources = true
+          end
+
           resource.add_to_sub_menu(@sub_menus)
         end
       end

--- a/lib/active_admin/namespace.rb
+++ b/lib/active_admin/namespace.rb
@@ -27,7 +27,7 @@ module ActiveAdmin
   class Namespace
     RegisterEvent = 'active_admin.namespace.register'.freeze
 
-    attr_reader :application, :resources, :name, :menus
+    attr_reader :application, :resources, :name, :menus, :sub_menus
 
     def initialize(application, name)
       @application = application
@@ -105,6 +105,7 @@ module ActiveAdmin
 
     def reset_menu!
       @menus.clear!
+      @sub_menus.clear!
     end
 
     # Add a callback to be ran when we build the menu
@@ -156,12 +157,19 @@ module ActiveAdmin
 
     def build_menu_collection
       @menus = MenuCollection.new
+      @sub_menus = MenuCollection.new
 
       @menus.on_build do |menus|
         build_default_utility_nav
 
         resources.each do |resource|
           resource.add_to_menu(@menus)
+        end
+      end
+
+      @sub_menus.on_build do |menus|
+        resources.each do |resource|
+          resource.add_to_sub_menu(@sub_menus)
         end
       end
     end

--- a/lib/active_admin/page.rb
+++ b/lib/active_admin/page.rb
@@ -73,6 +73,10 @@ module ActiveAdmin
       false
     end
 
+    def show_sub_menu?(*)
+      false
+    end
+
     def add_default_action_items
     end
 

--- a/lib/active_admin/resource.rb
+++ b/lib/active_admin/resource.rb
@@ -119,7 +119,8 @@ module ActiveAdmin
 
     def belongs_to(target, options = {})
       @belongs_to = Resource::BelongsTo.new(self, target, options)
-      self.navigation_menu_name = target unless @belongs_to.optional?
+      self.sub_navigation_menu_name = target
+      #self.navigation_menu_name = target unless @belongs_to.optional?
       controller.send :belongs_to, target, options.dup
     end
 

--- a/lib/active_admin/resource.rb
+++ b/lib/active_admin/resource.rb
@@ -124,6 +124,18 @@ module ActiveAdmin
       controller.send :belongs_to, target, options.dup
     end
 
+    def nested_resources=(value)
+      @nested_resources = value
+    end
+
+    def has_nested_resources?
+      @nested_resources
+    end
+
+    def show_sub_menu?(action)
+      sub_menu_item? || (has_nested_resources? && ["show", "edit"].include?(action))
+    end
+
     def belongs_to_config
       @belongs_to
     end

--- a/lib/active_admin/resource/menu.rb
+++ b/lib/active_admin/resource/menu.rb
@@ -31,7 +31,7 @@ module ActiveAdmin
         }
       end
 
-      attr_writer :navigation_menu_name
+      attr_writer :navigation_menu_name, :sub_navigation_menu_name
 
       def navigation_menu_name
         case @navigation_menu_name ||= DEFAULT_MENU
@@ -46,9 +46,19 @@ module ActiveAdmin
         namespace.fetch_menu(navigation_menu_name)
       end
 
+      def sub_navigation_menu
+        namespace.sub_menus.fetch(@sub_navigation_menu_name)
+      end
+
       def add_to_menu(menu_collection)
-        if include_in_menu?
+        if include_in_menu? && !sub_menu_item?
           @menu_item = menu_collection.add navigation_menu_name, menu_item_options
+        end
+      end
+
+      def add_to_sub_menu(menu_collection)
+        if include_in_menu? && sub_menu_item?
+          @menu_item = menu_collection.add @sub_navigation_menu_name, menu_item_options
         end
       end
 
@@ -57,6 +67,10 @@ module ActiveAdmin
       # Should this resource be added to the menu system?
       def include_in_menu?
         @include_in_menu != false
+      end
+
+      def sub_menu_item?
+        !@sub_navigation_menu_name.nil?
       end
 
     end

--- a/lib/active_admin/resource/menu.rb
+++ b/lib/active_admin/resource/menu.rb
@@ -47,7 +47,12 @@ module ActiveAdmin
       end
 
       def sub_navigation_menu
-        namespace.sub_menus.fetch(@sub_navigation_menu_name)
+        if has_nested_resources? && !sub_menu_item?
+          menu = resource_name.to_s.underscore.to_sym
+          namespace.sub_menus.fetch(menu)
+        else
+          namespace.sub_menus.fetch(@sub_navigation_menu_name)
+        end
       end
 
       def add_to_menu(menu_collection)

--- a/lib/active_admin/view_factory.rb
+++ b/lib/active_admin/view_factory.rb
@@ -6,6 +6,7 @@ module ActiveAdmin
     # Register Helper Renderers
     register  global_navigation:   ActiveAdmin::Views::TabbedNavigation,
               utility_navigation:  ActiveAdmin::Views::TabbedNavigation,
+              sub_navigation:      ActiveAdmin::Views::TabbedNavigation,
               site_title:          ActiveAdmin::Views::SiteTitle,
               unsupported_browser: ActiveAdmin::Views::UnsupportedBrowser,
               action_items:        ActiveAdmin::Views::ActionItems,

--- a/lib/active_admin/views/header.rb
+++ b/lib/active_admin/views/header.rb
@@ -9,11 +9,16 @@ module ActiveAdmin
         @menu = menu
         @utility_menu = @namespace.fetch_menu(:utility_navigation)
 
-        build_site_title
-        build_global_navigation
-        build_utility_navigation
-      end
+        div class: "navigation" do
+          build_site_title
+          build_global_navigation
+          build_utility_navigation
+        end
 
+        div class: "subnav" do
+          build_sub_navigation
+        end
+      end
 
       def build_site_title
         insert_tag view_factory.site_title, @namespace
@@ -21,6 +26,13 @@ module ActiveAdmin
 
       def build_global_navigation
         insert_tag view_factory.global_navigation, @menu, class: 'header-item tabs'
+      end
+
+      def build_sub_navigation
+        if active_admin_config.belongs_to?
+          menu = active_admin_config.sub_navigation_menu
+          insert_tag view_factory.sub_navigation, menu, :class => "tabs"
+        end
       end
 
       def build_utility_navigation

--- a/lib/active_admin/views/header.rb
+++ b/lib/active_admin/views/header.rb
@@ -9,15 +9,18 @@ module ActiveAdmin
         @menu = menu
         @utility_menu = @namespace.fetch_menu(:utility_navigation)
 
-        div class: "navigation" do
+        classes = Arbre::HTML::ClassList.new
+        classes << "navigation"
+        classes << "has_subnav" if has_sub_nav?
+
+        div class: classes do
           build_site_title
           build_global_navigation
           build_utility_navigation
         end
 
-        div class: "subnav" do
-          build_sub_navigation
-        end
+        build_sub_navigation
+
       end
 
       def build_site_title
@@ -29,14 +32,22 @@ module ActiveAdmin
       end
 
       def build_sub_navigation
-        if active_admin_config.belongs_to?
-          menu = active_admin_config.sub_navigation_menu
-          insert_tag view_factory.sub_navigation, menu, :class => "tabs"
+        if has_sub_nav?
+          div class: "subnav" do
+            menu = active_admin_config.sub_navigation_menu
+            insert_tag view_factory.sub_navigation, menu, :class => "tabs"
+          end
         end
       end
 
       def build_utility_navigation
         insert_tag view_factory.utility_navigation, @utility_menu, id: "utility_nav", class: 'header-item tabs'
+      end
+
+      private
+
+      def has_sub_nav?
+        (active_admin_config.belongs_to? && !active_admin_config.has_nested_resources?) || active_admin_config.show_sub_menu?(params[:action])
       end
 
     end

--- a/lib/active_admin/views/tabbed_navigation.rb
+++ b/lib/active_admin/views/tabbed_navigation.rb
@@ -41,7 +41,7 @@ module ActiveAdmin
 
       def build_menu_item(item)
         li id: item.id do |li|
-          li.add_class "current" if item.current? assigns[:current_tab]
+          li.add_class "current" if item.current?(assigns[:current_tab]) || item.current?(assigns[:current_sub_tab])
 
           text_node link_to item.label(self), item.url(self), item.html_options
 


### PR DESCRIPTION
*Warning, this is still work in progress.*

![Nested resource sub navigation](https://f.cloud.github.com/assets/25094/1244989/d3218230-2a94-11e3-965d-134142b06567.png)

The core idea is to add a sub navigation menu when viewing a nested resource. This allows the user to keep context of where they are within the global navigation while being able to navigate between related nested resources.

This PR is to get feedback on the feature's overall idea and help define any additional DSL needs.

### Definition

The resources for the image above are defined as:

```ruby
ActiveAdmin.register Bid do
end

ActiveAdmin.regitster CostLine do
  belongs_to :bid
end

ActiveAdmin.register Resource do
  belongs_to :bid
end
```

### Tasks

- [ ] Specs
- [ ] Tree of belongs_to relationships
- [ ] Considerations for backward compatibility with existing functionality for nested resource menus.
- [ ] Handle optional relationships (i.e. `belongs_to optional: true`).
- [ ] Better styles for sub menu.