### PR TITLE
Add ability to order by hstore columns in PostgreSQL

### DIFF
--- a/docs/3-index-pages/index-as-table.md
+++ b/docs/3-index-pages/index-as-table.md
@@ -116,6 +116,15 @@ index do
 end
 ```
 
+It's also possible to sort by PostgreSQL's hstore column key. You should set `sortable`
+option to a `column->'key'` value:
+
+```ruby
+index do
+  column :keywords, sortable: "meta->'keywords'"
+end
+```
+
 ## Associated Sorting
 
 You're normally able to sort columns alphabetically, but by default you

--- a/lib/active_admin.rb
+++ b/lib/active_admin.rb
@@ -39,6 +39,7 @@ module ActiveAdmin
   autoload :MenuCollection,           'active_admin/menu_collection'
   autoload :MenuItem,                 'active_admin/menu_item'
   autoload :Namespace,                'active_admin/namespace'
+  autoload :OrderClause,              'active_admin/order_clause'
   autoload :Page,                     'active_admin/page'
   autoload :PagePresenter,            'active_admin/page_presenter'
   autoload :PageController,           'active_admin/page_controller'

--- a/lib/active_admin/order_clause.rb
+++ b/lib/active_admin/order_clause.rb
@@ -1,0 +1,26 @@
+module ActiveAdmin
+  class OrderClause
+    attr_reader :field, :order
+
+    def initialize(clause)
+      clause =~ /^([\w\_\.]+)(->'\w+')?_(desc|asc)$/
+      @column = $1
+      @op = $2
+      @order = $3
+
+      @field = [@column, @op].compact.join
+    end
+
+    def valid?
+      @field.present? && @order.present?
+    end
+
+    def to_sql(active_admin_config)
+      table = active_admin_config.resource_column_names.include?(@column) ? active_admin_config.resource_table_name : nil
+      table_column = (@column =~ /\./) ? @column :
+        [table, active_admin_config.resource_quoted_column_name(@column)].compact.join(".")
+
+      [table_column, @op, ' ', @order].compact.join
+    end
+  end
+end

--- a/lib/active_admin/resource_controller/data_access.rb
+++ b/lib/active_admin/resource_controller/data_access.rb
@@ -214,17 +214,13 @@ module ActiveAdmin
         active_admin_authorization.scope_collection(collection, action_name)
       end
 
-
       def apply_sorting(chain)
         params[:order] ||= active_admin_config.sort_order
-        if params[:order] && params[:order] =~ /^([\w\_\.]+)_(desc|asc)$/
-          column = $1
-          order  = $2
-          table  = active_admin_config.resource_column_names.include?(column) ? active_admin_config.resource_table_name : nil
-          table_column = (column =~ /\./) ? column :
-            [table, active_admin_config.resource_quoted_column_name(column)].compact.join(".")
+        
+        order_clause = OrderClause.new params[:order]
 
-          chain.reorder("#{table_column} #{order}")
+        if order_clause.valid?
+          chain.reorder(order_clause.to_sql(active_admin_config))
         else
           chain # just return the chain
         end

--- a/lib/active_admin/views/components/table_for.rb
+++ b/lib/active_admin/views/components/table_for.rb
@@ -101,10 +101,14 @@ module ActiveAdmin
       #   current_sort[0] #=> sort_key
       #   current_sort[1] #=> asc | desc
       def current_sort
-        @current_sort ||= if params[:order] =~ /^([\w\_\.]+)_(desc|asc)$/
-          [$1,$2]
-        else
-          []
+        @current_sort ||= begin
+          order_clause = OrderClause.new params[:order]
+          
+          if order_clause.valid?
+            [order_clause.field, order_clause.order]
+          else
+            []
+          end
         end
       end
 

--- a/spec/unit/order_clause_spec.rb
+++ b/spec/unit/order_clause_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe ActiveAdmin::OrderClause do
+  subject { described_class.new clause }
+
+  let(:application) { ActiveAdmin::Application.new }
+  let(:namespace)   { ActiveAdmin::Namespace.new application, :admin }
+  let(:config)      { ActiveAdmin::Resource.new namespace, Post }
+
+  describe 'id_asc (existing column)' do
+    let(:clause) { 'id_asc' }
+
+    it { should be_valid }
+    its(:field) { should == 'id' }
+    its(:order) { should == 'asc' }
+
+    specify '#to_sql prepends table name' do
+      expect(subject.to_sql(config)).to eq '"posts"."id" asc'
+    end
+  end
+
+  describe 'virtual_column_asc' do
+    let(:clause) { 'virtual_column_asc' }
+
+    it { should be_valid }
+    its(:field) { should == 'virtual_column' }
+    its(:order) { should == 'asc' }
+
+    specify '#to_sql' do
+      expect(subject.to_sql(config)).to eq '"virtual_column" asc'
+    end
+  end
+
+  describe "hstore_col->'field'_desc" do
+    let(:clause) { "hstore_col->'field'_desc" }
+
+    it { should be_valid }
+    its(:field) { should == "hstore_col->'field'" }
+    its(:order) { should == 'desc' }
+
+    it 'converts to sql' do
+      expect(subject.to_sql(config)).to eq %Q("hstore_col"->'field' desc)
+    end
+  end
+
+  describe '_asc' do
+    let(:clause) { '_asc' }
+
+    it { should_not be_valid }
+  end
+
+  describe 'nil' do
+    let(:clause) { nil }
+
+    it { should_not be_valid }
+  end
+end

--- a/spec/unit/resource_controller/data_access_spec.rb
+++ b/spec/unit/resource_controller/data_access_spec.rb
@@ -25,21 +25,23 @@ describe ActiveAdmin::ResourceController::DataAccess do
 
   describe "sorting" do
 
-    context "for table columns" do
+    context "valid clause" do
       let(:params){ {:order => "id_asc" }}
-      it "should prepend the table name" do
+
+      it "reorders chain" do
         chain = double "ChainObj"
         expect(chain).to receive(:reorder).with('"posts"."id" asc').once.and_return(Post.search)
         controller.send :apply_sorting, chain
       end
     end
 
-    context "for virtual columns" do
-      let(:params){ {:order => "virtual_id_asc" }}
-      it "should not prepend the table name" do
+    context "invalid clause" do
+      let(:params){ {:order => "_asc" }}
+      
+      it "returns chain untouched" do
         chain = double "ChainObj"
-        expect(chain).to receive(:reorder).with('"virtual_id" asc').once.and_return(Post.search)
-        controller.send :apply_sorting, chain
+        expect(chain).not_to receive(:reorder)
+        expect(controller.send(:apply_sorting, chain)).to eq chain
       end
     end
 


### PR DESCRIPTION
Example:

``` ruby
class Device < ActiveRecord::Base
  store_accessor :information, :model
end
```

``` ruby
ActiveAdmin.register Device do
  index do
    column :model, sortable: "information->'model'"
  end
end
```
