### PR TITLE
Prevent drop down menu from being cut off

### DIFF
--- a/app/assets/javascripts/active_admin/lib/dropdown-menu.js.coffee
+++ b/app/assets/javascripts/active_admin/lib/dropdown-menu.js.coffee
@@ -74,15 +74,22 @@ class ActiveAdmin.DropdownMenu
 
     button_left = @$menuButton.position().left
     button_center =  @$menuButton.outerWidth() / 2
+    button_right = button_left + button_center * 2
     menu_center = @$menuList.outerWidth() / 2
     nipple_center = @$nipple.outerWidth() / 2
+    window_right = $(window).width()
 
     centered_menu_left = button_left + button_center - menu_center
+    centered_menu_right = button_left + button_center + menu_center
 
     if centered_menu_left < 0
       # Left align with button
       @$menuList.css 'left', button_left
       @$nipple.css   'left', button_center - nipple_center
+    else if centered_menu_right > window_right
+      # Right align with button
+      @$menuList.css 'right', window_right - button_right
+      @$nipple.css   'right', button_center - nipple_center
     else
       # Center align under button
       @$menuList.css 'left', centered_menu_left

--- a/app/assets/stylesheets/active_admin/components/_dropdown_menu.scss
+++ b/app/assets/stylesheets/active_admin/components/_dropdown_menu.scss
@@ -116,6 +116,7 @@
           text-decoration: none;
           text-align: center;
           -webkit-font-smoothing: antialiased;
+          white-space: nowrap;
 
           &:hover {
             @include highlight-gradient;


### PR DESCRIPTION
If the menu was wide enough some of it could be cut off when it was
displayed.
