### PR TITLE
Ensure multiple instances of attributes_table_for alternate columns properly

### DIFF
--- a/lib/active_admin/views/components/attributes_table.rb
+++ b/lib/active_admin/views/components/attributes_table.rb
@@ -54,11 +54,12 @@ module ActiveAdmin
       # a single record.
       def build_colgroups
         return if single_record?
+        reset_cycle(self.class.to_s)
         within @table do
           col # column for row headers
           @collection.each do |record|
             classes = Arbre::HTML::ClassList.new
-            classes << cycle(:even, :odd)
+            classes << cycle(:even, :odd, :name => self.class.to_s)
             classes << dom_class_name_for(record)
             col(:id => dom_id_for(record), :class => classes)
           end


### PR DESCRIPTION
When there are more than one attributes_table_for being rendered with an
odd number of records, the column alternation becomes out of sync. Now the
alternation cycle is reset each time.

![image](https://f.cloud.github.com/assets/25094/1367563/5ba73f00-3940-11e3-89cc-4611e2fd232f.png)
