### PR TITLE
Bump master to 1.0.0.pre

### DIFF
--- a/lib/active_admin/version.rb
+++ b/lib/active_admin/version.rb
@@ -1,3 +1,3 @@
 module ActiveAdmin
-  VERSION = '0.6.1'
+  VERSION = '1.0.0.pre'
 end


### PR DESCRIPTION
This keeps `bundle outdated` from incorrectly reporting that `0.6.2` is a higher version than the one I'm using at `master`. Also more clearly shows intention of master being the future and us shooting straight for a `1.0.0` release. Right now, if I'm using `master`, my version is still reported as `0.6.1`.
