### PR TITLE
Properly handle index scopes overflow

### DIFF
--- a/app/assets/stylesheets/active_admin/components/_table_tools.css.scss
+++ b/app/assets/stylesheets/active_admin/components/_table_tools.css.scss
@@ -1,5 +1,5 @@
 .table_tools {
-  display: block;
+  @include clearfix;
   margin-bottom: 16px;
 }
 
@@ -9,6 +9,7 @@ a.table_tools_button, .table_tools .dropdown_menu_button {
   @include border-colors(#d9d9d9, #d0d0d0, #c5c5c5);
   font-size: 0.9em;
   padding: 4px 14px 4px;
+  margin: 0;
 
   &:not(.disabled) {
     &:hover {
@@ -23,28 +24,29 @@ a.table_tools_button, .table_tools .dropdown_menu_button {
   }
 }
 
-.table_tools_segmented_control {
-  display: inline-block;
-  margin: 0;
-  padding: 0;
+// If the Batch Action selector is present, offset the scopes so that if they
+// overflow, they don't appear directly below the Batch Action selector itself.
+.table_tools #batch_actions_selector + .table_tools_segmented_control {
+  float: right;
+  width: calc(100% - 125px);
+}
 
+.table_tools_segmented_control {
   li {
-    display: inline-block;
-    margin-left: -7px;
+    float: left;
 
     a {
-      border-radius: 0px;
+      border-width: 1px .5px 1px .5px;
+      border-radius: 0;
     }
 
-    &:first-child {
-      margin-left: 0;
-
-      a {
-        border-radius: 12px 0 0 12px;
-      }
+    &:first-child a {
+      border-left-width: 1px;
+      border-radius: 12px 0 0 12px;
     }
 
     &:last-child a {
+      border-right-width: 1px;
       border-radius: 0 12px 12px 0;
     }
 
@@ -59,5 +61,4 @@ a.table_tools_button, .table_tools .dropdown_menu_button {
     }
 
   }
-
 }


### PR DESCRIPTION
For #2743, starting from #2667

Now you get this:
![screen shot 2013-11-28 at 8 53 33 pm](https://f.cloud.github.com/assets/688886/1642829/1ce57278-58a3-11e3-9102-c970d04a3b6d.png)

The only downside is this layout relies on a static, preset width for the batch actions button. For languages with a longer button translation, this happens:
![screen shot 2013-11-28 at 8 54 05 pm](https://f.cloud.github.com/assets/688886/1642834/42eb5640-58a3-11e3-9685-ca193102cfd4.png)
