### PR TITLE
Translate missing spanish strings

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -35,7 +35,7 @@ es:
         less_than: "Menor que"
     main_content: "Por favor implemente %{model}#main_content para mostrar contenido."
     logout: "Salir"
-    powered_by: "Powered by %{active_admin} %{version}"
+    powered_by: "Funciona con %{active_admin} %{version}"
     sidebars:
       filters: "Filtros"
     pagination:
@@ -44,13 +44,13 @@ es:
       one_page: "Mostrando <b>un total de %{n}</b> %{model}"
       multiple: "Mostrando %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> de un total de <b>%{total}</b>"
       multiple_without_total: "Mostrando %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-    blank_slate:
-      content: "No hay %{resource_name} aún."
-      link: "Añadir"
       entry:
         one: "registro"
         other: "registros"
     any: "Cualquiera"
+    blank_slate:
+      content: "No hay %{resource_name} aún."
+      link: "Añadir"
     batch_actions:
       button_label: "Acciones en masa"
       default_confirmation: "¿Seguro que quieres hacer esto?"
@@ -71,9 +71,23 @@ es:
       resource: "Recurso"
       no_comments_yet: "Aún sin comentarios."
       title_content: "Comentarios (%{count})"
+      no_comments_yet: "No hay comentarios aún."
+      author_missing: "Anónimo"
+      title_content: "Comentarios (%{count})"
       errors:
         empty_text: "El comentario no fue guardado, el texto estaba vacío."
     devise:
+      username:
+        title: "Nombre de usuario"
+      email:
+        title: "Email"
+      subdomain:
+        title: "Subdominio"
+      password:
+        title: "Password"
+      sign_up:
+        title: "Registrarse"
+        submit: "Registrarse"
       login:
         title: "iniciar sesión"
         remember_me: "Recordarme"
@@ -84,6 +98,9 @@ es:
       change_password:
         title: "Cambie su contraseña"
         submit: "Cambiar mi contraseña"
+      unlock:
+        title: "Reenviar instrucciones de desbloqueo"
+        submit: "Reenviar instrucciones de desbloqueo"
       resend_confirmation_instructions:
           title: "Reenviar instrucciones de confirmación"
           submit: "Reenviar instrucciones de confirmación"


### PR DESCRIPTION
Translate missing strings from `es.yml`.

Also, a question. I wanted to add translation for the model name, something like this:

```
es:
  activerecord:
    models:
      admin_user: 'Administrador'
```

It's ok to add keys/strings to a locale file that aren't present in `en.yml`? I ask because that file is usually considered the canonical list of strings to translate, but I noticed some Formtastic strings here in
`es.yml`
