### PR TITLE
Properly styled registrations#new template for admin users 

### DIFF
--- a/app/views/active_admin/devise/registrations/new.html.erb
+++ b/app/views/active_admin/devise/registrations/new.html.erb
@@ -1,0 +1,22 @@
+<div id="login">
+  <h2><%= title "#{render_or_call_method_or_proc_on(self, active_admin_application.site_title)} #{t('active_admin.devise.sign_up.title')}" %></h2>
+
+  <% scope = Devise::Mapping.find_scope!(resource_name) %>
+  <%= active_admin_form_for(resource, :as => resource_name, :url => send(:"#{scope}_registration_path"), :html => { :id => "registration_new" }) do |f|
+    f.inputs do
+      resource.class.authentication_keys.each { |key| 
+        f.input key, :label => t('active_admin.devise.'+key.to_s+'.title'), :input_html => {:autofocus => true}
+      }
+      f.input :password, :label => t('active_admin.devise.password.title')
+      f.input :password_confirmation, :lable => t('active_admin.devise.password_confirmation.title')
+
+    end
+    f.actions do
+      f.action :submit, :label => t('active_admin.devise.login.submit'), :button_html => { :value => t('active_admin.devise.sign_up.submit') }
+    end
+  end
+  %>
+
+  <%= render :partial => "active_admin/devise/shared/links" %>
+</div>
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,6 +85,9 @@ en:
         title: "Subdomain"
       password: 
         title: "Password"
+      sign_up:
+        title: "Sign up"
+        submit: "Sign up"
       login:
         title: "Login"
         remember_me: "Remember me"

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -73,6 +73,9 @@ pl:
       errors:
         empty_text: "Komentarz nie został zapisany, zawartość była pusta."
     devise:
+      sign_up:
+        title: "Rejestracja"
+        submit: "Zarejestruj się"
       login:
         title: "Logowanie"
         remember_me: "Zapamiętaj mnie"

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -197,6 +197,7 @@ module ActiveAdmin
         ActiveAdmin::Devise::PasswordsController.send name, *args, &block
         ActiveAdmin::Devise::SessionsController.send  name, *args, &block
         ActiveAdmin::Devise::UnlocksController.send   name, *args, &block
+        ActiveAdmin::Devise::RegistrationsController.send   name, *args, &block
       end
     end
 

--- a/lib/active_admin/devise.rb
+++ b/lib/active_admin/devise.rb
@@ -22,7 +22,8 @@ module ActiveAdmin
       {
         :sessions => "active_admin/devise/sessions",
         :passwords => "active_admin/devise/passwords",
-        :unlocks => "active_admin/devise/unlocks"
+        :unlocks => "active_admin/devise/unlocks",
+        :registrations => "active_admin/devise/registrations"
       }
     end
 
@@ -64,6 +65,10 @@ module ActiveAdmin
 
     class UnlocksController < ::Devise::UnlocksController
       include ::ActiveAdmin::Devise::Controller
+    end
+
+    class RegistrationsController < ::Devise::RegistrationsController
+       include ::ActiveAdmin::Devise::Controller
     end
 
   end


### PR DESCRIPTION
For issue #2790

Disabled by default signing up for admin users  was using default Devise template for `registrations#new`

*make `registrations#new` template style inline with rest of the admin styling
*add translations for en and pl 
