### PR TITLE
"searchable" filter inputs still wraps in div.select_and_search

### DIFF
--- a/lib/active_admin/inputs/filter_base/search_method_select.rb
+++ b/lib/active_admin/inputs/filter_base/search_method_select.rb
@@ -30,7 +30,7 @@ module ActiveAdmin
 
         def wrapper_html_options
           opts = super
-          (opts[:class] ||= '') << ' select_and_search'
+          (opts[:class] ||= '') << ' select_and_search' unless seems_searchable?
           opts
         end
 


### PR DESCRIPTION
And this makes them looks like this:
![screen shot 2013-10-24 at 6 54 28 pm](https://f.cloud.github.com/assets/600768/1399865/3a560050-3cbc-11e3-824f-f861a528ece4.png)
