### PR TITLE
Custom row class

### DIFF
--- a/lib/active_admin/views/components/table_for.rb
+++ b/lib/active_admin/views/components/table_for.rb
@@ -12,6 +12,8 @@ module ActiveAdmin
         @resource_class = options.delete(:i18n)
         @collection     = Array(record_or_collection)
         @columns = []
+        @row_class = options.delete(:row_class)
+
         build_table
         super(options)
       end
@@ -75,7 +77,15 @@ module ActiveAdmin
       def build_table_body
         @tbody = tbody do
           # Build enough rows for our collection
-          @collection.each{|elem| tr(:class => cycle('odd', 'even'), :id => dom_id(elem)) }
+          @collection.each do |elem|
+            classes = [cycle('odd', 'even')]
+
+            if @row_class
+              classes << @row_class.call(elem)
+            end
+
+            tr(:class => classes.flatten.join(' '), :id => dom_id(elem))
+          end
         end
       end
 

--- a/lib/active_admin/views/index_as_table.rb
+++ b/lib/active_admin/views/index_as_table.rb
@@ -150,6 +150,17 @@ module ActiveAdmin
     # end
     # ```
     #
+    # ## Custom row class
+    #
+    # In order to add special class to table rows pass the proc object as a `:row_class` option
+    # of the `index` method.
+    #
+    # ```ruby
+    # index :row_class => -> (element) { element.active? "active" : "" } do
+    #   ...
+    # end
+    # ```
+    #
     class IndexAsTable < ActiveAdmin::Component
 
       def build(page_presenter, collection)
@@ -158,7 +169,8 @@ module ActiveAdmin
           :sortable => true,
           :class => "index_table index",
           :i18n => active_admin_config.resource_class,
-          :paginator => page_presenter[:paginator] != false
+          :paginator => page_presenter[:paginator] != false,
+          :row_class => page_presenter[:row_class]
         }
 
         table_for collection, table_options do |t|


### PR DESCRIPTION
### Custom row class

In order to add special class to table rows pass the proc object as a `:row_class` option
of the `index` method.

``` ruby
index :row_class => -> (element) { element.active? "active" : "" } do
  ...
end
```
