### PR TITLE
Translating devise portuguese sign_up strings

### DIFF
--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -85,6 +85,9 @@ pt-BR:
         title: "Subdomínio"
       password:
         title: "Senha"
+      sign_up:
+        title: "Cadastre-se"
+        submit: "Continuar"
       login:
         title: "Conta"
         remember_me: "Lembrar da senha"


### PR DESCRIPTION
I was setting locale files to show labels in portuguese because there is no translation for sign_up.
