### PR TITLE
Add the belongs_to functionality to Page resources

### DIFF
--- a/features/registering_pages.feature
+++ b/features/registering_pages.feature
@@ -146,3 +146,19 @@ Feature: Registering Pages
     And I follow "Check"
     Then I should see the content "Chocolate lØves You Too!"
     And I should see the Active Admin layout
+
+  Scenario: Displaying parent information from a belongs_to page
+    Given a configuration of:
+    """
+    ActiveAdmin.register Post
+    ActiveAdmin.register_page "Status" do
+      belongs_to :post
+
+      content do
+        "Status page for #{parent.title}"
+      end
+    end
+    """
+    And 1 post with the title "Post 1" exists
+    When I go to the first post custom status page
+    Then I should see the content "Status page for Post 1"

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -21,6 +21,8 @@ module NavigationHelpers
       "/admin/login"
     when /the first post show page/
       "/admin/posts/1"
+    when /the first post custom status page/
+      "/admin/posts/1/status"
     when /the first post edit page/
       "/admin/posts/1/edit"
     when /the admin password reset form with token "([^"]*)"/

--- a/lib/active_admin/page.rb
+++ b/lib/active_admin/page.rb
@@ -69,10 +69,6 @@ module ActiveAdmin
       false
     end
 
-    def belongs_to?
-      false
-    end
-
     def add_default_action_items
     end
 
@@ -84,5 +80,19 @@ module ActiveAdmin
       @page_actions = []
     end
 
+    def belongs_to(target, options = {})
+      @belongs_to = Resource::BelongsTo.new(self, target, options)
+      self.navigation_menu_name = target unless @belongs_to.optional?
+      controller.send :belongs_to, target, options.dup
+    end
+
+    def belongs_to_config
+      @belongs_to
+    end
+
+    # Do we belong to another resource?
+    def belongs_to?
+      !!belongs_to_config
+    end
   end
 end

--- a/lib/active_admin/page_dsl.rb
+++ b/lib/active_admin/page_dsl.rb
@@ -24,5 +24,9 @@ module ActiveAdmin
         define_method(name, &block || Proc.new{})
       end
     end
+
+    def belongs_to(target, options = {})
+      config.belongs_to(target, options)
+    end
   end
 end

--- a/spec/unit/namespace/register_page_spec.rb
+++ b/spec/unit/namespace/register_page_spec.rb
@@ -71,4 +71,30 @@ describe ActiveAdmin::Namespace, "registering a page" do
       end
     end # describe "disabling the menu"
   end # describe "adding to the menu"
+
+  describe "adding as a belongs to" do
+    context "when not optional" do
+      before do
+        namespace.register_page "Reports" do
+          belongs_to :author
+        end
+      end
+
+      it "should be excluded from the menu" do
+        expect(menu["Reports"]).to be_nil
+      end
+    end
+
+    context "when optional" do
+      before do
+        namespace.register_page "Reports" do
+          belongs_to :author, :optional => true
+        end
+      end
+
+      it "should be in the menu" do
+        expect(menu["Reports"]).to_not be_nil
+      end
+    end
+  end # describe "adding as a belongs to"
 end

--- a/spec/unit/page_spec.rb
+++ b/spec/unit/page_spec.rb
@@ -66,61 +66,52 @@ module ActiveAdmin
     end
 
     context "with belongs to config" do
-      let!(:post_registration) { namespace.register Post }
-      let!(:page_registration) {
+      let!(:post_config) { namespace.register Post }
+      let!(:page_config) {
         namespace.register_page page_name do
           belongs_to :post
         end
       }
 
-      subject { page_registration }
+      it "configures page with belongs_to" do
+        expect(page_config.belongs_to?).to be true
+      end
 
-      its(:belongs_to?)          { should be_true }
-      its(:navigation_menu_name) { should eq(:post) }
+      it "sets navigation menu to parent" do
+        expect(page_config.navigation_menu_name).to eq :post
+      end
 
-      describe "#belongs_to_config" do
-        subject { page_registration.belongs_to_config }
+      it "builds a belongs_to relationship" do
+        belongs_to = page_config.belongs_to_config
 
-        it              { should_not be_nil }
-        its(:target)    { should eq(post_registration) }
-        its(:owner)     { should eq(page_registration) }
-        its(:optional?) { should be_false }
+        expect(belongs_to.target).to eq(post_config)
+        expect(belongs_to.owner).to eq(page_config)
+        expect(belongs_to.optional?).to be_falsy
       end
 
       it "forwards belongs_to call to controller" do
         options = { :optional => true }
-        subject.controller.should_receive(:belongs_to).with(:post, options)
-        subject.belongs_to :post, options
+        expect(page_config.controller).to receive(:belongs_to).with(:post, options)
+
+        page_config.belongs_to :post, options
       end
     end # context "with belongs to config" do
 
     context "with optional belongs to config" do
-      let!(:post_registration) { namespace.register Post }
-      let!(:page_registration) {
+      let!(:post_config) { namespace.register Post }
+      let!(:page_config) {
         namespace.register_page page_name do
           belongs_to :post, :optional => true
         end
       }
 
-      subject { page_registration }
-
-      its(:navigation_menu_name) { should eq(:default) }
-
-      describe "#belongs_to_config" do
-        subject { page_registration.belongs_to_config }
-
-        it              { should_not be_nil }
-        its(:target)    { should eq(post_registration) }
-        its(:owner)     { should eq(page_registration) }
-        its(:optional?) { should be_true }
+      it "does not override default navigation menu" do
+        expect(page_config.navigation_menu_name).to eq(:default)
       end
     end # context "with optional belongs to config" do
 
-    context "without belongs to config" do
-      subject { config }
-
-      its(:belongs_to?)       { should be_false }
-      its(:belongs_to_config) { should be_nil }
-    end # context "without belongs to config" do
+    it "has no belongs_to by default" do
+      expect(config.belongs_to?).to be_falsy
+    end
   end
 end

--- a/spec/unit/page_spec.rb
+++ b/spec/unit/page_spec.rb
@@ -11,6 +11,7 @@ module ActiveAdmin
 
     let(:application){ ActiveAdmin::Application.new }
     let(:namespace){ Namespace.new(application, :admin) }
+    let(:page_name) { "Chocolate I lØve You!" }
 
     def config(options = {})
       @config ||= namespace.register_page("Chocolate I lØve You!", options)
@@ -56,10 +57,6 @@ module ActiveAdmin
       end
     end
 
-    it "should not belong_to anything" do
-      expect(config.belongs_to?).to eq false
-    end
-
     it "should not have any action_items" do
       expect(config.action_items?).to eq false
     end
@@ -68,5 +65,62 @@ module ActiveAdmin
       expect(config.sidebar_sections?).to eq false
     end
 
+    context "with belongs to config" do
+      let!(:post_registration) { namespace.register Post }
+      let!(:page_registration) {
+        namespace.register_page page_name do
+          belongs_to :post
+        end
+      }
+
+      subject { page_registration }
+
+      its(:belongs_to?)          { should be_true }
+      its(:navigation_menu_name) { should eq(:post) }
+
+      describe "#belongs_to_config" do
+        subject { page_registration.belongs_to_config }
+
+        it              { should_not be_nil }
+        its(:target)    { should eq(post_registration) }
+        its(:owner)     { should eq(page_registration) }
+        its(:optional?) { should be_false }
+      end
+
+      it "forwards belongs_to call to controller" do
+        options = { :optional => true }
+        subject.controller.should_receive(:belongs_to).with(:post, options)
+        subject.belongs_to :post, options
+      end
+    end # context "with belongs to config" do
+
+    context "with optional belongs to config" do
+      let!(:post_registration) { namespace.register Post }
+      let!(:page_registration) {
+        namespace.register_page page_name do
+          belongs_to :post, :optional => true
+        end
+      }
+
+      subject { page_registration }
+
+      its(:navigation_menu_name) { should eq(:default) }
+
+      describe "#belongs_to_config" do
+        subject { page_registration.belongs_to_config }
+
+        it              { should_not be_nil }
+        its(:target)    { should eq(post_registration) }
+        its(:owner)     { should eq(page_registration) }
+        its(:optional?) { should be_true }
+      end
+    end # context "with optional belongs to config" do
+
+    context "without belongs to config" do
+      subject { config }
+
+      its(:belongs_to?)       { should be_false }
+      its(:belongs_to_config) { should be_nil }
+    end # context "without belongs to config" do
   end
 end


### PR DESCRIPTION
Allow Page resources to use the same belongs_to functionality as Resource.

``` ruby
ActiveAdmin.register_page "Post Report" do
  belongs_to :post

  content do
    # ...
  end
end
```
