### PR TITLE
Add xdan-datetimepicker-rails and datetime_picker input

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'inherited_resources', '~> 1.4.1'
   s.add_dependency 'jquery-rails'
   s.add_dependency 'jquery-ui-rails',     '~> 5.0'
+  s.add_dependency 'xdan-datetimepicker-rails'
   s.add_dependency 'kaminari',            '~> 0.15'
   s.add_dependency 'rails',               '>= 3.2', '< 4.2'
   s.add_dependency 'ransack',             '~> 1.3'

--- a/app/assets/javascripts/active_admin/application.js.coffee
+++ b/app/assets/javascripts/active_admin/application.js.coffee
@@ -6,6 +6,11 @@ $ ->
     options = $(@).data 'datepicker-options'
     $(@).datepicker $.extend(defaults, options)
 
+  $(document).on 'focus', '.xdan-datetime-picker:not(.hasDatepicker)', ->
+    defaults = formatDate: 'y-m-d', format: 'Y-m-d H:i'
+    options = $(@).data 'datepicker-options'
+    $(@).datetimepicker $.extend(defaults, options)
+
   # Clear Filters button
   $('.clear_filters_btn').click ->
     window.location.search = ''

--- a/app/assets/javascripts/active_admin/application.js.coffee
+++ b/app/assets/javascripts/active_admin/application.js.coffee
@@ -6,10 +6,10 @@ $ ->
     options = $(@).data 'datepicker-options'
     $(@).datepicker $.extend(defaults, options)
 
-  $(document).on 'focus', '.xdan-datetime-picker:not(.hasDatepicker)', ->
-    defaults = formatDate: 'y-m-d', format: 'Y-m-d H:i'
+  $(document).on 'focus', '.combined-date-time-picker', ->
+    defaults = formatDate: 'y-m-d', format: 'Y-m-d H:i', allowBlank: true
     options = $(@).data 'datepicker-options'
-    $(@).datetimepicker $.extend(defaults, options)
+    $(@).datetimepicker($.extend(defaults, options)).trigger('open.xdsoft')
 
   # Clear Filters button
   $('.clear_filters_btn').click ->

--- a/app/assets/javascripts/active_admin/application.js.coffee
+++ b/app/assets/javascripts/active_admin/application.js.coffee
@@ -1,4 +1,19 @@
 # Initializers
+@setupDateTimePicker = (container) ->
+  defaults = {
+    formatDate: 'y-m-d',
+    format: 'Y-m-d H:i',
+    allowBlank: true,
+    defaultSelect: false,
+    validateOnBlur: false
+  }
+
+  entries = $(container).find('.combined-date-time-picker')
+  entries.each (index, entry) ->
+    options = $(entry).data 'datepicker-options'
+    $(entry).datetimepicker $.extend(defaults, options)
+
+
 $ ->
   # jQuery datepickers (also evaluates dynamically added HTML)
   $(document).on 'focus', '.datepicker:not(.hasDatepicker)', ->
@@ -6,10 +21,9 @@ $ ->
     options = $(@).data 'datepicker-options'
     $(@).datepicker $.extend(defaults, options)
 
-  $(document).on 'focus', '.combined-date-time-picker', ->
-    defaults = formatDate: 'y-m-d', format: 'Y-m-d H:i', allowBlank: true
-    options = $(@).data 'datepicker-options'
-    $(@).datetimepicker($.extend(defaults, options)).trigger('open.xdsoft')
+  setupDateTimePicker $('body')
+  $(document).on 'has_many_add:after', '.has_many_container', (e, fieldset) ->
+    setupDateTimePicker fieldset
 
   # Clear Filters button
   $('.clear_filters_btn').click ->

--- a/app/assets/javascripts/active_admin/base.js.coffee
+++ b/app/assets/javascripts/active_admin/base.js.coffee
@@ -4,6 +4,7 @@
 #= require jquery-ui/sortable
 #= require jquery-ui/widget
 #= require jquery_ujs
+#= require jquery.xdan.datetimepicker
 #
 #= require_self
 #= require_tree ./lib

--- a/app/assets/stylesheets/active_admin/_base.css.scss
+++ b/app/assets/stylesheets/active_admin/_base.css.scss
@@ -2,6 +2,9 @@
 // Reset Away!
 @include global-reset;
 
+// Third-party libraries
+@import "jquery.xdan.datetimepicker";
+
 // Partials
 @import "active_admin/typography";
 @import "active_admin/header";

--- a/docs/5-forms.md
+++ b/docs/5-forms.md
@@ -114,6 +114,20 @@ form do |f|
 end
 ```
 
+## Combined DateTime Picker
+
+ActiveAdmin also offers the `combined_date_time_picker` input, which uses the [XDSoft DateTime Picker gem](https://github.com/shekibobo/xdan-datetimepicker-rails).
+The `combined_date_time_picker` input accepts many of the options available to the standard jQueryUI Datepicker. For example:
+
+```ruby
+form do |f|
+  f.input :starts_at, as: :datepicker, datepicker_options: { min_date: "2013-10-8",        max_date: "+3D" }
+  f.input :ends_at,   as: :datepicker, datepicker_options: { min_date: 3.days.ago.to_date, max_date: "+1W +5D" }
+end
+```
+
+See [the datetimepicker documentation for more details](http://xdsoft.net/jqplugins/datetimepicker/).
+
 ## Displaying Errors
 
 To display a list of all validation errors:

--- a/lib/active_admin.rb
+++ b/lib/active_admin.rb
@@ -10,6 +10,7 @@ require 'sass-rails'
 require 'inherited_resources'
 require 'jquery-rails'
 require 'jquery-ui-rails'
+require 'xdan-datetimepicker-rails'
 require 'coffee-rails'
 require 'arbre'
 

--- a/lib/active_admin/inputs.rb
+++ b/lib/active_admin/inputs.rb
@@ -3,6 +3,7 @@ module ActiveAdmin
     extend ActiveSupport::Autoload
 
     autoload :DatepickerInput
+    autoload :CombinedDateTimePickerInput
 
     autoload :FilterBase
     autoload :FilterStringInput

--- a/lib/active_admin/inputs/combined_date_time_picker_input.rb
+++ b/lib/active_admin/inputs/combined_date_time_picker_input.rb
@@ -1,9 +1,9 @@
 module ActiveAdmin
   module Inputs
-    class DatetimePickerInput < ::Formtastic::Inputs::StringInput
+    class CombinedDateTimePickerInput < ::Formtastic::Inputs::StringInput
       def input_html_options
         super.tap do |options|
-          options[:class] = [options[:class], "xdan-datetime-picker"].compact.join(' ')
+          options[:class] = [options[:class], "combined-date-time-picker"].compact.join(' ')
           options[:data] ||= {}
           options[:data].merge! datepicker_options
           options[:value] ||= value

--- a/lib/active_admin/inputs/datetime_picker_input.rb
+++ b/lib/active_admin/inputs/datetime_picker_input.rb
@@ -1,0 +1,28 @@
+module ActiveAdmin
+  module Inputs
+    class DatetimePickerInput < ::Formtastic::Inputs::StringInput
+      def input_html_options
+        super.tap do |options|
+          options[:class] = [options[:class], "xdan-datetime-picker"].compact.join(' ')
+          options[:data] ||= {}
+          options[:data].merge! datepicker_options
+          options[:value] ||= value
+        end
+      end
+
+      def value
+        val = object.send(method)
+        return DateTime.new(val.year, val.month, val.day, val.hour, val.min).strftime("%Y-%m-%d %H:%M") if val.is_a?(Time)
+        return val if val.nil?
+        val.to_s
+      end
+
+      private
+        def datepicker_options
+          options = self.options.fetch(:datepicker_options, {})
+          options = Hash[options.map{ |k, v| [k.to_s.camelcase(:lower), v] }]
+          { datepicker_options: options }
+        end
+    end
+  end
+end

--- a/lib/active_admin/inputs/filter_date_range_input.rb
+++ b/lib/active_admin/inputs/filter_date_range_input.rb
@@ -25,7 +25,7 @@ module ActiveAdmin
       def input_html_options(input_name = gt_input_name)
         current_value = @object.public_send input_name
         { size: 12,
-          class: "datepicker",
+          class: "combined-date-time-picker",
           max: 10,
           value: current_value.respond_to?(:strftime) ? current_value.strftime("%Y-%m-%d") : "" }
       end

--- a/spec/unit/filters/filter_form_builder_spec.rb
+++ b/spec/unit/filters/filter_form_builder_spec.rb
@@ -157,13 +157,13 @@ describe ActiveAdmin::Filters::ViewHelper do
     let(:body) { filter :created_at }
 
     it "should generate a date greater than" do
-      expect(body).to have_tag("input", attributes: { name: "q[created_at_gteq]", class: "datepicker"})
+      expect(body).to have_tag("input", attributes: { name: "q[created_at_gteq]", class: "combined-date-time-picker"})
     end
     it "should generate a seperator" do
       expect(body).to have_tag("span", attributes: { class: "seperator"})
     end
     it "should generate a date less than" do
-      expect(body).to have_tag("input", attributes: { name: "q[created_at_lteq]", class: "datepicker"})
+      expect(body).to have_tag("input", attributes: { name: "q[created_at_lteq]", class: "combined-date-time-picker"})
     end
   end
 

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -575,6 +575,7 @@ describe ActiveAdmin::FormBuilder do
           end
         end
       end
+
       it "should generate a text input with the class of datepicker" do
         expect(body).to have_tag("input", attributes: {  type: "text",
                                                             class: "datepicker",
@@ -601,6 +602,46 @@ describe ActiveAdmin::FormBuilder do
                                                         "data-datepicker-options" => CGI::escapeHTML({
                                                           minDate: "2013-10-18",
                                                           maxDate: "2013-12-31" }.to_json) })
+      end
+    end
+  end
+
+  describe "combined_date_time_picker input" do
+    context 'with default options' do
+      let :body do
+        build_form do |f|
+          f.inputs do
+            f.input :created_at, as: :combined_date_time_picker
+          end
+        end
+      end
+
+      it "should generate a text input with the class of combined-date-time-picker" do
+        expect(body).to have_tag("input", attributes: { type: "text",
+                                                        class: "combined-date-time-picker",
+                                                        name: "post[created_at]" })
+      end
+    end
+
+    context 'with date range options' do
+      let :body do
+        build_form do |f|
+          f.inputs do
+            f.input :created_at, as: :combined_date_time_picker,
+                                  datepicker_options: {
+                                    min_date: Date.new(2013, 10, 18),
+                                    max_date: "2013-12-31" }
+          end
+        end
+      end
+
+      it 'should generate a combined_date_time_picker text input with data min and max dates' do
+        expect(body).to have_tag("input", attributes: { type: "text",
+                                                        class: "combined-date-time-picker",
+                                                        name: "post[created_at]",
+                                                        data: { datepicker_options: {
+                                                          minDate: "2013-10-18",
+                                                          maxDate: "2013-12-31" }.to_json }})
       end
     end
   end

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -639,9 +639,9 @@ describe ActiveAdmin::FormBuilder do
         expect(body).to have_tag("input", attributes: { type: "text",
                                                         class: "combined-date-time-picker",
                                                         name: "post[created_at]",
-                                                        data: { datepicker_options: {
+                                                        "data-datepicker-options" => CGI::escapeHTML({
                                                           minDate: "2013-10-18",
-                                                          maxDate: "2013-12-31" }.to_json }})
+                                                          maxDate: "2013-12-31" }.to_json) })
       end
     end
   end


### PR DESCRIPTION
Adds [XDSoft's DateTime picker](http://xdsoft.net/jqplugins/datetimepicker/) as the `combined_date_time_picker` input for forms.

[IRC](https://botbot.me/freenode/activeadmin/msg/12028495/) prompting this PR.

Please try this out and see if there's any tweaks or suggestions to better implement this, or if you notice any bugs.

<!---
@huboard:{"order":3208.0,"milestone_order":3000,"custom_state":""}
-->
