### PR TITLE
Clean up code style issues in Gemfile, Rakefile and *.gemspec.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ Bundler::GemHelper.install_tasks
 
 def cmd(command)
   puts command
-  raise unless system command
+  fail unless system command
 end
 
 require File.expand_path('../spec/support/detect_rails_version', __FILE__)
@@ -13,14 +13,14 @@ require File.expand_path('../spec/support/detect_rails_version', __FILE__)
 # Import all our rake tasks
 FileList['tasks/**/*.rake'].each { |task| import task }
 
-task :default => :test
+task default: :test
 
 begin
   require 'jasmine'
   load 'jasmine/tasks/jasmine.rake'
 rescue LoadError
   task :jasmine do
-    abort "Jasmine is not available. In order to run jasmine, you must: (sudo) gem install jasmine"
+    abort 'Jasmine is not available. In order to run jasmine, you must: (sudo) gem install jasmine'
   end
 end
 

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -1,33 +1,33 @@
 # -*- encoding: utf-8 -*-
-$:.push File.expand_path("../lib", __FILE__)
-require "active_admin/version"
+$LOAD_PATH << File.expand_path('../lib', __FILE__)
+require 'active_admin/version'
 
 Gem::Specification.new do |s|
   s.name          = %q{activeadmin}
-  s.license       = "MIT"
+  s.license       = 'MIT'
   s.version       = ActiveAdmin::VERSION
   s.platform      = Gem::Platform::RUBY
   s.homepage      = %q{http://activeadmin.info}
-  s.authors       = ["Greg Bell"]
-  s.email         = ["gregdbell@gmail.com"]
+  s.authors       = ['Greg Bell']
+  s.email         = ['gregdbell@gmail.com']
   s.description   = %q{The administration framework for Ruby on Rails.}
   s.summary       = %q{The administration framework for Ruby on Rails.}
 
   s.files         = `git ls-files`.split("\n").sort
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  s.require_paths = ["lib"]
+  s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
+  s.require_paths = ['lib']
 
-  s.add_dependency "arbre",               "~> 1.0"
-  s.add_dependency "bourbon"
-  s.add_dependency "coffee-rails"
-  s.add_dependency "devise",              "~> 3.2"
-  s.add_dependency "formtastic",          "~> 2.3.0.rc2" # change to 2.3 when stable is released
-  s.add_dependency "inherited_resources", "~> 1.3"
-  s.add_dependency "jquery-rails"
-  s.add_dependency "jquery-ui-rails"
-  s.add_dependency "kaminari",            "~> 0.15"
-  s.add_dependency "rails",               ">= 3.2", "< 4.1"
-  s.add_dependency "ransack",             "~> 1.0"
-  s.add_dependency "sass-rails"
+  s.add_dependency 'arbre',               '~> 1.0'
+  s.add_dependency 'bourbon'
+  s.add_dependency 'coffee-rails'
+  s.add_dependency 'devise',              '~> 3.2'
+  s.add_dependency 'formtastic',          '~> 2.3.0.rc2' # change to 2.3 when stable is released
+  s.add_dependency 'inherited_resources', '~> 1.3'
+  s.add_dependency 'jquery-rails'
+  s.add_dependency 'jquery-ui-rails'
+  s.add_dependency 'kaminari',            '~> 0.15'
+  s.add_dependency 'rails',               '>= 3.2', '< 4.1'
+  s.add_dependency 'ransack',             '~> 1.0'
+  s.add_dependency 'sass-rails'
 end


### PR DESCRIPTION
- use single quotes
- use the new Ruby 1.9.3 hash syntax
- use $LOAD_PATH instead of $.
- use fail instead of raise for system exceptions
