### PR TITLE
Strong param generators

### DIFF
--- a/lib/generators/active_admin/resource/templates/admin.rb
+++ b/lib/generators/active_admin/resource/templates/admin.rb
@@ -1,3 +1,17 @@
 ActiveAdmin.register <%= class_name %> do
 
+  <% if Rails::VERSION::MAJOR == 4 || defined?(ActionController::StrongParameters) %>
+  # See permitted parameters documentation:
+  # https://github.com/gregbell/active_admin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
+  #
+  # permit_params :list, :of, :attributes, :on, :model
+  #
+  # or
+  #
+  # permit_params do
+  #  permitted = [:permitted, :attributes]
+  #  permitted << :other if resource.something?
+  #  permitted
+  # end
+  <% end %>
 end


### PR DESCRIPTION
Rough implementation of #2574. Does not yet support `accepts_nested_attributes_for`.
