### PR TITLE
Fix a bug that caused has_many fields to be lost

### DIFF
--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -104,7 +104,7 @@ module ActiveAdmin
       end
 
       tag = @already_in_an_inputs_block ? :li : :div
-      template.content_tag tag,  html, class: "has_many_container #{assoc}", 'data-sortable' => builder_options[:sortable]
+      form_buffers.last << template.content_tag(tag, html, class: "has_many_container #{assoc}", 'data-sortable' => builder_options[:sortable])
     end
 
     def semantic_errors(*args)


### PR DESCRIPTION
6ccc79d2b197dd07ef845017334ea8580ce85ee7 doesn't append the return value of `content_tag` to `form_buffers`, which causes the tag to be lost.
