### PR TITLE
i18n simple fix

### DIFF
--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -46,6 +46,8 @@ ru:
       multiple_without_total: "Результат: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
       entry:
         one: "запись"
+        few: "записи"
+        many: "записей"
         other: "записей"
     any: "Любой"
     blank_slate:


### PR DESCRIPTION
Fixing error `translation data {:one=>"запись", :other=>"записей"} can not be used with :count => 2` for russian locale
