### PR TITLE
Evaluate CSV block at runtime inside view context

### DIFF
--- a/app/views/active_admin/resource/index.csv.erb
+++ b/app/views/active_admin/resource/index.csv.erb
@@ -3,7 +3,7 @@
 
   default = active_admin_application.csv_options
   options = default.merge active_admin_config.csv_builder.options
-  columns = active_admin_config.csv_builder.columns
+  columns = active_admin_config.csv_builder.render_columns(self)
 
   csv_output = CSV.generate(options) do |csv|
     csv << columns.map(&:name)

--- a/lib/active_admin/csv_builder.rb
+++ b/lib/active_admin/csv_builder.rb
@@ -17,25 +17,45 @@ module ActiveAdmin
     # The CSVBuilder's columns would be Id followed by this
     # resource's content columns
     def self.default_for_resource(resource)
-      new(resource: resource).tap do |csv_builder|
-        csv_builder.column(:id)
+      new(resource: resource) do
+        column(:id)
         resource.content_columns.each do |content_column|
-          csv_builder.column(content_column.name.to_sym)
+          column(content_column.name.to_sym)
         end
       end
     end
 
-    attr_reader :columns, :options
+    attr_reader :columns, :options, :view_context
 
     def initialize(options={}, &block)
       @resource = options.delete(:resource)
-      @columns, @options = [], options
-      instance_exec &block if block_given?
+      @columns, @options, @block = [], options, block
     end
 
     # Add a column
     def column(name, &block)
       @columns << Column.new(name, @resource, block)
+    end
+
+    # Runs the `csv` dsl block and render our columns
+    # Called from `index.csv.erb`, which passes in the current view context.
+    # This provides methods that could be called in the views to be called within
+    # the CSV block. Any method not defined on the CSV builder will instead be
+    # sent to the view context in order to emulate the capabilities of the `index`
+    # DSL.
+    def render_columns(view_context = nil)
+      @view_context = view_context
+      @columns = [] # we want to re-render these every instance
+      instance_eval &@block if @block.present?
+      columns
+    end
+
+    def method_missing(method, *args, &block)
+      if @view_context.respond_to?(method)
+        @view_context.send(method, *args, &block)
+      else
+        super
+      end
     end
 
     class Column

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -196,7 +196,7 @@ module ActiveAdmin
     describe "#csv_builder" do
       context "when no csv builder set" do
         it "should return a default column builder with id and content columns" do
-          expect(config.csv_builder.columns.size).to eq Category.content_columns.size + 1
+          expect(config.csv_builder.render_columns.size).to eq Category.content_columns.size + 1
         end
       end
 


### PR DESCRIPTION
Previously: **Let current controller instance be available to csv block**

Possibly fixes #2798.

I don't particularly like this solution, but it seems like the simplest way to make it happen without any huge rewrites.

Basic concept:
1. Don't evaluate the columns block when AA loads, but store the block to run later.
2. Pass the current controller instance into the CSVBuilder whenever we render.
3. Clear out the columns before we render, since they could be different depending on the current request
4. Call to render the columns from the CSV view, and evaluate our dsl block when we actually make a request

Now, `csv` will behave slightly more like `index`, in that we can modify our columns given some detail about the current request, such as a parent `belongs_to` resource or a parameter that was passed.

For instance:

``` ruby
ActiveAdmin.register Meeting do
  belongs_to :event
  controller do
    public :parent # in this case, parent is the event of "belongs_to :event"
  end

  index do
    selectable_column
    id_column
    allowed_things = %i(name summary created_at updated_at)
    controller.params[:show_columns].slice(*allowed_things).each do |thing|
      column(thing) { |meeting| meeting.send(thing) }
    end
    default_actions
  end

  csv do
    allowed_things = %i(name summary created_at updated_at)
    controller.params[:show_columns].slice(*allowed_things).each do |thing|
      column(thing) { |meeting| meeting.send(thing) }
    end
  end
end
```
