### PR TITLE
Fix css for tab menu dropdown with multiple menu rows

### DIFF
--- a/app/assets/stylesheets/active_admin/_header.css.scss
+++ b/app/assets/stylesheets/active_admin/_header.css.scss
@@ -101,7 +101,7 @@
       ul {
         background: $hover-menu-item-background;
         @include rounded-all(0,10px,10px,10px);
-        @include shadow(0, 1px, 3px, #444);
+        @include shadow(0, 1px, 2px, #444);
         position: absolute;
         width: 175px;
         margin-top: 5px;
@@ -109,7 +109,7 @@
         display: none;
         padding: 3px 0px 5px 0;
         list-style: none;
-        z-index: 1010;
+        z-index: 1060;
 
         li {
           margin: 0px;


### PR DESCRIPTION
Case:
 ![](https://photos-1.dropbox.com/t/0/AABkETNza2Qjr0Oy08eX5UIT6xACJYgYn_xzBPAmOz0lkw/12/11190302/png/1024x768/3/1384516800/0/2/Screenshot%202013-11-15%2014.06.57.png/F6kalYkrygcDwUEXcrhq3x6YHJ-waFdDYx5aTiQ-SSA)
