### PR TITLE
Add transposed_table_for to render a collection in columns

### DIFF
--- a/lib/active_admin/views/components/transposed_table_for.rb
+++ b/lib/active_admin/views/components/transposed_table_for.rb
@@ -1,0 +1,135 @@
+class TransposedTableFor < Arbre::HTML::Table
+  builder_method :transposed_table_for
+
+  def tag_name
+    'table'
+  end
+
+  def build(collection, options = {})
+    @resource_class = options.delete(:i18n)
+    @collection = collection
+    @columns = []
+    build_table
+
+    super(options)
+
+    add_class "transposed"
+  end
+
+  def column(*args, &block)
+    options = default_options.merge(args.extract_options!)
+    title = args[0]
+    data  = args[1] || args[0]
+
+    col = Column.new(title, data, @resource_class, options, &block)
+    @columns << col
+
+    if @columns.size == 1
+      within @header_row do
+        th(col.pretty_title, class: col.html_class)
+
+        @collection.each do |item|
+          build_table_header(col, item)
+        end
+      end
+    else
+
+      # Build a row
+      within @tbody do
+        classes = Arbre::HTML::ClassList.new
+        classes << cycle('odd', 'even')
+        classes << col.html_class
+
+        tr(:class => classes) do
+          build_table_head_cell(col)
+
+          @collection.each do |item|
+            build_table_cell(col, item)
+          end
+        end
+      end
+    end
+  end
+
+  # Returns the columns to display based on the conditional block
+  def visible_columns
+    @visible_columns ||= @columns.select{ |col| col.display_column? }
+  end
+
+  protected
+
+  def build_table
+    build_table_head
+    build_table_body
+  end
+
+  def build_table_header(col, item)
+    th(:class => col.html_class) do
+      render(col, item)
+    end
+  end
+
+  def build_table_head_cell(col)
+    classes = Arbre::HTML::ClassList.new
+    classes << col.html_class
+    th(col.pretty_title, :class => classes)
+  end
+
+  def build_table_head
+    @thead = thead do
+      @header_row = tr
+    end
+  end
+
+  def build_table_body
+    @tbody = tbody
+  end
+
+  def build_table_cell(col, item)
+    td(:class =>  col.html_class) do
+      render(col, item)
+    end
+  end
+
+  def render(col, item)
+    rvalue = call_method_or_proc_on(item, col.data, :exec => false)
+    if col.data.is_a?(Symbol)
+      rvalue = pretty_format(rvalue)
+    end
+    rvalue
+  end
+
+  def default_options
+    {
+      :i18n => @resource_class
+    }
+  end
+
+  class Column
+
+    attr_accessor :title, :data , :html_class
+
+    def initialize(*args, &block)
+      @options = args.extract_options!
+
+      @title = args[0]
+      @html_class = @options.delete(:class) || @title.to_s.downcase.underscore.gsub(/ +/,'_')
+      @data  = args[1] || args[0]
+      @data = block if block
+      @resource_class = args[2]
+    end
+
+    def pretty_title
+      if @title.is_a?(Symbol)
+        default_title =  @title.to_s.titleize
+        if @options[:i18n] && @options[:i18n].respond_to?(:human_attribute_name)
+          @title = @options[:i18n].human_attribute_name(@title, :default => default_title)
+        else
+          default_title
+        end
+      else
+        @title
+      end
+    end
+  end
+end

--- a/spec/unit/views/components/transposed_table_for_spec.rb
+++ b/spec/unit/views/components/transposed_table_for_spec.rb
@@ -1,0 +1,178 @@
+require 'spec_helper'
+
+describe TransposedTableFor do
+  describe "creating with the dsl" do
+
+    let(:collection) do
+      [Post.new(:title => "First Post"), Post.new(:title => "Second Post"), Post.new(:title => "Third Post")]
+    end
+
+    let(:assigns){ { :collection => collection } }
+    let(:helpers){ mock_action_view }
+
+    let(:thead) { table.find_by_tag("thead").first }
+    let(:tbody) { table.find_by_tag("tbody").first }
+
+    context "the rendered table" do
+      let(:table) do
+        render_arbre_component assigns do
+          transposed_table_for(collection) do
+            column :title
+            column :created_at
+            column :updated_at
+          end
+        end
+      end
+
+      it "includes the 'transposed' class" do
+        table.class_list.should include("transposed")
+      end
+
+      it "alternates 'odd' and 'even' row classes" do
+        tbody.find_by_tag("tr")[0].class_list.should include("odd")
+        tbody.find_by_tag("tr")[1].class_list.should include("even")
+      end
+    end
+
+    context "when creating a column with a symbol" do
+      let(:table) do
+        render_arbre_component assigns do
+          transposed_table_for(collection) do
+            column :title
+          end
+        end
+      end
+
+      it "should create a table header based on the symbol" do
+        table.find_by_tag("th").first.content.should == "Title"
+      end
+
+      it "should create a table column for each element in the collection" do
+        table.find_by_tag("thead").first.find_by_tag("th").size.should == 4 # 1 for head, 3 for rows
+      end
+
+      it "should create a table row for each column defined" do
+        table.find_by_tag("tr").size.should == 1
+      end
+
+      ["First Post", "Second Post", "Third Post"].each_with_index do |content, index|
+        it "should create a cell with #{content}" do
+          table.find_by_tag("th")[1 + index].content.should == content
+        end
+      end
+    end
+
+    context "when creating many columns with symbols" do
+      let(:table) do
+        render_arbre_component assigns do
+          transposed_table_for(collection) do
+            column :title
+            column :created_at
+          end
+        end
+      end
+
+      # Title      | First Post | Second Post | Third Post
+      # --------------------------------------------------
+      # Created At | 2013-01-01 | 2013-02-01  | 2013-03-01
+
+      it "should create a table header based on the symbol" do
+        table.find_by_tag("th").first.content.should == "Title"
+        table.find_by_tag("th").last.content.should == "Created At"
+      end
+
+      it "should add a class to each table header based on the col title" do
+        table.find_by_tag("th").first.class_list.should include("title")
+        table.find_by_tag("th").last.class_list.should  include("created_at")
+      end
+
+      it "should create a table column for each element in the collection" do
+        thead.find_by_tag("th").size.should == 4 # 1 for heading, 3 for columns
+      end
+
+      it "should create a thead cell for each column" do
+        thead.find_by_tag("th").size.should == 3 + 1
+      end
+
+      it "should create a cell for each tbody column" do
+        tbody.find_by_tag("td").size.should == 3
+      end
+
+      it "should add a class for each head cell based on the col name" do
+        table.find_by_tag("th")[1..3].each do |title|
+          title.class_list.should include("title")
+        end
+      end
+
+      it "should add a class for each body cell based on the col name" do
+        tbody.find_by_tag("td")[1..3].each do |title|
+          title.class_list.should include("created_at")
+        end
+      end
+    end
+
+    context "when creating a column with block content" do
+      let(:table) do
+        render_arbre_component assigns do
+          transposed_table_for(collection) do
+            column :title do |post|
+              span(post.title)
+            end
+          end
+        end
+      end
+
+      it "should add a class to each table header based on the col name" do
+        table.find_by_tag("th").first.class_list.should include("title")
+      end
+
+      [ "<span>First Post</span>",
+        "<span>Second Post</span>",
+        "<span>Third Post</span>" ].each_with_index do |content, index|
+        it "should create a cell with #{content}" do
+          table.find_by_tag("th")[1 + index].content.strip.should == content
+        end
+      end
+    end
+
+    context "when creating a column with multiple block content" do
+      let(:table) do
+        render_arbre_component assigns do
+          transposed_table_for(collection) do
+            column :title do |post|
+              span(post.title)
+              span(post.title)
+            end
+          end
+        end
+      end
+
+      3.times do |index|
+        it "should create a cell with multiple elements in row #{index}" do
+          table.find_by_tag("th")[1 + index].find_by_tag("span").size.should == 2
+        end
+      end
+    end
+
+    context "when creating many columns with symbols, blocks and strings" do
+      let(:table) do
+        render_arbre_component assigns do
+          transposed_table_for(collection) do
+            column "My Custom Title", :title
+            column :created_at, :class => "datetime"
+          end
+        end
+      end
+
+      it "should add a class to each table header  based on class option or the col name" do
+        table.find_by_tag("th").first.class_list.should  include("my_custom_title")
+        table.find_by_tag("th").last.class_list.should  include("datetime")
+      end
+
+      it "should add a class to each cell based  on class option or the col name" do
+        table.find_by_tag("th").first.class_list.should include("my_custom_title")
+        table.find_by_tag("th").last.class_list.should  include("datetime")
+      end
+    end
+  end
+end


### PR DESCRIPTION
A new component to render records in table columns rather than table rows. The image shows the difference between the two components.

![transposed_table_for](https://f.cloud.github.com/assets/25094/1276013/432adbe2-2e25-11e3-867e-2582c8c3b95b.png)

``` ruby
transposed_table_for CostType.all do
  column :name
  column :id
  column :created_at
end

table_for CostType.all do
  column :name
  column :id
  column :created_at
end
```

I considered using a `row` call, but thought it would be nice to have the exact same API as `table_for` for portability. Thoughts?
