### PR TITLE
Allow customized text for new record link in has_many forms.

### DIFF
--- a/docs/5-forms.md
+++ b/docs/5-forms.md
@@ -57,6 +57,11 @@ You can create forms with nested models using the `has_many` method:
             cf.input :title
           end
         end
+        f.inputs do
+          f.has_many :comment, :new_record => 'Leave Comment' do |cf|
+            cf.input :body
+          end
+        end
         f.actions
       end
 
@@ -69,6 +74,7 @@ on the association to use this option.
 The `:heading` option will add a custom heading to has_many form. You can hide a heading by setting `:heading => false`.
 
 The `:new_record` option will show or hide new record link at the bottom of has_many form. It is set as true by default.
+You can also customize the text for the new record link by setting the `:new_record` option to a string.
 
 ## Displaying Errors
 

--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -80,7 +80,7 @@ module ActiveAdmin
 
           inputs options, &form_block
 
-          js = options[:new_record] ? js_for_has_many(association, form_block, template) : ""
+          js = options[:new_record] ? js_for_has_many(association, form_block, template, options[:new_record]) : ""
           form_buffers.last << js.html_safe
         end
       end
@@ -167,7 +167,7 @@ module ActiveAdmin
     end
 
     # Capture the ADD JS
-    def js_for_has_many(association, form_block, template)
+    def js_for_has_many(association, form_block, template, new_record_link_text)
       assoc_reflection = object.class.reflect_on_association(association)
       assoc_name       = assoc_reflection.klass.model_name
       placeholder      = "NEW_#{assoc_name.to_s.upcase.split(' ').join('_')}_RECORD"
@@ -180,7 +180,7 @@ module ActiveAdmin
       js = template.escape_javascript js
 
       onclick = "$(this).before('#{js}'.replace(/#{placeholder}/g, new Date().getTime())); return false;"
-      text    = I18n.t 'active_admin.has_many_new', :model => assoc_name.human
+      text    = new_record_link_text.is_a?(String) ? new_record_link_text : I18n.t('active_admin.has_many_new', :model => assoc_name.human)
 
       template.link_to(text, "#", :onclick => onclick, :class => "button").html_safe
     end

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -380,6 +380,22 @@ describe ActiveAdmin::FormBuilder do
 
     end
 
+    describe "with custom new record link" do
+      let :body do
+        build_form({:url => '/categories'}, Category.new) do |f|
+          f.object.posts.build
+          f.has_many :posts, :new_record => 'My Custom New Post' do |p|
+            p.input :title
+          end
+        end
+      end
+
+      it "should add a custom new record link" do
+        body.should have_tag('a', 'My Custom New Post')
+      end
+
+    end
+
     describe "with allow destroy" do
       context "with an existing post" do
         let :body do


### PR DESCRIPTION
Overload the :new_record option, so that if a string is provided, it
will use the string for the new_record link text. Fallback to the
existing behavior if :new_record is not a string.
