### PR TITLE
Fix flash margin left over from #2567

### DIFF
--- a/app/assets/stylesheets/active_admin/components/_flash_messages.css.scss
+++ b/app/assets/stylesheets/active_admin/components/_flash_messages.css.scss
@@ -8,10 +8,8 @@ body.logged_in {
       font-weight: bold;
       font-size: 1.1em;
       line-height: 1.0em;
-      margin-bottom: 10px;
       padding: 13px 30px 11px;
       position: relative;
-      top: -15px;
 
       &.flash_notice {
         @include gradient(#dce9dd, #ccdfcd);
@@ -35,7 +33,6 @@ body.logged_out {
     color: #666;
     font-weight: bold;
     line-height: 1.0em;
-    margin-bottom: 10px;
     padding: 0;
   }
 }


### PR DESCRIPTION
Fixes this, which was caused by #2567
![screen shot 2013-10-15 at 11 02 15 am](https://f.cloud.github.com/assets/688886/1335178/973b65e4-35b4-11e3-8293-e3e260e1233a.png)
