### PR TITLE
Batch actions / scope fixed for all languages.

### DIFF
--- a/app/assets/stylesheets/active_admin/components/_table_tools.css.scss
+++ b/app/assets/stylesheets/active_admin/components/_table_tools.css.scss
@@ -26,9 +26,12 @@ a.table_tools_button, .table_tools .dropdown_menu_button {
 
 // If the Batch Action selector is present, offset the scopes so that if they
 // overflow, they don't appear directly below the Batch Action selector itself.
+.table_tools .batch_actions_selector {
+  float: left;
+}
 .table_tools .batch_actions_selector + .table_tools_segmented_control {
-  float: right;
-  width: calc(100% - 125px);
+  float: left;
+  margin-left: 10px;
 }
 
 .table_tools_segmented_control {


### PR DESCRIPTION
First the scopes were under the batch actions if the text was longer than "Batch Actions". Position is now dynamic and depends on the length of the batch actions.

Before:
![bildschirmfoto 2014-01-23 um 09 18 55](https://f.cloud.github.com/assets/5446019/1982811/83f15f1a-8407-11e3-8de3-011b2f47b7f7.png)

After:
![bildschirmfoto 2014-01-23 um 09 18 48](https://f.cloud.github.com/assets/5446019/1982813/88e0379e-8407-11e3-931f-1b8fbf4eeb0a.png)
![bildschirmfoto 2014-01-23 um 09 18 33](https://f.cloud.github.com/assets/5446019/1982814/8a2e581a-8407-11e3-8d1c-9f8f0b7f8593.png)
