### PR TITLE
Only use association reflections for filters

### DIFF
--- a/lib/active_admin/filters/resource_extension.rb
+++ b/lib/active_admin/filters/resource_extension.rb
@@ -98,9 +98,9 @@ module ActiveAdmin
 
       # Returns a default set of filters for the associations
       def default_association_filters
-        if resource_class.respond_to?(:reflections)
-          poly, not_poly = resource_class.reflections.partition{ |_,r| r.macro == :belongs_to && r.options[:polymorphic] }
-          filters        = poly.map{ |_,r| r.foreign_type } + not_poly.map(&:first)
+        if resource_class.respond_to?(:reflect_on_all_associations)
+          poly, not_poly = resource_class.reflect_on_all_associations.partition{ |r| r.macro == :belongs_to && r.options[:polymorphic] }
+          filters        = poly.map(&:foreign_type) + not_poly.map(&:name)
           filters.map &:to_sym
         else
           []


### PR DESCRIPTION
Edge Case:

Model.reflections typically only returns association reflections.
However, there is a case where it may return other reflections. For
instance, if a model uses the `compose_of` macro, the attribute for
which `composed_of` is called shows up as a reflection, despite not
being an association.

This makes sure that `#default_association_filters` will only return
association filters. It also cleans up the code a bit since we end
up working with an `Array` instead of a `Hash`.
