### PR TITLE
Form input[type=number] missing error border

### DIFF
--- a/app/assets/stylesheets/active_admin/_forms.css.scss
+++ b/app/assets/stylesheets/active_admin/_forms.css.scss
@@ -165,7 +165,7 @@ form {
     }
 
     &.error {
-      input[type=text], input[type=password], input[type=email], input[type=url], input[type=tel], textarea {
+      input[type=text], input[type=password], input[type=email], input[type=number], input[type=url], input[type=tel], textarea {
         border: 1px solid $error-color;
       }
     }


### PR DESCRIPTION
![image](https://f.cloud.github.com/assets/25094/1431062/b12153fe-40c9-11e3-86ab-6a05e056848c.png)

Highlight number inputs with an error border when an error occurs. The image shows the `<input type="number">` is missing the red border.
