### PR TITLE
Make column max_width and min_width options friendlier

### DIFF
--- a/lib/active_admin/views/components/columns.rb
+++ b/lib/active_admin/views/components/columns.rb
@@ -133,16 +133,23 @@ module ActiveAdmin
         styles << "width: #{column_with_span_width}%;"
 
         if max_width
-          styles << "max-width: #{max_width};"
+          styles << "max-width: #{safe_width(max_width)};"
         end
 
         if min_width
-          styles << "min-width: #{min_width};"
+          styles << "min-width: #{safe_width(min_width)};"
         end
 
         styles << "margin-right: #{margin_width}%;" unless is_last_column
 
         set_attribute :style, styles.join(" ")
+      end
+
+      private
+
+      # Converts values without a '%' or 'px' suffix to a pixel value
+      def safe_width(width)
+        width.to_s.gsub(/\A(\d+)\z/, '\1px')
       end
 
     end

--- a/spec/unit/views/components/columns_spec.rb
+++ b/spec/unit/views/components/columns_spec.rb
@@ -112,8 +112,23 @@ describe ActiveAdmin::Views::Columns do
       expect(cols.children.first.attr(:style)).to eq "width: 49.0%; max-width: 100px; margin-right: 2%;"
     end
 
-    it "should omit the value if not presetn" do
-      expect(cols.children.last.attr(:style)).to eq "width: 49.0%;"
+    it "should omit the value if not present" do
+      cols.children.last.attr(:style).should == "width: 49.0%;"
+    end
+
+    context "when passed an integer value" do
+      let(:cols) do
+        render_arbre_component do
+          columns do
+            column(:max_width => 100){ "Hello World" }
+            column(){ "Hello World" }
+          end
+        end
+      end
+
+      it "should be treated as pixels" do
+        cols.children.first.attr(:style).should == "width: 49.0%; max-width: 100px; margin-right: 2%;"
+      end
     end
 
   end
@@ -133,8 +148,23 @@ describe ActiveAdmin::Views::Columns do
       expect(cols.children.first.attr(:style)).to eq "width: 49.0%; min-width: 100px; margin-right: 2%;"
     end
 
-    it "should omit the value if not presetn" do
-      expect(cols.children.last.attr(:style)).to eq "width: 49.0%;"
+    it "should omit the value if not present" do
+      cols.children.last.attr(:style).should == "width: 49.0%;"
+    end
+
+    context "when passed an integer value" do
+      let(:cols) do
+        render_arbre_component do
+          columns do
+            column(:min_width => 100){ "Hello World" }
+            column(){ "Hello World" }
+          end
+        end
+      end
+
+      it "should be treated as pixels" do
+        cols.children.first.attr(:style).should == "width: 49.0%; min-width: 100px; margin-right: 2%;"
+      end
     end
 
   end


### PR DESCRIPTION
Convert sizes without a '%' or 'px' suffix to a pixel width
