### PR TITLE
Non-arrays get through and break on #first

### DIFF
--- a/lib/active_admin/views/components/attributes_table.rb
+++ b/lib/active_admin/views/components/attributes_table.rb
@@ -5,7 +5,7 @@ module ActiveAdmin
       builder_method :attributes_table_for
 
       def build(obj, *attrs)
-        @collection     = obj.respond_to?(:each) && !obj.is_a?(Hash) ? obj : [obj]
+        @collection     = is_array?(obj) ? obj : [obj]
         @resource_class = @collection.first.class
         options = { }
         options[:for] = @collection.first if single_record?
@@ -98,6 +98,10 @@ module ActiveAdmin
 
       def single_record?
         @single_record ||= @collection.size == 1
+      end
+      
+      def is_array?(obj)
+        obj.respond_to?(:each) && obj.respond_to?(:first) && !obj.is_a?(Hash)
       end
     end
 


### PR DESCRIPTION
I had a single decorator object that still managed to get through and then have `#first` called on it.
