### PR TITLE
Only reorder collection if it is grouped

### DIFF
--- a/lib/active_admin/helpers/collection.rb
+++ b/lib/active_admin/helpers/collection.rb
@@ -7,46 +7,9 @@ module ActiveAdmin
       # the ORDER statement mentions a column defined in the SELECT statement.
       #
       # We remove the ORDER statement to work around this issue.
-      #
-      # If you use includes method on collection you will potentially call two queries for each
-      # association. For example, if you ORDER BY created_at DESC, calls
-      # to this method will remove the order clause and execute the query bringing
-      # back results sorted by id ASC (which is probably equivalent to created_at ASC)
-      # and all the associations for that result set will be eager loaded as well as
-      # the ones for your intended result set sorted by created_at DESC.
-      #
-      # Example:
-      #   class Company < ActiveRecord::Base
-      #     has_many :users
-      #   end
-      #
-      #   ActiveAdmin.register Company do
-      #     config.per_page = 5
-      #     config.sort_order = 'created_at_desc'
-      #     
-      #     actions :index
-      #
-      #     controller do
-      #       def index
-      #         index! do |format|
-      #           @companies = collection.includes(:users); format.html
-      #         end
-      #       end
-      #     end
-      #
-      #     # rest of admin code
-      #
-      #   SELECT * FROM companies ORDER BY created_at DESC LIMIT 5 OFFSET 0; # ids: 10, 9, 8, 7, 6
-      #   SELECT * FROM users WHERE company_id IN (10,9,8,7,6)
-      #
-      #   # now collection_size is called (e.g. from #items_in_collection?
-      #
-      #   SELECT * FROM companies LIMIT 5 OFFSET 0; # ids: 1,2,3,4,5
-      #   SELECT * FROM users WHERE company_id IN (1,2,3,4,5)
-      #
-      #   So we should only use this work around if the #group method was called on the
-      #   ActiveRecord::Relation. Or else proceed as normal.
       def collection_size(collection=collection)
+        collection = collection.scoped
+        
         if collection.group_values.present?
           size = collection.reorder("").count
           # when GROUP BY is used, AR returns Hash instead of Fixnum for .size

--- a/spec/unit/views/components/paginated_collection_spec.rb
+++ b/spec/unit/views/components/paginated_collection_spec.rb
@@ -29,6 +29,8 @@ describe ActiveAdmin::Views::PaginatedCollection do
 
     before do
       collection.stub(:reorder) { collection }
+      collection.stub(:scoped) { collection }
+      collection.stub(:group_values) { [] } unless collection.respond_to?(:group_values)
     end
 
     context "when specifying collection" do


### PR DESCRIPTION
Only need to use work around of GROUP BY + COUNT queries if we are actually using grouping.
