### PR TITLE
Removing Devise dependency

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.add_dependency "arbre",               "~> 1.0"
   s.add_dependency "bourbon"
   s.add_dependency "coffee-rails"
-  s.add_dependency "devise",              "~> 3.0"
   s.add_dependency "formtastic",          "~> 2.3.0.rc2" # change to 2.3 when stable is released
   s.add_dependency "inherited_resources", "~> 1.3"
   s.add_dependency "jquery-rails"

--- a/lib/active_admin.rb
+++ b/lib/active_admin.rb
@@ -2,7 +2,6 @@ require 'active_support/core_ext/class/attribute' # needed for Ransack
 require 'ransack'
 require 'ransack_ext'
 require 'bourbon'
-require 'devise'
 require 'kaminari'
 require 'formtastic'
 require 'sass-rails'
@@ -27,7 +26,7 @@ module ActiveAdmin
   autoload :ControllerAction,         'active_admin/controller_action'
   autoload :CSVBuilder,               'active_admin/csv_builder'
   autoload :Deprecation,              'active_admin/deprecation'
-  autoload :Devise,                   'active_admin/devise'
+  autoload :Devise,                   'active_admin/devise' if defined?(Devise)
   autoload :DSL,                      'active_admin/dsl'
   autoload :Event,                    'active_admin/event'
   autoload :FormBuilder,              'active_admin/form_builder'


### PR DESCRIPTION
Only load Devise module if Devise has already been loaded

Fixes #2648
