### PR TITLE
Fix line-collision on wrapped header titles

### DIFF
--- a/app/assets/stylesheets/active_admin/structure/_title_bar.scss
+++ b/app/assets/stylesheets/active_admin/structure/_title_bar.scss
@@ -25,6 +25,7 @@
     margin: 0;
     padding: 0;
     font-size: 2.6em;
+    line-height: 100%;
     font-weight: bold;
   }
 


### PR DESCRIPTION
When titles in headers are too long, they wrap. Line-height is too small, which makes them overlap. This changes the header `h2` to have a line-height of 100%. It shouldn't mess with the current display for single-line headers, but will make the multi-line headers look better.
