### PR TITLE
Re-add Ruby 2.0 to .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ before_install:
   - gem install bundler # use the latest bundler, since Travis doesn't update for us
 rvm:
   - 1.9.3
+  - 2.0.0
   - 2.1.0
 env:
   - RAILS=3.2.16


### PR DESCRIPTION
The change to Ruby 2.1 in .travis.yml accidentaly dropped the tests in
Ruby 2.0. This change re-adds it so that now Ruby 1.9.3, 2.0.0 and 2.1.0
are tested.
