### PR TITLE
Remove outdated documentation

### DIFF
--- a/docs/2-resource-customization.md
+++ b/docs/2-resource-customization.md
@@ -75,9 +75,6 @@ ActiveAdmin.register Post, as: "Article"
 
 The resource will then be available at `/admin/articles`.
 
-This will also change the key of the resource params passed to the controller.
-In Rails 4, the `permitted_params` key will need to be changed from `:post` to `:article`.
-
 ## Customize the Namespace
 
 We use the `admin` namespace by default, but you can use anything:


### PR DESCRIPTION
[skip ci]

This is probably no longer needed now that we have the
`permit_params` dsl. However, it might still be useful if
people for some reason still want to use the older technique.

I would still probably remove the line, though, so as no to be
confusing.
