### PR TITLE
Can customize or remove blank slate link

### DIFF
--- a/features/index/index_blank_slate.feature
+++ b/features/index/index_blank_slate.feature
@@ -59,3 +59,25 @@ Feature: Index Blank Slate
       end
       """
     And I should see "There are no Posts yet. Create one"
+
+  Scenario: Customizing the default table with no resources
+    Given an index configuration of:
+      """
+        ActiveAdmin.register Post do
+          index blank_slate_link: ->{link_to("Go to dashboard", admin_root_path)} do |post|
+          end
+        end
+      """
+    When I follow "Go to dashboard"
+    Then I should see "Dashboard"
+
+  Scenario: Customizing the default table with no blank slate link
+    Given an index configuration of:
+      """
+        ActiveAdmin.register Post do
+          index blank_slate_link: false do |post|
+          end
+        end
+      """
+    Then I should see "There are no Posts yet."
+    And I should not see "Create one"

--- a/lib/active_admin/views/pages/index.rb
+++ b/lib/active_admin/views/pages/index.rb
@@ -113,7 +113,7 @@ module ActiveAdmin
         def render_blank_slate
           blank_slate_content = I18n.t("active_admin.blank_slate.content", resource_name: active_admin_config.plural_resource_label)
           if controller.action_methods.include?('new') && authorized?(ActiveAdmin::Auth::CREATE, active_admin_config.resource_class)
-            blank_slate_content += " " + link_to(I18n.t("active_admin.blank_slate.link"), new_resource_path)
+            blank_slate_content = [blank_slate_content, blank_slate_link].compact.join(" ")
           end
           insert_tag(view_factory.blank_slate, blank_slate_content)
         end
@@ -140,6 +140,22 @@ module ActiveAdmin
           end
         end
 
+        private
+
+        def blank_slate_link
+          if config.options.has_key?(:blank_slate_link)
+            blank_slate_link = config.options[:blank_slate_link]
+            if blank_slate_link.is_a?(Proc)
+              instance_exec(&blank_slate_link)
+            end
+          else
+            default_blank_slate_link
+          end
+        end
+
+        def default_blank_slate_link
+          link_to(I18n.t("active_admin.blank_slate.link"), new_resource_path)
+        end
       end
     end
   end


### PR DESCRIPTION
There are some cases where you would want to be able to change the link text or url that appears when there are no resources.  Or you may just want to remove it altogether and use the default new button.
