### PR TITLE
Ensure undecorated object assign for comment's resource_type

### DIFF
--- a/lib/active_admin/orm/active_record/comments/comment.rb
+++ b/lib/active_admin/orm/active_record/comments/comment.rb
@@ -13,7 +13,8 @@ module ActiveAdmin
     before_create :set_resource_type
 
     # @returns [String] The name of the record to use for the polymorphic relationship
-    def self.resource_type(record)
+    def self.resource_type(resource)
+      record = resource.respond_to?(:decorated?) && resource.decorated? ? resource.model : resource
       record.class.name.to_s
     end
 

--- a/spec/unit/comments_spec.rb
+++ b/spec/unit/comments_spec.rb
@@ -6,7 +6,7 @@ describe "Comments" do
   describe ActiveAdmin::Comment do
     subject(:comment){ ActiveAdmin::Comment.new }
 
-    it "Has valid Associations and Validations" do
+    it "has valid Associations and Validations" do
       expect(comment).to belong_to :resource
       expect(comment).to belong_to :author
       expect(comment).to validate_presence_of :resource
@@ -50,6 +50,29 @@ describe "Comments" do
       end
     end
 
+    describe ".resource_type" do
+      let(:post) { Post.create!(:title => "Testing.") }
+      let(:post_decorator) { double 'PostDecorator' }
+
+      before { post_decorator.stub :model => post, :decorated? => true }
+
+      context "when a decorated object is passed" do
+        let(:resource) { post_decorator }
+
+        it "returns undeorated object class string" do
+          expect(ActiveAdmin::Comment.resource_type resource).to eql 'Post'
+        end
+      end
+
+      context "when an undecorated object is passed" do
+        let(:resource) { post }
+
+        it "returns object class string" do
+          expect(ActiveAdmin::Comment.resource_type resource).to eql 'Post'
+        end
+      end
+    end
+
     describe ".resource_id_type" do
       it "should be :string" do
         expect(ActiveAdmin::Comment.resource_id_type).to eql :string
@@ -70,7 +93,7 @@ describe "Comments" do
       end
     end
 
-    describe "Commenting on child of STI resource" do
+    describe "commenting on child of STI resource" do
       let(:publisher) { Publisher.create!(:username => "tenderlove") }
       let(:namespace_name) { "admin" }
 


### PR DESCRIPTION
Comments form were being generated from decorated `@resource`, breaking
`AA::Comments`. This patch acts on `AA::Comment.resource_type` there is
being used to populate `resource_type` hidden input in comments' form.

Fix #2733.
