### PR TITLE
Fix top padding for index pages

### DIFF
--- a/app/assets/stylesheets/active_admin/structure/_main_structure.scss
+++ b/app/assets/stylesheets/active_admin/structure/_main_structure.scss
@@ -4,7 +4,7 @@
 
 #active_admin_content {
   margin: 0;
-  padding: 25px $horizontal-page-margin;
+  padding: $horizontal-page-margin;
 
   #main_content_wrapper {
     float: left;

--- a/app/assets/stylesheets/active_admin/structure/_title_bar.scss
+++ b/app/assets/stylesheets/active_admin/structure/_title_bar.scss
@@ -8,7 +8,6 @@
   width: 100%;
   position: relative;
   margin: 0;
-  margin-bottom: 15px;
   padding: 10px $horizontal-page-margin;
   z-index: 800;
 


### PR DESCRIPTION
Before:
![screen shot 2013-10-14 at 9 23 30 pm](https://f.cloud.github.com/assets/688886/1331017/78ff3438-3542-11e3-8b4a-4b7f3feebe71.png)
After:
![screen shot 2013-10-14 at 9 28 30 pm](https://f.cloud.github.com/assets/688886/1331018/7ebde7d4-3542-11e3-9546-b7c3446371a3.png)
It's easier to see the difference if you open the images up in separate tabs, and quickly switch between them.
