### PR TITLE
Add translation for 'Anonymous' author

### DIFF
--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -69,6 +69,7 @@
       add: "Add Comment"
       resource: "Resource"
       no_comments_yet: "No comments yet."
+      author_missing: "Anonymous"
       title_content: "Comments (%{count})"
       errors:
         empty_text: "Comment wasn't saved, text was empty."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,6 +71,7 @@ en:
       add: "Add Comment"
       resource: "Resource"
       no_comments_yet: "No comments yet."
+      author_missing: "Anonymous"
       title_content: "Comments (%{count})"
       errors:
         empty_text: "Comment wasn't saved, text was empty."

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -69,6 +69,7 @@
       add: "Adicionar Comentário"
       resource: "Objeto"
       no_comments_yet: "Nenhum comentário."
+      author_missing: "Anônimo"
       title_content: "Comentários: %{count}"
       errors:
         empty_text: "O comentário não foi salvo porque o texto estava vazio."

--- a/lib/active_admin/orm/active_record/comments/views/active_admin_comments.rb
+++ b/lib/active_admin/orm/active_record/comments/views/active_admin_comments.rb
@@ -30,7 +30,7 @@ module ActiveAdmin
           div :for => comment do
             div :class => 'active_admin_comment_meta' do
               h4 :class => 'active_admin_comment_author' do
-                comment.author ? auto_link(comment.author) : 'Anonymous'
+                comment.author ? auto_link(comment.author) : I18n.t('active_admin.comments.author_missing')
               end
               span pretty_format comment.created_at
             end


### PR DESCRIPTION
When a comment author is removed he is shown as 'Anonymous' without
options for translation.

Fix #2563:

![screen shot 2013-10-13 at 5 58 28 pm](https://f.cloud.github.com/assets/379894/1322787/3ba266c6-344a-11e3-9e3a-92519da367fa.png)
