### PR TITLE
use default controller methods on the comment resource

### DIFF
--- a/lib/active_admin/orm/active_record/comments.rb
+++ b/lib/active_admin/orm/active_record/comments.rb
@@ -25,7 +25,7 @@ ActiveAdmin.after_load do |app|
   app.namespaces.values.each do |namespace|
     if namespace.comments?
       namespace.register ActiveAdmin::Comment, as: namespace.comments_registration_name do
-        actions :index, :show, :create
+        actions :all
 
         menu false unless namespace.show_comments_in_menu
 


### PR DESCRIPTION
It is quite normal to CRUD the AA::Comment resource.

Another concerning is the override the whole AA::Comment resouce, right now there isn't seem to have a convenient way to override this.
