### PR TITLE
Add custom sorting methods

### DIFF
--- a/lib/active_admin/order_clause.rb
+++ b/lib/active_admin/order_clause.rb
@@ -2,11 +2,11 @@ module ActiveAdmin
   class OrderClause
     attr_reader :field, :order
 
-    def initialize(clause)
-      clause =~ /^([\w\_\.]+)(->'\w+')?_(desc|asc)$/
+    def initialize(clause, order)
+      clause =~ /^([\w\_\.]+)(->'\w+')?$/
       @column = $1
       @op = $2
-      @order = $3
+      @order = order
 
       @field = [@column, @op].compact.join
     end

--- a/lib/active_admin/resource_controller/data_access.rb
+++ b/lib/active_admin/resource_controller/data_access.rb
@@ -216,13 +216,26 @@ module ActiveAdmin
 
       def apply_sorting(chain)
         params[:order] ||= active_admin_config.sort_order
-        
-        order_clause = OrderClause.new params[:order]
+
+        match = params[:order].match(/([\w\.->']+)_(asc|desc)\z/)
+        @field, @direction = match.captures if match
+
+        apply_custom_sort(chain) || apply_order_clause(chain) || chain
+      end
+
+      def apply_custom_sort(chain)
+        sort_method = "sort_by_#{@field}".to_sym
+
+        if chain.respond_to?(sort_method)
+          chain.send sort_method, @direction.to_sym
+        end
+      end
+
+      def apply_order_clause(chain)
+        order_clause = OrderClause.new @field, @direction
 
         if order_clause.valid?
           chain.reorder(order_clause.to_sql(active_admin_config))
-        else
-          chain # just return the chain
         end
       end
 

--- a/spec/unit/order_clause_spec.rb
+++ b/spec/unit/order_clause_spec.rb
@@ -1,14 +1,15 @@
 require 'spec_helper'
 
 describe ActiveAdmin::OrderClause do
-  subject { described_class.new clause }
+  subject { described_class.new clause, order }
 
   let(:application) { ActiveAdmin::Application.new }
   let(:namespace)   { ActiveAdmin::Namespace.new application, :admin }
   let(:config)      { ActiveAdmin::Resource.new namespace, Post }
 
   describe 'id_asc (existing column)' do
-    let(:clause) { 'id_asc' }
+    let(:clause) { 'id' }
+    let(:order) { 'asc' }
 
     it { should be_valid }
     its(:field) { should == 'id' }
@@ -20,7 +21,8 @@ describe ActiveAdmin::OrderClause do
   end
 
   describe 'virtual_column_asc' do
-    let(:clause) { 'virtual_column_asc' }
+    let(:clause) { 'virtual_column' }
+    let(:order) { 'asc' }
 
     it { should be_valid }
     its(:field) { should == 'virtual_column' }
@@ -32,7 +34,8 @@ describe ActiveAdmin::OrderClause do
   end
 
   describe "hstore_col->'field'_desc" do
-    let(:clause) { "hstore_col->'field'_desc" }
+    let(:clause) { "hstore_col->'field'" }
+    let(:order) { 'desc' }
 
     it { should be_valid }
     its(:field) { should == "hstore_col->'field'" }
@@ -44,13 +47,15 @@ describe ActiveAdmin::OrderClause do
   end
 
   describe '_asc' do
-    let(:clause) { '_asc' }
+    let(:clause) { '' }
+    let(:order) { 'asc' }
 
     it { should_not be_valid }
   end
 
   describe 'nil' do
     let(:clause) { nil }
+    let(:order) { nil }
 
     it { should_not be_valid }
   end


### PR DESCRIPTION
I was looking for a way to specify a custom search method for a table column, but didn't find anything. I followed the pattern from MetaSearch of defining `sort_by_x_asc` and `sort_by_x_desc` methods that get called if available and return a scope. If you'd prefer a different interface, I can change it to something else.

I made this request before on the rails4 branch (#2469), but it was closed during the merge of that branch into master.
