### PR TITLE
Update README with info about dependencies for Rails 4.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ Until it's ready, you can get Rails 4 support today by tracking master:
 gem 'activeadmin', github: 'gregbell/active_admin'
 ```
 
+On Rails 4.1, you'll also need to declare the following dependencies:
+```ruby
+gem 'polyamorous', github: 'activerecord-hackery/polyamorous'
+gem 'ransack', github: 'activerecord-hackery/ransack', branch: 'rails-4.1'
+gem 'formtastic', github: 'justinfrench/formtastic'
+```
+
 The plan is to follow [semantic versioning](http://semver.org/) as of 1.0.0. The 0.6.x line will
 still be maintained, and we will backport bug fixes into future 0.6.x releases. If you don't want
 to have to wait for a release, you can track the branch instead:


### PR DESCRIPTION
Adds information about the other branches you need to track to use ActiveAdmin on Rails 4.1.

I understand that this will be a bit of a moving target, but it would definitely have helped me get up and running more quickly!
