### PR TITLE
(docs) Update partial path

### DIFF
--- a/docs/5-forms.md
+++ b/docs/5-forms.md
@@ -28,7 +28,7 @@ If you require a more custom form than the DSL can provide, use a partial instea
 
 ```ruby
 ActiveAdmin.register Post do
-  form partial: 'form'
+  form partial: 'admin/posts/form'
 end
 ```
 


### PR DESCRIPTION
A mismatch between the partial path and where you create the partial will throw a "ActionView::MissingTemplate" error in Rails 4.

Active admin is trying to find a partial in app/views rather than where it actually is (app/views/admin/posts/form)
