### PR TITLE
Fix using Javascript reserved keyword

### DIFF
--- a/app/assets/javascripts/active_admin/application.js.coffee
+++ b/app/assets/javascripts/active_admin/application.js.coffee
@@ -27,4 +27,4 @@ $ ->
   if (batch_actions_selector = $('.table_tools .batch_actions_selector')).length
     batch_actions_selector.next().css
       width: "calc(100% - 10px - #{batch_actions_selector.outerWidth()}px)"
-      float: 'right'
+      'float': 'right'


### PR DESCRIPTION
float is a reserved word in javascript. This causes compilation errors using yui-compressor.

http://mattsnider.com/reserved-words-in-javascript/
