### PR TITLE
Allow min/max dates to be set on datepicker input

### DIFF
--- a/app/assets/javascripts/active_admin/components/application.js.coffee
+++ b/app/assets/javascripts/active_admin/components/application.js.coffee
@@ -2,7 +2,9 @@
 $ ->
   # jQuery datepickers (also evaluates dynamically added HTML)
   $(document).on 'focus', '.datepicker:not(.hasDatepicker)', ->
-    $(@).datepicker dateFormat: 'yy-mm-dd'
+    defaults = dateFormat: 'yy-mm-dd'
+    options = $(@).data 'datepicker-options'
+    $(@).datepicker $.extend(defaults, options)
 
   # Clear Filters button
   $('.clear_filters_btn').click ->

--- a/lib/active_admin/inputs/datepicker_input.rb
+++ b/lib/active_admin/inputs/datepicker_input.rb
@@ -2,10 +2,19 @@ module ActiveAdmin
   module Inputs
     class DatepickerInput < ::Formtastic::Inputs::StringInput
       def input_html_options
-        options = super
-        options[:class] = [options[:class], "datepicker"].compact.join(' ')
-        options
+        super.tap do |options|
+          options[:class] = [options[:class], "datepicker"].compact.join(' ')
+          options[:data] ||= {}
+          options[:data].merge! datepicker_options
+        end
       end
+
+      private
+        def datepicker_options
+          options = self.options.fetch(:datepicker_options, {})
+          options = Hash[options.map{ |k, v| [k.to_s.camelcase(:lower), v] }]
+          { :datepicker_options => options }
+        end
     end
   end
 end

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -474,17 +474,40 @@ describe ActiveAdmin::FormBuilder do
   end
 
   describe "datepicker input" do
-    let :body do
-      build_form do |f|
-        f.inputs do
-          f.input :created_at, :as => :datepicker
+    context 'with default options' do
+      let :body do
+        build_form do |f|
+          f.inputs do
+            f.input :created_at, :as => :datepicker
+          end
         end
       end
+      it "should generate a text input with the class of datepicker" do
+        body.should have_tag("input", :attributes => {  :type => "text",
+                                                            :class => "datepicker",
+                                                            :name => "post[created_at]" })
+      end
     end
-    it "should generate a text input with the class of datepicker" do
-      body.should have_tag("input", :attributes => {  :type => "text",
-                                                          :class => "datepicker",
-                                                          :name => "post[created_at]" })
+
+    context 'with date range options' do
+      let :body do
+        build_form do |f|
+          f.inputs do
+            f.input :created_at, :as => :datepicker,
+                                  :datepicker_options => {
+                                    :min_date => Date.new(2013, 10, 18),
+                                    :max_date => "2013-12-31" }
+          end
+        end
+        it 'should generate a datepicker text input with data min and max dates' do
+          body.should have_tag("input", :attributes => { :type => "text",
+                                                            :class => "datepicker",
+                                                            :name => "post[created_at]",
+                                                            :data => { :datepicker_options => {
+                                                              :minDate => "2013-10-18",
+                                                              :maxDate => "2013-12-31" }.to_json }})
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Allows :max_date and :min_date options to be passed to :datepicker input.

``` ruby
f.input :starts_at, as: :datepicker, datepicker_options: { min_date: "2013-10-8", max_date: 3.days.from_now.to_date }
f.input :ends_at, as: :datepicker, datepicker_options: { min_date: 3.days.ago.to_date, max_date: "+1W +5D" }
```
