### PR TITLE
Update dependencies so we can bundle with Rails 4.1

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'jquery-rails'
   s.add_dependency 'jquery-ui-rails'
   s.add_dependency 'kaminari',            '~> 0.15'
-  s.add_dependency 'rails',               '>= 3.2', '< 4.1'
+  s.add_dependency 'rails',               '>= 3.2', '<= 4.1'
   s.add_dependency 'ransack',             '~> 1.0'
   s.add_dependency 'sass-rails'
 end


### PR DESCRIPTION
```
Bundler could not find compatible versions for gem "rails":
  In Gemfile:
    activeadmin (>= 0) ruby depends on
      rails (< 4.1, >= 3.2) ruby

    rails (4.1.0)
```

These gemspec changes should be released.
