### PR TITLE
Fix docs re: custom resource retrieval

### DIFF
--- a/docs/2-resource-customization.md
+++ b/docs/2-resource-customization.md
@@ -274,7 +274,7 @@ If you need to completely replace the record retrieving code (e.g., you have a c
 ```ruby
 ActiveAdmin.register Post do
   controller do
-    def resource
+    def find_resource
       Post.where(id: params[:id]).first!
     end
   end


### PR DESCRIPTION
The documentation for custom resource retrieval incorrectly states that the user should redefine the controller's resource method, but this can have a number of unintended consequences.  Instead, the user should redefine the find_resource method.
