### PR TITLE
Allow to duplicate 'Batch Actions' button at the bottom

### DIFF
--- a/app/assets/javascripts/active_admin/lib/batch_actions.js.coffee
+++ b/app/assets/javascripts/active_admin/lib/batch_actions.js.coffee
@@ -3,15 +3,16 @@ $ ->
   #
   # Use ActiveAdmin.modal_dialog to prompt user if confirmation is required for current Batch Action
   #
-  $('#batch_actions_selector li a').click (e)->
+  $('.batch_actions_selector li a').click (e)->
     e.stopPropagation() # prevent Rails UJS click event
+    e.preventDefault()
     if message = $(@).data 'confirm'
       ActiveAdmin.modal_dialog message, $(@).data('inputs'), (inputs)=>
         $(@).trigger 'confirm:complete', inputs
     else
       $(@).trigger 'confirm:complete'
 
-  $('#batch_actions_selector li a').on 'confirm:complete', (e, inputs)->
+  $('.batch_actions_selector li a').on 'confirm:complete', (e, inputs)->
     if val = JSON.stringify inputs
       $('#batch_action_inputs').val val
     else
@@ -24,7 +25,7 @@ $ ->
   # Add checkbox selection to resource tables and lists if batch actions are enabled
   #
 
-  if $("#batch_actions_selector").length && $(":checkbox.toggle_all").length
+  if $(".batch_actions_selector").length && $(":checkbox.toggle_all").length
 
     if $(".paginated_collection table.index_table").length
       $(".paginated_collection table.index_table").tableCheckboxToggler()
@@ -33,6 +34,6 @@ $ ->
 
     $(document).on 'change', '.paginated_collection :checkbox', ->
       if $(".paginated_collection :checkbox:checked").length
-        $("#batch_actions_selector").aaDropdownMenu("enable")
+        $(".batch_actions_selector").each -> $(@).aaDropdownMenu("enable")
       else
-        $("#batch_actions_selector").aaDropdownMenu("disable")
+        $(".batch_actions_selector").each -> $(@).aaDropdownMenu("disable")

--- a/app/assets/stylesheets/active_admin/components/_table_tools.css.scss
+++ b/app/assets/stylesheets/active_admin/components/_table_tools.css.scss
@@ -26,7 +26,7 @@ a.table_tools_button, .table_tools .dropdown_menu_button {
 
 // If the Batch Action selector is present, offset the scopes so that if they
 // overflow, they don't appear directly below the Batch Action selector itself.
-.table_tools #batch_actions_selector + .table_tools_segmented_control {
+.table_tools .batch_actions_selector + .table_tools_segmented_control {
   float: right;
   width: calc(100% - 125px);
 }

--- a/features/step_definitions/batch_action_steps.rb
+++ b/features/step_definitions/batch_action_steps.rb
@@ -5,13 +5,13 @@ Then /^I (should|should not) be asked to confirm "([^"]*)" for "([^"]*)"$/ do |m
 end
 
 Then /^I (should|should not) see the batch action :([^\s]*) "([^"]*)"$/ do |maybe, sym, title|
-  selector = "#batch_actions_selector a.batch_action:contains('#{title}')"
+  selector = ".batch_actions_selector a.batch_action:contains('#{title}')"
   selector << "[href='#'][data-action='#{sym}']" if maybe == 'should'
   page.send maybe.sub(' ', '_'), have_css(selector)
 end
 
 Then /^the (\d+)(?:st|nd|rd|th) batch action should be "([^"]*)"$/ do |index, title|
-  page.all("#batch_actions_selector a.batch_action")[index.to_i - 1].text.should match title
+  page.all(".batch_actions_selector a.batch_action")[index.to_i - 1].text.should match title
 end
 
 When /^I check the (\d+)(?:st|nd|rd|th) record$/ do |index|
@@ -23,17 +23,17 @@ When /^I toggle the collection selection$/ do
 end
 
 Then /^I should see that the batch action button is disabled$/ do
-  page.should have_css "#batch_actions_selector .dropdown_menu_button.disabled"
+  page.should have_css ".batch_actions_selector .dropdown_menu_button.disabled"
 end
 
 Then /^I (should|should not) see the batch action (button|selector)$/ do |maybe, type|
-  selector = "div.table_tools #batch_actions_selector"
+  selector = "div.table_tools .batch_actions_selector"
   selector << ' .dropdown_menu_button' if maybe == 'should' && type == 'button'
   page.send maybe.sub(' ', '_'), have_css(selector)
 end
 
 Then /^I should see the batch action popover exists$/ do
-  page.should have_css "#batch_actions_selector"
+  page.should have_css ".batch_actions_selector"
 end
 
 Given /^I submit the batch action form with "([^"]*)"$/ do |action|

--- a/lib/active_admin/batch_actions/views/batch_action_selector.rb
+++ b/lib/active_admin/batch_actions/views/batch_action_selector.rb
@@ -24,7 +24,7 @@ module ActiveAdmin
 
       def build_drop_down
         dropdown_menu I18n.t("active_admin.batch_actions.button_label"),
-                      :id => "batch_actions_selector",
+                      :class => "batch_actions_selector dropdown_menu",
                       :button => { :class => "disabled" } do
           batch_actions_to_display.each do |batch_action|
             confirmation_text = render_or_call_method_or_proc_on(self, batch_action.confirm)


### PR DESCRIPTION
Switches 'Batch Actions' button selector from ID-based to class-based which allows to use multiple (duplicated) batch buttons. Duplicating button at the bottom speeds up batch operations on large tables (user don't have to scroll back to the top).

The following monkey-patch put into `app/config/initializers/active_admin.rb` does the trick:

``` ruby
module ActiveAdmin
  module Views
    module Pages
      class Index
        def main_content
          wrap_with_batch_action_form do
            build_table_tools
            build_collection
            build_table_tools
          end
        end
      end
    end
  end
end
```

`e.preventDefault()` is needed to prevent browser's default behavior when clicking on link with `href='#'` - it scrolls to the top
