### PR TITLE
Define a named root path, if namespace is root

### DIFF
--- a/lib/active_admin/router.rb
+++ b/lib/active_admin/router.rb
@@ -21,7 +21,7 @@ module ActiveAdmin
       router.instance_exec @application.namespaces.values do |namespaces|
         namespaces.each do |namespace|
           if namespace.root?
-            root :to => namespace.root_to
+            root :to => namespace.root_to, :as => :admin_root
           else
             namespace namespace.name do
               root :to => namespace.root_to


### PR DESCRIPTION
This is done to avoid following error

``` ruby
/home/gaurish/.rvm/gems/ruby-2.1.0/gems/actionpack-4.0.2/lib/action_dispatch/routing/route_set.rb:434:in `add_route': Invalid route name, already in use: 'root'  (ArgumentError)
You may have defined two routes with the same name using the `:as` option, or you may be overriding a route already defined by a resource with the same naming. For the latter, you can restrict the routes created with `resources` as explained here: 
http://guides.rubyonrails.org/routing.html#restricting-the-routes-created
```

**When This error occurs:**
if `config.default_namespace = false`
if AA is mounted on subdomain(`admin.yourname.com`)
if there is existing root path default.

Using the `as` option avoids conflict with existing root path of the app.
