### PR TITLE
Dropdown menu on click navigates to top of the page

### DIFF
--- a/app/assets/javascripts/active_admin/lib/dropdown-menu.js.coffee
+++ b/app/assets/javascripts/active_admin/lib/dropdown-menu.js.coffee
@@ -65,8 +65,7 @@ class ActiveAdmin.DropdownMenu
     $('body').click =>
       @close() if @isOpen
 
-    @$menuButton.click (e)=>
-      e.stopPropagation()
+    @$menuButton.click =>
       unless @isDisabled()
         if @isOpen then @close() else @open()
       false


### PR DESCRIPTION
Default dropdown_menu button has a `href='#'`, so when you click it, it opens menu and navigates to top because it opens '#' anchor.
This fix adds `preventDefault` analogue in jQuery (`return false`), so it prevents opening this anchor and page scrolling stays where it was.
