### PR TITLE
Fixing gittip badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Active Admin is a Ruby on Rails framework for creating elegant backends for webs
 [![Code Climate](https://codeclimate.com/github/gregbell/active_admin.png)  ](https://codeclimate.com/github/gregbell/active_admin)
 [![Gemnasium   ](https://gemnasium.com/gregbell/active_admin.png)           ](https://gemnasium.com/gregbell/active_admin)
 [![Coveralls   ](https://coveralls.io/repos/gregbell/active_admin/badge.png)](https://coveralls.io/r/gregbell/active_admin)
-[![Gittip      ](https://img.shields.io/gittip/activeadmin.png)             ](https://www.gittip.com/activeadmin)
+[![Gittip      ](http://img.shields.io/gittip/activeadmin.png)             ](https://www.gittip.com/activeadmin)
 
 ## Links
 


### PR DESCRIPTION
The gittip badge from shields.io wasn't displaying properly because I think their SSL Cert has expired or improperly configured on the server:
![Badge screenshot](https://s3.amazonaws.com/f.cl.ly/items/1u2I1r2p261v1x1H2H1Q/Screen%20Shot%202013-12-26%20at%2014.55.39.png)

![Invalid Cert](https://s3.amazonaws.com/f.cl.ly/items/252a0q0B2j3I3S44060D/Screen%20Shot%202013-12-26%20at%2014.56.23.png)

Simply using http solved the problem :smile: 
