### PR TITLE
! fix for comparison of Array with Array failed in sortable when updating existing records

### DIFF
--- a/features/index/format_as_csv.feature
+++ b/features/index/format_as_csv.feature
@@ -12,8 +12,8 @@ Feature: Format as CSV
     When I am on the index page for posts
     And I follow "CSV"
     And I should download a CSV file for "posts" containing:
-    | Id  | Title       | Body | Published at | Starred | Created at | Updated at |
-    | \d+ | Hello World |      |              |         | (.*)       | (.*)       |
+    | Id  | Title       | Body | Published at | Position | Starred | Created at | Updated at |
+    | \d+ | Hello World |      |              |          |         | (.*)       | (.*)       |
 
   Scenario: Default with alias
     Given a configuration of:
@@ -24,7 +24,7 @@ Feature: Format as CSV
     When I am on the index page for my_articles
     And I follow "CSV"
     And I should download a CSV file for "my-articles" containing:
-    | Id  | Title       | Body | Published at | Starred | Created at | Updated at |
+    | Id  | Title       | Body | Published at | Position | Starred | Created at | Updated at |
 
   Scenario: With CSV format customization
     Given a configuration of:

--- a/features/index/index_as_table.feature
+++ b/features/index/index_as_table.feature
@@ -180,14 +180,14 @@ Feature: Index as Table
       """
     When I am on the index page for posts
     Then I should see the "index_table_posts" table:
-      | [ ] | Id | Title        | Body | Published At | Starred | Created At | Updated At | |
-      | [ ] | 2 | Bye bye world | Move your...  |  | No | /.*/ | /.*/ | ViewEditDelete |
-      | [ ] | 1 | Hello World   | From the body |  | No | /.*/ | /.*/ | ViewEditDelete |
+      | [ ] | Id | Title        | Body | Published At | Position | Starred | Created At | Updated At | |
+      | [ ] | 2 | Bye bye world | Move your...  |  |  | No | /.*/ | /.*/ | ViewEditDelete |
+      | [ ] | 1 | Hello World   | From the body |  |  | No | /.*/ | /.*/ | ViewEditDelete |
     When I follow "Id"
     Then I should see the "index_table_posts" table:
-      | [ ] | Id | Title        | Body | Published At | Starred | Created At | Updated At | |
-      | [ ] | 1 | Hello World   | From the body |  | No | /.*/ | /.*/ | ViewEditDelete |
-      | [ ] | 2 | Bye bye world | Move your...  |  | No | /.*/ | /.*/ | ViewEditDelete |
+      | [ ] | Id | Title        | Body | Published At | Position | Starred | Created At | Updated At | |
+      | [ ] | 1 | Hello World   | From the body |  |  | No | /.*/ | /.*/ | ViewEditDelete |
+      | [ ] | 2 | Bye bye world | Move your...  |  |  | No | /.*/ | /.*/ | ViewEditDelete |
 
   Scenario: Sorting by a virtual column
     Given a post with the title "Hello World" exists

--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -83,8 +83,11 @@ module ActiveAdmin
       # make sure that the sortable children sorted in stable ascending order
       if column = builder_options[:sortable]
         children = object.send(assoc)
-        children = children.sort_by {|o| [o.send(column), o.id]}
-        options[:for] = [assoc,  children]
+        children.sort_by! do |o|
+          attribute = o.send(column)
+          [attribute.nil? ? Float::INFINITY : attribute, o.id || Float::INFINITY]
+        end
+        options[:for] = [assoc, children]
       end
 
       html = without_wrapper do

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -12,14 +12,14 @@ gsub_file 'config/database.yml', /^test:.*\n/, "test: &test\n"
 gsub_file 'config/database.yml', /\z/, "\ncucumber:\n  <<: *test\n  database: db/cucumber.sqlite3"
 gsub_file 'config/database.yml', /\z/, "\ncucumber_with_reloading:\n  <<: *test\n  database: db/cucumber.sqlite3"
 
-generate :model, "post title:string body:text published_at:datetime author_id:integer custom_category_id:integer starred:boolean"
+generate :model, "post title:string body:text published_at:datetime author_id:integer position:integer custom_category_id:integer starred:boolean"
 inject_into_file 'app/models/post.rb', %q{
   belongs_to :category, foreign_key: :custom_category_id
   belongs_to :author, class_name: 'User'
   has_many :taggings
   accepts_nested_attributes_for :author
   accepts_nested_attributes_for :taggings
-  attr_accessible :author unless Rails::VERSION::MAJOR > 3 && !defined? ProtectedAttributes
+  attr_accessible :author, :position unless Rails::VERSION::MAJOR > 3 && !defined? ProtectedAttributes
 }, after: 'class Post < ActiveRecord::Base'
 copy_file File.expand_path('../templates/post_decorator.rb', __FILE__), "app/models/post_decorator.rb"
 

--- a/spec/unit/filters/resource_spec.rb
+++ b/spec/unit/filters/resource_spec.rb
@@ -13,7 +13,7 @@ describe ActiveAdmin::Filters::ResourceExtension do
 
   it "should return the defaults if no filters are set" do
     expect(resource.filters.keys).to match_array([
-      :author, :body, :category, :created_at, :published_at, :starred, :taggings, :title, :updated_at
+      :author, :body, :category, :created_at, :position, :published_at, :starred, :taggings, :title, :updated_at
     ])
   end
 
@@ -97,7 +97,7 @@ describe ActiveAdmin::Filters::ResourceExtension do
       resource.add_filter :count, as: :string
 
       expect(resource.filters.keys).to match_array([
-        :author, :body, :category, :count, :created_at, :published_at, :starred, :taggings, :title, :updated_at
+        :author, :body, :category, :count, :created_at, :position, :published_at, :starred, :taggings, :title, :updated_at
       ])
     end
 

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -437,13 +437,52 @@ describe ActiveAdmin::FormBuilder do
         let :body do
           build_form({url: '/categories'}, Category.new) do |f|
             f.object.posts.build
-            f.has_many :posts, sortable: :custom_category_id do |p|
+            f.has_many :posts, sortable: :position do |p|
               p.input :title
             end
           end
         end
 
         it "shows the nested fields for unsaved records" do
+          body.should have_tag("fieldset", attributes: {class: "inputs has_many_fields"})
+        end
+
+      end
+      
+      context "with post returning nil for the sortable attribute" do
+        let :body do
+          build_form({url: '/categories'}, Category.new) do |f|
+            f.object.posts.build position: 3
+            f.object.posts.build
+            f.has_many :posts, sortable: :position do |p|
+              p.input :title
+            end
+          end
+        end
+
+        it "shows the nested fields for unsaved records" do
+          body.should have_tag("fieldset", attributes: {class: "inputs has_many_fields"})
+        end
+
+      end
+      
+      context "with existing and new posts" do
+        let! :category do
+          Category.create name: 'Name'
+        end
+        let! :post do
+          category.posts.create
+        end
+        let :body do
+          build_form({url: '/categories'}, category) do |f|
+            f.object.posts.build
+            f.has_many :posts, sortable: :position do |p|
+              p.input :title
+            end
+          end
+        end
+
+        it "shows the nested fields for saved and unsaved records" do
           body.should have_tag("fieldset", attributes: {class: "inputs has_many_fields"})
         end
 


### PR DESCRIPTION
I have regularly run into this error recently when using the sortable option in `has_many`: `comparison of Array with Array failed`. It is caused by the `sort_by` in sortable when both existing records with a present sortable column and new records with either present or not present sortable column are updated together.

This PR fixes this by pushing all records with a blank sortable attribute to the end of the list. It also prevents errors when new and existing errors are mixed together.

However I don't know if this is a sensible default for everyone using this feature. There are other possiblities I thought about:
- Defaults for the sortable attribute, however I think this should not be Active Admin's concern.
- Raise a more descriptive error when the sortable attribute is `nil`

Looking forward to discussing this.
