### PR TITLE
Fix overlapping flash message on non-logged pages

### DIFF
--- a/app/assets/stylesheets/active_admin/components/_flash_messages.css.scss
+++ b/app/assets/stylesheets/active_admin/components/_flash_messages.css.scss
@@ -34,5 +34,6 @@ body.logged_out {
     font-weight: bold;
     line-height: 1.0em;
     padding: 0;
+    margin-bottom: 8px;
   }
 }


### PR DESCRIPTION
Add some margin-bottom to flash messages on logged out pages

![screen shot 2013-11-03 at 7 32 40 pm](https://f.cloud.github.com/assets/379894/1461942/6cc4f086-44d8-11e3-97fc-c600b36a0fd7.png)

Fix [2650](https://github.com/gregbell/active_admin/issues/2650)
