### PR TITLE
bring ukrainian and russian locales up to date

### DIFF
--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -46,6 +46,8 @@ ru:
       multiple_without_total: "Результат: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
       entry:
         one: "запись"
+        few: "записи"
+        many: "записей"
         other: "записей"
     any: "Любой"
     blank_slate:
@@ -57,6 +59,8 @@ ru:
       delete_confirmation: "Вы уверены, что хотите удалить %{plural_model}?"
       succesfully_destroyed:
         one: "Успешно удалено: 1 %{model}"
+        few: "Успешно удалено: %{count} %{plural_model}"
+        many: "Успешно удалено: %{count} %{plural_model}"
         other: "Успешно удалено: %{count} %{plural_model}"
       selection_toggle_explanation: "(Отметить всё / Снять выделение)"
       link: "Создать"

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -47,6 +47,8 @@ uk:
       entry:
         one: "запис"
         other: "записів"
+        many: "записів"
+        few: "записи"
     any: "Будь-який"
     blank_slate:
       content: "Покищо немає %{resource_name}."
@@ -57,6 +59,8 @@ uk:
       delete_confirmation: "Ви впевнені, що хочете видалити %{plural_model}?"
       succesfully_destroyed:
         one: "Успішно видалено: 1 %{model}"
+        few: "Успішно видалено: %{count} %{plural_model}"
+        many: "Успішно видалено: %{count} %{plural_model}"
         other: "Успішно видалено: %{count} %{plural_model}"
       selection_toggle_explanation: "(Відмінити все / Зняти виділення)"
       link: "Створити"


### PR DESCRIPTION
I developed a tool for yaml file comparison, so now you can easily find out which translation keys are missing or deprecated. I fixed translations for ukrainian and russian languages using this gem:  https://github.com/HeeL/differz
The other native speakers can do that too. More details in the blog post: http://kvaziblog.com/posts/5
