### PR TITLE
Just a small addition, so now we can remove multiple filters inline

### DIFF
--- a/lib/active_admin/filters/dsl.rb
+++ b/lib/active_admin/filters/dsl.rb
@@ -9,7 +9,7 @@ module ActiveAdmin
 
       # For docs, please see ActiveAdmin::Filters::ResourceExtension#remove_filter
       def remove_filter(*attributes)
-        attributes.each { |attribute| config.remove_filter(attribute) }
+        config.remove_filter(*attributes)
       end
 
       # For docs, please see ActiveAdmin::Filters::ResourceExtension#preserve_default_filters!

--- a/lib/active_admin/filters/resource_extension.rb
+++ b/lib/active_admin/filters/resource_extension.rb
@@ -46,10 +46,10 @@ module ActiveAdmin
       # will raise a RuntimeError
       #
       # @param [Symbol] attribute The attribute to not filter on
-      def remove_filter(attribute)
+      def remove_filter(*attributes)
         raise Disabled unless filters_enabled?
 
-        (@filters_to_remove ||= []) << attribute.to_sym
+        attributes.each { |attribute| (@filters_to_remove ||= []) << attribute.to_sym }
       end
 
       # Add a filter for this resource. If filters are not enabled, this method

--- a/spec/unit/filters/resource_spec.rb
+++ b/spec/unit/filters/resource_spec.rb
@@ -61,6 +61,14 @@ describe ActiveAdmin::Filters::ResourceExtension do
     end
   end
 
+  describe "removing a multiple filters inline" do
+    it "should work" do
+      expect(resource.filters.keys).to include :author, :body
+      resource.remove_filter :author, :body
+      expect(resource.filters.keys).to_not include :author, :body
+    end
+  end
+
   describe "adding a filter" do
     it "should work" do
       resource.add_filter :title


### PR DESCRIPTION
Someone asked for feature to remove filters https://github.com/gregbell/active_admin/issues/2835

Active admin already had functionality but it only supported removing one filter per line. I added a little bit flexibility, so now we can remove multiple filters inline as was asked in issue.
