### PR TITLE
[2537] Autoload the comments model

### DIFF
--- a/lib/active_admin.rb
+++ b/lib/active_admin.rb
@@ -118,8 +118,8 @@ require 'active_admin/batch_actions'
 require 'active_admin/filters'
 
 # Require ORM-specific plugins
-require 'active_admin/orm/active_record' if defined?(::ActiveRecord)
-require 'active_admin/orm/mongoid' if defined?(::Mongoid)
+require 'active_admin/orm/active_record' if defined? ActiveRecord
+require 'active_admin/orm/mongoid'       if defined? Mongoid
 
 # Load gem-specific code only if that gem is being used
 require 'active_admin/cancan_adapter' if Gem.loaded_specs['cancan']

--- a/lib/active_admin/orm/active_record/comments.rb
+++ b/lib/active_admin/orm/active_record/comments.rb
@@ -1,4 +1,3 @@
-require 'active_admin/orm/active_record/comments/comment'
 require 'active_admin/orm/active_record/comments/views'
 require 'active_admin/orm/active_record/comments/show_page_helper'
 require 'active_admin/orm/active_record/comments/namespace_helper'
@@ -16,7 +15,12 @@ ActiveAdmin::Resource.send  :include, ActiveAdmin::Comments::ResourceHelper
 # Add the module to the show page
 ActiveAdmin.application.view_factory.show_page.send :include, ActiveAdmin::Comments::ShowPageHelper
 
-# Walk through all the loaded resources after they are loaded
+# Load the model as soon as it's referenced. By that point, Rails & Kaminari will be ready
+module ActiveAdmin
+  autoload :Comment, 'active_admin/orm/active_record/comments/comment'
+end
+
+# Walk through all the loaded namespaces after they're loaded
 ActiveAdmin.after_load do |app|
   app.namespaces.values.each do |namespace|
     if namespace.comments?

--- a/lib/active_admin/orm/active_record/comments/comment.rb
+++ b/lib/active_admin/orm/active_record/comments/comment.rb
@@ -1,11 +1,6 @@
-require 'kaminari/models/active_record_extension'
-
 module ActiveAdmin
-
-  # manually initialize kaminari for this model
-  ::ActiveRecord::Base.send :include, Kaminari::ActiveRecordExtension
-
   class Comment < ActiveRecord::Base
+
     belongs_to :resource, :polymorphic => true
     belongs_to :author,   :polymorphic => true
 
@@ -20,13 +15,9 @@ module ActiveAdmin
       record.class.base_class.name.to_s
     end
 
+    # Postgres adapters won't compare strings to numbers (issue 34)
     def self.resource_id_cast(record)
-      # Postgres adapters won't compare strings to numbers (issue 34)
-      if resource_id_type == :string
-        record.id.to_s
-      else
-        record.id
-      end
+      resource_id_type == :string ? record.id.to_s : record.id
     end
 
     def self.find_for_resource_in_namespace(resource, namespace)
@@ -44,6 +35,5 @@ module ActiveAdmin
     end
 
   end
-
 end
 

--- a/lib/active_admin/orm/active_record/comments/namespace_helper.rb
+++ b/lib/active_admin/orm/active_record/comments/namespace_helper.rb
@@ -3,7 +3,7 @@ module ActiveAdmin
 
     module NamespaceHelper
 
-      # Returns true of the namespace allows comments
+      # Returns true if the namespace allows comments
       def comments?
         allow_comments == true
       end


### PR DESCRIPTION
For #2537

By not loading the Comments model until Rails is initialized, we can rely on the user's changes to Kaminari settings.
