### PR TITLE
Fix Document: missing underscore

### DIFF
--- a/docs/3-index-pages.md
+++ b/docs/3-index-pages.md
@@ -148,7 +148,7 @@ You can define the default sort order for index pages:
 
 ```ruby
 ActiveAdmin.register Post do
-  config.sort_order = 'name asc'
+  config.sort_order = 'name_asc'
 end
 ```
 


### PR DESCRIPTION
config.sort_order requires an underscore between column_name and (asc|desc)
