### PR TITLE
Add action_item localizer

### DIFF
--- a/features/i18n.feature
+++ b/features/i18n.feature
@@ -41,3 +41,14 @@ Feature: Internationalization
     When I go to the dashboard
     When I follow "Bookstores"
     Then I should see "Download this:"
+
+  Scenario: Overriding resource details table title
+    Given a configuration of:
+    """
+      ActiveAdmin.register Post
+    """
+    And String "Post detailed information" corresponds to "resources.post.details"
+    And I am logged in
+    And a post exists
+    When I go to the last post's show page
+    Then I should see "Post detailed information"

--- a/features/step_definitions/i18n_steps.rb
+++ b/features/step_definitions/i18n_steps.rb
@@ -1,3 +1,11 @@
+Given /^String "([^"]*)" corresponds to "([^"]*)"$/ do |translation, key|
+  *seq, last_key = key.split('.')
+  result = seq.reverse.inject({last_key.to_sym => translation}) do |temp_result, nested_key|
+    {nested_key.to_sym => temp_result}
+  end
+  I18n.backend.store_translations :en, active_admin: result
+end
+
 When /^I set my locale to "([^"]*)"$/ do |lang|
   I18n.locale = lang
 end

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -45,6 +45,9 @@ module NavigationHelpers
     when /^the last author's last post page$/
       admin_user_post_path(User.last, Post.where(author_id: User.last.id).last)
 
+    when /^the last post's show page$/
+      admin_post_path(Post.last)
+
     when /^the last post's edit page$/
       edit_admin_post_path(Post.last)
 

--- a/lib/active_admin.rb
+++ b/lib/active_admin.rb
@@ -36,6 +36,7 @@ module ActiveAdmin
   autoload :Event,                    'active_admin/event'
   autoload :FormBuilder,              'active_admin/form_builder'
   autoload :Inputs,                   'active_admin/inputs'
+  autoload :Localizers,               'active_admin/localizers'
   autoload :Menu,                     'active_admin/menu'
   autoload :MenuCollection,           'active_admin/menu_collection'
   autoload :MenuItem,                 'active_admin/menu_item'

--- a/lib/active_admin/localizers.rb
+++ b/lib/active_admin/localizers.rb
@@ -1,0 +1,11 @@
+require 'active_admin/localizers/resource_localizer'
+
+module ActiveAdmin
+  module Localizers
+    class << self
+      def resource(active_admin_config)
+        ResourceLocalizer.from_resource(active_admin_config)
+      end
+    end
+  end
+end

--- a/lib/active_admin/localizers/resource_localizer.rb
+++ b/lib/active_admin/localizers/resource_localizer.rb
@@ -1,0 +1,35 @@
+module ActiveAdmin
+  module Localizers
+    class ResourceLocalizer
+      class << self
+        def from_resource(resource_config)
+          new(resource_config.resource_name.i18n_key, resource_config.resource_label)
+        end
+
+        def translate(key, options)
+          new(options.delete(:model_name), options.delete(:model)).translate(key, options)
+        end
+        alias_method :t, :translate
+      end
+
+      def initialize(model_name, model = nil)
+        @model_name = model_name
+        @model = model || model_name.to_s.titleize
+      end
+
+      def translate(key, options = {})
+        scope = options.delete(:scope)
+        specific_key = array_to_key('resources', @model_name, scope, key)
+        defaults = [array_to_key(scope, key), key.to_s.titleize]
+        ::I18n.t specific_key, options.reverse_merge(model: @model, default: defaults, scope: 'active_admin')
+      end
+      alias_method :t, :translate
+
+      protected
+
+      def array_to_key(*arr)
+        arr.flatten.compact.join('.').to_sym
+      end
+    end
+  end
+end

--- a/lib/active_admin/resource/action_items.rb
+++ b/lib/active_admin/resource/action_items.rb
@@ -64,7 +64,8 @@ module ActiveAdmin
       def add_default_new_action_item
         add_action_item :new, only: :index do
           if controller.action_methods.include?('new') && authorized?(ActiveAdmin::Auth::CREATE, active_admin_config.resource_class)
-            link_to I18n.t('active_admin.new_model', model: active_admin_config.resource_label), new_resource_path
+            localizer = ActiveAdmin::Localizers.resource(active_admin_config)
+            link_to localizer.t(:new_model), new_resource_path
           end
         end
       end
@@ -73,7 +74,8 @@ module ActiveAdmin
       def add_default_edit_action_item
         add_action_item :edit, only: :show do
           if controller.action_methods.include?('edit') && authorized?(ActiveAdmin::Auth::UPDATE, resource)
-            link_to I18n.t('active_admin.edit_model', model: active_admin_config.resource_label), edit_resource_path(resource)
+            localizer = ActiveAdmin::Localizers.resource(active_admin_config)
+            link_to localizer.t(:edit_model), edit_resource_path(resource)
           end
         end
       end
@@ -82,8 +84,9 @@ module ActiveAdmin
       def add_default_show_action_item
         add_action_item :destroy, only: :show do
           if controller.action_methods.include?('destroy') && authorized?(ActiveAdmin::Auth::DESTROY, resource)
-            link_to I18n.t('active_admin.delete_model', model: active_admin_config.resource_label), resource_path(resource),
-              method: :delete, data: {confirm: I18n.t('active_admin.delete_confirmation')}
+            localizer = ActiveAdmin::Localizers.resource(active_admin_config)
+            link_to localizer.t(:delete_model), resource_path(resource), method: :delete,
+              data: {confirm: localizer.t(:delete_confirmation)}
           end
         end
       end

--- a/lib/active_admin/resource/scopes.rb
+++ b/lib/active_admin/resource/scopes.rb
@@ -31,6 +31,7 @@ module ActiveAdmin
         title = args[0] rescue nil
         method = args[1] rescue nil
 
+        options[:localizer] ||= ActiveAdmin::Localizers.resource(self)
         scope = ActiveAdmin::Scope.new(title, method, options, &block)
 
         # Finds and replaces a scope by the same name if it already exists

--- a/lib/active_admin/scope.rb
+++ b/lib/active_admin/scope.rb
@@ -38,6 +38,7 @@ module ActiveAdmin
       @scope_method               = nil        if @scope_method == :all
       @scope_method, @scope_block = nil, block if block_given?
 
+      @localizer        = options[:localizer]
       @show_count       = options.fetch(:show_count, true)
       @display_if_block = options[:if]      || proc{ true }
       @default_block    = options[:default] || proc{ false }
@@ -47,7 +48,7 @@ module ActiveAdmin
       case @name
         when Proc   then @name.call.to_s
         when String then @name
-        when Symbol then @name.to_s.titleize
+        when Symbol then @localizer ? @localizer.t(@name, scope: 'scopes') : @name.to_s.titleize
         else             @name.to_s
       end
     end

--- a/lib/active_admin/views/components/scopes.rb
+++ b/lib/active_admin/views/components/scopes.rb
@@ -31,11 +31,10 @@ module ActiveAdmin
 
       def build_scope(scope, options)
         li class: classes_for_scope(scope) do
-          scope_name = I18n.t "active_admin.scopes.#{scope.id}", default: scope.name
-          params     = request.query_parameters.except :page, :scope, :commit, :format
+          params = request.query_parameters.except :page, :scope, :commit, :format
 
           a href: url_for(scope: scope.id, params: params), class: 'table_tools_button' do
-            text_node scope_name
+            text_node scope.name
             span class: 'count' do
               "(#{get_scope_count(scope)})"
             end if options[:scope_count] && scope.show_count

--- a/lib/active_admin/views/pages/form.rb
+++ b/lib/active_admin/views/pages/form.rb
@@ -8,8 +8,7 @@ module ActiveAdmin
           if form_presenter[:title]
             render_or_call_method_or_proc_on(resource, form_presenter[:title])
           else
-            assigns[:page_title] || I18n.t("active_admin.#{normalized_action}_model",
-                                      model: active_admin_config.resource_label)
+            assigns[:page_title] || ActiveAdmin::Localizers.resource(active_admin_config).t("#{normalized_action}_model")
           end
         end
 

--- a/lib/active_admin/views/pages/show.rb
+++ b/lib/active_admin/views/pages/show.rb
@@ -25,7 +25,8 @@ module ActiveAdmin
         end
 
         def attributes_table(*args, &block)
-          panel(I18n.t('active_admin.details', model: active_admin_config.resource_label)) do
+          table_title = ActiveAdmin::Localizers.resource(active_admin_config).t(:details)
+          panel(table_title) do
             attributes_table_for resource, *args, &block
           end
         end

--- a/spec/unit/config_shared_examples.rb
+++ b/spec/unit/config_shared_examples.rb
@@ -57,3 +57,16 @@ shared_examples_for "ActiveAdmin::Resource" do
 
   end
 end
+
+shared_examples_for "ActiveAdmin::Localizers::ResourceLocalizer" do
+  it "should use proper translation" do
+    string = ActiveAdmin::Localizers::ResourceLocalizer.t(action, model: model, model_name: model_name)
+    expect(string).to eq translation
+  end
+
+  it "should accessible via ActiveAdmin::Localizers" do
+    resource = double(resource_label: model, resource_name: double(i18n_key: model_name))
+    localizer = ActiveAdmin::Localizers.resource(resource)
+    expect(localizer.t(action)).to eq translation
+  end
+end

--- a/spec/unit/localizers/resource_localizer_spec.rb
+++ b/spec/unit/localizers/resource_localizer_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require File.expand_path('../config_shared_examples', File.dirname(__FILE__))
+
+describe ActiveAdmin::Localizers::ResourceLocalizer do
+  let(:action) { 'new_model' }
+  let(:model) { 'Comment' }
+  let(:model_name) { 'comment' }
+
+  it_behaves_like "ActiveAdmin::Localizers::ResourceLocalizer" do
+    let(:translation) { 'New Comment' }
+  end
+
+  describe "model action specified" do
+    before do
+      I18n.backend.store_translations :en, active_admin: {resources: {comment: {new_model: 'Write comment'}}}
+    end
+
+    it_behaves_like "ActiveAdmin::Localizers::ResourceLocalizer" do
+      let(:translation) { 'Write comment' }
+    end
+  end
+end

--- a/spec/unit/scope_spec.rb
+++ b/spec/unit/scope_spec.rb
@@ -139,6 +139,30 @@ describe ActiveAdmin::Scope do
       end
     end
 
+    context "with scope method and localizer" do
+      let(:localizer) do
+        loc = double(:localizer)
+        allow(loc).to receive(:t).with(:published, scope: 'scopes').and_return("All published")
+        loc
+      end
+      let(:scope)        { ActiveAdmin::Scope.new :published, :published, localizer: localizer }
+
+      describe '#name' do
+        subject { super().name }
+        it         { is_expected.to eq("All published")}
+      end
+
+      describe '#id' do
+        subject { super().id }
+        it           { is_expected.to eq("published")}
+      end
+
+      describe '#scope_method' do
+        subject { super().scope_method }
+        it { is_expected.to eq(:published) }
+      end
+    end
+
   end # describe "creating a scope"
 
   describe "#display_if_block" do


### PR DESCRIPTION
Now one can set custom button name and page title for new, edit, and destroy actions/pages rather than "New %{model}" and "Edit %{model}".
