### PR TITLE
More useful `actions` method for `index_as_table`

### DIFF
--- a/lib/active_admin/views/index_as_table.rb
+++ b/lib/active_admin/views/index_as_table.rb
@@ -240,7 +240,8 @@ module ActiveAdmin
         def actions(*args, &block)
           options = args.extract_options!
           show_default_links = options.delete(:defaults) { true }
-          column(*args, options) do |resource|
+          name = options.delete(:name) { "" }
+          column args.unshift(name), options do |resource|
             text_node default_actions(resource) if show_default_links
             text_node instance_exec(resource, &block) if block_given?
           end


### PR DESCRIPTION
Now you can pass any options which `column` supports.
For example:

``` ruby
ActiveAdmin.register Post do
  index do
    actions I18n.t('active_admin.edit'), :defaults => false, :class => "col-edit" do |post|
      link_to(I18n.t('active_admin.delete'), admin_post_path(post), :method => :delete, :data => {:confirm => I18n.t('active_admin.delete_confirmation')}, :class => "member_link delete_link")
    end
  end
end

```
