### PR TITLE
Update rspec to expect syntax, plus == to eq

### DIFF
--- a/spec/integration/default_namespace_spec.rb
+++ b/spec/integration/default_namespace_spec.rb
@@ -22,11 +22,11 @@ describe ActiveAdmin::Application do
       end
 
       it "should generate a log out path" do
-        destroy_admin_user_session_path.should == "/admin_users/logout"
+        expect(destroy_admin_user_session_path).to eq "/admin_users/logout"
       end
 
       it "should generate a log in path" do
-        new_admin_user_session_path.should == "/admin_users/login"
+        expect(new_admin_user_session_path).to eq "/admin_users/login"
       end
 
     end
@@ -49,11 +49,11 @@ describe ActiveAdmin::Application do
       end
 
       it "should generate a log out path" do
-        destroy_admin_user_session_path.should == "/test/logout"
+        expect(destroy_admin_user_session_path).to eq "/test/logout"
       end
 
       it "should generate a log in path" do
-        new_admin_user_session_path.should == "/test/login"
+        expect(new_admin_user_session_path).to eq "/test/login"
       end
 
     end

--- a/spec/integration/memory_spec.rb
+++ b/spec/integration/memory_spec.rb
@@ -19,7 +19,7 @@ describe "Memory Leak" do
 
       GC.start
       GC.disable if previously_disabled
-      count_instances_of(klass).should <= count
+      expect(count_instances_of(klass)).to be <= count
     end
   end
 

--- a/spec/integration/stylesheets_spec.rb
+++ b/spec/integration/stylesheets_spec.rb
@@ -1,41 +1,18 @@
 require 'spec_helper'
 
 describe "Stylesheets" do
-  if Rails.version[0..2] == '3.1'
-    require "sprockets"
-    context "when Rails 3.1.x" do
-      let(:css) do
-        assets = Rails.application.assets
-        assets.find_asset("active_admin.css")
-      end
-      it "should successfully render the scss stylesheets using sprockets" do
-        css.should_not be_nil
-      end
-      it "should not have any syntax errors" do
-        css.to_s.should_not include("Syntax error:")
-      end
-    end
+
+  require "sprockets"
+
+  let(:css) do
+    assets = Rails.application.assets
+    assets.find_asset("active_admin.css")
+  end
+  it "should successfully render the scss stylesheets using sprockets" do
+    expect(css).to_not be_nil
+  end
+  it "should not have any syntax errors" do
+    expect(css.to_s).to_not include("Syntax error:")
   end
 
-  if Rails.version[0..2] == '3.0'
-    context "when Rails 3.0.x" do
-      let(:stylesheet_path) do
-        Rails.root + 'public/stylesheets/active_admin.css'
-      end
-
-      before do
-        "rm #{stylesheet_path}" if File.exists?(stylesheet_path)
-        Sass::Plugin.force_update_stylesheets
-      end
-
-      it "should render the scss stylesheets using SASS" do
-        File.exists?(stylesheet_path).should be_true
-      end
-
-      it "should not have any syntax errors" do
-        css = File.read(stylesheet_path)
-        css.should_not include("Syntax error:")
-      end
-    end
-  end
 end

--- a/spec/unit/abstract_view_factory_spec.rb
+++ b/spec/unit/abstract_view_factory_spec.rb
@@ -13,20 +13,20 @@ describe ActiveAdmin::AbstractViewFactory do
     end
 
     it "should respond to :my_new_view_class" do
-      view_factory.respond_to? :my_new_view_class
+      expect(view_factory.respond_to? :my_new_view_class).to be true
     end
 
     it "should respond to :my_new_view_class=" do
-      view_factory.respond_to? :my_new_view_class=
+      expect(view_factory.respond_to? :my_new_view_class=).to be true
     end
 
     it "should generate a getter method" do
-      view_factory.my_new_view_class.should == view
+      expect(view_factory.my_new_view_class).to eq view
     end
 
     it "should be settable view a setter method" do
       view_factory.my_new_view_class = "Some Obj"
-      view_factory.my_new_view_class.should == "Some Obj"
+      expect(view_factory.my_new_view_class).to eq "Some Obj"
     end
   end
 
@@ -36,12 +36,12 @@ describe ActiveAdmin::AbstractViewFactory do
     end
 
     it "should be available through array syntax" do
-      view_factory[:my_new_view_class].should == view
+      expect(view_factory[:my_new_view_class]).to eq view
     end
 
     it "should be settable through array syntax" do
       view_factory[:my_new_view_class] = "My New View Class"
-      view_factory[:my_new_view_class].should == "My New View Class"
+      expect(view_factory[:my_new_view_class]).to eq "My New View Class"
     end
   end
 
@@ -50,12 +50,12 @@ describe ActiveAdmin::AbstractViewFactory do
       ActiveAdmin::AbstractViewFactory.register my_default_view_class: view
     end
     it "should generate a getter method" do
-      view_factory.my_default_view_class.should == view
+      expect(view_factory.my_default_view_class).to eq view
     end
     it "should be settable view a setter method and not change default" do
       view_factory.my_default_view_class = "Some Obj"
-      view_factory.my_default_view_class.should == "Some Obj"
-      view_factory.default_for(:my_default_view_class).should == view
+      expect(view_factory.my_default_view_class).to eq "Some Obj"
+      expect(view_factory.default_for(:my_default_view_class)).to eq view
     end
   end
 
@@ -71,7 +71,7 @@ describe ActiveAdmin::AbstractViewFactory do
 
     it "should use the subclass implementation" do
       factory = subclass.new
-      factory.my_subclassed_view.should == "From Subclass"
+      expect(factory.my_subclassed_view).to eq "From Subclass"
     end
   end
 

--- a/spec/unit/action_builder_spec.rb
+++ b/spec/unit/action_builder_spec.rb
@@ -24,13 +24,13 @@ describe 'defining new actions from registration blocks' do
       end
 
       it "should create a new public instance method" do
-        controller.public_instance_methods.collect(&:to_s).should include("comment")
+        expect(controller.public_instance_methods.collect(&:to_s)).to include("comment")
       end
       it "should add itself to the member actions config" do
-        controller.active_admin_config.member_actions.size.should == 1
+        expect(controller.active_admin_config.member_actions.size).to eq 1
       end
       it "should create a new named route" do
-        Rails.application.routes.url_helpers.methods.collect(&:to_s).should include("comment_admin_post_path")
+        expect(Rails.application.routes.url_helpers.methods.collect(&:to_s)).to include("comment_admin_post_path")
       end
     end
 
@@ -41,7 +41,7 @@ describe 'defining new actions from registration blocks' do
         end
       end
       it "should still generate a new empty action" do
-        controller.public_instance_methods.collect(&:to_s).should include("comment")
+        expect(controller.public_instance_methods.collect(&:to_s)).to include("comment")
       end
     end
 
@@ -76,13 +76,13 @@ describe 'defining new actions from registration blocks' do
         end
       end
       it "should create a new public instance method" do
-        controller.public_instance_methods.collect(&:to_s).should include("comments")
+        expect(controller.public_instance_methods.collect(&:to_s)).to include("comments")
       end
       it "should add itself to the member actions config" do
-        controller.active_admin_config.collection_actions.size.should == 1
+        expect(controller.active_admin_config.collection_actions.size).to eq 1
       end
       it "should create a new named route" do
-        Rails.application.routes.url_helpers.methods.collect(&:to_s).should include("comments_admin_posts_path")
+        expect(Rails.application.routes.url_helpers.methods.collect(&:to_s)).to include("comments_admin_posts_path")
       end
     end
     context "without a block" do
@@ -92,7 +92,7 @@ describe 'defining new actions from registration blocks' do
         end
       end
       it "should still generate a new empty action" do
-        controller.public_instance_methods.collect(&:to_s).should include("comments")
+        expect(controller.public_instance_methods.collect(&:to_s)).to include("comments")
       end
     end
     context "with :title" do
@@ -116,7 +116,7 @@ describe 'defining new actions from registration blocks' do
     match do |filter|
       filter.raw_filter.call
       @actual = filter.klass.instance_variable_get(:@page_title)
-      @actual == expected
+      expect(@actual).to eq expected
     end
 
     failure_message_for_should do |filter|

--- a/spec/unit/active_admin_spec.rb
+++ b/spec/unit/active_admin_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe ActiveAdmin do
   %w(register register_page unload! load! routes).each do |method|
     it "delegates ##{method} to application" do
-      ActiveAdmin.application.should_receive(method)
+      expect(ActiveAdmin.application).to receive(method)
 
       ActiveAdmin.send(method)
     end

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -11,90 +11,90 @@ describe ActiveAdmin::Application do
   end
 
   it "should have a default load path of ['app/admin']" do
-    application.load_paths.should == [File.expand_path('app/admin', Rails.root)]
+    expect(application.load_paths).to eq [File.expand_path('app/admin', Rails.root)]
   end
 
   it "should remove app/admin from the autoload paths (Active Admin deals with loading)" do
-    ActiveSupport::Dependencies.autoload_paths.should_not include(File.join(Rails.root, "app/admin"))
+    expect(ActiveSupport::Dependencies.autoload_paths).to_not include(File.join(Rails.root, "app/admin"))
   end
 
   it "should add app/admin to the Engine's watchable directories (loaded after the app itself)" do
-    ActiveAdmin::Engine.config.watchable_dirs.should have_key File.join(Rails.root, "app/admin")
+    expect(ActiveAdmin::Engine.config.watchable_dirs).to have_key File.join(Rails.root, "app/admin")
   end
 
   it "should store the site's title" do
-    application.site_title.should == ""
+    expect(application.site_title).to eq ""
   end
 
   it "should set the site title" do
     application.site_title = "New Title"
-    application.site_title.should == "New Title"
+    expect(application.site_title).to eq "New Title"
   end
 
   it "should store the site's title link" do
-    application.site_title_link.should == ""
+    expect(application.site_title_link).to eq ""
   end
 
   it "should set the site's title link" do
     application.site_title_link = "http://www.mygreatsite.com"
-    application.site_title_link.should == "http://www.mygreatsite.com"
+    expect(application.site_title_link).to eq "http://www.mygreatsite.com"
   end
 
   it "should store the site's title image" do
-    application.site_title_image.should == ""
+    expect(application.site_title_image).to eq ""
   end
 
   it "should set the site's title image" do
     application.site_title_image = "http://railscasts.com/assets/episodes/stills/284-active-admin.png?1316476106"
-    application.site_title_image.should == "http://railscasts.com/assets/episodes/stills/284-active-admin.png?1316476106"
+    expect(application.site_title_image).to eq "http://railscasts.com/assets/episodes/stills/284-active-admin.png?1316476106"
   end
-  
+
   it "should store the site's favicon" do
-    application.favicon.should == false
+    expect(application.favicon).to eq false
   end
 
   it "should set the site's favicon" do
     application.favicon = "/a/favicon.ico"
-    application.favicon.should == "/a/favicon.ico"
+    expect(application.favicon).to eq "/a/favicon.ico"
   end
 
   it "should have a view factory" do
-    application.view_factory.should be_an_instance_of(ActiveAdmin::ViewFactory)
+    expect(application.view_factory).to be_an_instance_of(ActiveAdmin::ViewFactory)
   end
 
   it "should allow comments by default" do
-    application.allow_comments.should == true
+    expect(application.allow_comments).to eq true
   end
 
   describe "authentication settings" do
 
     it "should have no default current_user_method" do
-      application.current_user_method.should == false
+      expect(application.current_user_method).to eq false
     end
 
     it "should have no default authentication method" do
-      application.authentication_method.should == false
+      expect(application.authentication_method).to eq false
     end
 
     it "should have a logout link path (Devise's default)" do
-      application.logout_link_path.should == :destroy_admin_user_session_path
+      expect(application.logout_link_path).to eq :destroy_admin_user_session_path
     end
 
     it "should have a logout link method (Devise's default)" do
-      application.logout_link_method.should == :get
+      expect(application.logout_link_method).to eq :get
     end
   end
 
   describe "files in load path" do
     it "should load files in the first level directory" do
-      application.files.should include(File.expand_path("app/admin/dashboard.rb", Rails.root))
+      expect(application.files).to include(File.expand_path("app/admin/dashboard.rb", Rails.root))
     end
 
     it "should load files from subdirectories" do
       FileUtils.mkdir_p(File.expand_path("app/admin/public", Rails.root))
       test_file = File.expand_path("app/admin/public/posts.rb", Rails.root)
       FileUtils.touch(test_file)
-      application.files.should include(test_file)
+      expect(application.files).to include(test_file)
     end
   end
 
@@ -102,38 +102,37 @@ describe ActiveAdmin::Application do
 
     it "should yield a new namespace" do
       application.namespace :new_namespace do |ns|
-        ns.name.should == :new_namespace
+        expect(ns.name).to eq :new_namespace
       end
     end
 
     it "should return an instantiated namespace" do
       admin = application.namespace :admin
-      admin.should == application.namespaces[:admin]
+      expect(admin).to eq application.namespaces[:admin]
     end
 
     it "should yield an existing namespace" do
       expect {
         application.namespace :admin do |ns|
-          ns.should == application.namespaces[:admin]
+          expect(ns).to eq application.namespaces[:admin]
           raise "found"
         end
       }.to raise_error("found")
     end
 
     it "should not pollute the global app" do
-      application.namespaces.keys.should be_empty
+      expect(application.namespaces.keys).to be_empty
       application.namespace(:brand_new_ns)
-      application.namespaces.keys.should eq [:brand_new_ns]
-      ActiveAdmin.application.namespaces.keys.should eq [:admin]
+      expect(application.namespaces.keys).to eq [:brand_new_ns]
+      expect(ActiveAdmin.application.namespaces.keys).to eq [:admin]
     end
   end
 
   describe "#register_page" do
     it "finds or create the namespace and register the page to it" do
       namespace = double
-      application.should_receive(:namespace).with("public").and_return namespace
-      namespace.should_receive(:register_page).with("My Page", {:namespace => "public"})
-
+      expect(application).to receive(:namespace).with("public").and_return namespace
+      expect(namespace).to receive(:register_page).with("My Page", {:namespace => "public"})
       application.register_page("My Page", :namespace => "public")
     end
   end

--- a/spec/unit/asset_registration_spec.rb
+++ b/spec/unit/asset_registration_spec.rb
@@ -10,43 +10,43 @@ describe ActiveAdmin::AssetRegistration do
 
   it "should register a stylesheet file" do
     register_stylesheet "active_admin.css"
-    stylesheets.length.should == 1
-    stylesheets.keys.first.should == "active_admin.css"
+    expect(stylesheets.length).to eq 1
+    expect(stylesheets.keys.first).to eq "active_admin.css"
   end
 
   it "should clear all existing stylesheets" do
     register_stylesheet "active_admin.css"
-    stylesheets.length.should == 1
+    expect(stylesheets.length).to eq 1
     clear_stylesheets!
-    stylesheets.should be_empty
+    expect(stylesheets).to be_empty
   end
 
   it "should allow media option when registering stylesheet" do
     register_stylesheet "active_admin.css", media: :print
-    stylesheets.values.first[:media].should == :print
+    expect(stylesheets.values.first[:media]).to eq :print
   end
 
   it "shouldn't register a stylesheet twice" do
     register_stylesheet "active_admin.css"
     register_stylesheet "active_admin.css"
-    stylesheets.length.should == 1
+    expect(stylesheets.length).to eq 1
   end
 
   it "should register a javascript file" do
     register_javascript "active_admin.js"
-    javascripts.should == ["active_admin.js"].to_set
+    expect(javascripts).to eq ["active_admin.js"].to_set
   end
 
   it "should clear all existing javascripts" do
     register_javascript "active_admin.js"
-    javascripts.should == ["active_admin.js"].to_set
+    expect(javascripts).to eq ["active_admin.js"].to_set
     clear_javascripts!
-    javascripts.should be_empty
+    expect(javascripts).to be_empty
   end
 
   it "shouldn't register a javascript twice" do
     register_javascript "active_admin.js"
     register_javascript "active_admin.js"
-    javascripts.length.should == 1
+    expect(javascripts.length).to eq 1
   end
 end

--- a/spec/unit/authorization/authorization_adapter_spec.rb
+++ b/spec/unit/authorization/authorization_adapter_spec.rb
@@ -7,7 +7,7 @@ describe ActiveAdmin::AuthorizationAdapter do
   describe "#authorized?" do
 
     it "should always return true" do
-      adapter.authorized?(:read, "Resource").should == true
+      expect(adapter.authorized?(:read, "Resource")).to be_true
     end
 
   end
@@ -16,7 +16,7 @@ describe ActiveAdmin::AuthorizationAdapter do
 
     it "should return the collection unscoped" do
       collection = double
-      adapter.scope_collection(collection, ActiveAdmin::Auth::READ).should == collection
+      expect(adapter.scope_collection(collection, ActiveAdmin::Auth::READ)).to eq collection
     end
 
   end
@@ -41,19 +41,19 @@ describe ActiveAdmin::AuthorizationAdapter do
     let(:adapter) { auth_class.new(double, double) }
 
     it "should match against a class" do
-      adapter.authorized?(:read, String).should == true
+      expect(adapter.authorized?(:read, String)).to be_true
     end
 
     it 'should match against an instance' do
-      adapter.authorized?(:read, "String").should == true
+      expect(adapter.authorized?(:read, "String")).to be_true
     end
 
     it 'should not match a different class' do
-      adapter.authorized?(:read, Hash).should == false
+      expect(adapter.authorized?(:read, Hash)).to be_false
     end
 
     it 'should not match a different instance' do
-      adapter.authorized?(:read, {}).should == false
+      expect(adapter.authorized?(:read, {})).to be_false
     end
 
   end

--- a/spec/unit/authorization/controller_authorization_spec.rb
+++ b/spec/unit/authorization/controller_authorization_spec.rb
@@ -12,28 +12,28 @@ describe Admin::PostsController, "Controller Authorization", :type => :controlle
   end
 
   it "should authorize the index action" do
-    authorization.should_receive(:authorized?).with(Auth::READ, Post).and_return true
+    expect(authorization).to receive(:authorized?).with(Auth::READ, Post).and_return true
     get :index
-    response.should be_success
+    expect(response).to be_success
   end
 
   it "should authorize the new action" do
-    authorization.should_receive(:authorized?).with(Auth::CREATE, an_instance_of(Post)).and_return true
+    expect(authorization).to receive(:authorized?).with(Auth::CREATE, an_instance_of(Post)).and_return true
     get :new
-    response.should be_success
+    expect(response).to be_success
   end
 
   it "should authorize the create action with the new resource" do
-    authorization.should_receive(:authorized?).with(Auth::CREATE, an_instance_of(Post)).and_return true
+    expect(authorization).to receive(:authorized?).with(Auth::CREATE, an_instance_of(Post)).and_return true
     post :create
-    response.should redirect_to action: 'show', id: Post.last.id
+    expect(response).to redirect_to action: 'show', id: Post.last.id
   end
 
   it "should redirect when the user isn't authorized" do
-    authorization.should_receive(:authorized?).with(Auth::READ, Post).and_return false
+    expect(authorization).to receive(:authorized?).with(Auth::READ, Post).and_return false
     get :index
-    response.body.should eq '<html><body>You are being <a href="http://test.host/admin">redirected</a>.</body></html>'
-    response.should redirect_to '/admin'
+    expect(response.body).to eq '<html><body>You are being <a href="http://test.host/admin">redirected</a>.</body></html>'
+    expect(response).to redirect_to '/admin'
   end
 
 end

--- a/spec/unit/auto_link_spec.rb
+++ b/spec/unit/auto_link_spec.rb
@@ -15,7 +15,7 @@ describe "auto linking resources" do
 
   context "when the resource is not registered" do
     it "should return the display name of the object" do
-      auto_link(post).should == "Hello World"
+      expect(auto_link(post)).to eq "Hello World"
     end
   end
 
@@ -24,7 +24,7 @@ describe "auto linking resources" do
       active_admin_namespace.register Post
     end
     it "should return a link with the display name of the object" do
-      self.should_receive(:link_to).with("Hello World", admin_post_path(post))
+      expect(self).to receive(:link_to).with("Hello World", admin_post_path(post))
       auto_link(post)
     end
   end

--- a/spec/unit/batch_actions/resource_spec.rb
+++ b/spec/unit/batch_actions/resource_spec.rb
@@ -11,7 +11,8 @@ describe ActiveAdmin::BatchActions::ResourceExtension do
   describe "default action" do
 
     it "should have the default action by default" do
-      resource.batch_actions.size.should == 1 and resource.batch_actions.first.sym == :destroy
+      expect(resource.batch_actions.size).to eq 1
+      expect(resource.batch_actions.first.sym == :destroy).to be_true
     end
 
   end
@@ -26,15 +27,15 @@ describe ActiveAdmin::BatchActions::ResourceExtension do
     end
 
     it "should add an batch action" do
-      resource.batch_actions.size.should == 1
+      expect(resource.batch_actions.size).to eq 1
     end
 
     it "should store an instance of BatchAction" do
-      resource.batch_actions.first.should be_an_instance_of(ActiveAdmin::BatchAction)
+      expect(resource.batch_actions.first).to be_an_instance_of(ActiveAdmin::BatchAction)
     end
 
     it "should store the block in the batch action" do
-      resource.batch_actions.first.block.should_not be_nil
+      expect(resource.batch_actions.first.block).to_not be_nil
     end
 
   end
@@ -46,7 +47,7 @@ describe ActiveAdmin::BatchActions::ResourceExtension do
     end
 
     it "should allow for batch action removal" do
-      resource.batch_actions.size.should == 0
+      expect(resource.batch_actions.size).to eq 0
     end
 
   end
@@ -54,7 +55,7 @@ describe ActiveAdmin::BatchActions::ResourceExtension do
   describe "#batch_action_path" do
 
     it "returns the path as a symbol" do
-      resource.batch_action_path.should == "/admin/posts/batch_action"
+      expect(resource.batch_action_path).to eq "/admin/posts/batch_action"
     end
 
   end
@@ -63,12 +64,12 @@ describe ActiveAdmin::BatchActions::ResourceExtension do
 
     it "should return true by default" do
       action = ActiveAdmin::BatchAction.new :default, "Default"
-      action.display_if_block.call.should == true
+      expect(action.display_if_block.call).to eq true
     end
 
     it "should return the :if block if set" do
       action = ActiveAdmin::BatchAction.new :with_block, "With Block", :if => proc { false }
-      action.display_if_block.call.should == false
+      expect(action.display_if_block.call).to eq false
     end
 
   end
@@ -77,13 +78,13 @@ describe ActiveAdmin::BatchActions::ResourceExtension do
 
     it "should have a default priority" do
       action = ActiveAdmin::BatchAction.new :default, "Default"
-      action.priority.should == 10
+      expect(action.priority).to eq 10
     end
 
     it "should correctly order two actions" do
       priority_one = ActiveAdmin::BatchAction.new :one, "One", :priority => 1
       priority_ten = ActiveAdmin::BatchAction.new :ten, "Ten", :priority => 10
-      priority_one.should be < priority_ten
+      expect(priority_one).to be < priority_ten
     end
 
   end

--- a/spec/unit/batch_actions/settings_spec.rb
+++ b/spec/unit/batch_actions/settings_spec.rb
@@ -8,54 +8,54 @@ describe "Batch Actions Settings" do
   it "should be disabled globally by default" do
     # Note: the default initializer would set it to true
 
-    app.batch_actions.should be_false
-    ns.batch_actions.should be_false
-    post_resource.batch_actions_enabled?.should be_false
+    expect(app.batch_actions).to be_false
+    expect(ns.batch_actions).to be_false
+    expect(post_resource.batch_actions_enabled?).to be_false
   end
 
   it "should be settable to true" do
     app.batch_actions = true
-    app.batch_actions.should == true
+    expect(app.batch_actions).to be_true
   end
 
   it "should be an inheritable_setting" do
     app.batch_actions = true
-    ns.batch_actions.should == true
+    expect(ns.batch_actions).to be_true
   end
 
   it "should be settable at the namespace level" do
     app.batch_actions = true
     ns.batch_actions = false
 
-    app.batch_actions.should == true
-    ns.batch_actions.should == false
+    expect(app.batch_actions).to be_true
+    expect(ns.batch_actions).to be_false
   end
 
   it "should be settable at the resource level" do
-    post_resource.batch_actions_enabled?.should == false
+    expect(post_resource.batch_actions_enabled?).to be_false
     post_resource.batch_actions = true
-    post_resource.batch_actions_enabled?.should == true
+    expect(post_resource.batch_actions_enabled?).to be_true
   end
 
   it "should inherit the setting on the resource from the namespace" do
     ns.batch_actions = false
-    post_resource.batch_actions_enabled?.should == false
-    post_resource.batch_actions.should be_empty
+    expect(post_resource.batch_actions_enabled?).to be_false
+    expect(post_resource.batch_actions).to be_empty
 
     post_resource.batch_actions = true
-    post_resource.batch_actions_enabled?.should == true
-    post_resource.batch_actions.should_not be_empty
+    expect(post_resource.batch_actions_enabled?).to be_true
+    expect(post_resource.batch_actions).to_not be_empty
   end
 
   it "should inherit the setting from the namespace when set to nil" do
     ns.batch_actions = true
 
     post_resource.batch_actions = true
-    post_resource.batch_actions_enabled?.should == true
-    post_resource.batch_actions.should_not be_empty
+    expect(post_resource.batch_actions_enabled?).to be_true
+    expect(post_resource.batch_actions).to_not be_empty
 
     post_resource.batch_actions = nil
-    post_resource.batch_actions_enabled?.should == true # inherited from namespace
-    post_resource.batch_actions.should_not be_empty
+    expect(post_resource.batch_actions_enabled?).to be_true # inherited from namespace
+    expect(post_resource.batch_actions).to_not be_empty
   end
 end

--- a/spec/unit/belongs_to_spec.rb
+++ b/spec/unit/belongs_to_spec.rb
@@ -9,11 +9,11 @@ describe ActiveAdmin::Resource::BelongsTo do
   let(:belongs_to){ ActiveAdmin::Resource::BelongsTo.new(post, :user) }
 
   it "should have an owner" do
-    belongs_to.owner.should == post
+    expect(belongs_to.owner).to eq post
   end
 
   it "should have a namespace" do
-    belongs_to.namespace.should == namespace
+    expect(belongs_to.namespace).to eq namespace
   end
 
   describe "finding the target" do
@@ -22,7 +22,7 @@ describe ActiveAdmin::Resource::BelongsTo do
       before { user } # Ensure user is registered
 
       it "should return the target resource" do
-        belongs_to.target.should == user
+        expect(belongs_to.target).to eq user
       end
     end
 
@@ -37,6 +37,6 @@ describe ActiveAdmin::Resource::BelongsTo do
 
   it "should be optional" do
     belongs_to = ActiveAdmin::Resource::BelongsTo.new post, :user, :optional => true
-    belongs_to.should be_optional
+    expect(belongs_to).to be_optional
   end
 end

--- a/spec/unit/cancan_adapter_spec.rb
+++ b/spec/unit/cancan_adapter_spec.rb
@@ -28,13 +28,13 @@ describe ActiveAdmin::CanCanAdapter do
     end
 
     it "should initialize the ability stored in the namespace configuration" do
-      auth.authorized?(:read, Post).should == true
-      auth.authorized?(:update, Post).should == false
+      expect(auth.authorized?(:read, Post)).to eq true
+      expect(auth.authorized?(:update, Post)).to eq false
     end
 
     it "should scope the collection with accessible_by" do
       collection = double
-      collection.should_receive(:accessible_by).with(auth.cancan_ability, :edit)
+      expect(collection).to receive(:accessible_by).with(auth.cancan_ability, :edit)
       auth.scope_collection(collection, :edit)
     end
 

--- a/spec/unit/comments_spec.rb
+++ b/spec/unit/comments_spec.rb
@@ -4,14 +4,14 @@ describe "Comments" do
   let(:application) { ActiveAdmin::Application.new }
 
   describe ActiveAdmin::Comment do
-    subject { ActiveAdmin::Comment.new }
+    subject(:comment){ ActiveAdmin::Comment.new }
 
-    describe "Associations and Validations" do
-      it { should belong_to :resource }
-      it { should belong_to :author }
-      it { should validate_presence_of :resource }
-      it { should validate_presence_of :body }
-      it { should validate_presence_of :namespace }
+    it "Has valid Associations and Validations" do
+      expect(comment).to belong_to :resource
+      expect(comment).to belong_to :author
+      expect(comment).to validate_presence_of :resource
+      expect(comment).to validate_presence_of :body
+      expect(comment).to validate_presence_of :namespace
     end
 
     describe ".find_for_resource_in_namespace" do
@@ -25,16 +25,16 @@ describe "Comments" do
       end
 
       it "should return a comment for the resource in the same namespace" do
-        ActiveAdmin::Comment.find_for_resource_in_namespace(post, namespace_name).should == [@comment]
+        expect(ActiveAdmin::Comment.find_for_resource_in_namespace(post, namespace_name)).to eq [@comment]
       end
 
       it "should not return a comment for the same resource in a different namespace" do
-        ActiveAdmin::Comment.find_for_resource_in_namespace(post, 'public').should == []
+        expect(ActiveAdmin::Comment.find_for_resource_in_namespace(post, 'public')).to eq []
       end
 
       it "should not return a comment for a different resource" do
         another_post = Post.create! :title => "Another Hello World"
-        ActiveAdmin::Comment.find_for_resource_in_namespace(another_post, namespace_name).should == []
+        expect(ActiveAdmin::Comment.find_for_resource_in_namespace(another_post, namespace_name)).to eq []
       end
     end
 
@@ -46,13 +46,13 @@ describe "Comments" do
         comment = ActiveAdmin::Comment.create! :resource => post,
                                                 :body => "Another Comment",
                                                 :namespace => namespace_name
-        ActiveAdmin::Comment.resource_id_cast(comment).class.should eql String
+        expect(ActiveAdmin::Comment.resource_id_cast(comment).class).to eql String
       end
     end
 
     describe ".resource_id_type" do
       it "should be :string" do
-        ActiveAdmin::Comment.resource_id_type.should eql :string
+        expect(ActiveAdmin::Comment.resource_id_type).to eql :string
       end
     end
 
@@ -66,7 +66,7 @@ describe "Comments" do
           :body => "Another Comment",
           :namespace => namespace_name)
 
-        ActiveAdmin::Comment.find_for_resource_in_namespace(tag, namespace_name).should == [comment]
+        expect(ActiveAdmin::Comment.find_for_resource_in_namespace(tag, namespace_name)).to eq [comment]
       end
     end
 
@@ -92,13 +92,13 @@ describe "Comments" do
       it "should have comments when the namespace allows comments" do
         ns = ActiveAdmin::Namespace.new(application, :admin)
         ns.allow_comments = true
-        ns.comments?.should be_true
+        expect(ns.comments?).to be_true
       end
 
       it "should not have comments when the namespace does not allow comments" do
         ns = ActiveAdmin::Namespace.new(application, :admin)
         ns.allow_comments = false
-        ns.comments?.should be_false
+        expect(ns.comments?).to be_false
       end
     end
   end
@@ -107,15 +107,15 @@ describe "Comments" do
     it "should add an attr_accessor :comments to ActiveAdmin::Resource" do
       ns = ActiveAdmin::Namespace.new(application, :admin)
       resource = ActiveAdmin::Resource.new(ns, Post)
-      resource.comments.should be_nil
+      expect(resource.comments).to be_nil
       resource.comments = true
-      resource.comments.should be_true
+      expect(resource.comments).to be_true
     end
     it "should disable comments if set to false" do
       ns = ActiveAdmin::Namespace.new(application, :admin)
       resource = ActiveAdmin::Resource.new(ns, Post)
       resource.comments = false
-      resource.comments?.should be_false
+      expect(resource.comments?).to be_false
     end
   end
 end

--- a/spec/unit/component_spec.rb
+++ b/spec/unit/component_spec.rb
@@ -8,11 +8,11 @@ describe ActiveAdmin::Component do
   let(:component){ component_class.new }
 
   it "should be a subclass of an html div" do
-    ActiveAdmin::Component.ancestors.should include(Arbre::HTML::Div)
+    expect(ActiveAdmin::Component.ancestors).to include(Arbre::HTML::Div)
   end
 
   it "should render to a div, even as a subclass" do
-    component.tag_name.should == 'div'
+    expect(component.tag_name).to eq 'div'
   end
 
 end

--- a/spec/unit/controller_filters_spec.rb
+++ b/spec/unit/controller_filters_spec.rb
@@ -6,27 +6,27 @@ describe ActiveAdmin::Application do
                       ActiveAdmin::Devise::UnlocksController, ActiveAdmin::Devise::PasswordsController] }
 
   it 'before_filter' do
-    controllers.each{ |c| c.should_receive(:before_filter).and_return(true) }
+    controllers.each{ |c| expect(c).to receive(:before_filter).and_return(true) }
     application.before_filter :my_filter, :only => :show
   end
 
   it 'skip_before_filter' do
-    controllers.each{ |c| c.should_receive(:skip_before_filter).and_return(true) }
+    controllers.each{ |c| expect(c).to receive(:skip_before_filter).and_return(true) }
     application.skip_before_filter :my_filter, :only => :show
   end
 
   it 'after_filter' do
-    controllers.each{ |c| c.should_receive(:after_filter).and_return(true) }
+    controllers.each{ |c| expect(c).to receive(:after_filter).and_return(true) }
     application.after_filter :my_filter, :only => :show
   end
 
   it 'around_filter' do
-    controllers.each{ |c| c.should_receive(:around_filter).and_return(true) }
+    controllers.each{ |c| expect(c).to receive(:around_filter).and_return(true) }
     application.around_filter :my_filter, :only => :show
   end
-  
+
   it 'skip_filter' do
-    controllers.each{ |c| c.should_receive(:skip_filter).and_return(true) }
+    controllers.each{ |c| expect(c).to receive(:skip_filter).and_return(true) }
     application.skip_filter :my_filter, :only => :show
   end
 end

--- a/spec/unit/csv_builder_spec.rb
+++ b/spec/unit/csv_builder_spec.rb
@@ -6,18 +6,18 @@ describe ActiveAdmin::CSVBuilder do
     let(:csv_builder) { ActiveAdmin::CSVBuilder.default_for_resource(Post) }
 
     it "should return a default csv_builder for Post" do
-      csv_builder.should be_a(ActiveAdmin::CSVBuilder)
+      expect(csv_builder).to be_a(ActiveAdmin::CSVBuilder)
     end
 
     specify "the first column should be Id" do
-      csv_builder.columns.first.name.should == 'Id'
-      csv_builder.columns.first.data.should == :id
+      expect(csv_builder.columns.first.name).to eq 'Id'
+      expect(csv_builder.columns.first.data).to eq :id
     end
 
     specify "the following columns should be content_column" do
       csv_builder.columns[1..-1].each_with_index do |column, index|
-        column.name.should == Post.content_columns[index].name.titleize
-        column.data.should == Post.content_columns[index].name.to_sym
+        expect(column.name).to eq Post.content_columns[index].name.titleize
+        expect(column.data).to eq Post.content_columns[index].name.to_sym
       end
     end
   end
@@ -26,7 +26,7 @@ describe ActiveAdmin::CSVBuilder do
     let(:builder){ ActiveAdmin::CSVBuilder.new }
 
     it "should have no columns" do
-      builder.columns.should == []
+      expect(builder.columns).to eq []
     end
   end
 
@@ -38,18 +38,18 @@ describe ActiveAdmin::CSVBuilder do
     end
 
     it "should have one column" do
-      builder.columns.size.should == 1
+      expect(builder.columns.size).to eq 1
     end
 
     describe "the column" do
       let(:column){ builder.columns.first }
 
       it "should have a name of 'Title'" do
-        column.name.should == "Title"
+        expect(column.name).to eq "Title"
       end
 
       it "should have the data :title" do
-        column.data.should == :title
+        expect(column.data).to eq :title
       end
     end
   end
@@ -64,18 +64,18 @@ describe ActiveAdmin::CSVBuilder do
     end
 
     it "should have one column" do
-      builder.columns.size.should == 1
+      expect(builder.columns.size).to eq 1
     end
 
     describe "the column" do
       let(:column){ builder.columns.first }
 
       it "should have a name of 'My title'" do
-        column.name.should == "My title"
+        expect(column.name).to eq "My title"
       end
 
       it "should have the data :title" do
-        column.data.should be_an_instance_of(Proc)
+        expect(column.data).to be_an_instance_of(Proc)
       end
     end
   end
@@ -86,7 +86,7 @@ describe ActiveAdmin::CSVBuilder do
     end
 
     it "should have proper separator" do
-      builder.options.should == {:col_sep => ";"}
+      expect(builder.options).to eq({:col_sep => ";"})
     end
   end
 
@@ -96,7 +96,7 @@ describe ActiveAdmin::CSVBuilder do
     end
 
     it "should have proper separator" do
-      builder.options.should == {:force_quotes => true}
+      expect(builder.options).to eq({:force_quotes => true})
     end
   end
 

--- a/spec/unit/devise_spec.rb
+++ b/spec/unit/devise_spec.rb
@@ -18,12 +18,12 @@ describe ActiveAdmin::Devise::Controller do
     before { Rails.configuration.action_controller[:relative_url_root] = '/foo' }
 
     it "should set the root path to the default namespace" do
-      controller.root_path.should == "/foo/admin"
+      expect(controller.root_path).to eq "/foo/admin"
     end
 
     it "should set the root path to '/' when no default namespace" do
       ActiveAdmin.application.stub default_namespace: false
-      controller.root_path.should == "/foo/"
+      expect(controller.root_path).to eq "/foo/"
     end
 
   end
@@ -33,12 +33,12 @@ describe ActiveAdmin::Devise::Controller do
     before { Rails.configuration.action_controller[:relative_url_root] = nil }
 
     it "should set the root path to the default namespace" do
-      controller.root_path.should == "/admin"
+      expect(controller.root_path).to eq "/admin"
     end
 
     it "should set the root path to '/' when no default namespace" do
       ActiveAdmin.application.stub default_namespace: false
-      controller.root_path.should == "/"
+      expect(controller.root_path).to eq "/"
     end
 
   end
@@ -67,7 +67,7 @@ describe ActiveAdmin::Devise::Controller do
     end
 
     it "should include scope path in root_path" do
-      controller.root_path.should == "#{SCOPE}/admin"
+      expect(controller.root_path).to eq "#{SCOPE}/admin"
     end
 
   end
@@ -81,32 +81,32 @@ describe ActiveAdmin::Devise::Controller do
 
       context "when Devise does not implement sign_out_via (version < 1.2)" do
         before do
-          ::Devise.should_receive(:respond_to?).with(:sign_out_via).and_return(false)
+          expect(::Devise).to receive(:respond_to?).with(:sign_out_via).and_return(false)
         end
 
         it "should not contain any customization for sign_out_via" do
-          config.should_not have_key(:sign_out_via)
+          expect(config).to_not have_key(:sign_out_via)
         end
       end
 
       context "when Devise implements sign_out_via (version >= 1.2)" do
         before do
-          ::Devise.should_receive(:respond_to?).with(:sign_out_via).and_return(true)
+         expect(::Devise).to receive(:respond_to?).with(:sign_out_via).and_return(true)
           ::Devise.stub(:sign_out_via) { :delete }
         end
 
         it "should contain the application.logout_link_method" do
-            ::Devise.should_receive(:sign_out_via).and_return(:delete)
-            ActiveAdmin.application.should_receive(:logout_link_method).and_return(:get)
+            expect(::Devise).to receive(:sign_out_via).and_return(:delete)
+            expect(ActiveAdmin.application).to receive(:logout_link_method).and_return(:get)
 
-            config[:sign_out_via].should include(:get)
+            expect(config[:sign_out_via]).to include(:get)
         end
 
         it "should contain Devise's logout_via_method(s)" do
-            ::Devise.should_receive(:sign_out_via).and_return([:delete, :post])
-            ActiveAdmin.application.should_receive(:logout_link_method).and_return(:get)
+            expect(::Devise).to receive(:sign_out_via).and_return([:delete, :post])
+            expect(ActiveAdmin.application).to receive(:logout_link_method).and_return(:get)
 
-            config[:sign_out_via].should == [:delete, :post, :get]
+            expect(config[:sign_out_via]).to eq [:delete, :post, :get]
         end
       end
 

--- a/spec/unit/dsl_spec.rb
+++ b/spec/unit/dsl_spec.rb
@@ -17,7 +17,7 @@ describe ActiveAdmin::DSL do
   describe "#include" do
 
     it "should call the included class method on the module that is included" do
-      MockModuleToInclude.should_receive(:included).with(dsl)
+      expect(MockModuleToInclude).to receive(:included).with(dsl)
       dsl.run_registration_block do
         include MockModuleToInclude
       end
@@ -28,7 +28,7 @@ describe ActiveAdmin::DSL do
   describe "#menu" do
 
     it "should set the menu_item_options on the configuration" do
-      config.should_receive(:menu_item_options=).with({:parent => "Admin"})
+      expect(config).to receive(:menu_item_options=).with({:parent => "Admin"})
       dsl.run_registration_block do
         menu :parent => "Admin"
       end
@@ -39,7 +39,7 @@ describe ActiveAdmin::DSL do
   describe "#navigation_menu" do
 
     it "should set the navigation_menu_name on the configuration" do
-      config.should_receive(:navigation_menu_name=).with(:admin)
+      expect(config).to receive(:navigation_menu_name=).with(:admin)
       dsl.run_registration_block do
         navigation_menu :admin
       end
@@ -52,7 +52,7 @@ describe ActiveAdmin::DSL do
         navigation_menu { :dynamic_menu }
       end
 
-      resource_config.navigation_menu_name.should == :dynamic_menu
+      expect(resource_config.navigation_menu_name).to eq :dynamic_menu
 
     end
 

--- a/spec/unit/event_spec.rb
+++ b/spec/unit/event_spec.rb
@@ -7,15 +7,15 @@ describe ActiveAdmin::EventDispatcher do
   let(:dispatcher){ ActiveAdmin::EventDispatcher.new }
 
   it "should add a subscriber for an event" do
-    dispatcher.subscribers(test_event).size.should == 0
+    expect(dispatcher.subscribers(test_event).size).to eq 0
     dispatcher.subscribe(test_event){ true }
-    dispatcher.subscribers(test_event).size.should == 1
+    expect(dispatcher.subscribers(test_event).size).to eq 1
   end
 
   it "should add a subscriber for multiple events" do
     dispatcher.subscribe(test_event, test_event + "1"){ true }
-    dispatcher.subscribers(test_event).size.should == 1
-    dispatcher.subscribers(test_event + "1").size.should == 1
+    expect(dispatcher.subscribers(test_event).size).to eq 1
+    expect(dispatcher.subscribers(test_event + "1").size).to eq 1
   end
 
   it "should call the dispatch block with no arguments" do
@@ -29,19 +29,19 @@ describe ActiveAdmin::EventDispatcher do
     arg = nil
     dispatcher.subscribe(test_event){|passed_in| arg = passed_in }
     dispatcher.dispatch(test_event, "My Arg")
-    arg.should == "My Arg"
+    expect(arg).to eq "My Arg"
   end
 
   it "should clear all subscribers" do
     dispatcher.subscribe(test_event){ false }
     dispatcher.subscribe(test_event + "_2"){ false }
     dispatcher.clear_all_subscribers!
-    dispatcher.subscribers(test_event).size.should == 0
-    dispatcher.subscribers(test_event + "_2").size.should == 0
+    expect(dispatcher.subscribers(test_event).size).to eq 0
+    expect(dispatcher.subscribers(test_event + "_2").size).to eq 0
   end
 
   it "should have a dispatcher available from ActiveAdmin::Event" do
-    ActiveAdmin::Event.should be_an_instance_of(ActiveAdmin::EventDispatcher)
+    expect(ActiveAdmin::Event).to be_an_instance_of(ActiveAdmin::EventDispatcher)
   end
 
 end

--- a/spec/unit/filters/filter_form_builder_spec.rb
+++ b/spec/unit/filters/filter_form_builder_spec.rb
@@ -43,20 +43,20 @@ describe ActiveAdmin::Filters::ViewHelper do
     let(:body) { filter :title }
 
     it "should generate a form which submits via get" do
-      body.should have_tag("form", :attributes => { :method => 'get', :class => 'filter_form' })
+      expect(body).to have_tag("form", :attributes => { :method => 'get', :class => 'filter_form' })
     end
 
     it "should generate a filter button" do
-      body.should have_tag("input", :attributes => { :type => "submit",
+      expect(body).to have_tag("input", :attributes => { :type => "submit",
                                                         :value => "Filter" })
     end
 
     it "should only generate the form once" do
-      body.to_s.scan(/q\[title_contains\]/).size.should == 1
+      expect(body.to_s.scan(/q\[title_contains\]/).size).to eq 1
     end
 
     it "should generate a clear filters link" do
-      body.should have_tag("a", "Clear Filters", :attributes => { :class => "clear_filters_btn" })
+      expect(body).to have_tag("a", "Clear Filters", :attributes => { :class => "clear_filters_btn" })
     end
   end
 
@@ -64,29 +64,29 @@ describe ActiveAdmin::Filters::ViewHelper do
     let(:body) { filter :title }
 
     it "should generate a select option for starts with" do
-      body.should have_tag("option", "Starts with", :attributes => { :value => 'title_starts_with' })
+      expect(body).to have_tag("option", "Starts with", :attributes => { :value => 'title_starts_with' })
     end
 
     it "should generate a select option for ends with" do
-      body.should have_tag("option", "Ends with", :attributes => { :value => 'title_ends_with' })
+      expect(body).to have_tag("option", "Ends with", :attributes => { :value => 'title_ends_with' })
     end
 
     it "should generate a select option for contains" do
-      body.should have_tag("option", "Contains", :attributes => { :value => 'title_contains' })
+      expect(body).to have_tag("option", "Contains", :attributes => { :value => 'title_contains' })
     end
 
     it "should generate a text field for input" do
-      body.should have_tag("input", :attributes => { :name => 'q[title_contains]' })
+      expect(body).to have_tag("input", :attributes => { :name => 'q[title_contains]' })
     end
-    
+
     it "should have a proper label" do
-      body.should have_tag('label', 'Title')
+      expect(body).to have_tag('label', 'Title')
     end
 
     it "should translate the label for text field" do
       begin
         I18n.backend.store_translations(:en, :activerecord => { :attributes => { :post => { :title => "Name" } } })
-        body.should have_tag('label', 'Name')
+        expect(body).to have_tag('label', 'Name')
       ensure
         I18n.backend.reload!
       end
@@ -98,21 +98,21 @@ describe ActiveAdmin::Filters::ViewHelper do
 
   describe "string attribute with sub filters" do
     let(:body) { filter :title_contains }
-    
+
     it "should generate a search field for a string attribute with query contains" do
-      body.should have_tag("input", :attributes => { :name => "q[title_contains]"})
-      body.should have_tag('label', 'Title contains')
+      expect(body).to have_tag("input", :attributes => { :name => "q[title_contains]"})
+      expect(body).to have_tag('label', 'Title contains')
     end
 
     it "should NOT generate a select option for contains" do
-      body.should_not have_tag("option", "Contains", :attributes => { :value => 'title_contains' })
+      expect(body).to_not have_tag("option", "Contains", :attributes => { :value => 'title_contains' })
     end
 
     context "using starts_with and as" do
       let(:body) { filter :title_starts_with }
 
       it "should generate a search field for a string attribute with query starts_with" do
-        body.should have_tag("input", :attributes => { :name => "q[title_starts_with]" })
+        expect(body).to have_tag("input", :attributes => { :name => "q[title_starts_with]" })
       end
     end
 
@@ -120,28 +120,28 @@ describe ActiveAdmin::Filters::ViewHelper do
       let(:body) { filter :title_ends_with }
 
       it "should generate a search field for a string attribute with query ends_with" do
-        body.should have_tag("input", :attributes => { :name => "q[title_ends_with]" })
+        expect(body).to have_tag("input", :attributes => { :name => "q[title_ends_with]" })
       end
     end
-    
+
     context "using contains and NO AS defined" do
       let(:body) { filter :title_contains }
 
       it "should generate a search field for a string attribute with query contains" do
-        body.should have_tag("input", :attributes => { :name => "q[title_contains]" })
+        expect(body).to have_tag("input", :attributes => { :name => "q[title_contains]" })
       end
     end
   end
-  
+
   describe "text attribute" do
     let(:body) { filter :body }
 
     it "should generate a search field for a text attribute" do
-      body.should have_tag("input", :attributes => { :name => "q[body_contains]"})
+      expect(body).to have_tag("input", :attributes => { :name => "q[body_contains]"})
     end
 
     it "should have a proper label" do
-      body.should have_tag('label', 'Body')
+      expect(body).to have_tag('label', 'Body')
     end
   end
 
@@ -156,9 +156,9 @@ describe ActiveAdmin::Filters::ViewHelper do
       end
 
       it "should remove original ordering to prevent PostgreSQL error" do
-        scope.object.klass.should_receive(:reorder).with('title asc') {
+        expect(scope.object.klass).to receive(:reorder).with('title asc') {
           m = double uniq: double(pluck: ['A Title'])
-          m.uniq.should_receive(:pluck).with :title
+          expect(m.uniq).to receive(:pluck).with :title
           m
         }
         body
@@ -170,13 +170,13 @@ describe ActiveAdmin::Filters::ViewHelper do
     let(:body) { filter :created_at }
 
     it "should generate a date greater than" do
-      body.should have_tag("input", :attributes => { :name => "q[created_at_gteq]", :class => "datepicker"})
+      expect(body).to have_tag("input", :attributes => { :name => "q[created_at_gteq]", :class => "datepicker"})
     end
     it "should generate a seperator" do
-      body.should have_tag("span", :attributes => { :class => "seperator"})
+      expect(body).to have_tag("span", :attributes => { :class => "seperator"})
     end
     it "should generate a date less than" do
-      body.should have_tag("input", :attributes => { :name => "q[created_at_lteq]", :class => "datepicker"})
+      expect(body).to have_tag("input", :attributes => { :name => "q[created_at_lteq]", :class => "datepicker"})
     end
   end
 
@@ -184,16 +184,16 @@ describe ActiveAdmin::Filters::ViewHelper do
     let(:body) { filter :id }
 
     it "should generate a select option for equal to" do
-      body.should have_tag("option", "Equals", :attributes => { :value => 'id_equals' })
+      expect(body).to have_tag("option", "Equals", :attributes => { :value => 'id_equals' })
     end
     it "should generate a select option for greater than" do
-      body.should have_tag("option", "Greater than")
+      expect(body).to have_tag("option", "Greater than")
     end
     it "should generate a select option for less than" do
-      body.should have_tag("option", "Less than")
+      expect(body).to have_tag("option", "Less than")
     end
     it "should generate a text field for input" do
-      body.should have_tag("input", :attributes => { :name => 'q[id_equals]' })
+      expect(body).to have_tag("input", :attributes => { :name => 'q[id_equals]' })
     end
     it "should select the option which is currently being filtered"
   end
@@ -203,7 +203,7 @@ describe ActiveAdmin::Filters::ViewHelper do
       let(:body) { filter :starred }
 
       it "should create a check box for equals to" do
-        body.should have_tag("input", :attributes => {
+        expect(body).to have_tag("input", :attributes => {
                                             :name => "q[starred_eq]",
                                             :type => "checkbox" })
       end
@@ -211,7 +211,7 @@ describe ActiveAdmin::Filters::ViewHelper do
       it "should translate the label for boolean field" do
         begin
           I18n.backend.store_translations(:en, :activerecord => { :attributes => { :post => { :starred => "Faved" } } })
-          body.should have_tag('label', 'Faved')
+          expect(body).to have_tag('label', 'Faved')
         ensure
           I18n.backend.reload!
         end
@@ -222,7 +222,7 @@ describe ActiveAdmin::Filters::ViewHelper do
       let(:body) { filter :title_present, :as => :boolean }
 
       it "should create a check box for equals to" do
-        body.should have_tag("input", :attributes => {
+        expect(body).to have_tag("input", :attributes => {
                                             :name => "q[title_present]",
                                             :type => "checkbox" })
       end
@@ -239,9 +239,9 @@ describe ActiveAdmin::Filters::ViewHelper do
       let(:body) { filter :author_id }
 
       it "should generate a numeric filter" do
-        body.should have_tag 'label', 'Author' # really this should be Author ID :/
-        body.should have_tag 'option', :attributes => { :value => 'author_id_less_than' }
-        body.should have_tag 'input',  :attributes => { :id => 'q_author_id', :name => 'q[author_id_equals]'}
+        expect(body).to have_tag 'label', 'Author' # really this should be Author ID :/
+        expect(body).to have_tag 'option', :attributes => { :value => 'author_id_less_than' }
+        expect(body).to have_tag 'input',  :attributes => { :id => 'q_author_id', :name => 'q[author_id_equals]'}
       end
     end
 
@@ -249,14 +249,14 @@ describe ActiveAdmin::Filters::ViewHelper do
       let(:body) { filter :author }
 
       it "should generate a select" do
-        body.should have_tag "select",             :attributes => { :name => "q[author_id_eq]" }
+        expect(body).to have_tag "select",             :attributes => { :name => "q[author_id_eq]" }
       end
       it "should set the default text to 'Any'" do
-        body.should have_tag "option", "Any",      :attributes => { :value => "" }
+        expect(body).to have_tag "option", "Any",      :attributes => { :value => "" }
       end
       it "should create an option for each related object" do
-        body.should have_tag "option", "John Doe", :attributes => { :value => @john.id }
-        body.should have_tag "option", "Jane Doe", :attributes => { :value => @jane.id }
+        expect(body).to have_tag "option", "John Doe", :attributes => { :value => @john.id }
+        expect(body).to have_tag "option", "Jane Doe", :attributes => { :value => @jane.id }
       end
 
       context "with a proc" do
@@ -265,13 +265,13 @@ describe ActiveAdmin::Filters::ViewHelper do
         end
 
         it "should use call the proc as the collection" do
-          body.should have_tag("option", "Title One")
-          body.should have_tag("option", "Title Two")
+          expect(body).to have_tag("option", "Title One")
+          expect(body).to have_tag("option", "Title Two")
         end
 
         it "should render the collection in the context of the view" do
           body = filter(:title, :as => :select, :collection => proc{[a_helper_method]})
-          body.should have_tag("option", "A Helper Method")
+          expect(body).to have_tag("option", "A Helper Method")
         end
       end
     end
@@ -280,11 +280,11 @@ describe ActiveAdmin::Filters::ViewHelper do
       let(:body) { filter :author, :as => :check_boxes }
 
       it "should create a check box for each related object" do
-        body.should have_tag("input", :attributes => {
+        expect(body).to have_tag("input", :attributes => {
                                             :name => "q[author_id_in][]",
                                             :type => "checkbox",
                                             :value => @john.id })
-        body.should have_tag("input", :attributes => {
+        expect(body).to have_tag("input", :attributes => {
                                             :name => "q[author_id_in][]",
                                             :type => "checkbox",
                                             :value => @jane.id })
@@ -332,16 +332,16 @@ describe ActiveAdmin::Filters::ViewHelper do
       let(:body) { filter :authors }
 
       it "should generate a select" do
-        body.should have_tag 'select', :attributes => { :name => "q[posts_author_id_eq]" }
+        expect(body).to have_tag 'select', :attributes => { :name => "q[posts_author_id_eq]" }
       end
 
       it "should set the default text to 'Any'" do
-        body.should have_tag "option", "Any", :attributes => { :value => "" }
+        expect(body).to have_tag "option", "Any", :attributes => { :value => "" }
       end
 
       it "should create an option for each related object" do
-        body.should have_tag "option", "John Doe", :attributes => { :value => john.id }
-        body.should have_tag "option", "Jane Doe", :attributes => { :value => jane.id }
+        expect(body).to have_tag "option", "John Doe", :attributes => { :value => john.id }
+        expect(body).to have_tag "option", "Jane Doe", :attributes => { :value => jane.id }
       end
     end
 
@@ -349,11 +349,11 @@ describe ActiveAdmin::Filters::ViewHelper do
       let(:body) { filter :authors, :as => :check_boxes }
 
       it "should create a check box for each related object" do
-        body.should have_tag("input", :attributes => {
+        expect(body).to have_tag("input", :attributes => {
                                             :name => "q[posts_author_id_in][]",
                                             :type => "checkbox",
                                             :value => john.id })
-        body.should have_tag("input", :attributes => {
+        expect(body).to have_tag("input", :attributes => {
                                             :name => "q[posts_author_id_in][]",
                                             :type => "checkbox",
                                             :value => jane.id })
@@ -365,24 +365,24 @@ describe ActiveAdmin::Filters::ViewHelper do
     context "with :if block" do
       it "should be displayed if true" do
         body = filter :body,   if: proc{true}
-        body.should     have_tag "input", attributes: {name: "q[body_contains]"}
+        expect(body).to have_tag "input", attributes: {name: "q[body_contains]"}
       end
 
       it "should NOT be displayed if false" do
         body = filter :author, if: proc{false}
-        body.should_not have_tag "input", attributes: {name: "q[author_id_eq]"}
+        expect(body).to_not have_tag "input", attributes: {name: "q[author_id_eq]"}
       end
     end
 
     context "with :unless block" do
       it "should be displayed if false" do
         body = filter :created_at, unless: proc{false}
-        body.should     have_tag "input", attributes: {name: "q[created_at_gteq]"}
+        expect(body).to     have_tag "input", attributes: {name: "q[created_at_gteq]"}
       end
 
       it "should NOT be displayed if true" do
         body = filter :updated_at, unless: proc{true}
-        body.should_not have_tag "input", attributes: {name: "q[updated_at_gteq]"}
+        expect(body).to_not have_tag "input", attributes: {name: "q[updated_at_gteq]"}
       end
     end
   end
@@ -391,31 +391,31 @@ describe ActiveAdmin::Filters::ViewHelper do
 
     it "should work as select" do
       body = filter :custom_searcher, as: :select, collection: ['foo']
-      body.should have_tag "select", attributes: { name: "q[custom_searcher]" }
+      expect(body).to have_tag "select", attributes: { name: "q[custom_searcher]" }
     end
 
     it "should work as string" do
       body = filter :custom_searcher, as: :string
-      body.should have_tag "input", attributes: { name: "q[custom_searcher]" }
+      expect(body).to have_tag "input", attributes: { name: "q[custom_searcher]" }
     end
   end
 
   describe "blank option" do
     context "for a select filter" do
       it "should be there by default" do
-        filter(:author).should have_tag "option", "Any"
+        expect(filter(:author)).to have_tag "option", "Any"
       end
       it "should be able to be disabled" do
-        filter(:author, include_blank: false).should_not have_tag "option", "Any"
+        expect(filter(:author, include_blank: false)).to_not have_tag "option", "Any"
       end
     end
 
     context "for a multi-select filter" do
       it "should not be there by default" do
-        filter(:author, multiple: true).should_not have_tag "option", "Any"
+        expect(filter(:author, multiple: true)).to_not have_tag "option", "Any"
       end
       it "should be able to be enabled" do
-        filter(:author, multiple: true, include_blank: true).should have_tag "option", "Any"
+        expect(filter(:author, multiple: true, include_blank: true)).to have_tag "option", "Any"
       end
     end
   end

--- a/spec/unit/filters/resource_spec.rb
+++ b/spec/unit/filters/resource_spec.rb
@@ -8,47 +8,47 @@ describe ActiveAdmin::Filters::ResourceExtension do
   end
 
   it "should return the defaults if no filters are set" do
-    resource.filters.keys.sort.should == [
+    expect(resource.filters.keys).to match_array([
       :author, :body, :category, :created_at, :published_at, :starred, :taggings, :title, :updated_at
-    ]
+    ])
   end
 
   it "should not have defaults when filters are disabled on the resource" do
     resource.filters = false
-    resource.filters.should be_empty
+    expect(resource.filters).to be_empty
   end
 
   it "should not have defaults when the filters are disabled on the namespace" do
     resource.namespace.filters = false
-    resource.filters.should be_empty
+    expect(resource.filters).to be_empty
   end
 
   it "should not have defaults when the filters are disabled on the application" do
     resource.namespace.application.filters = false
-    resource.filters.should be_empty
+    expect(resource.filters).to be_empty
   end
 
   describe "removing a filter" do
     it "should work" do
-      resource.filters.keys.should include :author
+      expect(resource.filters.keys).to include :author
       resource.remove_filter :author
-      resource.filters.keys.should_not include :author
+      expect(resource.filters.keys).to_not include :author
     end
 
     it "should work as a string" do
-      resource.filters.keys.should include :author
+      expect(resource.filters.keys).to include :author
       resource.remove_filter 'author'
-      resource.filters.keys.should_not include :author
+      expect(resource.filters.keys).to_not include :author
     end
 
     it "should be lazy" do
-      resource.should_not_receive :default_filters # this hits the DB
+      expect(resource).to_not receive :default_filters # this hits the DB
       resource.remove_filter :author
     end
 
     it "should not prevent the default filters from being added" do
       resource.remove_filter :author
-      resource.filters.should_not be_empty
+      expect(resource.filters).to_not be_empty
     end
 
     it "should raise an exception when filters are disabled" do
@@ -60,24 +60,24 @@ describe ActiveAdmin::Filters::ResourceExtension do
   describe "adding a filter" do
     it "should work" do
       resource.add_filter :title
-      resource.filters.should eq title: {}
+      expect(resource.filters).to eq title: {}
     end
 
     it "should work as a string" do
       resource.add_filter 'title'
-      resource.filters.should eq title: {}
+      expect(resource.filters).to eq title: {}
     end
 
     it "should work with specified options" do
       resource.add_filter :title, as: :string
-      resource.filters.should eq title: {as: :string}
+      expect(resource.filters).to eq title: {as: :string}
     end
 
     it "should override an existing filter" do
       resource.add_filter :title, one: :two
       resource.add_filter :title, three: :four
 
-      resource.filters.should eq title: {three: :four}
+      expect(resource.filters).to eq title: {three: :four}
     end
 
     it "should keep specified options" do
@@ -87,16 +87,16 @@ describe ActiveAdmin::Filters::ResourceExtension do
         opts.delete(:one)
       end
 
-      resource.filters.should eq title: {one: :two}
+      expect(resource.filters).to eq title: {one: :two}
     end
 
     it "should preserve default filters" do
       resource.preserve_default_filters!
       resource.add_filter :count, as: :string
 
-      resource.filters.keys.sort.should == [
+      expect(resource.filters.keys).to match_array([
         :author, :body, :category, :count, :created_at, :published_at, :starred, :taggings, :title, :updated_at
-      ]
+      ])
     end
 
     it "should raise an exception when filters are disabled" do
@@ -107,13 +107,13 @@ describe ActiveAdmin::Filters::ResourceExtension do
 
   it "should reset filters" do
     resource.add_filter :title
-    resource.filters.size.should == 1
+    expect(resource.filters.size).to eq 1
     resource.reset_filters!
-    resource.filters.size.should > 1
+    expect(resource.filters.size).to be > 1
   end
 
   it "should add a sidebar section for the filters" do
-    resource.sidebar_sections.first.name.should == :filters
+    expect(resource.sidebar_sections.first.name).to eq :filters
   end
 
 end

--- a/spec/unit/generators/install_spec.rb
+++ b/spec/unit/generators/install_spec.rb
@@ -4,19 +4,19 @@ describe "AA installation" do
   context "should create" do
 
     it "active_admin.css.scss" do
-      File.exists?(Rails.root + "app/assets/stylesheets/active_admin.css.scss").should be_true
+      expect(File.exists?(Rails.root + "app/assets/stylesheets/active_admin.css.scss")).to be_true
     end
 
     it "active_admin.js.coffee" do
-      File.exists?(Rails.root + "app/assets/javascripts/active_admin.js.coffee").should be_true
+      expect(File.exists?(Rails.root + "app/assets/javascripts/active_admin.js.coffee")).to be_true
     end
 
     it "the dashboard" do
-      File.exists?(Rails.root + "app/admin/dashboard.rb").should be_true
+      expect(File.exists?(Rails.root + "app/admin/dashboard.rb")).to be_true
     end
 
     it "the initializer" do
-      File.exists?(Rails.root + "config/initializers/active_admin.rb").should be_true
+      expect(File.exists?(Rails.root + "config/initializers/active_admin.rb")).to be_true
     end
 
   end

--- a/spec/unit/helpers/collection_spec.rb
+++ b/spec/unit/helpers/collection_spec.rb
@@ -17,49 +17,49 @@ describe ActiveAdmin::Helpers::Collection do
 
   describe "#collection_size" do
     it "should return the collection size for an ActiveRecord class" do
-      collection_size(Post).should == 3
+      expect(collection_size(Post)).to eq 3
     end
 
     it "should return the collection size for an ActiveRecord::Relation" do
-      collection_size(Post.where(:title => "A post")).should == 2
+      expect(collection_size(Post.where(:title => "A post"))).to eq 2
     end
 
     it "should return the collection size for a collection with group by" do
-      collection_size(Post.group(:title)).should == 2
+      expect(collection_size(Post.group(:title))).to eq 2
     end
 
     it "should return the collection size for a collection with group by, select and custom order" do
-      collection_size(Post.select("title, count(*) as nb_posts").group(:title).order("nb_posts")).should == 2
+      expect(collection_size(Post.select("title, count(*) as nb_posts").group(:title).order("nb_posts"))).to eq 2
     end
 
     it "should take the defined collection by default" do
       def collection; Post; end
 
-      collection_size.should == 3
+      expect(collection_size).to eq 3
 
       def collection; Post.where(:title => "An other post"); end
 
-      collection_size.should == 1
+      expect(collection_size).to eq 1
     end
   end
 
   describe "#collection_is_empty?" do
     it "should return true when the collection is empty" do
-      collection_is_empty?(Post.where(:title => "Non existing post")).should be_true
+      expect(collection_is_empty?(Post.where(:title => "Non existing post"))).to be_true
     end
 
     it "should return false when the collection is not empty" do
-      collection_is_empty?(Post.where(:title => "A post")).should be_false
+      expect(collection_is_empty?(Post.where(:title => "A post"))).to be_false
     end
 
     it "should take the defined collection by default" do
       def collection; Post; end
 
-      collection_is_empty?.should be_false
+      expect(collection_is_empty?).to be_false
 
       def collection; Post.where(:title => "Non existing post"); end
 
-      collection_is_empty?.should be_true
+      expect(collection_is_empty?).to be_true
     end
   end
 end

--- a/spec/unit/helpers/scope_chain_spec.rb
+++ b/spec/unit/helpers/scope_chain_spec.rb
@@ -11,8 +11,8 @@ describe ActiveAdmin::ScopeChain do
       let(:scope) { ActiveAdmin::Scope.new :published }
 
       it "should call the method on the relation and return it" do
-        relation.should_receive(:published).and_return(:scoped_relation)
-        scope_chain(scope, relation).should == :scoped_relation
+        expect(relation).to receive(:published).and_return(:scoped_relation)
+        expect(scope_chain(scope, relation)).to eq :scoped_relation
       end
     end
 
@@ -20,7 +20,7 @@ describe ActiveAdmin::ScopeChain do
       let(:scope) { ActiveAdmin::Scope.new :all }
 
       it "should return the relation" do
-        scope_chain(scope, relation).should == relation
+        expect(scope_chain(scope, relation)).to eq relation
       end
     end
 
@@ -28,7 +28,7 @@ describe ActiveAdmin::ScopeChain do
       let(:scope) { ActiveAdmin::Scope.new("My Scope"){|s| :scoped_relation } }
 
       it "should instance_exec the block and return it" do
-        scope_chain(scope, relation).should == :scoped_relation
+        expect(scope_chain(scope, relation)).to eq :scoped_relation
       end
     end
   end

--- a/spec/unit/helpers/settings_spec.rb
+++ b/spec/unit/helpers/settings_spec.rb
@@ -12,19 +12,19 @@ describe ActiveAdmin::Settings do
 
   it "should add a new setting with a default" do
     klass.setting :my_setting, "Hello World"
-    klass.default_settings[:my_setting].should == "Hello World"
+    expect(klass.default_settings[:my_setting]).to eq "Hello World"
   end
 
   it "should initialize the defaults" do
     klass.setting :my_setting, "Hello World"
-    klass.new.my_setting.should == "Hello World"
+    expect(klass.new.my_setting).to eq "Hello World"
   end
 
   it "should support settings of nil" do
     klass.setting :my_setting, :some_val
     inst = klass.new
     inst.my_setting = nil
-    inst.my_setting.should == nil
+    expect(inst.my_setting).to eq nil
   end
 
 end

--- a/spec/unit/menu_collection_spec.rb
+++ b/spec/unit/menu_collection_spec.rb
@@ -9,15 +9,15 @@ describe ActiveAdmin::MenuCollection do
     it "should initialize a new menu when first item" do
       menus.add :default, :label => "Hello World"
 
-      menus.fetch(:default).items.size.should == 1
-      menus.fetch(:default)["Hello World"].should be_an_instance_of(ActiveAdmin::MenuItem)
+      expect(menus.fetch(:default).items.size).to eq 1
+      expect(menus.fetch(:default)["Hello World"]).to be_an_instance_of(ActiveAdmin::MenuItem)
     end
 
     it "should add items to an existing menu" do
       menus.add :default, :label => "Hello World"
       menus.add :default, :label => "Hello World Again"
 
-      menus.fetch(:default).items.size.should == 2
+      expect(menus.fetch(:default).items.size).to eq 2
     end
 
   end
@@ -44,7 +44,7 @@ describe ActiveAdmin::MenuCollection do
         m.add :default, :label => "Hello World"
       end
 
-      menus.fetch(:default)["Hello World"].should_not be_nil
+      expect(menus.fetch(:default)["Hello World"]).to_not be_nil
     end
 
     it "re-runs the callbacks when the menu is cleared" do
@@ -52,9 +52,9 @@ describe ActiveAdmin::MenuCollection do
         m.add :default, :label => "Hello World"
       end
 
-      menus.fetch(:default)["Hello World"].should_not be_nil
+      expect(menus.fetch(:default)["Hello World"]).to_not be_nil
       menus.clear!
-      menus.fetch(:default)["Hello World"].should_not be_nil
+      expect(menus.fetch(:default)["Hello World"]).to_not be_nil
     end
 
   end

--- a/spec/unit/menu_item_spec.rb
+++ b/spec/unit/menu_item_spec.rb
@@ -7,56 +7,56 @@ module ActiveAdmin
 
     it "should have a label" do
       item = MenuItem.new(:label => "Dashboard")
-      item.label.should == "Dashboard"
+      expect(item.label).to eq "Dashboard"
     end
 
     it "should have a url" do
       item = MenuItem.new(:url => "/admin")
-      item.url.should == "/admin"
+      expect(item.url).to eq "/admin"
     end
 
     it "should have a priority of 10 by default" do
       item = MenuItem.new
-      item.priority.should == 10
+      expect(item.priority).to eq 10
     end
 
     context "conditional display" do
       it "should store a Proc internally and evaluate it when requested" do
         item = MenuItem.new
-        item.instance_variable_get(:@should_display).should be_a Proc
-        item.display?.should_not be_a Proc
+        expect(item.instance_variable_get(:@should_display)).to be_a Proc
+        expect(item.display?).to_not be_a Proc
       end
 
       it "should show the item by default" do
-        MenuItem.new.display?.should == true
+        expect(MenuItem.new.display?).to eq true
       end
 
       it "should hide the item" do
-        MenuItem.new(:if => proc{false}).display?.should == false
+        expect(MenuItem.new(:if => proc{false}).display?).to eq false
       end
     end
 
     it "should default to an empty hash for html_options" do
       item = MenuItem.new
-      item.html_options.should be_empty
+      expect(item.html_options).to be_empty
     end
 
     it "should accept an options hash for link_to" do
       item = MenuItem.new :html_options => { :target => :blank }
-      item.html_options.should include(:target => :blank)
+      expect(item.html_options).to include(:target => :blank)
     end
 
     context "with no items" do
       it "should be empty" do
         item = MenuItem.new
-        item.items.should be_empty
+        expect(item.items).to be_empty
       end
 
       it "should accept new children" do
         item = MenuItem.new :label => "Dashboard"
         item.add            :label => "My Child Dashboard"
-        item.items.first.should be_a MenuItem
-        item.items.first.label.should == "My Child Dashboard"
+        expect(item.items.first).to be_a MenuItem
+        expect(item.items.first.label).to eq "My Child Dashboard"
       end
     end
 
@@ -72,23 +72,23 @@ module ActiveAdmin
       end
 
       it "should contain 5 submenu items" do
-        item.items.count.should == 5
+        expect(item.items.count).to eq 5
       end
 
       it "should give access to the menu item as an array" do
-        item['Blog'].label.should == 'Blog'
+        expect(item['Blog'].label).to eq 'Blog'
       end
 
       it "should sort items based on priority and name" do
-        item.items[0].label.should == 'Users'
-        item.items[1].label.should == 'Settings'
-        item.items[2].label.should == 'Blog'
-        item.items[3].label.should == 'Cars'
-        item.items[4].label.should == 'Analytics'
+        expect(item.items[0].label).to eq 'Users'
+        expect(item.items[1].label).to eq 'Settings'
+        expect(item.items[2].label).to eq 'Blog'
+        expect(item.items[3].label).to eq 'Cars'
+        expect(item.items[4].label).to eq 'Analytics'
       end
 
       it "children should hold a reference to their parent" do
-        item["Blog"].parent.should == item
+        expect(item["Blog"].parent).to eq item
       end
     end
 
@@ -97,7 +97,7 @@ module ActiveAdmin
 
       context "with no parent" do
         it "should return an empty array" do
-         item.ancestors.should == []
+         expect(item.ancestors).to eq []
         end
       end
 
@@ -107,7 +107,7 @@ module ActiveAdmin
           item["Create New"]
         end
         it "should return an array with the parent" do
-          sub_item.ancestors.should == [item]
+          expect(sub_item.ancestors).to eq [item]
         end
       end
 
@@ -123,7 +123,7 @@ module ActiveAdmin
         end
         let(:sub_item){ item["C1"]["C2"]["C3"] }
         it "should return an array with the parents in reverse order" do
-          sub_item.ancestors.should == [item["C1"]["C2"], item["C1"], item]
+          expect(sub_item.ancestors).to eq [item["C1"]["C2"], item["C1"], item]
         end
       end
     end # accessing ancestory
@@ -131,7 +131,7 @@ module ActiveAdmin
 
     describe "#id" do
       it "should be normalized" do
-        MenuItem.new(:id => "Foo Bar").id.should == "foo_bar"
+        expect(MenuItem.new(:id => "Foo Bar").id).to eq "foo_bar"
       end
 
       it "should not accept Procs" do

--- a/spec/unit/menu_spec.rb
+++ b/spec/unit/menu_spec.rb
@@ -9,13 +9,13 @@ describe ActiveAdmin::Menu do
   context "with no items" do
     it "should have an empty item collection" do
       menu = Menu.new
-      menu.items.should be_empty
+      expect(menu.items).to be_empty
     end
 
     it "should accept new items" do
       menu = Menu.new
       menu.add :label => "Dashboard"
-      menu.items.first.label.should == "Dashboard"
+      expect(menu.items.first.label).to eq "Dashboard"
     end
   end
 
@@ -28,7 +28,7 @@ describe ActiveAdmin::Menu do
     end
 
     it "should give access to the menu item as an array" do
-      menu['Dashboard'].label.should == 'Dashboard'
+      expect(menu['Dashboard'].label).to eq 'Dashboard'
     end
   end
 
@@ -37,7 +37,7 @@ describe ActiveAdmin::Menu do
       menu = Menu.new
       menu.add :parent => "Admin", :label => "Users"
 
-      menu["Admin"]["Users"].should be_an_instance_of(ActiveAdmin::MenuItem)
+      expect(menu["Admin"]["Users"]).to be_an_instance_of(ActiveAdmin::MenuItem)
     end
 
     it "should add a child to a parent if it exists" do
@@ -45,7 +45,7 @@ describe ActiveAdmin::Menu do
       menu.add :parent => "Admin", :label => "Users"
       menu.add :parent => "Admin", :label => "Projects"
 
-      menu["Admin"]["Projects"].should be_an_instance_of(ActiveAdmin::MenuItem)
+      expect(menu["Admin"]["Projects"]).to be_an_instance_of(ActiveAdmin::MenuItem)
     end
 
     it "should assign children regardless of resource file load order" do
@@ -53,8 +53,8 @@ describe ActiveAdmin::Menu do
       menu.add :parent => "Users", :label => "Posts"
       menu.add :label  => "Users", :url   => "/some/url"
 
-      menu["Users"].url.should == "/some/url"
-      menu["Users"]["Posts"].should be_a ActiveAdmin::MenuItem
+      expect(menu["Users"].url).to eq "/some/url"
+      expect(menu["Users"]["Posts"]).to be_a ActiveAdmin::MenuItem
     end
   end
 
@@ -65,7 +65,7 @@ describe ActiveAdmin::Menu do
       menu.add :label => proc{ "B" }, :id => "not related 2"
       menu.add :label => proc{ "A" }, :id => "not related 3"
 
-      menu.items.map(&:label).should == %w[A B G]
+      expect(menu.items.map(&:label)).to eq %w[A B G]
     end
   end
 end

--- a/spec/unit/namespace/authorization_spec.rb
+++ b/spec/unit/namespace/authorization_spec.rb
@@ -9,18 +9,18 @@ describe ActiveAdmin::Resource, "authorization" do
   describe "authorization_adapter" do
 
     it "should return AuthorizationAdapter by default" do
-      app.authorization_adapter.should       eq ActiveAdmin::AuthorizationAdapter
-      namespace.authorization_adapter.should eq ActiveAdmin::AuthorizationAdapter
+      expect(app.authorization_adapter).to       eq ActiveAdmin::AuthorizationAdapter
+      expect(namespace.authorization_adapter).to eq ActiveAdmin::AuthorizationAdapter
     end
 
     it "should be settable on the namespace" do
       namespace.authorization_adapter = auth
-      namespace.authorization_adapter.should eq auth
+      expect(namespace.authorization_adapter).to eq auth
     end
 
     it "should be settable on the application" do
       app.authorization_adapter = auth
-      app.authorization_adapter.should eq auth
+      expect(app.authorization_adapter).to eq auth
     end
 
   end

--- a/spec/unit/namespace/register_page_spec.rb
+++ b/spec/unit/namespace/register_page_spec.rb
@@ -13,15 +13,15 @@ describe ActiveAdmin::Namespace, "registering a page" do
     end
 
     it "should store the namespaced registered configuration" do
-      namespace.resources.keys.should include('Status')
+      expect(namespace.resources.keys).to include('Status')
     end
 
     it "should create a new controller in the default namespace" do
-      defined?(Admin::StatusController).should be_true
+      expect(defined?(Admin::StatusController)).to be_true
     end
 
     it "should create a menu item" do
-      menu["Status"].should be_an_instance_of(ActiveAdmin::MenuItem)
+      expect(menu["Status"]).to be_an_instance_of(ActiveAdmin::MenuItem)
     end
   end # context "with no configuration"
 
@@ -42,7 +42,7 @@ describe ActiveAdmin::Namespace, "registering a page" do
       end
 
       it "should add a new menu item" do
-        menu['Status'].should_not be_nil
+        expect(menu['Status']).to_not be_nil
       end
     end # describe "adding as a top level item"
 
@@ -53,10 +53,10 @@ describe ActiveAdmin::Namespace, "registering a page" do
         end
       end
       it "should generate the parent menu item" do
-        menu['Extra'].should_not be_nil
+       expect( menu['Extra']).to_not be_nil
       end
       it "should generate its own child item" do
-        menu['Extra']['Status'].should_not be_nil
+        expect(menu['Extra']['Status']).to_not be_nil
       end
     end # describe "adding as a child"
 
@@ -67,7 +67,7 @@ describe ActiveAdmin::Namespace, "registering a page" do
         end
       end
       it "should not create a menu item" do
-        menu["Status"].should be_nil
+        expect(menu["Status"]).to be_nil
       end
     end # describe "disabling the menu"
   end # describe "adding to the menu"

--- a/spec/unit/namespace/register_resource_spec.rb
+++ b/spec/unit/namespace/register_resource_spec.rb
@@ -16,17 +16,17 @@ describe ActiveAdmin::Namespace, "registering a resource" do
       namespace.register Category
     end
     it "should store the namespaced registered configuration" do
-      namespace.resources.keys.should include('Category')
+      expect(namespace.resources.keys).to include('Category')
     end
     it "should create a new controller in the default namespace" do
-      defined?(Admin::CategoriesController).should be_true
+      expect(defined?(Admin::CategoriesController)).to be_true
     end
     pending "should not create the dashboard controller" do
-      defined?(Admin::DashboardController).should_not be_true
+      defined?(Admin::DashboardController).to_not be_true
     end
     it "should create a menu item" do
-      menu["Categories"].should be_a ActiveAdmin::MenuItem
-      menu["Categories"].instance_variable_get(:@url).should be_a Proc
+      expect(menu["Categories"]).to be_a ActiveAdmin::MenuItem
+      expect(menu["Categories"].instance_variable_get(:@url)).to be_a Proc
     end
   end # context "with no configuration"
 
@@ -47,17 +47,17 @@ describe ActiveAdmin::Namespace, "registering a resource" do
     end
 
     it "should store the namespaced registered configuration" do
-      namespace.resources.keys.should include('Mock::Resource')
+      expect(namespace.resources.keys).to include('Mock::Resource')
     end
     it "should create a new controller in the default namespace" do
-      defined?(Admin::MockResourcesController).should be_true
+      expect(defined?(Admin::MockResourcesController)).to be_true
     end
     it "should create a menu item" do
-      menu["Mock Resources"].should be_an_instance_of(ActiveAdmin::MenuItem)
+      expect(menu["Mock Resources"]).to be_an_instance_of(ActiveAdmin::MenuItem)
     end
 
     it "should use the resource as the model in the controller" do
-      Admin::MockResourcesController.resource_class.should == Mock::Resource
+      expect(Admin::MockResourcesController.resource_class).to eq Mock::Resource
     end
   end # context "with a resource that's namespaced"
 
@@ -66,22 +66,22 @@ describe ActiveAdmin::Namespace, "registering a resource" do
 
     it "should return the resource when its been registered" do
       post = namespace.register Post
-      namespace.resource_for(Post).should == post
+      expect(namespace.resource_for(Post)).to eq post
     end
 
     it 'should return nil when the resource has not been registered' do
-      namespace.resource_for(Post).should == nil
+      expect(namespace.resource_for(Post)).to eq nil
     end
 
     it "should return the parent when the parent class has been registered and the child has not" do
       user = namespace.register User
-      namespace.resource_for(Publisher).should == user
+      expect(namespace.resource_for(Publisher)).to eq user
     end
 
     it "should return the resource if it and it's parent were registered" do
       user = namespace.register User
       publisher = namespace.register Publisher
-      namespace.resource_for(Publisher).should == publisher
+      expect(namespace.resource_for(Publisher)).to eq publisher
     end
   end # describe "finding resource instances"
 
@@ -91,7 +91,7 @@ describe ActiveAdmin::Namespace, "registering a resource" do
         namespace.register Category
       end
       it "should add a new menu item" do
-        menu['Categories'].should_not be_nil
+        expect(menu['Categories']).to_not be_nil
       end
     end # describe "adding as a top level item"
 
@@ -102,10 +102,10 @@ describe ActiveAdmin::Namespace, "registering a resource" do
         end
       end
       it "should generate the parent menu item" do
-        menu['Blog'].should_not be_nil
+        expect(menu['Blog']).to_not be_nil
       end
       it "should generate its own child item" do
-        menu['Blog']['Categories'].should_not be_nil
+        expect(menu['Blog']['Categories']).to_not be_nil
       end
     end # describe "adding as a child"
 
@@ -116,7 +116,7 @@ describe ActiveAdmin::Namespace, "registering a resource" do
         end
       end
       it "should not create a menu item" do
-        menu["Categories"].should be_nil
+        expect(menu["Categories"]).to be_nil
       end
     end # describe "disabling the menu"
 
@@ -128,7 +128,7 @@ describe ActiveAdmin::Namespace, "registering a resource" do
           end
         end
         it "should not show up in the menu" do
-          menu["Posts"].should be_nil
+          expect(menu["Posts"]).to be_nil
         end
       end
       context "when optional" do
@@ -138,7 +138,7 @@ describe ActiveAdmin::Namespace, "registering a resource" do
           end
         end
         it "should show up in the menu" do
-          menu["Posts"].should_not be_nil
+          expect(menu["Posts"]).to_not be_nil
         end
       end
     end
@@ -149,14 +149,14 @@ describe ActiveAdmin::Namespace, "registering a resource" do
       it "should be namespaced" do
         namespace = ActiveAdmin::Namespace.new(application, :one)
         namespace.register Category
-        defined?(One::CategoriesController).should be_true
+        expect(defined?(One::CategoriesController)).to be_true
       end
     end
     context "when not namespaced" do
       it "should not be namespaced" do
         namespace = ActiveAdmin::Namespace.new(application, :two)
         namespace.register Category
-        defined?(Two::CategoriesController).should be_true
+        expect(defined?(Two::CategoriesController)).to be_true
       end
     end
   end # describe "dashboard controller name"

--- a/spec/unit/namespace_spec.rb
+++ b/spec/unit/namespace_spec.rb
@@ -8,19 +8,19 @@ describe ActiveAdmin::Namespace do
     let(:namespace){ ActiveAdmin::Namespace.new(application, :admin) }
 
     it "should have an application instance" do
-      namespace.application.should == application
+      expect(namespace.application).to eq application
     end
 
     it "should have a name" do
-      namespace.name.should == :admin
+      expect(namespace.name).to eq :admin
     end
 
     it "should have no resources" do
-      namespace.resources.should be_empty
+      expect(namespace.resources).to be_empty
     end
 
     it "should not have any menu item" do
-      namespace.fetch_menu(:default).children.should be_empty
+      expect(namespace.fetch_menu(:default).children).to be_empty
     end
   end # context "when new"
 
@@ -29,13 +29,13 @@ describe ActiveAdmin::Namespace do
 
     it "should inherit the site title from the application" do
       ActiveAdmin::Namespace.setting :site_title, "Not the Same"
-      namespace.site_title.should == application.site_title
+      expect(namespace.site_title).to eq application.site_title
     end
 
     it "should be able to override the site title" do
-      namespace.site_title.should == application.site_title
+      expect(namespace.site_title).to eq application.site_title
       namespace.site_title = "My Site Title"
-      namespace.site_title.should_not == application.site_title
+      expect(namespace.site_title).to_not eq application.site_title
     end
   end
 
@@ -44,11 +44,11 @@ describe ActiveAdmin::Namespace do
     let(:namespace){ ActiveAdmin::Namespace.new(application, :admin) }
 
     it "returns the menu" do
-      namespace.fetch_menu(:default).should be_an_instance_of(ActiveAdmin::Menu)
+      expect(namespace.fetch_menu(:default)).to be_an_instance_of(ActiveAdmin::Menu)
     end
 
     it "should have utility nav menu" do
-      namespace.fetch_menu(:utility_navigation).should be_an_instance_of(ActiveAdmin::Menu)
+      expect(namespace.fetch_menu(:utility_navigation)).to be_an_instance_of(ActiveAdmin::Menu)
     end
 
     it "should raise an exception if the menu doesn't exist" do
@@ -66,7 +66,7 @@ describe ActiveAdmin::Namespace do
         menu.add :label => "menu item"
       end
 
-      namespace.fetch_menu(:default)["menu item"].should_not be_nil
+      expect(namespace.fetch_menu(:default)["menu item"]).to_not be_nil
     end
 
     it "should set a block on a custom menu" do
@@ -74,7 +74,7 @@ describe ActiveAdmin::Namespace do
         menu.add :label => "menu item"
       end
 
-      namespace.fetch_menu(:test)["menu item"].should_not be_nil
+      expect(namespace.fetch_menu(:test)["menu item"]).to_not be_nil
     end
   end
 
@@ -89,13 +89,13 @@ describe ActiveAdmin::Namespace do
     end
 
     it "should have a logout button to the far left" do
-      menu["Logout"].should_not be_nil
-      menu["Logout"].priority.should == 1
+      expect(menu["Logout"]).to_not be_nil
+      expect(menu["Logout"].priority).to eq 1
     end
 
     it "should have a static link with a target of :blank" do
-      menu["ActiveAdmin.info"].should_not be_nil
-      menu["ActiveAdmin.info"].html_options.should include(:target => :blank)
+      expect(menu["ActiveAdmin.info"]).to_not be_nil
+      expect(menu["ActiveAdmin.info"].html_options).to include(:target => :blank)
     end
 
   end

--- a/spec/unit/page_spec.rb
+++ b/spec/unit/page_spec.rb
@@ -18,54 +18,54 @@ module ActiveAdmin
 
     describe "controller name" do
       it "should return a namespaced controller name" do
-        config.controller_name.should == "Admin::ChocolateILoveYouController"
+        expect(config.controller_name).to eq "Admin::ChocolateILoveYouController"
       end
       context "when non namespaced controller" do
         let(:namespace){ ActiveAdmin::Namespace.new(application, :root) }
         it "should return a non namespaced controller name" do
-          config.controller_name.should == "ChocolateILoveYouController"
+          expect(config.controller_name).to eq "ChocolateILoveYouController"
         end
       end
     end
 
     describe "#resource_name" do
       it "returns the name" do
-        config.resource_name.should == "Chocolate I lØve You!"
+        expect(config.resource_name).to eq "Chocolate I lØve You!"
       end
 
       it "returns the singular, lowercase name" do
-        config.resource_name.singular.should == "chocolate i lØve you!"
+        expect(config.resource_name.singular).to eq "chocolate i lØve you!"
       end
     end
 
     describe "#plural_resource_label" do
       it "returns the singular name" do
-        config.plural_resource_label.should == "Chocolate I lØve You!"
+        expect(config.plural_resource_label).to eq "Chocolate I lØve You!"
       end
     end
 
     describe "#underscored_resource_name" do
       it "returns the resource name underscored" do
-        config.underscored_resource_name.should == "chocolate_i_love_you"
+        expect(config.underscored_resource_name).to eq "chocolate_i_love_you"
       end
     end
 
     describe "#camelized_resource_name" do
       it "returns the resource name camel case" do
-        config.camelized_resource_name.should == "ChocolateILoveYou"
+        expect(config.camelized_resource_name).to eq "ChocolateILoveYou"
       end
     end
 
     it "should not belong_to anything" do
-      config.belongs_to?.should == false
+      expect(config.belongs_to?).to eq false
     end
 
     it "should not have any action_items" do
-      config.action_items?.should == false
+      expect(config.action_items?).to eq false
     end
 
     it "should not have any sidebar_sections" do
-      config.sidebar_sections?.should == false
+      expect(config.sidebar_sections?).to eq false
     end
 
   end

--- a/spec/unit/pretty_format_spec.rb
+++ b/spec/unit/pretty_format_spec.rb
@@ -5,31 +5,31 @@ describe "#pretty_format" do
 
   context "when a String is passed in" do
     it "should return the String passed in" do
-      pretty_format("hello").should == "hello"
+      expect(pretty_format("hello")).to eq "hello"
     end
   end
 
   context "when a Date or a Time is passed in" do
     it "should return a localized Date or Time with long format" do
       t = Time.now
-      self.should_receive(:localize).with(t, {:format => :long}) { "Just Now!" }
-      pretty_format(t).should == "Just Now!"
+      expect(self).to receive(:localize).with(t, {:format => :long}) { "Just Now!" }
+      expect(pretty_format(t)).to eq "Just Now!"
     end
   end
 
   context "when an ActiveRecord object is passed in" do
     it "should delegate to auto_link" do
       post = Post.new
-      self.should_receive(:auto_link).with(post) { "model name" }
-      pretty_format(post).should == "model name"
+      expect(self).to receive(:auto_link).with(post) { "model name" }
+      expect(pretty_format(post)).to eq "model name"
     end
   end
 
   context "when something else is passed in" do
     it "should delegate to display_name" do
       something = Class.new.new
-      self.should_receive(:display_name).with(something) { "I'm not famous" }
-      pretty_format(something).should == "I'm not famous"
+      expect(self).to receive(:display_name).with(something) { "I'm not famous" }
+      expect(pretty_format(something)).to eq "I'm not famous"
     end
   end
 end

--- a/spec/unit/resource/action_items_spec.rb
+++ b/spec/unit/resource/action_items_spec.rb
@@ -17,15 +17,15 @@ describe ActiveAdmin::Resource::ActionItems do
     end
 
     it "should add an action item" do
-      resource.action_items.size.should == 1
+      expect(resource.action_items.size).to eq 1
     end
 
     it "should store an instance of ActionItem" do
-      resource.action_items.first.should be_an_instance_of(ActiveAdmin::ActionItem)
+      expect(resource.action_items.first).to be_an_instance_of(ActiveAdmin::ActionItem)
     end
 
     it "should store the block in the action item" do
-      resource.action_items.first.block.should_not be_nil
+      expect(resource.action_items.first.block).to_not be_nil
     end
 
   end
@@ -43,7 +43,7 @@ describe ActiveAdmin::Resource::ActionItems do
     end
 
     it "should return only relevant action items" do
-      resource.action_items_for(:index).size.should == 1
+      expect(resource.action_items_for(:index).size).to eq 1
       expect {
         resource.action_items_for(:index).first.call
       }.to raise_exception(StandardError)
@@ -54,7 +54,7 @@ describe ActiveAdmin::Resource::ActionItems do
   describe "default action items" do
 
     it "should have 3 action items" do
-      resource.action_items.size.should == 3
+      expect(resource.action_items.size).to eq 3
     end
 
   end

--- a/spec/unit/resource/naming_spec.rb
+++ b/spec/unit/resource/naming_spec.rb
@@ -20,66 +20,66 @@ module ActiveAdmin
     describe "singular resource name" do
       context "when class" do
         it "should be the underscored singular resource name" do
-          config.resource_name.singular.should == "category"
+          expect(config.resource_name.singular).to eq "category"
         end
       end
       context "when a class in a module" do
         it "should underscore the module and the class" do
-          Resource.new(namespace, Mock::Resource).resource_name.singular.should == "mock_resource"
+          expect(Resource.new(namespace, Mock::Resource).resource_name.singular).to eq "mock_resource"
         end
       end
       context "when you pass the 'as' option" do
         it "should underscore the passed through string" do
-          config(:as => "Blog Category").resource_name.singular.should == "blog_category"
+          expect(config(:as => "Blog Category").resource_name.singular).to eq "blog_category"
         end
       end
     end
 
     describe "resource label" do
       it "should return a pretty name" do
-        config.resource_label.should == "Category"
+        expect(config.resource_label).to eq "Category"
       end
 
       it "should return the plural version" do
-        config.plural_resource_label.should == "Categories"
+        expect(config.plural_resource_label).to eq "Categories"
       end
 
       context "when the :as option is given" do
         it "should return the custom name" do
-          config(:as => "My Category").resource_label.should == "My Category"
+          expect(config(:as => "My Category").resource_label).to eq "My Category"
         end
       end
 
       context "when a class in a module" do
         it "should include the module and the class" do
-          Resource.new(namespace, Mock::Resource).resource_label.should == "Mock Resource"
+          expect(Resource.new(namespace, Mock::Resource).resource_label).to eq "Mock Resource"
         end
 
         it "should include the module and the pluralized class" do
-          Resource.new(namespace, Mock::Resource).plural_resource_label.should == "Mock Resources"
+          expect(Resource.new(namespace, Mock::Resource).plural_resource_label).to eq "Mock Resources"
         end
       end
 
       describe "I18n integration" do
         describe "singular label" do
           it "should return the titleized model_name.human" do
-            config.resource_name.should_receive(:translate).and_return "Da category"
+            expect(config.resource_name).to receive(:translate).and_return "Da category"
 
-            config.resource_label.should == "Da category"
+            expect(config.resource_label).to eq "Da category"
           end
         end
 
         describe "plural label" do
           it "should return the titleized plural version defined by i18n if available" do
-            config.resource_name.should_receive(:translate).at_least(:once).and_return "Da categories"
-            config.plural_resource_label.should == "Da categories"
+            expect(config.resource_name).to receive(:translate).at_least(:once).and_return "Da categories"
+            expect(config.plural_resource_label).to eq "Da categories"
           end
         end
 
         describe "plural label with not default locale" do
           it "should return the titleized plural version defined by i18n with custom :count if available" do
-            config.resource_name.should_receive(:translate).at_least(:once).and_return "Категории"
-            config.plural_resource_label(:count => 3).should == "Категории"
+            expect(config.resource_name).to receive(:translate).at_least(:once).and_return "Категории"
+            expect(config.plural_resource_label(:count => 3)).to eq "Категории"
           end
         end
 
@@ -87,16 +87,16 @@ module ActiveAdmin
           describe "singular label" do
             it "should translate the custom name" do
               config = config(:as => 'My Category')
-              config.resource_name.should_receive(:translate).and_return "Translated category"
-              config.resource_label.should == "Translated category"
+              expect(config.resource_name).to receive(:translate).and_return "Translated category"
+              expect(config.resource_label).to eq "Translated category"
             end
           end
 
           describe "plural label" do
             it "should translate the custom name" do
               config = config(:as => 'My Category')
-              config.resource_name.should_receive(:translate).at_least(:once).and_return "Translated categories"
-              config.plural_resource_label.should == "Translated categories"
+              expect(config.resource_name).to receive(:translate).at_least(:once).and_return "Translated categories"
+              expect(config.plural_resource_label).to eq "Translated categories"
             end
           end
         end
@@ -110,12 +110,12 @@ module ActiveAdmin
 
       [:==, :===, :eql?].each do |method|
         it "are equivalent when compared with #{method}" do
-          resource_name.public_send(method, duplicate_resource_name).should be_true
+          expect(resource_name.public_send(method, duplicate_resource_name)).to be_true
         end
       end
 
       it "have identical hash values" do
-        resource_name.hash.should == duplicate_resource_name.hash
+        expect(resource_name.hash).to eq duplicate_resource_name.hash
       end
     end
   end

--- a/spec/unit/resource/page_presenters_spec.rb
+++ b/spec/unit/resource/page_presenters_spec.rb
@@ -6,19 +6,19 @@ describe ActiveAdmin::Resource::PagePresenters do
   let(:resource){ namespace.register(Post) }
 
   it "should have an empty set of configs on initialize" do
-    resource.page_presenters.should == {}
+    expect(resource.page_presenters).to eq ({})
   end
 
   it "should add a show page presenter" do
     page_presenter = ActiveAdmin::PagePresenter.new
     resource.set_page_presenter(:show, page_presenter)
-    resource.page_presenters[:show].should == page_presenter
+    expect(resource.page_presenters[:show]).to eq page_presenter
   end
 
   it "should add an index page presenter" do
     page_presenter = ActiveAdmin::PagePresenter.new({:as => :table})
     resource.set_page_presenter(:index, page_presenter)
-    resource.page_presenters[:index].default.should == page_presenter
+    expect(resource.page_presenters[:index].default).to eq page_presenter
   end
 
   describe "#get_page_presenter" do
@@ -26,17 +26,17 @@ describe ActiveAdmin::Resource::PagePresenters do
     it "should return a page config when set" do
       page_presenter = ActiveAdmin::PagePresenter.new
       resource.set_page_presenter(:index, page_presenter)
-      resource.get_page_presenter(:index).should == page_presenter
+      expect(resource.get_page_presenter(:index)).to eq page_presenter
     end
 
     it "should return a specific index page config when set" do
       page_presenter = ActiveAdmin::PagePresenter.new
       resource.set_page_presenter(:index, page_presenter)
-      resource.get_page_presenter(:index, "table").should == page_presenter
+      expect(resource.get_page_presenter(:index, "table")).to eq page_presenter
     end
 
     it "should return nil when no page config set" do
-      resource.get_page_presenter(:index).should == nil
+      expect(resource.get_page_presenter(:index)).to eq nil
     end
 
   end

--- a/spec/unit/resource/pagination_spec.rb
+++ b/spec/unit/resource/pagination_spec.rb
@@ -14,24 +14,24 @@ module ActiveAdmin
 
     describe "#paginate" do
       it "should default to true" do
-        config.paginate.should == true
+        expect(config.paginate).to eq true
       end
 
       it "should be settable to false" do
         config.paginate = false
-        config.paginate.should == false
+        expect(config.paginate).to eq false
       end
     end
 
     describe "#per_page" do
       it "should default to namespace.default_per_page" do
-        namespace.should_receive(:default_per_page).and_return(5)
-        config.per_page.should == 5
+        expect(namespace).to receive(:default_per_page).and_return(5)
+        expect(config.per_page).to eq 5
       end
 
       it "should be settable" do
         config.per_page = 5
-        config.per_page.should == 5
+        expect(config.per_page).to eq 5
       end
     end
   end

--- a/spec/unit/resource/routes_spec.rb
+++ b/spec/unit/resource/routes_spec.rb
@@ -10,27 +10,27 @@ module ActiveAdmin
         let(:category) { Category.new { |c| c.id = 123 } }
 
         it "should return the route prefix" do
-          config.route_prefix.should eq 'admin'
+          expect(config.route_prefix).to eq 'admin'
         end
 
         it "should return the route collection path" do
-          config.route_collection_path.should eq '/admin/categories'
+          expect(config.route_collection_path).to eq '/admin/categories'
         end
 
         it "should return the route instance path" do
-          config.route_instance_path(category).should eq '/admin/categories/123'
+          expect(config.route_instance_path(category)).to eq '/admin/categories/123'
         end
       end
 
       context "when in the root namespace" do
         let!(:config) { ActiveAdmin.register Category, :namespace => false }
         it "should have a nil route_prefix" do
-          config.route_prefix.should be_nil
+          expect(config.route_prefix).to be_nil
         end
 
         it "should generate a correct route" do
           reload_routes!
-          config.route_collection_path.should == "/categories"
+          expect(config.route_collection_path).to eq "/categories"
         end
       end
 
@@ -40,7 +40,7 @@ module ActiveAdmin
         before{ reload_routes! }
 
         it "should return the plural route with _index" do
-          config.route_collection_path.should == "/admin/news"
+          expect(config.route_collection_path).to eq "/admin/news"
         end
       end
 
@@ -61,11 +61,11 @@ module ActiveAdmin
         before{ reload_routes! }
 
         it "should nest the collection path" do
-          config.route_collection_path(category_id: 1).should == "/admin/categories/1/posts"
+          expect(config.route_collection_path(category_id: 1)).to eq "/admin/categories/1/posts"
         end
 
         it "should nest the instance path" do
-          config.route_instance_path(post).should == "/admin/categories/1/posts/3"
+          expect(config.route_instance_path(post)).to eq "/admin/categories/1/posts/3"
         end
       end
     end

--- a/spec/unit/resource/scopes_spec.rb
+++ b/spec/unit/resource/scopes_spec.rb
@@ -16,26 +16,26 @@ module ActiveAdmin
 
       it "should add a scope" do
         config.scope :published
-        config.scopes.first.should be_a(ActiveAdmin::Scope)
-        config.scopes.first.name.should == "Published"
+        expect(config.scopes.first).to be_a(ActiveAdmin::Scope)
+        expect(config.scopes.first.name).to eq "Published"
       end
 
       it "should retrive a scope by its id" do
         config.scope :published
-        config.get_scope_by_id(:published).name.should == "Published"
+        expect(config.get_scope_by_id(:published).name).to eq "Published"
       end
 
       it "should not add a scope with the same name twice" do
         config.scope :published
         config.scope :published
-        config.scopes.size.should == 1
+        expect(config.scopes.size).to eq 1
       end
 
       it "should update a scope with the same id" do
         config.scope :published
-        config.scopes.first.scope_block.should be_nil
+        expect(config.scopes.first.scope_block).to be_nil
         config.scope(:published){  }
-        config.scopes.first.scope_block.should_not be_nil
+        expect(config.scopes.first.scope_block).to_not be_nil
       end
 
     end

--- a/spec/unit/resource/sidebars_spec.rb
+++ b/spec/unit/resource/sidebars_spec.rb
@@ -17,7 +17,7 @@ describe ActiveAdmin::Resource::Sidebars do
     end
 
     it "should add a sidebar section" do
-      resource.should have(1).sidebar_sections
+      expect(resource).to have(1).sidebar_sections
     end
 
   end
@@ -34,8 +34,8 @@ describe ActiveAdmin::Resource::Sidebars do
     end
 
     it "should only return the relevant action items" do
-      resource.should have(2).sidebar_sections
-      resource.sidebar_sections_for("index").should == [only_index]
+      expect(resource).to have(2).sidebar_sections
+      expect(resource.sidebar_sections_for("index")).to eq [only_index]
     end
 
   end

--- a/spec/unit/resource_collection_spec.rb
+++ b/spec/unit/resource_collection_spec.rb
@@ -12,37 +12,37 @@ describe ActiveAdmin::ResourceCollection do
   let(:resource){ double resource_name: "MyResource" }
 
   it "should have no resources when new" do
-    collection.should be_empty
+    expect(collection).to be_empty
   end
 
   it "should be enumerable" do
     collection.add(resource)
-    collection.each{ |r| r.should == resource }
+    collection.each{ |r| expect(r).to eq resource }
   end
 
   it "should return the available keys" do
     collection.add resource
-    collection.keys.should == [resource.resource_name]
+    expect(collection.keys).to eq [resource.resource_name]
   end
 
   describe "adding a new resource" do
     it "should return the resource" do
-      collection.add(resource).should == resource
+      expect(collection.add(resource)).to eq resource
     end
 
     it "should add a new resource" do
       collection.add(resource)
-      collection.values.should == [resource]
+      expect(collection.values).to eq [resource]
     end
 
     it "should be available by name" do
       collection.add(resource)
-      collection[resource.resource_name].should == resource
+      expect(collection[resource.resource_name]).to eq resource
     end
 
     it "shouldn't happen twice" do
       collection.add(resource); collection.add(resource)
-      collection.values.should == [resource]
+      expect(collection.values).to eq [resource]
     end
   end
 
@@ -61,27 +61,27 @@ describe ActiveAdmin::ResourceCollection do
       end
 
       it "should find resource by class" do
-        collection[resource_class].should == resource
+        expect(collection[resource_class]).to eq resource
       end
 
       it "should find resource by class string" do
-        collection[resource_class.to_s].should == resource
+        expect(collection[resource_class.to_s]).to eq resource
       end
 
       it "should find inherited resource by class" do
-        collection[inherited_resource_class].should == inherited_resource
+        expect(collection[inherited_resource_class]).to eq inherited_resource
       end
 
       it "should find inherited resource by class string" do
-        collection[inherited_resource_class.to_s].should == inherited_resource
+        expect(collection[inherited_resource_class.to_s]).to eq inherited_resource
       end
 
       it "should return nil when the resource_class does not respond to base_class and it is not in the collection" do
-        collection[double].should == nil
+        expect(collection[double]).to eq nil
       end
 
       it "should return nil when a resource class is NOT in the collection" do
-        collection[unregistered_class].should == nil
+        expect(collection[unregistered_class]).to eq nil
       end
     end
 
@@ -91,7 +91,7 @@ describe ActiveAdmin::ResourceCollection do
       end
 
       it "should find resource by inherited class" do
-        collection[inherited_resource_class].should == resource
+        expect(collection[inherited_resource_class]).to eq resource
       end
     end
 
@@ -104,15 +104,15 @@ describe ActiveAdmin::ResourceCollection do
       end
 
       it "should find resource by class" do
-        collection[resource_class].should == renamed_resource
+        expect(collection[resource_class]).to eq renamed_resource
       end
 
       it "should find resource by class string" do
-        collection[resource_class.to_s].should == renamed_resource
+        expect(collection[resource_class.to_s]).to eq renamed_resource
       end
 
       it "should find resource by name" do
-        collection[name].should == renamed_resource
+        expect(collection[name]).to eq renamed_resource
       end
     end
   end
@@ -128,7 +128,7 @@ describe ActiveAdmin::ResourceCollection do
       end
 
       it "contains both resources" do
-        collection.values.should include(resource, resource_renamed)
+        expect(collection.values).to include(resource, resource_renamed)
       end
     end
 
@@ -139,7 +139,7 @@ describe ActiveAdmin::ResourceCollection do
       end
 
       it "contains both resources" do
-        collection.values.should include(resource, resource_renamed)
+        expect(collection.values).to include(resource, resource_renamed)
       end
     end
 
@@ -152,7 +152,7 @@ describe ActiveAdmin::ResourceCollection do
       end
 
       it "the collection contains one instance of that resource" do
-        collection.values.should eq([resource])
+        expect(collection.values).to eq([resource])
       end
     end
   end

--- a/spec/unit/resource_controller/data_access_spec.rb
+++ b/spec/unit/resource_controller/data_access_spec.rb
@@ -17,7 +17,7 @@ describe ActiveAdmin::ResourceController::DataAccess do
     let(:params){ {:q => {} }}
     it "should call the search method" do
       chain = double "ChainObj"
-      chain.should_receive(:ransack).with(params[:q]).once.and_return(Post.ransack)
+      expect(chain).to receive(:ransack).with(params[:q]).once.and_return(Post.ransack)
       controller.send :apply_filtering, chain
     end
 
@@ -29,7 +29,7 @@ describe ActiveAdmin::ResourceController::DataAccess do
       let(:params){ {:order => "id_asc" }}
       it "should prepend the table name" do
         chain = double "ChainObj"
-        chain.should_receive(:reorder).with('"posts"."id" asc').once.and_return(Post.search)
+        expect(chain).to receive(:reorder).with('"posts"."id" asc').once.and_return(Post.search)
         controller.send :apply_sorting, chain
       end
     end
@@ -38,7 +38,7 @@ describe ActiveAdmin::ResourceController::DataAccess do
       let(:params){ {:order => "virtual_id_asc" }}
       it "should not prepend the table name" do
         chain = double "ChainObj"
-        chain.should_receive(:reorder).with('"virtual_id" asc').once.and_return(Post.search)
+        expect(chain).to receive(:reorder).with('"virtual_id" asc').once.and_return(Post.search)
         controller.send :apply_sorting, chain
       end
     end
@@ -50,8 +50,8 @@ describe ActiveAdmin::ResourceController::DataAccess do
     context "when no current scope" do
       it "should set collection_before_scope to the chain and return the chain" do
         chain = double "ChainObj"
-        controller.send(:apply_scoping, chain).should == chain
-        controller.send(:collection_before_scope).should == chain
+        expect(controller.send(:apply_scoping, chain)).to eq chain
+        expect(controller.send(:collection_before_scope)).to eq chain
       end
     end
 
@@ -62,9 +62,9 @@ describe ActiveAdmin::ResourceController::DataAccess do
         current_scope = double "CurrentScope"
         controller.stub(:current_scope) { current_scope }
 
-        controller.should_receive(:scope_chain).with(current_scope, chain) { scoped_chain }
-        controller.send(:apply_scoping, chain).should == scoped_chain
-        controller.send(:collection_before_scope).should == chain
+        expect(controller).to receive(:scope_chain).with(current_scope, chain) { scoped_chain }
+        expect(controller.send(:apply_scoping, chain)).to eq scoped_chain
+        expect(controller.send(:collection_before_scope)).to eq chain
       end
     end
 

--- a/spec/unit/resource_controller/sidebars_spec.rb
+++ b/spec/unit/resource_controller/sidebars_spec.rb
@@ -10,7 +10,7 @@ describe ActiveAdmin::ResourceController::Sidebars do
 
     subject { find_before_filter controller, :skip_sidebar! }
 
-    it { should set_skip_sidebar_to nil }
+    it {should set_skip_sidebar_to nil}
   end
 
   describe '#skip_sidebar!' do
@@ -36,7 +36,7 @@ describe ActiveAdmin::ResourceController::Sidebars do
       object = klass.new
       object.send filter.raw_filter if filter
       @actual = object.instance_variable_get(:@skip_sidebar)
-      @actual == expected
+      expect(@actual).to eq expected
     end
 
     failure_message_for_should do |filter|

--- a/spec/unit/resource_controller_spec.rb
+++ b/spec/unit/resource_controller_spec.rb
@@ -11,7 +11,7 @@ describe ActiveAdmin::ResourceController do
 
     it "should do nothing when no authentication_method set" do
       namespace = controller.class.active_admin_config.namespace
-      namespace.should_receive(:authentication_method).once.and_return(nil)
+      expect(namespace).to receive(:authentication_method).once.and_return(nil)
 
       controller.send(:authenticate_active_admin_user)
     end
@@ -19,10 +19,10 @@ describe ActiveAdmin::ResourceController do
     it "should call the authentication_method when set" do
       namespace = controller.class.active_admin_config.namespace
 
-      namespace.should_receive(:authentication_method).twice.
+      expect(namespace).to receive(:authentication_method).twice.
         and_return(:authenticate_admin_user!)
 
-      controller.should_receive(:authenticate_admin_user!).and_return(true)
+      expect(controller).to receive(:authenticate_admin_user!).and_return(true)
 
       controller.send(:authenticate_active_admin_user)
     end
@@ -34,21 +34,21 @@ describe ActiveAdmin::ResourceController do
 
     it "should return nil when no current_user_method set" do
       namespace = controller.class.active_admin_config.namespace
-      namespace.should_receive(:current_user_method).once.and_return(nil)
+      expect(namespace).to receive(:current_user_method).once.and_return(nil)
 
-      controller.send(:current_active_admin_user).should == nil
+      expect(controller.send(:current_active_admin_user)).to eq nil
     end
 
     it "should call the current_user_method when set" do
       user = double
       namespace = controller.class.active_admin_config.namespace
 
-      namespace.should_receive(:current_user_method).twice.
+      expect(namespace).to receive(:current_user_method).twice.
         and_return(:current_admin_user)
 
-      controller.should_receive(:current_admin_user).and_return(user)
+      expect(controller).to receive(:current_admin_user).and_return(user)
 
-      controller.send(:current_active_admin_user).should == user
+      expect(controller.send(:current_active_admin_user)).to eq user
     end
   end
 
@@ -87,23 +87,23 @@ describe ActiveAdmin::ResourceController do
       let(:resource){ double("Resource", :save => true) }
 
       before do
-        resource.should_receive(:save)
+        expect(resource).to receive(:save)
       end
 
       it "should call the before create callback" do
-        controller.should_receive(:call_before_create).with(resource)
+        expect(controller).to receive(:call_before_create).with(resource)
         controller.send :create_resource, resource
       end
       it "should call the before save callback" do
-        controller.should_receive(:call_before_save).with(resource)
+        expect(controller).to receive(:call_before_save).with(resource)
         controller.send :create_resource, resource
       end
       it "should call the after save callback" do
-        controller.should_receive(:call_after_save).with(resource)
+        expect(controller).to receive(:call_after_save).with(resource)
         controller.send :create_resource, resource
       end
       it "should call the after create callback" do
-        controller.should_receive(:call_after_create).with(resource)
+        expect(controller).to receive(:call_after_create).with(resource)
         controller.send :create_resource, resource
       end
     end
@@ -114,24 +114,24 @@ describe ActiveAdmin::ResourceController do
       let(:attributes){ [{}] }
 
       before do
-        resource.should_receive(:attributes=).with(attributes[0])
-        resource.should_receive(:save)
+        expect(resource).to receive(:attributes=).with(attributes[0])
+        expect(resource).to receive(:save)
       end
 
       it "should call the before update callback" do
-        controller.should_receive(:call_before_update).with(resource)
+        expect(controller).to receive(:call_before_update).with(resource)
         controller.send :update_resource, resource, attributes
       end
       it "should call the before save callback" do
-        controller.should_receive(:call_before_save).with(resource)
+        expect(controller).to receive(:call_before_save).with(resource)
         controller.send :update_resource, resource, attributes
       end
       it "should call the after save callback" do
-        controller.should_receive(:call_after_save).with(resource)
+        expect(controller).to receive(:call_after_save).with(resource)
         controller.send :update_resource, resource, attributes
       end
       it "should call the after create callback" do
-        controller.should_receive(:call_after_update).with(resource)
+        expect(controller).to receive(:call_after_update).with(resource)
         controller.send :update_resource, resource, attributes
       end
     end
@@ -141,16 +141,16 @@ describe ActiveAdmin::ResourceController do
       let(:resource){ double("Resource", :destroy => true) }
 
       before do
-        resource.should_receive(:destroy)
+        expect(resource).to receive(:destroy)
       end
 
       it "should call the before destroy callback" do
-        controller.should_receive(:call_before_destroy).with(resource)
+        expect(controller).to receive(:call_before_destroy).with(resource)
         controller.send :destroy_resource, resource
       end
 
       it "should call the after destroy callback" do
-        controller.should_receive(:call_after_destroy).with(resource)
+        expect(controller).to receive(:call_after_destroy).with(resource)
         controller.send :destroy_resource, resource
       end
     end
@@ -183,7 +183,7 @@ describe Admin::PostsController, :type => "controller" do
       end
 
       it 'returns a PostDecorator that wraps the post' do
-        subject.title.should == post.title
+        expect(subject.title).to eq post.title
       end
     end
   end
@@ -199,12 +199,12 @@ describe Admin::PostsController, :type => "controller" do
 
     it {
       pending # doesn't pass when running whole spec suite (WTF)
-      should be_kind_of(ActiveRecord::Relation)
+      should be kind_of(ActiveRecord::Relation)
     }
 
     it "returns a collection of posts" do
       pending # doesn't pass when running whole spec suite (WTF)
-      subject.first.should be_kind_of(Post)
+      expect(subject.first).to be_kind_of(Post)
     end
 
     context 'with a decorator' do
@@ -213,12 +213,12 @@ describe Admin::PostsController, :type => "controller" do
 
       it 'returns a PostDecorator' do
         pending # doesn't pass when running whole spec suite (WTF)
-        subject.should be_kind_of(PostDecorator::DecoratedEnumerableProxy)
+        expect(subject).to be_kind_of(PostDecorator::DecoratedEnumerableProxy)
       end
 
       it 'returns a PostDecorator that wraps the post' do
         pending # doesn't pass when running whole spec suite (WTF)
-        subject.first.title.should == Post.first.title
+        expect(subject.first.title).to eq Post.first.title
       end
     end
   end

--- a/spec/unit/resource_registration_spec.rb
+++ b/spec/unit/resource_registration_spec.rb
@@ -7,13 +7,13 @@ describe "Registering an object to administer" do
     namespace = ActiveAdmin::Namespace.new(application, :admin)
     it "should call register on the namespace" do
       application.namespaces[namespace.name] = namespace
-      namespace.should_receive(:register)
+      expect(namespace).to receive(:register)
 
       application.register Category
     end
 
     it "should dispatch a Resource::RegisterEvent" do
-      ActiveAdmin::Event.should_receive(:dispatch).with(ActiveAdmin::Resource::RegisterEvent, an_instance_of(ActiveAdmin::Resource))
+      expect(ActiveAdmin::Event).to receive(:dispatch).with(ActiveAdmin::Resource::RegisterEvent, an_instance_of(ActiveAdmin::Resource))
       application.register Category
     end
   end
@@ -22,14 +22,14 @@ describe "Registering an object to administer" do
     it "should call register on the namespace" do
       namespace = ActiveAdmin::Namespace.new(application, :hello_world)
       application.namespaces[namespace.name] = namespace
-      namespace.should_receive(:register)
+      expect(namespace).to receive(:register)
 
       application.register Category, :namespace => :hello_world
     end
 
     it "should generate a Namespace::RegisterEvent and a Resource::RegisterEvent" do
-      ActiveAdmin::Event.should_receive(:dispatch).with(ActiveAdmin::Namespace::RegisterEvent, an_instance_of(ActiveAdmin::Namespace))
-      ActiveAdmin::Event.should_receive(:dispatch).with(ActiveAdmin::Resource::RegisterEvent, an_instance_of(ActiveAdmin::Resource))
+      expect(ActiveAdmin::Event).to receive(:dispatch).with(ActiveAdmin::Namespace::RegisterEvent, an_instance_of(ActiveAdmin::Namespace))
+      expect(ActiveAdmin::Event).to receive(:dispatch).with(ActiveAdmin::Resource::RegisterEvent, an_instance_of(ActiveAdmin::Resource))
       application.register Category, :namespace => :not_yet_created
     end
   end
@@ -38,7 +38,7 @@ describe "Registering an object to administer" do
     it "should call register on the root namespace" do
       namespace = ActiveAdmin::Namespace.new(application, :root)
       application.namespaces[namespace.name] = namespace
-      namespace.should_receive(:register)
+      expect(namespace).to receive(:register)
 
       application.register Category, :namespace => false
     end
@@ -48,8 +48,8 @@ describe "Registering an object to administer" do
     it "should run the dsl in the same config object" do
       config_1 = ActiveAdmin.register(Category) { filter :name }
       config_2 = ActiveAdmin.register(Category) { filter :id }
-      config_1.should == config_2
-      config_1.filters.size.should == 2
+      expect(config_1).to eq config_2
+      expect(config_1.filters.size).to eq 2
     end
   end
 

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -19,33 +19,33 @@ module ActiveAdmin
 
     describe "#resource_table_name" do
       it "should return the resource's table name" do
-        config.resource_table_name.should == '"categories"'
+        expect(config.resource_table_name).to eq '"categories"'
       end
       context "when the :as option is given" do
         it "should return the resource's table name" do
-          config(:as => "My Category").resource_table_name.should == '"categories"'
+          expect(config(:as => "My Category").resource_table_name).to eq '"categories"'
         end
       end
     end
 
     describe "#resource_column_names" do
       it "should return the resource's column names" do
-        config.resource_column_names.should == Category.column_names
+        expect(config.resource_column_names).to eq Category.column_names
       end
     end
 
     describe '#decorator_class' do
       it 'returns nil by default' do
-        config.decorator_class.should be_nil
+        expect(config.decorator_class).to be_nil
       end
       context 'when a decorator is defined' do
         let(:resource) { namespace.register(Post) { decorate_with PostDecorator } }
         specify '#decorator_class_name should return PostDecorator' do
-          resource.decorator_class_name.should == '::PostDecorator'
+          expect(resource.decorator_class_name).to eq '::PostDecorator'
         end
 
         it 'returns the decorator class' do
-          resource.decorator_class.should == PostDecorator
+          expect(resource.decorator_class).to eq PostDecorator
         end
       end
     end
@@ -53,12 +53,12 @@ module ActiveAdmin
 
     describe "controller name" do
       it "should return a namespaced controller name" do
-        config.controller_name.should == "Admin::CategoriesController"
+        expect(config.controller_name).to eq "Admin::CategoriesController"
       end
       context "when non namespaced controller" do
         let(:namespace){ ActiveAdmin::Namespace.new(application, :root) }
         it "should return a non namespaced controller name" do
-          config.controller_name.should == "CategoriesController"
+          expect(config.controller_name).to eq "CategoriesController"
         end
       end
     end
@@ -81,15 +81,15 @@ module ActiveAdmin
     describe "#belongs_to" do
 
       it "should build a belongs to configuration" do
-        config.belongs_to_config.should be_nil
+        expect(config.belongs_to_config).to be_nil
         config.belongs_to :posts
-        config.belongs_to_config.should_not be_nil
+        expect(config.belongs_to_config).to_not be_nil
       end
 
       it "should set the target menu to the belongs to target" do
-        config.navigation_menu_name.should == ActiveAdmin::DEFAULT_MENU
+        expect(config.navigation_menu_name).to eq ActiveAdmin::DEFAULT_MENU
         config.belongs_to :posts
-        config.navigation_menu_name.should == :posts
+        expect(config.navigation_menu_name).to eq :posts
       end
 
     end
@@ -105,7 +105,7 @@ module ActiveAdmin
         end
         it "should call the proc for the begin of association chain" do
           begin_of_association_chain = @resource.controller.new.send(:begin_of_association_chain)
-          begin_of_association_chain.should == "scoped"
+          expect(begin_of_association_chain).to eq "scoped"
         end
       end
 
@@ -117,9 +117,9 @@ module ActiveAdmin
         end
         it "should call the method for the begin of association chain" do
           controller = @resource.controller.new
-          controller.should_receive(:current_user).and_return(true)
+          expect(controller).to receive(:current_user).and_return(true)
           begin_of_association_chain = controller.send(:begin_of_association_chain)
-          begin_of_association_chain.should == true
+          expect(begin_of_association_chain).to eq true
         end
       end
 
@@ -131,7 +131,7 @@ module ActiveAdmin
             end
           end
           it "should return the pluralized collection name" do
-            @resource.controller.new.send(:method_for_association_chain).should == :categories
+            expect(@resource.controller.new.send(:method_for_association_chain)).to eq :categories
           end
         end
         context "when passing in the method as an option" do
@@ -141,7 +141,7 @@ module ActiveAdmin
             end
           end
           it "should return the method from the option" do
-            @resource.controller.new.send(:method_for_association_chain).should == :blog_categories
+            expect(@resource.controller.new.send(:method_for_association_chain)).to eq :blog_categories
           end
         end
       end
@@ -152,22 +152,22 @@ module ActiveAdmin
 
       context "when resource class responds to primary_key" do
         it "should sort by primary key desc by default" do
-          MockResource.should_receive(:primary_key).and_return("pk")
+          expect(MockResource).to receive(:primary_key).and_return("pk")
           config = Resource.new(namespace, MockResource)
-          config.sort_order.should == "pk_desc"
+          expect(config.sort_order).to eq "pk_desc"
         end
       end
 
       context "when resource class does not respond to primary_key" do
         it "should default to id" do
           config = Resource.new(namespace, MockResource)
-          config.sort_order.should == "id_desc"
+          expect(config.sort_order).to eq "id_desc"
         end
       end
 
       it "should be set-able" do
         config.sort_order = "task_id_desc"
-        config.sort_order.should == "task_id_desc"
+        expect(config.sort_order).to eq "task_id_desc"
       end
 
     end
@@ -176,19 +176,19 @@ module ActiveAdmin
 
       it "should add a scope" do
         config.scope :published
-        config.scopes.first.should be_a(ActiveAdmin::Scope)
-        config.scopes.first.name.should == "Published"
+        expect(config.scopes.first).to be_a(ActiveAdmin::Scope)
+        expect(config.scopes.first.name).to eq "Published"
       end
 
       it "should retrive a scope by its id" do
         config.scope :published
-        config.get_scope_by_id(:published).name.should == "Published"
+        expect(config.get_scope_by_id(:published).name).to eq "Published"
       end
 
       it "should retrieve the default scope by proc" do
         config.scope :published, :default => proc{ true }
         config.scope :all
-        config.default_scope.name.should == "Published"
+        expect(config.default_scope.name).to eq "Published"
       end
 
     end
@@ -196,7 +196,7 @@ module ActiveAdmin
     describe "#csv_builder" do
       context "when no csv builder set" do
         it "should return a default column builder with id and content columns" do
-          config.csv_builder.columns.size.should == Category.content_columns.size + 1
+          expect(config.csv_builder.columns.size).to eq Category.content_columns.size + 1
         end
       end
 
@@ -204,7 +204,7 @@ module ActiveAdmin
         it "shuld return the csv_builder we set" do
           csv_builder = CSVBuilder.new
           config.csv_builder = csv_builder
-          config.csv_builder.should == csv_builder
+          expect(config.csv_builder).to eq csv_builder
         end
       end
     end
@@ -217,13 +217,13 @@ module ActiveAdmin
       end
 
       it 'can find the resource' do
-        resource.find_resource('12345').should == post
+        expect(resource.find_resource('12345')).to eq post
       end
 
       context 'with a decorator' do
         let(:resource) { namespace.register(Post) { decorate_with PostDecorator } }
         it 'decorates the resource' do
-          resource.find_resource('12345').should == PostDecorator.new(post)
+          expect(resource.find_resource('12345')).to eq PostDecorator.new(post)
         end
       end
 
@@ -235,7 +235,7 @@ module ActiveAdmin
         end
 
         it 'can find the post by the custom primary key' do
-          resource.find_resource('55555').should == different_post
+          expect(resource.find_resource('55555')).to eq different_post
         end
       end
     end

--- a/spec/unit/routing_spec.rb
+++ b/spec/unit/routing_spec.rb
@@ -14,25 +14,25 @@ describe ActiveAdmin, "Routing", :type => :routing do
   end
 
   it "should route to the admin dashboard" do
-    get('/admin').should route_to 'admin/dashboard#index'
+    expect(get('/admin')).to route_to 'admin/dashboard#index'
   end
 
   describe "standard resources" do
     context "when in admin namespace" do
       it "should route the index path" do
-        admin_posts_path.should == "/admin/posts"
+        expect(admin_posts_path).to eq "/admin/posts"
       end
 
       it "should route the show path" do
-        admin_post_path(1).should == "/admin/posts/1"
+        expect(admin_post_path(1)).to eq "/admin/posts/1"
       end
 
       it "should route the new path" do
-        new_admin_post_path.should == "/admin/posts/new"
+        expect(new_admin_post_path).to eq "/admin/posts/new"
       end
 
       it "should route the edit path" do
-        edit_admin_post_path(1).should == "/admin/posts/1/edit"
+        expect(edit_admin_post_path(1)).to eq "/admin/posts/1/edit"
       end
     end
 
@@ -42,19 +42,19 @@ describe ActiveAdmin, "Routing", :type => :routing do
       end
 
       it "should route the index path" do
-        posts_path.should == "/posts"
+        expect(posts_path).to eq "/posts"
       end
 
       it "should route the show path" do
-        post_path(1).should == "/posts/1"
+        expect(post_path(1)).to eq "/posts/1"
       end
 
       it "should route the new path" do
-        new_post_path.should == "/posts/new"
+        expect(new_post_path).to eq "/posts/new"
       end
 
       it "should route the edit path" do
-        edit_post_path(1).should == "/posts/1/edit"
+        expect(edit_post_path(1)).to eq "/posts/1/edit"
       end
     end
 
@@ -67,8 +67,8 @@ describe ActiveAdmin, "Routing", :type => :routing do
         end
 
         it "should default to GET" do
-          {:get  => "/admin/posts/1/do_something"}.should     be_routable
-          {:post => "/admin/posts/1/do_something"}.should_not be_routable
+          expect({:get  => "/admin/posts/1/do_something"}).to     be_routable
+          expect({:post => "/admin/posts/1/do_something"}).to_not be_routable
         end
       end
 
@@ -80,7 +80,7 @@ describe ActiveAdmin, "Routing", :type => :routing do
         end
 
         it "should properly route" do
-          {:post => "/admin/posts/1/do_something"}.should be_routable
+          expect({:post => "/admin/posts/1/do_something"}).to be_routable
         end
       end
 
@@ -92,11 +92,11 @@ describe ActiveAdmin, "Routing", :type => :routing do
         end
 
         it "should properly route the first verb" do
-          {:put => "/admin/posts/1/do_something"}.should be_routable
+          expect({:put => "/admin/posts/1/do_something"}).to be_routable
         end
 
         it "should properly route the second verb" do
-          {:delete => "/admin/posts/1/do_something"}.should be_routable
+          expect({:delete => "/admin/posts/1/do_something"}).to be_routable
         end
       end
     end
@@ -104,19 +104,19 @@ describe ActiveAdmin, "Routing", :type => :routing do
 
   describe "belongs to resource" do
     it "should route the nested index path" do
-      admin_user_posts_path(1).should == "/admin/users/1/posts"
+      expect(admin_user_posts_path(1)).to eq "/admin/users/1/posts"
     end
 
     it "should route the nested show path" do
-      admin_user_post_path(1,2).should == "/admin/users/1/posts/2"
+      expect(admin_user_post_path(1,2)).to eq "/admin/users/1/posts/2"
     end
 
     it "should route the nested new path" do
-      new_admin_user_post_path(1).should == "/admin/users/1/posts/new"
+      expect(new_admin_user_post_path(1)).to eq "/admin/users/1/posts/new"
     end
 
     it "should route the nested edit path" do
-      edit_admin_user_post_path(1,2).should == "/admin/users/1/posts/2/edit"
+      expect(edit_admin_user_post_path(1,2)).to eq "/admin/users/1/posts/2/edit"
     end
 
     context "with collection action" do
@@ -132,8 +132,8 @@ describe ActiveAdmin, "Routing", :type => :routing do
       end
 
       it "should properly route the collection action" do
-        { :get => "/admin/users/do_something" }.
-          should route_to({ :controller => 'admin/users',:action => 'do_something'})
+        expect({ get: "/admin/users/do_something" }).to \
+          route_to({ controller: 'admin/users', action: 'do_something'})
       end
     end
   end
@@ -145,7 +145,7 @@ describe ActiveAdmin, "Routing", :type => :routing do
       end
 
       it "should route to the page under /admin" do
-        admin_chocolate_i_love_you_path.should == "/admin/chocolate_i_love_you"
+        expect(admin_chocolate_i_love_you_path).to eq "/admin/chocolate_i_love_you"
       end
 
       context "when in the root namespace" do
@@ -154,7 +154,7 @@ describe ActiveAdmin, "Routing", :type => :routing do
         end
 
         it "should route to page under /" do
-          chocolate_i_love_you_path.should == "/chocolate_i_love_you"
+          expect(chocolate_i_love_you_path).to eq "/chocolate_i_love_you"
         end
       end
 
@@ -164,7 +164,7 @@ describe ActiveAdmin, "Routing", :type => :routing do
         end
 
         it "should not inject _index_ into the route name" do
-          admin_log_path.should == "/admin/log"
+          expect(admin_log_path).to eq "/admin/log"
         end
       end
     end

--- a/spec/unit/scope_spec.rb
+++ b/spec/unit/scope_spec.rb
@@ -52,7 +52,7 @@ describe ActiveAdmin::Scope do
 
       it "should properly render the proc" do
         scope = ActiveAdmin::Scope.new proc{ Date.today.strftime '%A' }, :foobar
-        scope.name.should eq Date.today.strftime '%A'
+        expect(scope.name).to eq Date.today.strftime '%A'
       end
     end
 
@@ -62,12 +62,12 @@ describe ActiveAdmin::Scope do
 
     it "should return true by default" do
       scope = ActiveAdmin::Scope.new(:default)
-      scope.display_if_block.call.should == true
+      expect(scope.display_if_block.call).to eq true
     end
 
     it "should return the :if block if set" do
       scope = ActiveAdmin::Scope.new(:with_block, nil, :if => proc{ false })
-      scope.display_if_block.call.should == false
+      expect(scope.display_if_block.call).to eq false
     end
 
   end
@@ -76,17 +76,17 @@ describe ActiveAdmin::Scope do
 
     it "should accept a boolean" do
       scope = ActiveAdmin::Scope.new(:method, nil, :default => true)
-      scope.default_block.should == true
+      expect(scope.default_block).to eq true
     end
 
     it "should default to a false #default_block" do
       scope = ActiveAdmin::Scope.new(:method, nil)
-      scope.default_block.call.should == false
+      expect(scope.default_block.call).to eq false
     end
 
     it "should store the :default proc" do
       scope = ActiveAdmin::Scope.new(:with_block, nil, :default => proc{ true })
-      scope.default_block.call.should == true
+      expect(scope.default_block.call).to eq true
     end
 
   end
@@ -95,12 +95,12 @@ describe ActiveAdmin::Scope do
 
     it "should allow setting of show_count to prevent showing counts" do
       scope = ActiveAdmin::Scope.new(:default, nil, :show_count => false)
-      scope.show_count.should == false
+      expect(scope.show_count).to eq false
     end
 
     it "should set show_count to true if not passed in" do
       scope = ActiveAdmin::Scope.new(:default)
-      scope.show_count.should == true
+      expect(scope.show_count).to eq true
     end
 
   end

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -11,13 +11,13 @@ describe ActiveAdmin::Settings do
   describe "class API" do
     it "should create settings" do
       subject.setting :foo, 'bar'
-      subject.default_settings[:foo].should eq 'bar'
+      expect(subject.default_settings[:foo]).to eq 'bar'
     end
 
     it "should create deprecated settings" do
-      ActiveAdmin::Deprecation.should_receive(:deprecate).twice
+      expect(ActiveAdmin::Deprecation).to receive(:deprecate).twice
       subject.deprecated_setting :baz, 32
-      subject.default_settings[:baz].should eq 32
+      expect(subject.default_settings[:baz]).to eq 32
     end
   end
 
@@ -30,16 +30,16 @@ describe ActiveAdmin::Settings do
     let(:instance) { subject.new }
 
     it "should have access to a default value" do
-      instance.foo.should eq 'bar'
+      expect(instance.foo).to eq 'bar'
       instance.foo = 'qqq'
-      instance.foo.should eq 'qqq'
+      expect(instance.foo).to eq 'qqq'
     end
 
     it "should have access to a deprecated value" do
-      ActiveAdmin::Deprecation.should_receive(:warn).exactly(3).times
-      instance.baz.should eq 32
+      expect(ActiveAdmin::Deprecation).to receive(:warn).exactly(3).times
+      expect(instance.baz).to eq 32
       instance.baz = [45]
-      instance.baz.should eq [45]
+      expect(instance.baz).to eq [45]
     end
   end
 
@@ -68,20 +68,20 @@ describe ActiveAdmin::Settings::Inheritance do
   describe "class API" do
     it "should add setting to an heir" do
       subject.inheritable_setting :one, 2
-      heir.default_settings[:one].should eq 2
+      expect(heir.default_settings[:one]).to eq 2
     end
 
     it "should add deprecated setting to an heir" do
-      ActiveAdmin::Deprecation.should_receive(:deprecate).exactly(4).times
+      expect(ActiveAdmin::Deprecation).to receive(:deprecate).exactly(4).times
       subject.deprecated_inheritable_setting :three, 4
-      heir.default_settings[:three].should eq 4
+      expect(heir.default_settings[:three]).to eq 4
     end
   end
 
   describe "instance API" do
     before{ subject.inheritable_setting :left, :right }
     it "should work" do
-      heir.new.left.should eq :right
+      expect(heir.new.left).to eq :right
     end
   end
 

--- a/spec/unit/view_factory_spec.rb
+++ b/spec/unit/view_factory_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 def it_should_have_view(key, value)
   it "should have #{value} for view key '#{key}'" do
-    subject.send(key).should  == value
+    expect(subject.send(key)).to  eq value
   end
 end
 

--- a/spec/unit/view_helpers/breadcrumbs_spec.rb
+++ b/spec/unit/view_helpers/breadcrumbs_spec.rb
@@ -27,7 +27,7 @@ describe "Breadcrumbs" do
       let(:path) { "/admin" }
 
       it "should not have any items" do
-        trail.size.should == 0
+        expect(trail.size).to eq 0
       end
     end
 
@@ -35,11 +35,11 @@ describe "Breadcrumbs" do
       let(:path) { "/admin/users" }
 
       it "should have one item" do
-        trail.size.should == 1
+        expect(trail.size).to eq 1
       end
       it "should have a link to /admin" do
-        trail[0][:name].should == "Admin"
-        trail[0][:path].should == "/admin"
+        expect(trail[0][:name]).to eq "Admin"
+        expect(trail[0][:path]).to eq "/admin"
       end
     end
 
@@ -47,15 +47,15 @@ describe "Breadcrumbs" do
       let(:path) { "/admin/users/1" }
 
       it "should have 2 items" do
-        trail.size.should == 2
+        expect(trail.size).to eq 2
       end
       it "should have a link to /admin" do
-        trail[0][:name].should == "Admin"
-        trail[0][:path].should == "/admin"
+        expect(trail[0][:name]).to eq "Admin"
+        expect(trail[0][:path]).to eq "/admin"
       end
       it "should have a link to /admin/users" do
-        trail[1][:name].should == "Users"
-        trail[1][:path].should == "/admin/users"
+        expect(trail[1][:name]).to eq "Users"
+        expect(trail[1][:path]).to eq "/admin/users"
       end
     end
 
@@ -63,29 +63,29 @@ describe "Breadcrumbs" do
       let(:path) { "/admin/users/1/posts" }
 
       it "should have 3 items" do
-        trail.size.should == 3
+        expect(trail.size).to eq 3
       end
       it "should have a link to /admin" do
-        trail[0][:name].should == "Admin"
-        trail[0][:path].should == "/admin"
+        expect(trail[0][:name]).to eq "Admin"
+        expect(trail[0][:path]).to eq "/admin"
       end
       it "should have a link to /admin/users" do
-        trail[1][:name].should == "Users"
-        trail[1][:path].should == "/admin/users"
+        expect(trail[1][:name]).to eq "Users"
+        expect(trail[1][:path]).to eq "/admin/users"
       end
 
       context "when User.find(1) doesn't exist" do
         before { user_config.stub(find_resource: nil) }
         it "should have a link to /admin/users/1" do
-          trail[2][:name].should == "1"
-          trail[2][:path].should == "/admin/users/1"
+          expect(trail[2][:name]).to eq "1"
+          expect(trail[2][:path]).to eq "/admin/users/1"
         end
       end
 
       context "when User.find(1) does exist" do
         it "should have a link to /admin/users/1 using display name" do
-          trail[2][:name].should == "Jane Doe"
-          trail[2][:path].should == "/admin/users/1"
+          expect(trail[2][:name]).to eq "Jane Doe"
+          expect(trail[2][:path]).to eq "/admin/users/1"
         end
       end
     end
@@ -94,22 +94,22 @@ describe "Breadcrumbs" do
       let(:path) { "/admin/users/4e24d6249ccf967313000000/posts" }
 
       it "should have 3 items" do
-        trail.size.should == 3
+        expect(trail.size).to eq 3
       end
       it "should have a link to /admin" do
-        trail[0][:name].should == "Admin"
-        trail[0][:path].should == "/admin"
+        expect(trail[0][:name]).to eq "Admin"
+        expect(trail[0][:path]).to eq "/admin"
       end
       it "should have a link to /admin/users" do
-        trail[1][:name].should == "Users"
-        trail[1][:path].should == "/admin/users"
+        expect(trail[1][:name]).to eq "Users"
+        expect(trail[1][:path]).to eq "/admin/users"
       end
 
       context "when User.find(4e24d6249ccf967313000000) doesn't exist" do
         before { user_config.stub(find_resource: nil) }
         it "should have a link to /admin/users/4e24d6249ccf967313000000" do
-          trail[2][:name].should == "4e24d6249ccf967313000000"
-          trail[2][:path].should == "/admin/users/4e24d6249ccf967313000000"
+          expect(trail[2][:name]).to eq "4e24d6249ccf967313000000"
+          expect(trail[2][:path]).to eq "/admin/users/4e24d6249ccf967313000000"
         end
       end
 
@@ -118,8 +118,8 @@ describe "Breadcrumbs" do
           user_config.stub find_resource: double(display_name: 'Hello :)')
         end
         it "should have a link to /admin/users/4e24d6249ccf967313000000 using display name" do
-          trail[2][:name].should == "Hello :)"
-          trail[2][:path].should == "/admin/users/4e24d6249ccf967313000000"
+          expect(trail[2][:name]).to eq "Hello :)"
+          expect(trail[2][:path]).to eq "/admin/users/4e24d6249ccf967313000000"
         end
       end
     end
@@ -128,23 +128,23 @@ describe "Breadcrumbs" do
       let(:path) { "/admin/users/1/posts/1" }
 
       it "should have 4 items" do
-        trail.size.should == 4
+        expect(trail.size).to eq 4
       end
       it "should have a link to /admin" do
-        trail[0][:name].should == "Admin"
-        trail[0][:path].should == "/admin"
+        expect(trail[0][:name]).to eq "Admin"
+        expect(trail[0][:path]).to eq "/admin"
       end
       it "should have a link to /admin/users" do
-        trail[1][:name].should == "Users"
-        trail[1][:path].should == "/admin/users"
+        expect(trail[1][:name]).to eq "Users"
+        expect(trail[1][:path]).to eq "/admin/users"
       end
       it "should have a link to /admin/users/1" do
-        trail[2][:name].should == "Jane Doe"
-        trail[2][:path].should == "/admin/users/1"
+        expect(trail[2][:name]).to eq "Jane Doe"
+        expect(trail[2][:path]).to eq "/admin/users/1"
       end
       it "should have a link to /admin/users/1/posts" do
-        trail[3][:name].should == "Posts"
-        trail[3][:path].should == "/admin/users/1/posts"
+        expect(trail[3][:name]).to eq "Posts"
+        expect(trail[3][:path]).to eq "/admin/users/1/posts"
       end
     end
 
@@ -152,27 +152,27 @@ describe "Breadcrumbs" do
       let(:path) { "/admin/users/1/posts/1/edit" }
 
       it "should have 5 items" do
-        trail.size.should == 5
+        expect(trail.size).to eq 5
       end
       it "should have a link to /admin" do
-        trail[0][:name].should == "Admin"
-        trail[0][:path].should == "/admin"
+        expect(trail[0][:name]).to eq "Admin"
+        expect(trail[0][:path]).to eq "/admin"
       end
       it "should have a link to /admin/users" do
-        trail[1][:name].should == "Users"
-        trail[1][:path].should == "/admin/users"
+        expect(trail[1][:name]).to eq "Users"
+        expect(trail[1][:path]).to eq "/admin/users"
       end
       it "should have a link to /admin/users/1" do
-        trail[2][:name].should == "Jane Doe"
-        trail[2][:path].should == "/admin/users/1"
+        expect(trail[2][:name]).to eq "Jane Doe"
+        expect(trail[2][:path]).to eq "/admin/users/1"
       end
       it "should have a link to /admin/users/1/posts" do
-        trail[3][:name].should == "Posts"
-        trail[3][:path].should == "/admin/users/1/posts"
+        expect(trail[3][:name]).to eq "Posts"
+        expect(trail[3][:path]).to eq "/admin/users/1/posts"
       end
       it "should have a link to /admin/users/1/posts/1" do
-        trail[4][:name].should == "Hello World"
-        trail[4][:path].should == "/admin/users/1/posts/1"
+        expect(trail[4][:name]).to eq "Hello World"
+        expect(trail[4][:path]).to eq "/admin/users/1/posts/1"
       end
     end
 

--- a/spec/unit/view_helpers/display_name_spec.rb
+++ b/spec/unit/view_helpers/display_name_spec.rb
@@ -11,30 +11,30 @@ describe "display_name" do
           m.to_s
         end
       end.new
-      display_name(r).should eq m.to_s
+      expect(display_name(r)).to eq m.to_s
     end
   end
 
   it "should memeoize the result for the class" do
     subject { Class.new.new }
-    subject.should_receive(:name).twice.and_return "My Name"
-    display_name(subject).should eq "My Name"
-    ActiveAdmin.application.should_not_receive(:display_name_methods)
-    display_name(subject).should eq "My Name"
+    expect(subject).to receive(:name).twice.and_return "My Name"
+    expect(display_name(subject)).to eq "My Name"
+    expect(ActiveAdmin.application).to_not receive(:display_name_methods)
+    expect(display_name(subject)).to eq "My Name"
   end
 
   it "should not call a method if it's an association" do
     subject { Class.new.new }
     subject.stub_chain(:class, :reflect_on_all_associations).and_return [ double(name: :login) ]
     subject.stub :login
-    subject.should_not_receive :login
+    expect(subject).to_not receive :login
     subject.stub(:email).and_return 'foo@bar.baz'
-    display_name(subject).should eq 'foo@bar.baz'
+    expect(display_name(subject)).to eq 'foo@bar.baz'
   end
 
   [nil, false].each do |type|
     it "should return nil when the passed object is #{type.inspect}" do
-      display_name(type).should eq nil
+      expect(display_name(type)).to eq nil
     end
   end
 

--- a/spec/unit/view_helpers/download_format_links_helper_spec.rb
+++ b/spec/unit/view_helpers/download_format_links_helper_spec.rb
@@ -18,17 +18,17 @@ describe ActiveAdmin::ViewHelpers::DownloadFormatLinksHelper do
     end
 
     it "extends the class to add a formats class method that returns the default formats." do
-      Foo.formats.should == [:csv, :xml, :json]
+      expect(Foo.formats).to eq [:csv, :xml, :json]
     end
 
     it "does not let you alter the formats array directly" do
       Foo.formats << :xlsx
-      Foo.formats.should == [:csv, :xml, :json]
+      expect(Foo.formats).to eq [:csv, :xml, :json]
     end
 
     it "allows us to add new formats" do
       Foo.add_format :xlsx
-      Foo.formats.should == [:csv, :xml, :json, :xlsx]
+      expect(Foo.formats).to eq [:csv, :xml, :json, :xlsx]
     end
 
     it "raises an exception if you provide an unregisterd mime type extension" do

--- a/spec/unit/view_helpers/fields_for_spec.rb
+++ b/spec/unit/view_helpers/fields_for_spec.rb
@@ -6,45 +6,45 @@ describe ActiveAdmin::ViewHelpers::FormHelper, ".fields_for" do
   it "should skip :action, :controller and :commit" do
     fields_for_params(
       :scope => "All", :action => "index", :controller => "PostController", :commit => "Filter", :utf8 => "Yes!").
-      should == [ { :scope => "All" } ]
+      should eq [ { :scope => "All" } ]
   end
 
   it "should skip the except" do
     fields_for_params({:scope => "All", :name => "Greg"}, :except => :name).
-      should == [ { :scope => "All" } ]
+      should eq [ { :scope => "All" } ]
   end
 
   it "should allow an array for the except" do
     fields_for_params({:scope => "All", :name => "Greg", :age => "12"}, :except => [:name, :age]).
-      should == [ { :scope => "All" } ]
+      should eq [ { :scope => "All" } ]
   end
 
   it "should work with hashes" do
     params = fields_for_params(:filters => { :name => "John", :age => "12" })
 
-    params.size.should == 2
-    params.should include({"filters[name]" => "John" })
-    params.should include({ "filters[age]" => "12" })
+    expect(params.size).to eq 2
+    expect(params).to include({"filters[name]" => "John" })
+    expect(params).to include({ "filters[age]" => "12" })
   end
 
   it "should work with nested hashes" do
     fields_for_params(:filters => { :user => { :name => "John" }}).
-      should == [ { "filters[user][name]" => "John" } ]
+      should eq [ { "filters[user][name]" => "John" } ]
   end
 
   it "should work with arrays" do
     fields_for_params(:people => ["greg", "emily", "philippe"]).
-      should == [ { "people[]" => "greg" },
+      should eq [ { "people[]" => "greg" },
                   { "people[]" => "emily" },
                   { "people[]" => "philippe" } ]
   end
 
   it "should work with symbols" do
     fields_for_params(:filter => :id).
-      should == [ { :filter => "id" } ]
+      should eq [ { :filter => "id" } ]
   end
 
   it "should work with booleans" do
-    fields_for_params(:booleantest => false).should == [ { :booleantest => false } ]
+    expect(fields_for_params(:booleantest => false)).to eq [ { :booleantest => false } ]
   end
 end

--- a/spec/unit/view_helpers/form_helper_spec.rb
+++ b/spec/unit/view_helpers/form_helper_spec.rb
@@ -8,7 +8,7 @@ describe ActiveAdmin::ViewHelpers::FormHelper do
     let(:default_options) { { builder: ActiveAdmin::FormBuilder } }
 
     it 'calls semantic_form_for with the ActiveAdmin form builder' do
-      view.should_receive(:semantic_form_for).with(resource, builder: ActiveAdmin::FormBuilder)
+      expect(view).to receive(:semantic_form_for).with(resource, builder: ActiveAdmin::FormBuilder)
       view.active_admin_form_for(resource)
     end
 
@@ -16,7 +16,7 @@ describe ActiveAdmin::ViewHelpers::FormHelper do
       # We can't use a stub here because options gets marshalled, and a new
       # instance built. Any constant will work.
       custom_builder = Object
-      view.should_receive(:semantic_form_for).with(resource, builder: custom_builder)
+      expect(view).to receive(:semantic_form_for).with(resource, builder: custom_builder)
       view.active_admin_form_for(resource, builder: custom_builder)
     end
 
@@ -24,12 +24,12 @@ describe ActiveAdmin::ViewHelpers::FormHelper do
       let(:decorated) { double 'decorated_resource', model: resource }
 
       it 'can disable automatic decoration' do
-        view.should_receive(:semantic_form_for).with(resource, default_options.merge(decorate: false))
+        expect(view).to receive(:semantic_form_for).with(resource, default_options.merge(decorate: false))
         view.active_admin_form_for(decorated, decorate: false)
       end
 
       it 'can enable automatic decoration' do
-        view.should_receive(:semantic_form_for).with(decorated, default_options.merge(decorate: true))
+        expect(view).to receive(:semantic_form_for).with(decorated, default_options.merge(decorate: true))
         view.active_admin_form_for(decorated, decorate: true)
       end
     end
@@ -39,16 +39,16 @@ describe ActiveAdmin::ViewHelpers::FormHelper do
     let(:view) { action_view }
 
     it "should render hidden field tags for params" do
-      view.hidden_field_tags_for(:scope => "All", :filter => "None").should ==
+      expect(view.hidden_field_tags_for(:scope => "All", :filter => "None")).to eq \
         %{<input id="hidden_active_admin_scope" name="scope" type="hidden" value="All" />\n<input id="hidden_active_admin_filter" name="filter" type="hidden" value="None" />}
     end
 
     it "should generate not default id for hidden input" do
-      view.hidden_field_tags_for(:scope => "All")[/id="([^"]+)"/, 1].should_not == "scope"
+      expect(view.hidden_field_tags_for(:scope => "All")[/id="([^"]+)"/, 1]).to_not eq "scope"
     end
 
     it "should filter out the field passed via the option :except" do
-      view.hidden_field_tags_for({:scope => "All", :filter => "None"}, :except => :filter).should ==
+      expect(view.hidden_field_tags_for({:scope => "All", :filter => "None"}, :except => :filter)).to eq \
         %{<input id="hidden_active_admin_scope" name="scope" type="hidden" value="All" />}
     end
   end

--- a/spec/unit/view_helpers/method_or_proc_helper_spec.rb
+++ b/spec/unit/view_helpers/method_or_proc_helper_spec.rb
@@ -12,13 +12,11 @@ describe MethodOrProcHelper do
   describe "#call_method_or_exec_proc" do
 
     it "should call the method in the context when a symbol" do
-      context.call_method_or_exec_proc(:receiver_in_context).
-        should == receiver
+      expect(context.call_method_or_exec_proc(:receiver_in_context)).to eq receiver
     end
 
     it "should call the method in the context when a string" do
-      context.call_method_or_exec_proc("receiver_in_context").
-        should == receiver
+      expect(context.call_method_or_exec_proc("receiver_in_context")).to eq receiver
     end
 
     it "should exec a proc in the context" do
@@ -36,17 +34,15 @@ describe MethodOrProcHelper do
     context "when a symbol" do
 
       it 'should call the method on the receiver' do
-        receiver.should_receive(:hello).and_return("hello")
+        expect(receiver).to receive(:hello).and_return("hello")
 
-        context.call_method_or_proc_on(receiver, "hello").
-          should == "hello"
+        expect(context.call_method_or_proc_on(receiver, "hello")).to eq "hello"
       end
 
       it "should receive additional arguments" do
-        receiver.should_receive(:hello).with("world").and_return("hello world")
+        expect(receiver).to receive(:hello).with("world").and_return("hello world")
 
-        context.call_method_or_proc_on(receiver, :hello, "world").
-          should == "hello world"
+        expect(context.call_method_or_proc_on(receiver, :hello, "world")).to eq "hello world"
       end
 
     end

--- a/spec/unit/views/components/action_list_popover_spec.rb
+++ b/spec/unit/views/components/action_list_popover_spec.rb
@@ -12,7 +12,7 @@ describe ActiveAdmin::Views::ActionListPopover do
   end
 
   it "should have an id" do
-    the_popover.id.should == "my_awesome_action_list_popover"
+    expect(the_popover.id).to eq "my_awesome_action_list_popover"
   end
 
   describe "the action list" do
@@ -21,7 +21,6 @@ describe ActiveAdmin::Views::ActionListPopover do
     end
 
     its(:tag_name) { should eql("ul") }
-
     its(:content){ should include("<li><a href=\"#\">My First Great Action</a></li>") }
     its(:content){ should include("<li><a href=\"http://www.google.com\">My Second Great Action</a></li>") }
 

--- a/spec/unit/views/components/attributes_table_spec.rb
+++ b/spec/unit/views/components/attributes_table_spec.rb
@@ -61,17 +61,17 @@ describe ActiveAdmin::Views::AttributesTable do
         let(:table) { instance_eval &table_decleration }
 
         it "should render a div wrapper with the class '.attributes_table'" do
-          table.tag_name.should == 'div'
-          table.attr(:class).should include('attributes_table')
+          expect(table.tag_name).to eq 'div'
+          expect(table.attr(:class)).to include('attributes_table')
         end
 
         it "should add id and type class" do
-          table.class_names.should include("post")
-          table.id.should == "attributes_table_post_1"
+          expect(table.class_names).to include("post")
+          expect(table.id).to eq "attributes_table_post_1"
         end
 
         it "should render 3 rows" do
-          table.find_by_tag("tr").size.should == 3
+          expect(table.find_by_tag("tr").size).to eq 3
         end
 
         describe "rendering the rows" do
@@ -86,10 +86,10 @@ describe ActiveAdmin::Views::AttributesTable do
               let(:current_row){ table.find_by_tag("tr")[i] }
 
               it "should have the title '#{set[0]}'" do
-                current_row.find_by_tag("th").first.content.should == title
+                expect(current_row.find_by_tag("th").first.content).to eq title
               end
               it "should have the content '#{set[1]}'" do
-                current_row.find_by_tag("td").first.content.chomp.strip.should == content
+                expect(current_row.find_by_tag("td").first.content.chomp.strip).to eq content
               end
             end
           end
@@ -105,13 +105,13 @@ describe ActiveAdmin::Views::AttributesTable do
           row :created_at
         end
       }
-      table.find_by_tag("tr").first.to_s.
-        split("\n").first.lstrip.
-          should == '<tr class="row row-title">'
+      expect(table.find_by_tag("tr").first.to_s.
+        split("\n").first.lstrip).
+          to eq '<tr class="row row-title">'
 
-      table.find_by_tag("tr").last.to_s.
-        split("\n").first.lstrip.
-          should == '<tr class="row row-created_at">'
+      expect(table.find_by_tag("tr").last.to_s.
+        split("\n").first.lstrip).
+          to eq '<tr class="row row-created_at">'
     end
 
     it "should allow html options for the row itself" do
@@ -120,9 +120,8 @@ describe ActiveAdmin::Views::AttributesTable do
           row("Wee", :class => "custom_row", :style => "custom_style") { }
         end
       }
-      table.find_by_tag("tr").first.to_s.
-        split("\n").first.lstrip.
-          should == '<tr class="row custom_row" style="custom_style">'
+      expect(table.find_by_tag("tr").first.to_s.split("\n").first.lstrip).
+        to eq '<tr class="row custom_row" style="custom_style">'
     end
 
     it "should allow html content inside the attributes table" do
@@ -131,7 +130,7 @@ describe ActiveAdmin::Views::AttributesTable do
           row("ID"){ span(post.id, :class => 'id') }
         end
       }
-      table.find_by_tag("td").first.content.chomp.strip.should == "<span class=\"id\">1</span>"
+      expect(table.find_by_tag("td").first.content.chomp.strip).to eq "<span class=\"id\">1</span>"
     end
 
     it "should check if an association exists when an attribute has id in it" do
@@ -139,7 +138,7 @@ describe ActiveAdmin::Views::AttributesTable do
       table = render_arbre_component(assigns) {
         attributes_table_for post, :author_id
       }
-      table.find_by_tag('td').first.content.should == 'John Doe'
+      expect(table.find_by_tag('td').first.content).to eq 'John Doe'
     end
 
     context "with a collection" do
@@ -158,38 +157,38 @@ describe ActiveAdmin::Views::AttributesTable do
       end
 
       it "does not set id on the table" do
-        table.attr(:id).should be_nil
+        expect(table.attr(:id)).to be_nil
       end
 
       context "colgroup" do
         let(:cols) { table.find_by_tag "col" }
 
         it "contains a col for each record (plus headers)" do
-          cols.size.should == (2 + 1)
+          expect(cols.size).to eq (2 + 1)
         end
 
         it "assigns an id to each col" do
           cols[1..-1].each_with_index do |col, index|
-            col.id.should == "attributes_table_post_#{index + 1}"
+            expect(col.id).to eq "attributes_table_post_#{index + 1}"
           end
         end
 
         it "assigns a class to each col" do
           cols[1..-1].each_with_index do |col, index|
-            col.class_names.should include("post")
+            expect(col.class_names).to include("post")
           end
         end
 
         it "assigns alternation classes to each col" do
           cols[1..-1].each_with_index do |col, index|
-            col.class_names.should include(["even", "odd"][index % 2])
+            expect(col.class_names).to include(["even", "odd"][index % 2])
           end
         end
       end
 
       context "when rendering the rows" do
         it "should contain 3 columns" do
-          table.find_by_tag("tr").first.children.size.should == 3
+          expect(table.find_by_tag("tr").first.children.size).to eq 3
         end
 
         [
@@ -202,14 +201,14 @@ describe ActiveAdmin::Views::AttributesTable do
             let(:current_row){ table.find_by_tag("tr")[i] }
 
             it "should have the title '#{set[0]}'" do
-              current_row.find_by_tag("th").first.content.should == title
+              expect(current_row.find_by_tag("th").first.content).to eq title
             end
 
             context "with defined attribute name translation" do
               it "should have the translated attribute name in the title" do
                 begin
                   I18n.backend.store_translations(:en, :activerecord => { :attributes => { :post => { :title => 'Translated Title', :id => 'Translated Id' } } })
-                  current_row.find_by_tag("th").first.content.should == "Translated #{title}"
+                  expect(current_row.find_by_tag("th").first.content).to eq "Translated #{title}"
                 ensure
                   I18n.backend.reload!
                 end
@@ -218,7 +217,7 @@ describe ActiveAdmin::Views::AttributesTable do
 
             set[1..-1].each_with_index do |content, index|
               it "column #{index} should have the content '#{content}'" do
-                current_row.find_by_tag("td")[index].content.chomp.strip.should == content
+                expect(current_row.find_by_tag("td")[index].content.chomp.strip).to eq content
               end
             end
           end

--- a/spec/unit/views/components/batch_action_popover_spec.rb
+++ b/spec/unit/views/components/batch_action_popover_spec.rb
@@ -14,7 +14,7 @@ describe ActiveAdmin::BatchActions::BatchActionPopover do
   end
 
   it "should have an id" do
-    the_popover.id.should == "batch_actions_popover"
+    expect(the_popover.id).to eq "batch_actions_popover"
   end
 
   describe "the action list" do

--- a/spec/unit/views/components/columns_spec.rb
+++ b/spec/unit/views/components/columns_spec.rb
@@ -12,16 +12,16 @@ describe ActiveAdmin::Views::Columns do
     end
 
     it "should have the class .columns" do
-      cols.class_list.should include("columns")
+      expect(cols.class_list).to include("columns")
     end
 
     it "should have one column" do
-      cols.children.size.should == 1
-      cols.children.first.class_list.should include("column")
+      expect(cols.children.size).to eq 1
+      expect(cols.children.first.class_list).to include("column")
     end
 
     it "should have one column with the width 100.0%" do
-      cols.children.first.attr(:style).should include("width: 100.0%")
+      expect(cols.children.first.attr(:style)).to include("width: 100.0%")
     end
   end
 
@@ -36,15 +36,15 @@ describe ActiveAdmin::Views::Columns do
     end
 
     it "should have two columns" do
-      cols.children.size.should == 2
+      expect(cols.children.size).to eq 2
     end
 
     it "should have a first column with width 49% and margin 2%" do
-      cols.children.first.attr(:style).should == "width: 49.0%; margin-right: 2%;"
+      expect(cols.children.first.attr(:style)).to eq "width: 49.0%; margin-right: 2%;"
     end
 
     it "should have a second column with width 49% and no right margin" do
-      cols.children.last.attr(:style).should == "width: 49.0%;"
+      expect(cols.children.last.attr(:style)).to eq "width: 49.0%;"
     end
   end
 
@@ -61,18 +61,18 @@ describe ActiveAdmin::Views::Columns do
     end
 
     it "should have four columns" do
-      cols.children.size.should == 4
+      expect(cols.children.size).to eq 4
     end
 
 
     (0..2).to_a.each do |index|
       it "should have column #{index + 1} with width 49% and margin 2%" do
-        cols.children[index].attr(:style).should == "width: 23.5%; margin-right: 2%;"
+        expect(cols.children[index].attr(:style)).to eq "width: 23.5%; margin-right: 2%;"
       end
     end
 
     it "should have column 4 with width 49% and no margin" do
-      cols.children[3].attr(:style).should == "width: 23.5%;"
+      expect(cols.children[3].attr(:style)).to eq "width: 23.5%;"
     end
   end
 
@@ -89,11 +89,11 @@ describe ActiveAdmin::Views::Columns do
     end
 
     it "should set the span when declared" do
-      cols.children.first.attr(:style).should == "width: 49.0%; margin-right: 2%;"
+      expect(cols.children.first.attr(:style)).to eq "width: 49.0%; margin-right: 2%;"
     end
 
     it "should default to 1 if not passed in" do
-      cols.children.last.attr(:style).should == "width: 23.5%;"
+      expect(cols.children.last.attr(:style)).to eq "width: 23.5%;"
     end
   end
 
@@ -109,11 +109,11 @@ describe ActiveAdmin::Views::Columns do
     end
 
     it "should set the max with if passed in" do
-      cols.children.first.attr(:style).should == "width: 49.0%; max-width: 100px; margin-right: 2%;"
+      expect(cols.children.first.attr(:style)).to eq "width: 49.0%; max-width: 100px; margin-right: 2%;"
     end
 
     it "should omit the value if not presetn" do
-      cols.children.last.attr(:style).should == "width: 49.0%;"
+      expect(cols.children.last.attr(:style)).to eq "width: 49.0%;"
     end
 
   end
@@ -130,11 +130,11 @@ describe ActiveAdmin::Views::Columns do
     end
 
     it "should set the min with if passed in" do
-      cols.children.first.attr(:style).should == "width: 49.0%; min-width: 100px; margin-right: 2%;"
+      expect(cols.children.first.attr(:style)).to eq "width: 49.0%; min-width: 100px; margin-right: 2%;"
     end
 
     it "should omit the value if not presetn" do
-      cols.children.last.attr(:style).should == "width: 49.0%;"
+      expect(cols.children.last.attr(:style)).to eq "width: 49.0%;"
     end
 
   end

--- a/spec/unit/views/components/index_list_spec.rb
+++ b/spec/unit/views/components/index_list_spec.rb
@@ -20,13 +20,13 @@ describe ActiveAdmin::Views::IndexList do
       end
     end
 
-    its(:tag_name) { should == 'ul' }
+    its(:tag_name) { should eq 'ul'}
 
     it "should contain the names of available indexes in links" do
       a_tags = subject.find_by_tag("a")
-      a_tags.size.should == 2
-      a_tags.first.to_s.should include("Table")
-      a_tags.last.to_s.should include("List")
+      expect(a_tags.size).to eq 2
+      expect(a_tags.first.to_s).to include("Table")
+      expect(a_tags.last.to_s).to include("List")
     end
   end
 end

--- a/spec/unit/views/components/paginated_collection_spec.rb
+++ b/spec/unit/views/components/paginated_collection_spec.rb
@@ -37,7 +37,7 @@ describe ActiveAdmin::Views::PaginatedCollection do
       end
 
       it "should set :collection as the passed in collection" do
-        pagination.find_by_class('pagination_information').first.content.should == "Displaying <b>all 3</b> posts"
+        expect(pagination.find_by_class('pagination_information').first.content).to eq "Displaying <b>all 3</b> posts"
       end
 
       it "should raise error if collection has no pagination scope" do
@@ -56,7 +56,7 @@ describe ActiveAdmin::Views::PaginatedCollection do
       let(:pagination) { paginated_collection(collection, :param_name => :post_page) }
 
       it "should customize the page number parameter in pagination links" do
-        pagination.children.last.content.should match(/\/admin\/posts\?post_page=2/)
+        expect(pagination.children.last.content).to match(/\/admin\/posts\?post_page=2/)
       end
     end
 
@@ -69,7 +69,7 @@ describe ActiveAdmin::Views::PaginatedCollection do
       let(:pagination) { paginated_collection(collection, :download_links => false) }
 
       it "should not render download links" do
-        pagination.find_by_tag('div').last.content.should_not match(/Download:/)
+        expect(pagination.find_by_tag('div').last.content).to_not match(/Download:/)
       end
     end
 
@@ -82,7 +82,7 @@ describe ActiveAdmin::Views::PaginatedCollection do
       let(:pagination) { paginated_collection(collection, :entry_name => "message") }
 
       it "should use :entry_name as the collection name" do
-        pagination.find_by_class('pagination_information').first.content.should == "Displaying <b>1</b> message"
+        expect(pagination.find_by_class('pagination_information').first.content).to eq "Displaying <b>1</b> message"
       end
     end
 
@@ -90,7 +90,7 @@ describe ActiveAdmin::Views::PaginatedCollection do
       let(:pagination) { paginated_collection(collection, :entry_name => "message") }
 
       it "should use :entry_name as the collection name" do
-        pagination.find_by_class('pagination_information').first.content.should == "Displaying <b>all 3</b> messages"
+        expect(pagination.find_by_class('pagination_information').first.content).to eq "Displaying <b>all 3</b> messages"
       end
     end
 
@@ -103,7 +103,7 @@ describe ActiveAdmin::Views::PaginatedCollection do
       let(:pagination) { paginated_collection(collection, :entry_name => "singular", :entries_name => "plural") }
 
       it "should use :entry_name as the collection name" do
-        pagination.find_by_class('pagination_information').first.content.should == "Displaying <b>1</b> singular"
+        expect(pagination.find_by_class('pagination_information').first.content).to eq "Displaying <b>1</b> singular"
       end
     end
 
@@ -111,7 +111,7 @@ describe ActiveAdmin::Views::PaginatedCollection do
       let(:pagination) { paginated_collection(collection, :entry_name => "singular", :entries_name => "plural") }
 
       it "should use :entries_name as the collection name" do
-        pagination.find_by_class('pagination_information').first.content.should == "Displaying <b>all 3</b> plural"
+        expect(pagination.find_by_class('pagination_information').first.content).to eq "Displaying <b>all 3</b> plural"
       end
     end
 
@@ -124,12 +124,12 @@ describe ActiveAdmin::Views::PaginatedCollection do
       let(:pagination) { paginated_collection(collection) }
 
       it "should use 'post' as the collection name when there is no I18n translation" do
-        pagination.find_by_class('pagination_information').first.content.should == "Displaying <b>1</b> post"
+        expect(pagination.find_by_class('pagination_information').first.content).to eq "Displaying <b>1</b> post"
       end
 
       it "should use 'Singular' as the collection name when there is an I18n translation" do
         I18n.stub(:translate) { "Singular" }
-        pagination.find_by_class('pagination_information').first.content.should == "Displaying <b>1</b> Singular"
+        expect(pagination.find_by_class('pagination_information').first.content).to eq "Displaying <b>1</b> Singular"
       end
     end
 
@@ -137,12 +137,12 @@ describe ActiveAdmin::Views::PaginatedCollection do
       let(:pagination) { paginated_collection(collection) }
 
       it "should use 'posts' as the collection name when there is no I18n translation" do
-        pagination.find_by_class('pagination_information').first.content.should == "Displaying <b>all 3</b> posts"
+        expect(pagination.find_by_class('pagination_information').first.content).to eq "Displaying <b>all 3</b> posts"
       end
 
       it "should use 'Plural' as the collection name when there is an I18n translation" do
         I18n.stub(:translate) { "Plural" }
-        pagination.find_by_class('pagination_information').first.content.should == "Displaying <b>all 3</b> Plural"
+        expect(pagination.find_by_class('pagination_information').first.content).to eq "Displaying <b>all 3</b> Plural"
       end
     end
 
@@ -155,7 +155,7 @@ describe ActiveAdmin::Views::PaginatedCollection do
       let(:pagination) { paginated_collection(collection) }
 
       it "should display 'No entries found'" do
-        pagination.find_by_class('pagination_information').first.content.should == "No entries found"
+        expect(pagination.find_by_class('pagination_information').first.content).to eq "No entries found"
       end
     end
 
@@ -168,7 +168,7 @@ describe ActiveAdmin::Views::PaginatedCollection do
       let(:pagination) { paginated_collection(collection) }
 
       it "should display proper message (including number and not hash)" do
-        pagination.find_by_class('pagination_information').first.content.should == "Displaying <b>all 2</b> posts"
+        expect(pagination.find_by_class('pagination_information').first.content).to eq "Displaying <b>all 2</b> posts"
       end
     end
 
@@ -181,8 +181,8 @@ describe ActiveAdmin::Views::PaginatedCollection do
       let(:pagination) { paginated_collection(collection) }
 
       it "should display proper message (including number and not hash)" do
-        pagination.find_by_class('pagination_information').first.content.
-          gsub('&nbsp;',' ').should == "Displaying posts <b>1 - 2</b> of <b>3</b> in total"
+        expect(pagination.find_by_class('pagination_information').first.content.gsub('&nbsp;',' ')).
+          to eq "Displaying posts <b>1 - 2</b> of <b>3</b> in total"
       end
     end
 
@@ -194,8 +194,8 @@ describe ActiveAdmin::Views::PaginatedCollection do
       let(:pagination) { paginated_collection(collection) }
 
       it "should show the proper item counts" do
-        pagination.find_by_class('pagination_information').first.content.
-            gsub('&nbsp;',' ').should == "Displaying posts <b>61 - 81</b> of <b>81</b> in total"
+        expect(pagination.find_by_class('pagination_information').first.content.gsub('&nbsp;',' ')).
+          to eq "Displaying posts <b>61 - 81</b> of <b>81</b> in total"
       end
     end
 
@@ -209,7 +209,7 @@ describe ActiveAdmin::Views::PaginatedCollection do
 
         it "should not show the total item counts" do
           info = pagination.find_by_class('pagination_information').first.content.gsub('&nbsp;',' ')
-          info.should eq "Displaying posts <b>1 - 30</b>"
+          expect(info).to eq "Displaying posts <b>1 - 30</b>"
         end
       end
 
@@ -218,7 +218,7 @@ describe ActiveAdmin::Views::PaginatedCollection do
 
         it "should show the total item counts" do
           info = pagination.find_by_class('pagination_information').first.content.gsub('&nbsp;',' ')
-          info.should eq "Displaying posts <b>1 - 30</b> of <b>256</b> in total"
+          expect(info).to eq "Displaying posts <b>1 - 30</b> of <b>256</b> in total"
         end
       end
     end

--- a/spec/unit/views/components/panel_spec.rb
+++ b/spec/unit/views/components/panel_spec.rb
@@ -11,22 +11,22 @@ describe ActiveAdmin::Views::Panel do
   end
 
   it "should have a title h3" do
-    the_panel.find_by_tag("h3").first.content.should == "My Title"
+    expect(the_panel.find_by_tag("h3").first.content).to eq "My Title"
   end
 
   it "should have a contents div" do
-    the_panel.find_by_tag("div").first.class_list.should include("panel_contents")
+    expect(the_panel.find_by_tag("div").first.class_list).to include("panel_contents")
   end
 
   it "should add children to the contents div" do
-    the_panel.find_by_tag("span").first.parent.should == the_panel.find_by_tag("div").first
+    expect(the_panel.find_by_tag("span").first.parent).to eq the_panel.find_by_tag("div").first
   end
 
   it "should set the icon" do
     the_panel = render_arbre_component do
       panel("Title", :icon => :arrow_down)
     end
-    the_panel.find_by_tag("h3").first.content.should include("span class=\"icon")
+    expect(the_panel.find_by_tag("h3").first.content).to include("span class=\"icon")
   end
 
   it "should allow a html_safe title (without icon)" do
@@ -34,7 +34,7 @@ describe ActiveAdmin::Views::Panel do
     the_panel = render_arbre_component do
       panel(title_with_html)
     end
-    the_panel.find_by_tag("h3").first.content.should eq(title_with_html)
+    expect(the_panel.find_by_tag("h3").first.content).to eq(title_with_html)
   end
 
   describe "#children?" do
@@ -43,7 +43,7 @@ describe ActiveAdmin::Views::Panel do
       the_panel = render_arbre_component do
         panel("A Panel")
       end
-      the_panel.children?.should == false
+      expect(the_panel.children?).to eq false
     end
 
   end

--- a/spec/unit/views/components/popover_spec.rb
+++ b/spec/unit/views/components/popover_spec.rb
@@ -11,23 +11,23 @@ describe ActiveAdmin::Views::Popover do
   end
 
   it "should have the class of 'sidebar_section'" do
-    the_popover.class_list.should include("popover")
+    expect(the_popover.class_list).to include("popover")
   end
 
   it "should have an inner content element class of 'popover_contents'" do
-    the_popover.find_by_tag("div").first.class_list.should include("popover_contents")
+    expect(the_popover.find_by_tag("div").first.class_list).to include("popover_contents")
   end
 
   it "should have the popover content in the inner content element" do
-    the_popover.find_by_class("popover_contents").first.content.should include("Hello World, this is popover content baby.")
+    expect(the_popover.find_by_class("popover_contents").first.content).to include("Hello World, this is popover content baby.")
   end
 
   it "should have an id" do
-    the_popover.id.should == "my_awesome_popover"
+    expect(the_popover.id).to eq "my_awesome_popover"
   end
 
   it "should be hidden" do
-    the_popover.attributes.should include(:style => "display: none");
+    expect(the_popover.attributes).to include(:style => "display: none");
   end
 
 end

--- a/spec/unit/views/components/sidebar_section_spec.rb
+++ b/spec/unit/views/components/sidebar_section_spec.rb
@@ -15,23 +15,23 @@ describe ActiveAdmin::Views::SidebarSection do
   end
 
   it "should have a title h3" do
-    html.find_by_tag("h3").first.content.should == "Help Section"
+    expect(html.find_by_tag("h3").first.content).to eq "Help Section"
   end
 
   it "should have the class of 'sidebar_section'" do
-    html.class_list.should include("sidebar_section")
+    expect(html.class_list).to include("sidebar_section")
   end
 
   it "should have an id based on the title" do
-    html.id.should == "help-section_sidebar_section"
+    expect(html.id).to eq "help-section_sidebar_section"
   end
 
   it "should have a contents div" do
-    html.find_by_tag("div").first.class_list.should include("panel_contents")
+    expect(html.find_by_tag("div").first.class_list).to include("panel_contents")
   end
 
   it "should add children to the contents div" do
-    html.find_by_tag("span").first.parent.should == html.find_by_tag("div").first
+    expect(html.find_by_tag("span").first.parent).to eq html.find_by_tag("div").first
   end
 
 end

--- a/spec/unit/views/components/site_title_spec.rb
+++ b/spec/unit/views/components/site_title_spec.rb
@@ -18,18 +18,18 @@ describe ActiveAdmin::Views::SiteTitle do
                          site_title_link: nil
 
       site_title = build_title(namespace)
-      site_title.content.should eq "Hello World"
+      expect(site_title.content).to eq "Hello World"
     end
 
     it "renders the return value of a method when a symbol" do
-      helpers.should_receive(:hello_world).and_return("Hello World")
+      expect(helpers).to receive(:hello_world).and_return("Hello World")
 
       namespace = double site_title: :hello_world,
                          site_title_image: nil,
                          site_title_link: nil
 
       site_title = build_title(namespace)
-      site_title.content.should eq "Hello World"
+      expect(site_title.content).to eq "Hello World"
     end
 
     it "renders the return value of a proc" do
@@ -38,7 +38,7 @@ describe ActiveAdmin::Views::SiteTitle do
                          site_title_link: nil
 
       site_title = build_title(namespace)
-      site_title.content.should eq "Hello World"
+      expect(site_title.content).to eq "Hello World"
     end
 
   end
@@ -46,7 +46,7 @@ describe ActiveAdmin::Views::SiteTitle do
   context "when an image" do
 
     it "renders the string when a string is passed in" do
-      helpers.should_receive(:image_tag).
+      expect(helpers).to receive(:image_tag).
         with("an/image.png", alt: nil, id: "site_title_image").
         and_return '<img src="/assets/an/image.png" />'.html_safe
 
@@ -55,7 +55,7 @@ describe ActiveAdmin::Views::SiteTitle do
                          site_title_link: nil
 
       site_title = build_title(namespace)
-      site_title.content.strip.should eq '<img src="/assets/an/image.png" />'
+      expect(site_title.content.strip).to eq '<img src="/assets/an/image.png" />'
     end
 
   end
@@ -68,7 +68,7 @@ describe ActiveAdmin::Views::SiteTitle do
                          site_title_link: "/"
 
       site_title = build_title(namespace)
-      site_title.content.should eq '<a href="/">Hello World</a>'
+      expect(site_title.content).to eq '<a href="/">Hello World</a>'
     end
 
   end

--- a/spec/unit/views/components/status_tag_spec.rb
+++ b/spec/unit/views/components/status_tag_spec.rb
@@ -14,44 +14,44 @@ describe ActiveAdmin::Views::StatusTag do
     subject { status_tag(nil) }
 
 
-    its(:tag_name)    { should == 'span' }
+    its(:tag_name)    { should eq 'span' }
     its(:class_list)  { should include('status_tag') }
 
     context "when status is 'completed'" do
       subject { status_tag('completed') }
 
-      its(:tag_name)    { should == 'span' }
+      its(:tag_name)    { should eq 'span' }
       its(:class_list)  { should include('status_tag') }
       its(:class_list)  { should include('completed') }
-      its(:content)     { should == 'Completed' }
+      its(:content)     { should eq 'Completed' }
     end
 
     context "when status is 'in_progress'" do
       subject { status_tag('in_progress') }
 
       its(:class_list)  { should include('in_progress') }
-      its(:content)     { should == 'In Progress' }
+      its(:content)     { should eq 'In Progress' }
     end
 
     context "when status is 'In progress'" do
       subject { status_tag('In progress') }
 
       its(:class_list)  { should include('in_progress') }
-      its(:content)     { should == 'In Progress' }
+      its(:content)     { should eq 'In Progress' }
     end
 
     context "when status is an empty string" do
       subject { status_tag('') }
 
       its(:class_list)  { should include('status_tag') }
-      its(:content)     { should == '' }
+      its(:content)     { should eq '' }
     end
 
     context "when status is nil" do
       subject { status_tag(nil) }
 
       its(:class_list)  { should include('status_tag') }
-      its(:content)     { should == '' }
+      its(:content)     { should eq '' }
     end
 
     context "when status is 'Active' and type is :ok" do
@@ -73,7 +73,7 @@ describe ActiveAdmin::Views::StatusTag do
     context "when status is 'Active' and label is 'on'" do
       subject { status_tag('Active', :label => 'on') }
 
-      its(:content)     { should == 'on' }
+      its(:content)     { should eq 'on' }
       its(:class_list)  { should include('status_tag') }
       its(:class_list)  { should include('active') }
       its(:class_list)  { should_not include('on') }
@@ -82,13 +82,13 @@ describe ActiveAdmin::Views::StatusTag do
     context "when status is 'So useless', type is :ok, class is 'woot awesome' and id is 'useless'" do
       subject { status_tag('So useless', :ok, :class => 'woot awesome', :id => 'useless') }
 
-      its(:content)     { should == 'So Useless' }
+      its(:content)     { should eq 'So Useless' }
       its(:class_list)  { should include('status_tag') }
       its(:class_list)  { should include('ok') }
       its(:class_list)  { should include('so_useless') }
       its(:class_list)  { should include('woot') }
       its(:class_list)  { should include('awesome') }
-      its(:id)          { should == 'useless' }
+      its(:id)          { should eq 'useless' }
     end
 
   end # describe "#status_tag"

--- a/spec/unit/views/components/table_for_spec.rb
+++ b/spec/unit/views/components/table_for_spec.rb
@@ -20,16 +20,16 @@ describe ActiveAdmin::Views::TableFor do
       end
 
       it "should create a table header based on the symbol" do
-        table.find_by_tag("th").first.content.should == "Title"
+        expect(table.find_by_tag("th").first.content).to eq "Title"
       end
 
       it "should create a table row for each element in the collection" do
-        table.find_by_tag("tr").size.should == 4 # 1 for head, 3 for rows
+        expect(table.find_by_tag("tr").size).to eq 4 # 1 for head, 3 for rows
       end
 
       ["First Post", "Second Post", "Third Post"].each_with_index do |content, index|
         it "should create a cell with #{content}" do
-          table.find_by_tag("td")[index].content.should == content
+          expect(table.find_by_tag("td")[index].content).to eq content
         end
       end
     end
@@ -45,30 +45,26 @@ describe ActiveAdmin::Views::TableFor do
       end
 
       it "should create a table header based on the symbol" do
-        table.find_by_tag("th").first.content.should == "Title"
-        table.find_by_tag("th").last.content.should == "Created At"
+        expect(table.find_by_tag("th").first.content).to eq "Title"
+        expect(table.find_by_tag("th").last.content).to eq "Created At"
       end
 
       it "should add a class to each table header based on the col name" do
-        table.find_by_tag("th").first
-          .class_list.to_a.join(' ').should == "col col-title"
-        table.find_by_tag("th").last
-          .class_list.to_a.join(' ').should  == "col col-created_at"
+        expect(table.find_by_tag("th").first.class_list.to_a.join(' ')).to eq "col col-title"
+        expect(table.find_by_tag("th").last.class_list.to_a.join(' ')).to eq "col col-created_at"
       end
 
       it "should create a table row for each element in the collection" do
-        table.find_by_tag("tr").size.should == 4 # 1 for head, 3 for rows
+        expect(table.find_by_tag("tr").size).to eq 4 # 1 for head, 3 for rows
       end
 
       it "should create a cell for each column" do
-        table.find_by_tag("td").size.should == 6
+        expect(table.find_by_tag("td").size).to eq 6
       end
 
       it "should add a class for each cell based on the col name" do
-        table.find_by_tag("td").first
-          .class_list.to_a.join(' ').should  == "col col-title"
-        table.find_by_tag("td").last
-          .class_list.to_a.join(' ').should  == "col col-created_at"
+        expect(table.find_by_tag("td").first.class_list.to_a.join(' ')).to eq "col col-title"
+        expect(table.find_by_tag("td").last.class_list.to_a.join(' ')).to eq "col col-created_at"
       end
     end
 
@@ -84,14 +80,14 @@ describe ActiveAdmin::Views::TableFor do
       end
 
       it "should add a class to each table header based on the col name" do
-        table.find_by_tag("th").first.class_list.should include("col-title")
+        expect(table.find_by_tag("th").first.class_list).to include("col-title")
       end
 
       [ "<span>First Post</span>",
         "<span>Second Post</span>",
         "<span>Third Post</span>" ].each_with_index do |content, index|
         it "should create a cell with #{content}" do
-          table.find_by_tag("td")[index].content.strip.should == content
+          expect(table.find_by_tag("td")[index].content.strip).to eq content
         end
       end
     end
@@ -110,7 +106,7 @@ describe ActiveAdmin::Views::TableFor do
 
       3.times do |index|
         it "should create a cell with multiple elements in row #{index}" do
-          table.find_by_tag("td")[index].find_by_tag("span").size.should == 2
+          expect(table.find_by_tag("td")[index].find_by_tag("span").size).to eq 2
         end
       end
     end
@@ -128,17 +124,13 @@ describe ActiveAdmin::Views::TableFor do
 
 
       it "should add a class to each table header  based on class option or the col name" do
-        table.find_by_tag("th").first
-          .class_list.to_a.join(' ').should  == "col col-my_custom_title"
-        table.find_by_tag("th").last
-          .class_list.to_a.join(' ').should  == "col datetime"
+        expect(table.find_by_tag("th").first.class_list.to_a.join(' ')).to eq "col col-my_custom_title"
+        expect(table.find_by_tag("th").last.class_list.to_a.join(' ')).to eq "col datetime"
       end
 
       it "should add a class to each cell based  on class option or the col name" do
-        table.find_by_tag("td").first
-          .class_list.to_a.join(' ').should  == "col col-my_custom_title"
-        table.find_by_tag("td").last
-          .class_list.to_a.join(' ').should  == "col datetime"
+        expect(table.find_by_tag("td").first.class_list.to_a.join(' ')).to eq "col col-my_custom_title"
+        expect(table.find_by_tag("td").last.class_list.to_a.join(' ')).to eq "col datetime"
       end
     end
 
@@ -151,7 +143,7 @@ describe ActiveAdmin::Views::TableFor do
         end
       end
       it "should render" do
-        table.find_by_tag("th").first.content.should == "Title"
+        expect(table.find_by_tag("th").first.content).to eq "Title"
       end
     end
 
@@ -197,5 +189,6 @@ describe ActiveAdmin::Views::TableFor do
       let(:table_column){ build_column("Category", :category, Post) }
       it { should_not be_sortable }
     end
+
   end
 end

--- a/spec/unit/views/pages/form_spec.rb
+++ b/spec/unit/views/pages/form_spec.rb
@@ -21,14 +21,14 @@ describe ActiveAdmin::Views::Pages::Form do
       it "should show the set page title" do
         arbre_context.assigns[:page_title] = "My Page Title"
         page = ActiveAdmin::Views::Pages::Form.new(arbre_context)
-        page.title.should eq "My Page Title"
+        expect(page.title).to eq "My Page Title"
       end
     end
 
     context "when page_title is not assigned" do
       it "should show the correct I18n text" do
         page = ActiveAdmin::Views::Pages::Form.new(arbre_context)
-        page.title.should eq "Edit Post"
+        expect(page.title).to eq "Edit Post"
       end
     end
   end

--- a/spec/unit/views/pages/layout_spec.rb
+++ b/spec/unit/views/pages/layout_spec.rb
@@ -39,23 +39,23 @@ describe ActiveAdmin::Views::Pages::Layout do
   it "should be the @page_title if assigned in the controller" do
     assigns[:page_title] = "My Page Title"
 
-    layout.title.should == "My Page Title"
+    expect(layout.title).to eq "My Page Title"
   end
 
   it "should be the default translation" do
     helpers.params[:action] = "edit"
 
-    layout.title.should == "Edit"
+    expect(layout.title).to eq "Edit"
   end
 
   describe "the body" do
 
     it "should have class 'active_admin'" do
-      layout.build.class_list.should include 'active_admin'
+      expect(layout.build.class_list).to include 'active_admin'
     end
 
     it "should have namespace class" do
-      layout.build.class_list.should include "#{active_admin_namespace.name}_namespace"
+      expect(layout.build.class_list).to include "#{active_admin_namespace.name}_namespace"
     end
 
   end

--- a/spec/unit/views/pages/show_spec.rb
+++ b/spec/unit/views/pages/show_spec.rb
@@ -11,7 +11,7 @@ describe ActiveAdmin::Views::Pages::Show do
 
       it "normally returns the resource" do
         page = ActiveAdmin::Views::Pages::Show.new(arbre_context)
-        page.resource.should == 'Test Resource'
+        expect(page.resource).to eq 'Test Resource'
       end
     end
 

--- a/spec/unit/views/tabbed_navigation_spec.rb
+++ b/spec/unit/views/tabbed_navigation_spec.rb
@@ -51,62 +51,62 @@ describe ActiveAdmin::Views::TabbedNavigation do
     end
 
     it "should generate a ul" do
-      html.should have_tag("ul")
+      expect(html).to have_tag("ul")
     end
 
     it "should generate an li for each item" do
-      html.should have_tag("li", :parent => { :tag => "ul" })
+      expect(html).to have_tag("li", :parent => { :tag => "ul" })
     end
 
     it "should generate a link for each item" do
-      html.should have_tag("a", "Blog Posts", :attributes => { :href => '/admin/posts' })
+      expect(html).to have_tag("a", "Blog Posts", :attributes => { :href => '/admin/posts' })
     end
 
     it "should generate a nested list for children" do
-      html.should have_tag("ul", :parent => { :tag => "li" })
+      expect(html).to have_tag("ul", :parent => { :tag => "li" })
     end
 
     it "should generate a nested list with li for each child" do
-      html.should have_tag("li", :parent => { :tag => "ul" }, :attributes => {:id => "a_sub_reports"})
-      html.should have_tag("li", :parent => { :tag => "ul" }, :attributes => {:id => "b_sub_reports"})
+      expect(html).to have_tag("li", :parent => { :tag => "ul" }, :attributes => {:id => "a_sub_reports"})
+      expect(html).to have_tag("li", :parent => { :tag => "ul" }, :attributes => {:id => "b_sub_reports"})
     end
 
     it "should generate a valid id from a label proc" do
-      html.should have_tag("li", :parent => { :tag => "ul" }, :attributes => {:id => "label_proc_sub_reports"})
+      expect(html).to have_tag("li", :parent => { :tag => "ul" }, :attributes => {:id => "label_proc_sub_reports"})
     end
 
     it "should not generate a link for user administration" do
-      html.should_not have_tag("a", "User administration", :attributes => { :href => '/admin/user-administration' })
+      expect(html).to_not have_tag("a", "User administration", :attributes => { :href => '/admin/user-administration' })
     end
 
     it "should generate the administration parent menu" do
-      html.should have_tag("a", "Administration", :attributes => { :href => '/admin/administration' })
+      expect(html).to have_tag("a", "Administration", :attributes => { :href => '/admin/administration' })
     end
 
     it "should not generate a link for order management" do
-      html.should_not have_tag("a", "Order management", :attributes => { :href => '/admin/order-management' })
+      expect(html).to_not have_tag("a", "Order management", :attributes => { :href => '/admin/order-management' })
     end
 
     it "should not generate a link for bill management" do
-      html.should_not have_tag("a", "Bill management", :attributes => { :href => '/admin/bill-management' })
+      expect(html).to_not have_tag("a", "Bill management", :attributes => { :href => '/admin/bill-management' })
     end
 
     it "should not generate the management parent menu" do
-      html.should_not have_tag("a", "Management", :attributes => { :href => '#' })
+      expect(html).to_not have_tag("a", "Management", :attributes => { :href => '#' })
     end
 
     describe "marking current item" do
 
       it "should add the 'current' class to the li" do
         assigns[:current_tab] = menu["Blog Posts"]
-        html.should have_tag("li", :attributes => { :class => "current" })
+        expect(html).to have_tag("li", :attributes => { :class => "current" })
       end
 
       it "should add the 'current' and 'has_nested' classes to the li and 'current' to the sub li" do
         assigns[:current_tab] = menu["Reports"]["A Sub Reports"]
-        html.should have_tag("li", :attributes => { :id => "reports", :class => /current/ })
-        html.should have_tag("li", :attributes => { :id => "reports", :class => /has_nested/ })
-        html.should have_tag("li", :attributes => { :id => "a_sub_reports", :class => "current" })
+        expect(html).to have_tag("li", :attributes => { :id => "reports", :class => /current/ })
+        expect(html).to have_tag("li", :attributes => { :id => "reports", :class => /has_nested/ })
+        expect(html).to have_tag("li", :attributes => { :id => "a_sub_reports", :class => "current" })
       end
 
     end
@@ -117,24 +117,24 @@ describe ActiveAdmin::Views::TabbedNavigation do
 
     it "should return one item with no if block" do
       menu.add :label => "Hello World", :url => "/"
-      tabbed_navigation.menu_items.should == menu.items
+      expect(tabbed_navigation.menu_items).to eq menu.items
     end
 
     it "should not include menu items with an if block that returns false" do
       menu.add :label => "Don't Show", :url => "/", :priority => 10, :if => proc{ false }
-      tabbed_navigation.menu_items.should be_empty
+      expect(tabbed_navigation.menu_items).to be_empty
     end
 
     it "should not include menu items with an if block that calls a method that returns false" do
       menu.add :label => "Don't Show", :url => "/", :priority => 10, :if => :admin_logged_in?
-      tabbed_navigation.menu_items.should be_empty
+      expect(tabbed_navigation.menu_items).to be_empty
     end
 
     it "should not display any items that have no children to display" do
       menu.add :label => "Parent", :url => "#" do |p|
         p.add :label => "Child", :url => "/", :priority => 10, :if => proc{ false }
       end
-      tabbed_navigation.menu_items.should be_empty
+      expect(tabbed_navigation.menu_items).to be_empty
     end
 
     it "should display a parent that has a child to display" do
@@ -142,7 +142,7 @@ describe ActiveAdmin::Views::TabbedNavigation do
         p.add :label => "Hidden Child", :url => "/", :priority => 10, :if => proc{ false }
         p.add :label => "Child", :url => "/"
       end
-      tabbed_navigation.should have(1).menu_items
+      expect(tabbed_navigation).to have(1).menu_items
     end
 
   end


### PR DESCRIPTION
As you may well know, using 'expect' over 'should' is a recommended practice because of dealing with delegate/proxy objects as detailed in http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax.
As detailed in the blog post "In the future, we plan to change the defaults so that only expect is available unless you explicitly enable should. We may do this as soon as RSpec 3.0, but we want to give users plenty of time to get acquianted with it."
I'm seeing many other newer and updated gems adopt it and I thought you might like to consider it for active admin.
There wasn't an easy replacement for the "its" one liners so I have left many of them.
Sorry for the relatively large branch.
All tests pass.  Feel free to change of course.
