### PR TITLE
Fix wrong fieldset detection for a nested form fields

### DIFF
--- a/app/assets/javascripts/active_admin/components/has_many.js.coffee
+++ b/app/assets/javascripts/active_admin/components/has_many.js.coffee
@@ -32,7 +32,7 @@ $ ->
     parent.trigger before_add = $.Event 'has_many_add:before'
 
     unless before_add.isDefaultPrevented()
-      index = parent.data('has_many_index') || parent.children('fieldset').length - 1
+      index = parent.data('has_many_index') || parent.find('fieldset').length - 1
       parent.data has_many_index: ++index
 
       regex = new RegExp elem.data('placeholder'), 'g'


### PR DESCRIPTION
Hi. Here is small patch to fix wrong fieldset count detection for a nested form fields.
Here are steps to reproduce current bug(still exists):
1. Create active admin resource for a model with has_many relation
2. Add nested form fields.

```
form do |f|
  f.inputs "Car Details" do
    f.input :automaker
    f.input :title
    f.inputs do
      f.has_many :tags, heading: 'Tags', allow_destroy: true do |t|
        t.input :title
      end
    end
  end
  f.actions
end
```
1. Create a new record with some nested records with active admin. (A car with some tags in my case)
2. Go to edit page for this record
3. Click 'Add New Tag' button. It will create new fieldset with wrong NEW_TAG_RECORD (equals 0)
4. Click 'Save'
5. Created nested record _replaces_ first one.
