### PR TITLE
Remove unneeded Formtastic overridden method

### DIFF
--- a/lib/active_admin/inputs/filter_boolean_input.rb
+++ b/lib/active_admin/inputs/filter_boolean_input.rb
@@ -15,10 +15,6 @@ module ActiveAdmin
         method =~ search_conditions ? method : "#{method}_eq"
       end
 
-      def checked?
-        object && boolean_checked?(object.send(search_method), checked_value)
-      end
-
       def input_html_options
         { name: "q[#{ search_method }]" }
       end


### PR DESCRIPTION
Looking at Formtastic the `boolean_checked?` method was reverted and then added back since `2.2.0`

I think we can rely on Formtastic `checked?` method [see there](https://github.com/justinfrench/formtastic/blob/master/lib/formtastic/inputs/boolean_input.rb#L104)

Fix #2950
