### PR TITLE
default namespace devise problem

### DIFF
--- a/lib/active_admin/devise.rb
+++ b/lib/active_admin/devise.rb
@@ -5,7 +5,7 @@ module ActiveAdmin
 
     def self.config
       config = {
-        path: ActiveAdmin.application.default_namespace,
+        path: ActiveAdmin.application.default_namespace || "/",
         controllers: ActiveAdmin::Devise.controllers,
         path_names: { sign_in: 'login', sign_out: "logout" }
       }

--- a/spec/integration/default_namespace_spec.rb
+++ b/spec/integration/default_namespace_spec.rb
@@ -22,11 +22,11 @@ describe ActiveAdmin::Application do
       end
 
       it "should generate a log out path" do
-        expect(destroy_admin_user_session_path).to eq "/admin_users/logout"
+        expect(destroy_admin_user_session_path).to eq "/logout"
       end
 
       it "should generate a log in path" do
-        expect(new_admin_user_session_path).to eq "/admin_users/login"
+        expect(new_admin_user_session_path).to eq "/login"
       end
 
     end


### PR DESCRIPTION
I have a Problem with the `default_namespace` config option.

Without any config change, the routes are:

```
new_user_session_path       GET     /admin/login(.:format)
new_admin_customer_path GET     /admin/customers/new(.:format)
```

With `config.default_namespace = false` the routes are:

```
new_user_session_path       GET     /users/login(.:format)
customers_path          GET     /customers(.:format)
```

But I think the routes should be:

```
new_user_session_path       GET     /login(.:format)
customers_path          GET     /customers(.:format)
```
