### PR TITLE
allow svg icons to be resized

### DIFF
--- a/app/assets/stylesheets/active_admin/mixins/_icons.css.scss
+++ b/app/assets/stylesheets/active_admin/mixins/_icons.css.scss
@@ -10,7 +10,6 @@ span.icon svg { vertical-align: baseline; }
 
 @mixin icon-size ($size) {
   span.icon { width: $size; height: $size; }
-  span.icon svg { width: $size; height: $size; }
 }
 
 @mixin icon($color, $size) {

--- a/lib/active_admin/iconic.rb
+++ b/lib/active_admin/iconic.rb
@@ -7,32 +7,34 @@ module ActiveAdmin
     @@default_color = "#5E6469"
     mattr_accessor :default_color
 
-    # Default width to use for icons
-    @@default_width = 15
-    mattr_accessor :default_width
-
-    # Default height to use for icons
-    @@default_height = 15
-    mattr_accessor :default_height
 
     # Render an icon:
-    #   Iconic.icon :loop
+    #   Iconic.icon :loop, width: 100, height: 100, color: "#5E6469"
+    #   Iconic.icon :loop, width: "1em", height: "1em", color: "#5E6469"
+    # NOTE: you can omit the dimensions if they are specified in css
     def self.icon(name, options = {})
       options = {
         :color => default_color,
-        :width => default_width,
-        :height => default_height,
         :id => ""
       }.merge(options)
-
 
       options[:style] = "fill:#{options[:color]};"
       options[:fill] = options.delete(:color)
 
+      css = options.delete(:css) || {}
+
+      # extract desired dimensions to be used as the wrapper's inline styles
       # Convert to strings representations of pixels
       [:width, :height].each do |key|
-        options[key] = "#{options[key]}px" unless options[key].is_a?(String)
+        value = options.delete key
+        css[key] ||= "#{value}px" unless value.blank? || value.is_a?(String)
       end
+      css_str = css.map {|k,v| "#{k}:#{v}"}.join(";")
+      css_str = "style=\"#{css_str}\"" if css_str.present?
+
+      
+      # make the svg itself expand to its parent
+      options[:width] = options[:height] = "100%"
 
       template = ICONS[name.to_sym]
 
@@ -41,7 +43,8 @@ module ActiveAdmin
         options.each do |key, value|
           svg.gsub!("{#{key}}", value)
         end
-        "<span class=\"icon icon_#{name}\">#{svg}</span>".html_safe
+
+        "<span class=\"icon icon_#{name}\" #{css_str}>#{svg}</span>".html_safe
       else
         raise "Could not find the icon named #{name}"
       end


### PR DESCRIPTION
This is to address #2621
It allows the svg icon sizes to overrideable via the Iconic helper.
