### PR TITLE
Simplified the index page title method

### DIFF
--- a/lib/active_admin/views/pages/index.rb
+++ b/lib/active_admin/views/pages/index.rb
@@ -7,9 +7,8 @@ module ActiveAdmin
       class Index < Base
 
         def title
-          case config[:title]
-          when Proc   then controller.instance_exec &config[:title]
-          when String then config[:title]
+          if config[:title]
+            render_or_call_method_or_proc_on(controller, config[:title])
           else
             assigns[:page_title] || active_admin_config.plural_resource_label
           end


### PR DESCRIPTION
I think the method still does the same thing, it's just simplified and works the same way the show page's title method does.
