### PR TITLE
Prevent `has_many` options from rendering as input attrs

### DIFF
--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -50,6 +50,7 @@ module ActiveAdmin
 
     def has_many(assoc, options = {}, &block)
       options = {for: assoc, new_record: true}.merge options
+      block_options = options.extract!(:heading, :new_record, :allow_destroy)
       options[:class] ||= ""
       options[:class] << "inputs has_many_fields"
 
@@ -62,7 +63,7 @@ module ActiveAdmin
           contents << template.content_tag(:li) do
             template.link_to I18n.t('active_admin.has_many_remove'), "#", class: 'button has_many_remove'
           end
-        elsif options[:allow_destroy]
+        elsif block_options[:allow_destroy]
           has_many_form.input :_destroy, as: :boolean, wrapper_html: {class: 'has_many_delete'},
                                                        label: I18n.t('active_admin.has_many_delete')
         end
@@ -71,15 +72,15 @@ module ActiveAdmin
 
       form_buffers.last << with_new_form_buffer do
         template.content_tag :div, class: "has_many #{assoc}" do
-          unless options.key?(:heading) && !options[:heading]
+          unless block_options.key?(:heading) && !block_options[:heading]
             form_buffers.last << template.content_tag(:h3) do
-              options[:heading] || object.class.reflect_on_association(assoc).klass.model_name.human(count: 1.1)
+              block_options[:heading] || object.class.reflect_on_association(assoc).klass.model_name.human(count: 1.1)
             end
           end
 
           inputs options, &form_block
 
-          form_buffers.last << js_for_has_many(assoc, form_block, template, options[:new_record]) if options[:new_record]
+          form_buffers.last << js_for_has_many(assoc, form_block, template, block_options[:new_record]) if block_options[:new_record]
         end
       end
     end


### PR DESCRIPTION
Noticed this while working on #2660, but these options were getting passed in to every single input and were being rendered out as attributes on each fieldset. This PR sanitizes the options hash before building the fieldset, keeping this from happening.
