### PR TITLE
Add .Thumbs.db to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 ## MAC OS
 .DS_Store
 
+## WINDOWS
+.Thumbs.db
+
 ## TEXTMATE
 *.tmproj
 tmtags


### PR DESCRIPTION
Windows generates .Thumbs.db files for folders. GIT should ignore those.
