### PR TITLE
Use `sort_by` instead of `sort_by!`

### DIFF
--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -83,7 +83,7 @@ module ActiveAdmin
       # make sure that the sortable children sorted in stable ascending order
       if column = builder_options[:sortable]
         children = object.send(assoc)
-        children.sort_by! do |o|
+        children = children.sort_by do |o|
           attribute = o.send(column)
           [attribute.nil? ? Float::INFINITY : attribute, o.id || Float::INFINITY]
         end


### PR DESCRIPTION
`sort_by!` and other mutator methods are blacklisted as of Ruby on Rails 4.1.0.rc2 and now yield `NoMethodError`.

References:
- https://github.com/rails/rails/commit/d4ee09c
