### PR TITLE
Check show action for id column in index

### DIFF
--- a/features/index/index_as_table.feature
+++ b/features/index/index_as_table.feature
@@ -133,6 +133,19 @@ Feature: Index as Table
     And I should not see a member link to "Delete"
     And I should see a member link to "Custom Action"
 
+  Scenario: Index page without show action
+    Given a post with the title "Hello World" and body "From the body" exists
+    And an index configuration of:
+      """
+      ActiveAdmin.register Post do
+        actions :index
+      end
+      """
+    Then I should not see a member link to "View"
+    And I should not see a member link to "Edit"
+    And I should not see a member link to "Delete"
+    And I should see "Hello World"
+
   Scenario: Associations are not sortable
     Given 1 post exists
     And an index configuration of:

--- a/lib/active_admin/views/index_as_table.rb
+++ b/lib/active_admin/views/index_as_table.rb
@@ -203,7 +203,11 @@ module ActiveAdmin
         # Display a column for the id
         def id_column
           column(resource_class.human_attribute_name(resource_class.primary_key), :sortable => resource_class.primary_key) do |resource|
-            link_to resource.id, resource_path(resource), :class => "resource_id_link"
+            if controller.action_methods.include?('show')
+              link_to resource.id, resource_path(resource), :class => "resource_id_link"
+            else
+              resource.id
+            end
           end
         end
 


### PR DESCRIPTION
If there's no show action, the ID column should not be a link by default.
#2869
