### PR TITLE
Convert specs to RSpec 2.14.8 syntax with Transpec

### DIFF
--- a/spec/unit/comments_spec.rb
+++ b/spec/unit/comments_spec.rb
@@ -103,8 +103,8 @@ describe "Comments" do
           body: "Lorem Ipsum",
           namespace: namespace_name)
 
-        ActiveAdmin::Comment.find_for_resource_in_namespace(publisher, namespace_name).last.resource_type.
-          should == 'Publisher'
+        expect(ActiveAdmin::Comment.find_for_resource_in_namespace(publisher, namespace_name).last.resource_type).
+          to eq('Publisher')
       end
     end
   end

--- a/spec/unit/config_shared_examples.rb
+++ b/spec/unit/config_shared_examples.rb
@@ -1,13 +1,13 @@
 shared_examples_for "ActiveAdmin::Config" do
   describe "namespace" do
     it "should return the namespace" do
-      config.namespace.should == namespace
+      expect(config.namespace).to eq(namespace)
     end
   end
 
   describe "page_presenters" do
     it "should return an empty hash by default" do
-      config.page_presenters.should == {}
+      expect(config.page_presenters).to eq({})
     end
   end
 
@@ -34,24 +34,24 @@ shared_examples_for "ActiveAdmin::Config" do
     describe "#menu_item_options" do
 
       it "initializes a new menu item with defaults" do
-          config.menu_item_options[:label].call.should == config.plural_resource_label
+          expect(config.menu_item_options[:label].call).to eq(config.plural_resource_label)
       end
 
       it "initialize a new menu item with custom options" do
         config.menu_item_options = { label: "Hello" }
-        config.menu_item_options[:label].should == "Hello"
+        expect(config.menu_item_options[:label]).to eq("Hello")
       end
 
     end
 
     describe "#include_in_menu?" do
       it "should be included in menu by default" do
-        config.include_in_menu?.should == true
+        expect(config.include_in_menu?).to eq(true)
       end
 
       it "should not be included in menu when menu set to false" do
         config.menu_item_options = false
-        config.include_in_menu?.should == false
+        expect(config.include_in_menu?).to eq(false)
       end
     end
 

--- a/spec/unit/csv_builder_spec.rb
+++ b/spec/unit/csv_builder_spec.rb
@@ -25,8 +25,8 @@ describe ActiveAdmin::CSVBuilder do
       let(:localized_name) { 'Titulo' }
 
       before do
-        Post.stub(:human_attribute_name).and_call_original
-        Post.stub(:human_attribute_name).with(:title){ localized_name }
+        allow(Post).to receive(:human_attribute_name).and_call_original
+        allow(Post).to receive(:human_attribute_name).with(:title){ localized_name }
       end
 
       it 'gets name from I18n' do

--- a/spec/unit/devise_spec.rb
+++ b/spec/unit/devise_spec.rb
@@ -92,7 +92,7 @@ describe ActiveAdmin::Devise::Controller do
       context "when Devise implements sign_out_via (version >= 1.2)" do
         before do
          expect(::Devise).to receive(:respond_to?).with(:sign_out_via).and_return(true)
-          ::Devise.stub(:sign_out_via) { :delete }
+          allow(::Devise).to receive(:sign_out_via) { :delete }
         end
 
         it "should contain the application.logout_link_method" do

--- a/spec/unit/filters/filter_form_builder_spec.rb
+++ b/spec/unit/filters/filter_form_builder_spec.rb
@@ -135,7 +135,7 @@ describe ActiveAdmin::Filters::ViewHelper do
 
     context "when loading collection from DB" do
       it "should use pluck for efficiency" do
-        builder.any_instance.should_receive(:pluck_column) { [] }
+        expect_any_instance_of(builder).to receive(:pluck_column) { [] }
         body
       end
 

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -52,19 +52,19 @@ describe ActiveAdmin::FormBuilder do
     end
 
    it "should generate a text input" do
-      body.should have_tag("input", attributes: { type: "text",
+      expect(body).to have_tag("input", attributes: { type: "text",
                                                      name: "post[title]" })
     end
     it "should generate a textarea" do
-      body.should have_tag("textarea", attributes: { name: "post[body]" })
+      expect(body).to have_tag("textarea", attributes: { name: "post[body]" })
     end
     it "should only generate the form once" do
-      body.scan(/Title/).size.should == 1
+      expect(body.scan(/Title/).size).to eq(1)
     end
     it "should generate actions" do
-      body.should have_tag("input", attributes: {  type: "submit",
+      expect(body).to have_tag("input", attributes: {  type: "submit",
                                                           value: "Submit Me" })
-      body.should have_tag("input", attributes: {  type: "submit",
+      expect(body).to have_tag("input", attributes: {  type: "submit",
                                                           value: "Another Button" })
     end
   end
@@ -88,7 +88,7 @@ describe ActiveAdmin::FormBuilder do
       end
     end
     it "should pass the options on to the form" do
-      body.should have_tag("form", attributes: { enctype: "multipart/form-data" })
+      expect(body).to have_tag("form", attributes: { enctype: "multipart/form-data" })
     end
   end
 
@@ -100,7 +100,7 @@ describe ActiveAdmin::FormBuilder do
       end
     end
     it "should pass the options on to the form" do
-      body.should have_tag("form", attributes: { enctype: "multipart/form-data" })
+      expect(body).to have_tag("form", attributes: { enctype: "multipart/form-data" })
     end
   end
 
@@ -113,14 +113,14 @@ describe ActiveAdmin::FormBuilder do
         end
         f.actions
       end
-      body.scan(/id="post_title"/).size.should == 1
+      expect(body.scan(/id="post_title"/).size).to eq(1)
     end
     it "should generate one button and a cancel link" do
       body = build_form do |f|
         f.actions
       end
-      body.scan(/type="submit"/).size.should == 1
-      body.scan(/class="cancel"/).size.should == 1
+      expect(body.scan(/type="submit"/).size).to eq(1)
+      expect(body.scan(/class="cancel"/).size).to eq(1)
     end
     it "should generate multiple actions" do
       body = build_form do |f|
@@ -129,8 +129,8 @@ describe ActiveAdmin::FormBuilder do
           f.action :submit, label: "Create & Edit"
         end
       end
-      body.scan(/type="submit"/).size.should == 2
-      body.scan(/class="cancel"/).size.should == 0
+      expect(body.scan(/type="submit"/).size).to eq(2)
+      expect(body.scan(/class="cancel"/).size).to eq(0)
     end
 
   end
@@ -143,14 +143,14 @@ describe ActiveAdmin::FormBuilder do
         end
         f.actions
       end
-      body.scan(/id="post_title"/).size.should == 1
+      expect(body.scan(/id="post_title"/).size).to eq(1)
     end
     it "should generate one button and a cancel link" do
       body = build_form do |f|
         f.actions
       end
-      body.scan(/type="submit"/).size.should == 1
-      body.scan(/class="cancel"/).size.should == 1
+      expect(body.scan(/type="submit"/).size).to eq(1)
+      expect(body.scan(/class="cancel"/).size).to eq(1)
     end
     it "should generate multiple actions" do
       body = build_form do |f|
@@ -159,8 +159,8 @@ describe ActiveAdmin::FormBuilder do
           f.action :submit, label: "Create & Edit"
         end
       end
-      body.scan(/type="submit"/).size.should == 2
-      body.scan(/class="cancel"/).size.should == 0
+      expect(body.scan(/type="submit"/).size).to eq(2)
+      expect(body.scan(/class="cancel"/).size).to eq(0)
     end
   end
 
@@ -171,11 +171,11 @@ describe ActiveAdmin::FormBuilder do
       end
     end
     it "should have a title input" do
-      body.should have_tag("input", attributes: { type: "text",
+      expect(body).to have_tag("input", attributes: { type: "text",
                                                           name: "post[title]" })
     end
     it "should have a body textarea" do
-      body.should have_tag("textarea", attributes: { name: "post[body]" })
+      expect(body).to have_tag("textarea", attributes: { name: "post[body]" })
     end
   end
 
@@ -195,7 +195,7 @@ describe ActiveAdmin::FormBuilder do
       end
     end
     it "should generate a nested text input once" do
-      body.scan("post_author_attributes_first_name_input").size.should == 1
+      expect(body.scan("post_author_attributes_first_name_input").size).to eq(1)
     end
   end
 
@@ -212,7 +212,7 @@ describe ActiveAdmin::FormBuilder do
         end
       end
       it "should create 2 options" do
-        body.scan(/<option/).size.should == 3
+        expect(body.scan(/<option/).size).to eq(3)
       end
     end
 
@@ -223,7 +223,7 @@ describe ActiveAdmin::FormBuilder do
         end
       end
       it "should create 2 radio buttons" do
-        body.scan(/type="radio"/).size.should == 2
+        expect(body.scan(/type="radio"/).size).to eq(2)
       end
     end
 
@@ -245,10 +245,10 @@ describe ActiveAdmin::FormBuilder do
       end
     end
     it "should generate a nested text input once" do
-      body.scan("post_author_attributes_first_name_input").size.should == 1
+      expect(body.scan("post_author_attributes_first_name_input").size).to eq(1)
     end
     it "should add an author first name field" do
-      body.should have_tag("input", attributes: { name: "post[author_attributes][first_name]"})
+      expect(body).to have_tag("input", attributes: { name: "post[author_attributes][first_name]"})
     end
   end
 
@@ -257,7 +257,7 @@ describe ActiveAdmin::FormBuilder do
       body = build_form do |f|
         f.input :title, wrapper_html: { class: "important" }
       end
-      body.should have_tag("li", attributes: {class: "important string input optional stringish"})
+      expect(body).to have_tag("li", attributes: {class: "important string input optional stringish"})
     end
   end
 
@@ -274,41 +274,41 @@ describe ActiveAdmin::FormBuilder do
 
       it "should translate the association name in header" do
         with_translation activerecord: {models: {post: {one: 'Blog Post', other: 'Blog Posts'}}} do
-          body.should have_tag('h3', 'Blog Posts')
+          expect(body).to have_tag('h3', 'Blog Posts')
         end
       end
 
       it "should use model name when there is no translation for given model in header" do
-        body.should have_tag('h3', 'Post')
+        expect(body).to have_tag('h3', 'Post')
       end
 
       it "should translate the association name in has many new button" do
         with_translation activerecord: {models: {post: {one: 'Blog Post', other: 'Blog Posts'}}} do
-          body.should have_tag('a', 'Add New Blog Post')
+          expect(body).to have_tag('a', 'Add New Blog Post')
         end
       end
 
       it "should translate the attribute name" do
         with_translation activerecord: {attributes: {post: {title: 'A very nice title'}}} do
-          body.should have_tag 'label', 'A very nice title'
+          expect(body).to have_tag 'label', 'A very nice title'
         end
       end
 
       it "should use model name when there is no translation for given model in has many new button" do
-        body.should have_tag('a', 'Add New Post')
+        expect(body).to have_tag('a', 'Add New Post')
       end
 
       it "should render the nested form" do
-        body.should have_tag("input", attributes: {name: "category[posts_attributes][0][title]"})
+        expect(body).to have_tag("input", attributes: {name: "category[posts_attributes][0][title]"})
       end
 
       it "should add a link to remove new nested records" do
-        Capybara.string(body).should have_css '.has_many_container > fieldset > ol > li > a', href: '#',
+        expect(Capybara.string(body)).to have_css '.has_many_container > fieldset > ol > li > a', href: '#',
           content: 'Remove', class: 'button has_many_remove', data: {placeholder: 'NEW_POST_RECORD'}
       end
 
       it "should add a link to add new nested records" do
-        Capybara.string(body).should have_css(".has_many_container > fieldset > ol > li > a", class: "button", href: "#", content: "Add New Post")
+        expect(Capybara.string(body)).to have_css(".has_many_container > fieldset > ol > li > a", class: "button", href: "#", content: "Add New Post")
       end
     end
 
@@ -323,11 +323,11 @@ describe ActiveAdmin::FormBuilder do
       end
 
       it "should accept a block with a second argument" do
-        body.should have_tag("label", "Title 1")
+        expect(body).to have_tag("label", "Title 1")
       end
 
       it "should add a custom header" do
-        body.should have_tag('h3', 'Post')
+        expect(body).to have_tag('h3', 'Post')
       end
 
     end
@@ -343,15 +343,15 @@ describe ActiveAdmin::FormBuilder do
       end
 
       it "should not add a header" do
-        body.should_not have_tag('h3', 'Post')
+        expect(body).not_to have_tag('h3', 'Post')
       end
 
       it "should not add link to new nested records" do
-        body.should_not have_tag('a', 'Add New Post')
+        expect(body).not_to have_tag('a', 'Add New Post')
       end
 
       it "should render the nested form" do
-        body.should have_tag("input", attributes: {name: "category[posts_attributes][0][title]"})
+        expect(body).to have_tag("input", attributes: {name: "category[posts_attributes][0][title]"})
       end
     end
 
@@ -366,7 +366,7 @@ describe ActiveAdmin::FormBuilder do
       end
 
       it "should add a custom header" do
-        body.should have_tag('h3', 'Test heading')
+        expect(body).to have_tag('h3', 'Test heading')
       end
 
     end
@@ -382,7 +382,7 @@ describe ActiveAdmin::FormBuilder do
       end
 
       it "should add a custom new record link" do
-        body.should have_tag('a', 'My Custom New Post')
+        expect(body).to have_tag('a', 'My Custom New Post')
       end
 
     end
@@ -399,15 +399,15 @@ describe ActiveAdmin::FormBuilder do
         end
 
         it "should include a boolean field for _destroy" do
-          body.should have_tag("input", attributes: {name: "category[posts_attributes][0][_destroy]"})
+          expect(body).to have_tag("input", attributes: {name: "category[posts_attributes][0][_destroy]"})
         end
 
         it "should have a check box with 'Remove' as its label" do
-          body.should have_tag("label", attributes: {for: "category_posts_attributes_0__destroy"}, content: "Delete")
+          expect(body).to have_tag("label", attributes: {for: "category_posts_attributes_0__destroy"}, content: "Delete")
         end
 
         it "should wrap the destroy field in an li with class 'has_many_delete'" do
-          Capybara.string(body).should have_css(".has_many_container > fieldset > ol > li.has_many_delete > input")
+          expect(Capybara.string(body)).to have_css(".has_many_container > fieldset > ol > li.has_many_delete > input")
         end
       end
 
@@ -422,11 +422,11 @@ describe ActiveAdmin::FormBuilder do
         end
 
         it "should not have a boolean field for _destroy" do
-          body.should_not have_tag("input", attributes: {name: "category[posts_attributes][0][_destroy]"})
+          expect(body).not_to have_tag("input", attributes: {name: "category[posts_attributes][0][_destroy]"})
         end
 
         it "should not have a check box with 'Remove' as its label" do
-          body.should_not have_tag("label", attributes: {for: "category_posts_attributes_0__destroy"}, content: "Remove")
+          expect(body).not_to have_tag("label", attributes: {for: "category_posts_attributes_0__destroy"}, content: "Remove")
         end
       end
     end
@@ -444,7 +444,7 @@ describe ActiveAdmin::FormBuilder do
         end
 
         it "shows the nested fields for unsaved records" do
-          body.should have_tag("fieldset", attributes: {class: "inputs has_many_fields"})
+          expect(body).to have_tag("fieldset", attributes: {class: "inputs has_many_fields"})
         end
 
       end
@@ -464,15 +464,15 @@ describe ActiveAdmin::FormBuilder do
         end
 
         it "should wrap the has_many fieldset in an li" do
-          Capybara.string(body).should have_css("ol > li.has_many_container")
+          expect(Capybara.string(body)).to have_css("ol > li.has_many_container")
         end
 
         it "should have a direct fieldset child" do
-          Capybara.string(body).should have_css("li.has_many_container > fieldset")
+          expect(Capybara.string(body)).to have_css("li.has_many_container > fieldset")
         end
 
         it "should not contain invalid li children" do
-          Capybara.string(body).should_not have_css("div.has_many_container > li")
+          expect(Capybara.string(body)).not_to have_css("div.has_many_container > li")
         end
       end
 
@@ -490,11 +490,11 @@ describe ActiveAdmin::FormBuilder do
         end
 
         it "should wrap the inner has_many fieldset in an ol > li" do
-          Capybara.string(body).should have_css(".has_many_container ol > li.has_many_container > fieldset")
+          expect(Capybara.string(body)).to have_css(".has_many_container ol > li.has_many_container > fieldset")
         end
 
         it "should not contain invalid li children" do
-          Capybara.string(body).should_not have_css(".has_many_container div.has_many_container > li")
+          expect(Capybara.string(body)).not_to have_css(".has_many_container div.has_many_container > li")
         end
       end
     end
@@ -508,7 +508,7 @@ describe ActiveAdmin::FormBuilder do
         end
       end
 
-      body.should have_tag("input", attributes: {name: "category[posts_attributes][0][title]"})
+      expect(body).to have_tag("input", attributes: {name: "category[posts_attributes][0][title]"})
     end
   end
 
@@ -531,7 +531,7 @@ describe ActiveAdmin::FormBuilder do
          eval source
        end
      end
-     body.scan(regex).size.should == 2
+     expect(body.scan(regex).size).to eq(2)
    end
   end
 
@@ -545,7 +545,7 @@ describe ActiveAdmin::FormBuilder do
         end
       end
       it "should generate a text input with the class of datepicker" do
-        body.should have_tag("input", attributes: {  type: "text",
+        expect(body).to have_tag("input", attributes: {  type: "text",
                                                             class: "datepicker",
                                                             name: "post[created_at]" })
       end

--- a/spec/unit/order_clause_spec.rb
+++ b/spec/unit/order_clause_spec.rb
@@ -11,8 +11,16 @@ describe ActiveAdmin::OrderClause do
     let(:clause) { 'id_asc' }
 
     it { should be_valid }
-    its(:field) { should == 'id' }
-    its(:order) { should == 'asc' }
+
+    describe '#field' do
+      subject { super().field }
+      it { should == 'id' }
+    end
+
+    describe '#order' do
+      subject { super().order }
+      it { should == 'asc' }
+    end
 
     specify '#to_sql prepends table name' do
       expect(subject.to_sql(config)).to eq '"posts"."id" asc'
@@ -23,8 +31,16 @@ describe ActiveAdmin::OrderClause do
     let(:clause) { 'virtual_column_asc' }
 
     it { should be_valid }
-    its(:field) { should == 'virtual_column' }
-    its(:order) { should == 'asc' }
+
+    describe '#field' do
+      subject { super().field }
+      it { should == 'virtual_column' }
+    end
+
+    describe '#order' do
+      subject { super().order }
+      it { should == 'asc' }
+    end
 
     specify '#to_sql' do
       expect(subject.to_sql(config)).to eq '"virtual_column" asc'
@@ -35,8 +51,16 @@ describe ActiveAdmin::OrderClause do
     let(:clause) { "hstore_col->'field'_desc" }
 
     it { should be_valid }
-    its(:field) { should == "hstore_col->'field'" }
-    its(:order) { should == 'desc' }
+
+    describe '#field' do
+      subject { super().field }
+      it { should == "hstore_col->'field'" }
+    end
+
+    describe '#order' do
+      subject { super().order }
+      it { should == 'desc' }
+    end
 
     it 'converts to sql' do
       expect(subject.to_sql(config)).to eq %Q("hstore_col"->'field' desc)

--- a/spec/unit/resource_controller/data_access_spec.rb
+++ b/spec/unit/resource_controller/data_access_spec.rb
@@ -7,7 +7,7 @@ describe ActiveAdmin::ResourceController::DataAccess do
 
   let(:controller) do
     rc = Admin::PostsController.new
-    rc.stub(:params) do
+    allow(rc).to receive(:params) do
       params
     end
     rc
@@ -61,7 +61,7 @@ describe ActiveAdmin::ResourceController::DataAccess do
         chain         = double "ChainObj"
         scoped_chain  = double "ScopedChain"
         current_scope = double "CurrentScope"
-        controller.stub(:current_scope) { current_scope }
+        allow(controller).to receive(:current_scope) { current_scope }
 
         expect(controller).to receive(:scope_chain).with(current_scope, chain) { scoped_chain }
         expect(controller.send(:apply_scoping, chain)).to eq scoped_chain

--- a/spec/unit/resource_controller/decorators_spec.rb
+++ b/spec/unit/resource_controller/decorators_spec.rb
@@ -68,7 +68,7 @@ describe ActiveAdmin::ResourceController::Decorators do
     let(:resource) { Post.new }
     let(:form_presenter) { double options: { decorate: decorate_form } }
     let(:decorator_class) { PostDecorator }
-    before { active_admin_config.stub(:get_page_presenter).with(:form).and_return form_presenter }
+    before { allow(active_admin_config).to receive(:get_page_presenter).with(:form).and_return form_presenter }
 
     subject(:applied) { controller.apply_decorator(resource) }
 

--- a/spec/unit/resource_controller_spec.rb
+++ b/spec/unit/resource_controller_spec.rb
@@ -164,22 +164,22 @@ describe Admin::PostsController, type: "controller" do
     let(:post) { Post.new title: "An incledibly unique Post Title" }
 
     before do
-      Post.stub(:find).and_return(post)
+      allow(Post).to receive(:find).and_return(post)
       controller.class_eval { public :resource }
-      controller.stub(:params).and_return({ id: '1' })
+      allow(controller).to receive(:params).and_return({ id: '1' })
     end
 
     subject { controller.resource }
 
     it "returns a Post" do
-      subject.should be_kind_of(Post)
+      expect(subject).to be_kind_of(Post)
     end
 
     context 'with a decorator' do
       let(:config) { controller.class.active_admin_config }
       before { config.decorator_class_name = '::PostDecorator' }
       it 'returns a PostDecorator' do
-        subject.should be_kind_of(PostDecorator)
+        expect(subject).to be_kind_of(PostDecorator)
       end
 
       it 'returns a PostDecorator that wraps the post' do
@@ -231,7 +231,7 @@ describe Admin::PostsController, type: "controller" do
         redirect_to collection_path
       end
 
-      controller.class.active_admin_config.stub(:batch_actions).and_return([batch_action])
+      allow(controller.class.active_admin_config).to receive(:batch_actions).and_return([batch_action])
     end
 
     describe "when params batch_action matches existing BatchAction" do

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -233,7 +233,7 @@ module ActiveAdmin
       let(:resource) { namespace.register(Post) }
       let(:post) { double }
       before do
-        Post.stub(:where).with('id' => '12345').and_return { [post] }
+        allow(Post).to receive(:where).with('id' => '12345') { [post] }
       end
 
       it 'can find the resource' do
@@ -250,8 +250,8 @@ module ActiveAdmin
       context 'when using a nonstandard primary key' do
         let(:different_post) { double }
         before do
-          Post.stub(:primary_key).and_return 'something_else'
-          Post.stub(:where).with('something_else' => '55555').and_return { [different_post] }
+          allow(Post).to receive(:primary_key).and_return 'something_else'
+          allow(Post).to receive(:where).with('something_else' => '55555') { [different_post] }
         end
 
         it 'can find the post by the custom primary key' do

--- a/spec/unit/routing_spec.rb
+++ b/spec/unit/routing_spec.rb
@@ -10,7 +10,7 @@ describe ActiveAdmin, "Routing", type: :routing do
   end
 
   it "should only have the namespaces necessary for route testing" do
-    ActiveAdmin.application.namespaces.keys.should eq [:admin, :root]
+    expect(ActiveAdmin.application.namespaces.keys).to eq [:admin, :root]
   end
 
   it "should route to the admin dashboard" do

--- a/spec/unit/scope_spec.rb
+++ b/spec/unit/scope_spec.rb
@@ -7,47 +7,123 @@ describe ActiveAdmin::Scope do
 
     context "when just a scope method" do
       let(:scope)        { ActiveAdmin::Scope.new :published }
-      its(:name)         { should == "Published"}
-      its(:id)           { should == "published"}
-      its(:scope_method) { should == :published }
+
+      describe '#name' do
+        subject { super().name }
+        it         { should == "Published"}
+      end
+
+      describe '#id' do
+        subject { super().id }
+        it           { should == "published"}
+      end
+
+      describe '#scope_method' do
+        subject { super().scope_method }
+        it { should == :published }
+      end
     end
 
     context "when scope method is :all" do
       let(:scope)        { ActiveAdmin::Scope.new :all }
-      its(:name)         { should == "All"}
-      its(:id)           { should == "all"}
+
+      describe '#name' do
+        subject { super().name }
+        it         { should == "All"}
+      end
+
+      describe '#id' do
+        subject { super().id }
+        it           { should == "all"}
+      end
       # :all does not return a chain but an array of active record
       # instances. We set the scope_method to nil then.
-      its(:scope_method) { should == nil }
-      its(:scope_block)  { should == nil }
+
+      describe '#scope_method' do
+        subject { super().scope_method }
+        it { should == nil }
+      end
+
+      describe '#scope_block' do
+        subject { super().scope_block }
+        it  { should == nil }
+      end
     end
 
     context 'when a name and scope method is :all' do
       let(:scope)        { ActiveAdmin::Scope.new 'Tous', :all }
-      its(:name)         { should eq 'Tous' }
-      its(:scope_method) { should be_nil }
-      its(:scope_block)  { should be_nil }
+
+      describe '#name' do
+        subject { super().name }
+        it         { should eq 'Tous' }
+      end
+
+      describe '#scope_method' do
+        subject { super().scope_method }
+        it { should be_nil }
+      end
+
+      describe '#scope_block' do
+        subject { super().scope_block }
+        it  { should be_nil }
+      end
     end
 
     context "when a name and scope method" do
       let(:scope)        { ActiveAdmin::Scope.new "With API Access", :with_api_access }
-      its(:name)         { should == "With API Access"}
-      its(:id)           { should == "with_api_access"}
-      its(:scope_method) { should == :with_api_access }
+
+      describe '#name' do
+        subject { super().name }
+        it         { should == "With API Access"}
+      end
+
+      describe '#id' do
+        subject { super().id }
+        it           { should == "with_api_access"}
+      end
+
+      describe '#scope_method' do
+        subject { super().scope_method }
+        it { should == :with_api_access }
+      end
     end
 
     context "when a name and scope block" do
       let(:scope)        { ActiveAdmin::Scope.new("My Scope"){|s| s } }
-      its(:name)         { should == "My Scope"}
-      its(:id)           { should == "my_scope"}
-      its(:scope_method) { should == nil }
-      its(:scope_block)  { should be_a(Proc)}
+
+      describe '#name' do
+        subject { super().name }
+        it         { should == "My Scope"}
+      end
+
+      describe '#id' do
+        subject { super().id }
+        it           { should == "my_scope"}
+      end
+
+      describe '#scope_method' do
+        subject { super().scope_method }
+        it { should == nil }
+      end
+
+      describe '#scope_block' do
+        subject { super().scope_block }
+        it  { should be_a(Proc)}
+      end
     end
 
     context "when a name has a space and lowercase" do
       let(:scope)        { ActiveAdmin::Scope.new("my scope") }
-      its(:name)         { should == "my scope"}
-      its(:id)           { should == "my_scope"}
+
+      describe '#name' do
+        subject { super().name }
+        it         { should == "my scope"}
+      end
+
+      describe '#id' do
+        subject { super().id }
+        it           { should == "my_scope"}
+      end
     end
 
     context "with a proc as the label" do

--- a/spec/unit/view_helpers/display_name_spec.rb
+++ b/spec/unit/view_helpers/display_name_spec.rb
@@ -24,9 +24,9 @@ describe "display_name" do
   it "should not call a method if it's an association" do
     subject = Class.new.new
     subject.stub_chain(:class, :reflect_on_all_associations).and_return [ double(name: :login) ]
-    subject.stub :login
+    allow(subject).to receive :login
     expect(subject).to_not receive :login
-    subject.stub(:email).and_return 'foo@bar.baz'
+    allow(subject).to receive(:email).and_return 'foo@bar.baz'
     expect(display_name subject).to eq 'foo@bar.baz'
   end
 

--- a/spec/unit/view_helpers/fields_for_spec.rb
+++ b/spec/unit/view_helpers/fields_for_spec.rb
@@ -4,19 +4,19 @@ describe ActiveAdmin::ViewHelpers::FormHelper, ".fields_for" do
   include ActiveAdmin::ViewHelpers::FormHelper
 
   it "should skip :action, :controller and :commit" do
-    fields_for_params(
-      scope: "All", action: "index", controller: "PostController", commit: "Filter", utf8: "Yes!").
-      should eq [ { scope: "All" } ]
+    expect(fields_for_params(
+      scope: "All", action: "index", controller: "PostController", commit: "Filter", utf8: "Yes!")).
+      to eq [ { scope: "All" } ]
   end
 
   it "should skip the except" do
-    fields_for_params({scope: "All", name: "Greg"}, except: :name).
-      should eq [ { scope: "All" } ]
+    expect(fields_for_params({scope: "All", name: "Greg"}, except: :name)).
+      to eq [ { scope: "All" } ]
   end
 
   it "should allow an array for the except" do
-    fields_for_params({scope: "All", name: "Greg", age: "12"}, except: [:name, :age]).
-      should eq [ { scope: "All" } ]
+    expect(fields_for_params({scope: "All", name: "Greg", age: "12"}, except: [:name, :age])).
+      to eq [ { scope: "All" } ]
   end
 
   it "should work with hashes" do
@@ -28,20 +28,20 @@ describe ActiveAdmin::ViewHelpers::FormHelper, ".fields_for" do
   end
 
   it "should work with nested hashes" do
-    fields_for_params(filters: { user: { name: "John" }}).
-      should eq [ { "filters[user][name]" => "John" } ]
+    expect(fields_for_params(filters: { user: { name: "John" }})).
+      to eq [ { "filters[user][name]" => "John" } ]
   end
 
   it "should work with arrays" do
-    fields_for_params(people: ["greg", "emily", "philippe"]).
-      should eq [ { "people[]" => "greg" },
+    expect(fields_for_params(people: ["greg", "emily", "philippe"])).
+      to eq [ { "people[]" => "greg" },
                   { "people[]" => "emily" },
                   { "people[]" => "philippe" } ]
   end
 
   it "should work with symbols" do
-    fields_for_params(filter: :id).
-      should eq [ { filter: "id" } ]
+    expect(fields_for_params(filter: :id)).
+      to eq [ { filter: "id" } ]
   end
 
   it "should work with booleans" do

--- a/spec/unit/views/components/action_list_popover_spec.rb
+++ b/spec/unit/views/components/action_list_popover_spec.rb
@@ -20,9 +20,20 @@ describe ActiveAdmin::Views::ActionListPopover do
       the_popover.find_by_class("popover_contents").first
     end
 
-    its(:tag_name) { should eql("ul") }
-    its(:content){ should include("<li><a href=\"#\">My First Great Action</a></li>") }
-    its(:content){ should include("<li><a href=\"http://www.google.com\">My Second Great Action</a></li>") }
+    describe '#tag_name' do
+      subject { super().tag_name }
+      it { should eql("ul") }
+    end
+
+    describe '#content' do
+      subject { super().content }
+      it{ should include("<li><a href=\"#\">My First Great Action</a></li>") }
+    end
+
+    describe '#content' do
+      subject { super().content }
+      it{ should include("<li><a href=\"http://www.google.com\">My Second Great Action</a></li>") }
+    end
 
   end
 

--- a/spec/unit/views/components/attributes_table_spec.rb
+++ b/spec/unit/views/components/attributes_table_spec.rb
@@ -7,8 +7,8 @@ describe ActiveAdmin::Views::AttributesTable do
 
     let(:post) do
       post = Post.new title: "Hello World", body: nil
-      post.stub(:id){ 1 }
-      post.stub(:new_record?){ false }
+      allow(post).to receive(:id){ 1 }
+      allow(post).to receive(:new_record?){ false }
       post
     end
 

--- a/spec/unit/views/components/batch_action_popover_spec.rb
+++ b/spec/unit/views/components/batch_action_popover_spec.rb
@@ -22,11 +22,25 @@ describe ActiveAdmin::BatchActions::BatchActionPopover do
       the_popover.find_by_class("popover_contents").first
     end
 
-    its(:tag_name) { should eql("ul") }
+    describe '#tag_name' do
+      subject { super().tag_name }
+      it { should eql("ul") }
+    end
 
-    its(:content){ should include("class=\"batch_action\" data-action=\"action_1\"") }
-    its(:content){ should include("class=\"batch_action\" data-action=\"action_2\"") }
-    its(:content){ should include("class=\"batch_action\" data-action=\"action_3\"") }
+    describe '#content' do
+      subject { super().content }
+      it{ should include("class=\"batch_action\" data-action=\"action_1\"") }
+    end
+
+    describe '#content' do
+      subject { super().content }
+      it{ should include("class=\"batch_action\" data-action=\"action_2\"") }
+    end
+
+    describe '#content' do
+      subject { super().content }
+      it{ should include("class=\"batch_action\" data-action=\"action_3\"") }
+    end
 
   end
 

--- a/spec/unit/views/components/blank_slate_spec.rb
+++ b/spec/unit/views/components/blank_slate_spec.rb
@@ -9,9 +9,19 @@ describe ActiveAdmin::Views::BlankSlate do
       end
     end
 
-    its(:tag_name)    { should eql 'div' }
-    its(:class_list)  { should include('blank_slate_container') }
+    describe '#tag_name' do
+      subject { super().tag_name }
+      it    { should eql 'div' }
+    end
 
-    its(:content)     { should include '<span class="blank_slate">There are no Posts yet. <a href="/posts/new">Create one</a></span>' }
+    describe '#class_list' do
+      subject { super().class_list }
+      it  { should include('blank_slate_container') }
+    end
+
+    describe '#content' do
+      subject { super().content }
+      it     { should include '<span class="blank_slate">There are no Posts yet. <a href="/posts/new">Create one</a></span>' }
+    end
   end
 end

--- a/spec/unit/views/components/index_list_spec.rb
+++ b/spec/unit/views/components/index_list_spec.rb
@@ -10,7 +10,7 @@ describe ActiveAdmin::Views::IndexList do
     let(:helpers) do
       helpers = mock_action_view
       helpers.stub url_for: "/"
-      helpers.stub(:params).and_return as: "table"
+      allow(helpers).to receive(:params).and_return as: "table"
       helpers
     end
 
@@ -20,7 +20,10 @@ describe ActiveAdmin::Views::IndexList do
       end
     end
 
-    its(:tag_name) { should eq 'ul'}
+    describe '#tag_name' do
+      subject { super().tag_name }
+      it { should eq 'ul'}
+    end
 
     it "should contain the names of available indexes in links" do
       a_tags = subject.find_by_tag("a")

--- a/spec/unit/views/components/paginated_collection_spec.rb
+++ b/spec/unit/views/components/paginated_collection_spec.rb
@@ -10,8 +10,8 @@ describe ActiveAdmin::Views::PaginatedCollection do
 
     let(:view) do
       view = mock_action_view
-      view.request.stub(:query_parameters).and_return page: '1'
-      view.request.stub(:path_parameters).and_return  controller: 'admin/posts', action: 'index'
+      allow(view.request).to receive(:query_parameters).and_return page: '1'
+      allow(view.request).to receive(:path_parameters).and_return  controller: 'admin/posts', action: 'index'
       view
     end
 
@@ -28,9 +28,9 @@ describe ActiveAdmin::Views::PaginatedCollection do
     end
 
     before do
-      collection.stub(:reorder) { collection }
-      collection.stub(:scoped) { collection }
-      collection.stub(:group_values) { [] } unless collection.respond_to?(:group_values)
+      allow(collection).to receive(:reorder) { collection }
+      allow(collection).to receive(:scoped) { collection }
+      allow(collection).to receive(:group_values) { [] } unless collection.respond_to?(:group_values)
     end
 
     context "when specifying collection" do
@@ -130,7 +130,7 @@ describe ActiveAdmin::Views::PaginatedCollection do
       end
 
       it "should use 'Singular' as the collection name when there is an I18n translation" do
-        I18n.stub(:translate) { "Singular" }
+        allow(I18n).to receive(:translate) { "Singular" }
         expect(pagination.find_by_class('pagination_information').first.content).to eq "Displaying <b>1</b> Singular"
       end
     end
@@ -143,7 +143,7 @@ describe ActiveAdmin::Views::PaginatedCollection do
       end
 
       it "should use 'Plural' as the collection name when there is an I18n translation" do
-        I18n.stub(:translate) { "Plural" }
+        allow(I18n).to receive(:translate) { "Plural" }
         expect(pagination.find_by_class('pagination_information').first.content).to eq "Displaying <b>all 3</b> Plural"
       end
     end

--- a/spec/unit/views/components/status_tag_spec.rb
+++ b/spec/unit/views/components/status_tag_spec.rb
@@ -14,88 +14,209 @@ describe ActiveAdmin::Views::StatusTag do
     subject { status_tag(nil) }
 
 
-    its(:tag_name)    { should eq 'span' }
-    its(:class_list)  { should include('status_tag') }
+    describe '#tag_name' do
+      subject { super().tag_name }
+      it    { should eq 'span' }
+    end
+
+    describe '#class_list' do
+      subject { super().class_list }
+      it  { should include('status_tag') }
+    end
 
     context "when status is 'completed'" do
       subject { status_tag('completed') }
 
-      its(:tag_name)    { should eq 'span' }
-      its(:class_list)  { should include('status_tag') }
-      its(:class_list)  { should include('completed') }
-      its(:content)     { should eq 'Completed' }
+      describe '#tag_name' do
+        subject { super().tag_name }
+        it    { should eq 'span' }
+      end
+
+      describe '#class_list' do
+        subject { super().class_list }
+        it  { should include('status_tag') }
+      end
+
+      describe '#class_list' do
+        subject { super().class_list }
+        it  { should include('completed') }
+      end
+
+      describe '#content' do
+        subject { super().content }
+        it     { should eq 'Completed' }
+      end
     end
 
     context "when status is 'in_progress'" do
       subject { status_tag('in_progress') }
 
-      its(:class_list)  { should include('in_progress') }
-      its(:content)     { should eq 'In Progress' }
+      describe '#class_list' do
+        subject { super().class_list }
+        it  { should include('in_progress') }
+      end
+
+      describe '#content' do
+        subject { super().content }
+        it     { should eq 'In Progress' }
+      end
     end
 
     context "when status is 'In progress'" do
       subject { status_tag('In progress') }
 
-      its(:class_list)  { should include('in_progress') }
-      its(:content)     { should eq 'In Progress' }
+      describe '#class_list' do
+        subject { super().class_list }
+        it  { should include('in_progress') }
+      end
+
+      describe '#content' do
+        subject { super().content }
+        it     { should eq 'In Progress' }
+      end
     end
 
     context "when status is an empty string" do
       subject { status_tag('') }
 
-      its(:class_list)  { should include('status_tag') }
-      its(:content)     { should eq '' }
+      describe '#class_list' do
+        subject { super().class_list }
+        it  { should include('status_tag') }
+      end
+
+      describe '#content' do
+        subject { super().content }
+        it     { should eq '' }
+      end
     end
     
     context "when status is false" do
       subject { status_tag('false') }
 
-      its(:class_list)  { should include('status_tag') }
-      its(:content)     { should == 'No' }
+      describe '#class_list' do
+        subject { super().class_list }
+        it  { should include('status_tag') }
+      end
+
+      describe '#content' do
+        subject { super().content }
+        it     { should == 'No' }
+      end
     end
 
     context "when status is nil" do
       subject { status_tag(nil) }
 
-      its(:class_list)  { should include('status_tag') }
-      its(:content)     { should == 'No' }
+      describe '#class_list' do
+        subject { super().class_list }
+        it  { should include('status_tag') }
+      end
+
+      describe '#content' do
+        subject { super().content }
+        it     { should == 'No' }
+      end
     end
 
     context "when status is 'Active' and type is :ok" do
       subject { status_tag('Active', :ok) }
 
-      its(:class_list)  { should include('status_tag') }
-      its(:class_list)  { should include('active') }
-      its(:class_list)  { should include('ok') }
+      describe '#class_list' do
+        subject { super().class_list }
+        it  { should include('status_tag') }
+      end
+
+      describe '#class_list' do
+        subject { super().class_list }
+        it  { should include('active') }
+      end
+
+      describe '#class_list' do
+        subject { super().class_list }
+        it  { should include('ok') }
+      end
     end
 
     context "when status is 'Active' and class is 'ok'" do
       subject { status_tag('Active', class: 'ok') }
 
-      its(:class_list)  { should include('status_tag') }
-      its(:class_list)  { should include('active') }
-      its(:class_list)  { should include('ok') }
+      describe '#class_list' do
+        subject { super().class_list }
+        it  { should include('status_tag') }
+      end
+
+      describe '#class_list' do
+        subject { super().class_list }
+        it  { should include('active') }
+      end
+
+      describe '#class_list' do
+        subject { super().class_list }
+        it  { should include('ok') }
+      end
     end
 
     context "when status is 'Active' and label is 'on'" do
       subject { status_tag('Active', label: 'on') }
 
-      its(:content)     { should eq 'on' }
-      its(:class_list)  { should include('status_tag') }
-      its(:class_list)  { should include('active') }
-      its(:class_list)  { should_not include('on') }
+      describe '#content' do
+        subject { super().content }
+        it     { should eq 'on' }
+      end
+
+      describe '#class_list' do
+        subject { super().class_list }
+        it  { should include('status_tag') }
+      end
+
+      describe '#class_list' do
+        subject { super().class_list }
+        it  { should include('active') }
+      end
+
+      describe '#class_list' do
+        subject { super().class_list }
+        it  { should_not include('on') }
+      end
     end
 
     context "when status is 'So useless', type is :ok, class is 'woot awesome' and id is 'useless'" do
       subject { status_tag('So useless', :ok, class: 'woot awesome', id: 'useless') }
 
-      its(:content)     { should eq 'So Useless' }
-      its(:class_list)  { should include('status_tag') }
-      its(:class_list)  { should include('ok') }
-      its(:class_list)  { should include('so_useless') }
-      its(:class_list)  { should include('woot') }
-      its(:class_list)  { should include('awesome') }
-      its(:id)          { should eq 'useless' }
+      describe '#content' do
+        subject { super().content }
+        it     { should eq 'So Useless' }
+      end
+
+      describe '#class_list' do
+        subject { super().class_list }
+        it  { should include('status_tag') }
+      end
+
+      describe '#class_list' do
+        subject { super().class_list }
+        it  { should include('ok') }
+      end
+
+      describe '#class_list' do
+        subject { super().class_list }
+        it  { should include('so_useless') }
+      end
+
+      describe '#class_list' do
+        subject { super().class_list }
+        it  { should include('woot') }
+      end
+
+      describe '#class_list' do
+        subject { super().class_list }
+        it  { should include('awesome') }
+      end
+
+      describe '#id' do
+        subject { super().id }
+        it          { should eq 'useless' }
+      end
     end
 
   end # describe "#status_tag"

--- a/spec/unit/views/components/table_for_spec.rb
+++ b/spec/unit/views/components/table_for_spec.rb
@@ -209,7 +209,11 @@ describe ActiveAdmin::Views::TableFor do
     context "when default" do
       let(:table_column){ build_column(:username) }
       it { should be_sortable }
-      its(:sort_key){ should == "username" }
+
+      describe '#sort_key' do
+        subject { super().sort_key }
+        it{ should == "username" }
+      end
     end
 
     context "when a block given with no sort key" do
@@ -220,7 +224,11 @@ describe ActiveAdmin::Views::TableFor do
     context "when a block given with a sort key" do
       let(:table_column){ build_column("Username", sortable: :username){ } }
       it { should be_sortable }
-      its(:sort_key){ should == "username" }
+
+      describe '#sort_key' do
+        subject { super().sort_key }
+        it{ should == "username" }
+      end
     end
 
     context "when sortable: false with a symbol" do

--- a/spec/unit/views/tabbed_navigation_spec.rb
+++ b/spec/unit/views/tabbed_navigation_spec.rb
@@ -17,7 +17,7 @@ describe ActiveAdmin::Views::TabbedNavigation do
   let(:html) { tabbed_navigation.to_s }
 
   before do
-    helpers.stub(:admin_logged_in?).and_return(false)
+    allow(helpers).to receive(:admin_logged_in?).and_return(false)
   end
 
   describe "rendering a menu" do


### PR DESCRIPTION
This conversion is done by Transpec 1.10.4 with the following command:
    transpec -f
- 71 conversions
  from: its(:attr) { }
    to: describe '#attr' do subject { super().attr }; it { } end
- 64 conversions
  from: obj.should
    to: expect(obj).to
- 25 conversions
  from: obj.stub(:message)
    to: allow(obj).to receive(:message)
- 23 conversions
  from: == expected
    to: eq(expected)
- 6 conversions
  from: obj.should_not
    to: expect(obj).not_to
- 2 conversions
  from: obj.stub(:message).and_return { value }
    to: obj.stub(:message) { value }
- 1 conversion
  from: Klass.any_instance.should_receive(:message)
    to: expect_any_instance_of(Klass).to receive(:message)
