### PR TITLE
fix deleting if and unless options from filters

### DIFF
--- a/lib/active_admin/filters/forms.rb
+++ b/lib/active_admin/filters/forms.rb
@@ -65,8 +65,8 @@ module ActiveAdmin
 
         form_for search, options do |f|
           filters.each do |attribute, opts|
-            should   = opts.delete(:if)     || proc{ true }
-            shouldnt = opts.delete(:unless) || proc{ false }
+            should   = opts[:if]     || proc{ true }
+            shouldnt = opts[:unless] || proc{ false }
 
             if call_method_or_proc_on(self, should) && !call_method_or_proc_on(self, shouldnt)
               f.filter attribute, opts

--- a/spec/unit/filters/filter_form_builder_spec.rb
+++ b/spec/unit/filters/filter_form_builder_spec.rb
@@ -392,6 +392,12 @@ describe ActiveAdmin::Filters::ViewHelper do
         body = filter :updated_at, unless: proc{true}
         expect(body).to_not have_tag "input", attributes: {name: "q[updated_at_gteq]"}
       end
+
+      it "should keep if and unless options" do
+         options =  {unless: proc{true}, if: proc{true} }
+         body = filter :updated_at,  options
+         expect(options).to eq({unless: proc{true}, if: proc{true} })
+      end
     end
   end
 


### PR DESCRIPTION
I have next code in one of my AA applications which use dynamic filter using if, unless options

```
Report::CustomCdr::CDR_COLUMNS.each do |key|
      filter Report::CustomData.normalized_column_name(key.to_s).to_sym, :if => proc{
        @custom_cdr.group_by_include? key
      }
  end
```

It works , but only first time, after reloading page I all filters are on the sidebar like it was no :if . I started to debug and noticed that after first rendering, if and unless options are not used anymore, because they were deleted in active_admin_filters_form_for method. 
