### PR TITLE
Remove old, unused dashboard_section helper

### DIFF
--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -200,11 +200,6 @@ module ActiveAdmin
       end
     end
 
-    # Helper method to add a dashboard section
-    def dashboard_section(name, options = {}, &block)
-      ActiveAdmin::Dashboards.add_section(name, options, &block)
-    end
-
     private
 
     # Return either the passed in namespace or the default


### PR DESCRIPTION
Didn't find any usage of this method throughout the code base. Plus `ActiveAdmin::Dashboards` no longer exists.
