### PR TITLE
Add formtastic translations to German locale

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -121,3 +121,12 @@ de:
     sessions:
       admin_user:
         signed_in: Erfolgreich als Administrator angemeldet.
+  formtastic:
+    yes: "Ja"
+    no: "Nein"
+    create: "%{model} anlegen"
+    update: "%{model} aktualisieren"
+    submit: "Abschicken"
+    cancel: "Abbrechen"
+    reset: "%{model} zurücksetzen"
+    required: "Pflichtfeld"


### PR DESCRIPTION
See #1724 for the underlying problem. formtastic keys are already present in some of the locales (es, es-MX, pl, and zh-CN), so I'm adding them to de as well.
