### PR TITLE
No empty space for hidden fields

### DIFF
--- a/app/assets/stylesheets/active_admin/_forms.css.scss
+++ b/app/assets/stylesheets/active_admin/_forms.css.scss
@@ -146,6 +146,11 @@ form {
       }
     }
 
+    /* Hidden fields */
+    &.hidden {
+      padding: 0;
+    }
+
     /* Errors */
     p.inline-errors {
       color: $error-color;


### PR DESCRIPTION
Stop displaying a 20px high empty spaces for hidden fields.
