### PR TITLE
Name action items; allow removing them by name

### DIFF
--- a/docs/10-custom-pages.md
+++ b/docs/10-custom-pages.md
@@ -59,7 +59,7 @@ Just like other resources, you can add action items. The difference here being t
 `:only` and `:except` don't apply because there's only one page it could apply to.
 
 ```ruby
-action_item do
+action_item :view_site do
   link_to "View Site", "/"
 end
 ```
@@ -74,7 +74,7 @@ page_action :add_event, method: :post do
   redirect_to admin_calendar_path, notice: "Your event was added"
 end
 
-action_item do
+action_item :add do
   link_to "Add Event", admin_calendar_add_event_path, method: :post
 end
 ```

--- a/docs/13-authorization-adapter.md
+++ b/docs/13-authorization-adapter.md
@@ -161,7 +161,7 @@ ActiveAdmin.register Post do
     redirect_to [:admin, post]
   end
 
-  action_item :only => :show do
+  action_item :publish, :only => :show do
     if !post.published? && authorized?(:publish, post)
       link_to "Publish", publish_admin_post_path(post), method: :post
     end

--- a/docs/8-custom-actions.md
+++ b/docs/8-custom-actions.md
@@ -122,11 +122,12 @@ end
 # Action Items
 
 To include your own action items (like the New, Edit and Delete buttons), add an
-`action_item` block. For example, to add a "View on site" button to view a blog
+`action_item` block. The first parameter is just a name to identify the action,
+and is required. For example, to add a "View on site" button to view a blog
 post:
 
 ```ruby
-action_item only: :show do
+action_item :view, only: :show do
   link_to 'View on site', post_path(post) if post.published?
 end
 ```
@@ -134,7 +135,7 @@ end
 Actions items also accept the `:if` option to conditionally display them:
 
 ```ruby
-action_item only: :show, if: proc{ current_admin_user.super_admin? } do
+action_item :super_action, only: :show, if: proc{ current_admin_user.super_admin? } do
   "Only display this to super admins on the show screen"
 end
 ```

--- a/features/action_item.feature
+++ b/features/action_item.feature
@@ -10,7 +10,7 @@ Feature: Action Item
     Given a configuration of:
     """
     ActiveAdmin.register Post do
-      action_item do
+      action_item :embiggen do
         link_to "Embiggen", '/'
       end
     end
@@ -32,7 +32,7 @@ Feature: Action Item
     Given a configuration of:
     """
     ActiveAdmin.register Post do
-      action_item :if => proc{ !current_active_admin_user.nil? } do
+      action_item :embiggen, :if => proc{ !current_active_admin_user.nil? } do
         link_to "Embiggen", '/'
       end
     end
@@ -54,7 +54,7 @@ Feature: Action Item
     Given a configuration of:
     """
     ActiveAdmin.register Post do
-      action_item :if => proc{ current_active_admin_user.nil? } do
+      action_item :embiggen, :if => proc{ current_active_admin_user.nil? } do
         link_to "Embiggen", '/'
       end
     end

--- a/features/registering_pages.feature
+++ b/features/registering_pages.feature
@@ -93,7 +93,7 @@ Feature: Registering Pages
     Given a configuration of:
     """
     ActiveAdmin.register_page "Status" do
-      action_item do
+      action_item :visit do
         link_to "Visit", "/"
       end
 

--- a/features/specifying_actions.feature
+++ b/features/specifying_actions.feature
@@ -23,7 +23,7 @@ Feature: Specifying Actions
     Given a configuration of:
       """
         ActiveAdmin.register Post do
-          action_item(:only => :index) do
+          action_item(:import, :only => :index) do
             link_to('Import Posts', import_admin_posts_path)
           end
 
@@ -43,7 +43,7 @@ Feature: Specifying Actions
     Given a configuration of:
       """
         ActiveAdmin.register Post do
-          action_item(:only => :show) do
+          action_item(:review, :only => :show) do
             link_to('Review', review_admin_post_path)
           end
 
@@ -69,7 +69,7 @@ Feature: Specifying Actions
     Given a configuration of:
       """
         ActiveAdmin.register Post do
-          action_item(:only => :show) do
+          action_item(:review, :only => :show) do
             link_to('Review', review_admin_post_path)
           end
 

--- a/lib/active_admin/dsl.rb
+++ b/lib/active_admin/dsl.rb
@@ -77,13 +77,21 @@ module ActiveAdmin
 
     # Add a new action item to the resource
     #
+    # @param [Symbol] name
     # @param [Hash] options valid keys include:
     #                 :only:  A single or array of controller actions to display
     #                         this action item on.
     #                 :except: A single or array of controller actions not to
     #                          display this action item on.
-    def action_item(options = {}, &block)
-      config.add_action_item(options, &block)
+    def action_item(name = nil, options = {}, &block)
+      if name.is_a?(Hash)
+        options = name
+        name = nil
+      end
+
+      Deprecation.warn "using `action_item` without a name is deprecated! Use `action_item(:edit)`." unless name
+
+      config.add_action_item(name, options, &block)
     end
 
     # Add a new batch action item to the resource

--- a/lib/active_admin/resource/action_items.rb
+++ b/lib/active_admin/resource/action_items.rb
@@ -18,13 +18,18 @@ module ActiveAdmin
 
       # Add a new action item to a resource
       #
+      # @param [Symbol] name
       # @param [Hash] options valid keys include:
       #                 :only:  A single or array of controller actions to display
       #                         this action item on.
       #                 :except: A single or array of controller actions not to
       #                          display this action item on.
-      def add_action_item(options = {}, &block)
-        self.action_items << ActiveAdmin::ActionItem.new(options, &block)
+      def add_action_item(name, options = {}, &block)
+        self.action_items << ActiveAdmin::ActionItem.new(name, options, &block)
+      end
+
+      def remove_action_item(name)
+        self.action_items.delete_if { |item| item.name == name }
       end
 
       # Returns a set of action items to display for a specific controller action
@@ -51,21 +56,21 @@ module ActiveAdmin
       # Adds the default action items to each resource
       def add_default_action_items
         # New link on index
-        add_action_item only: :index do
+        add_action_item :new, only: :index do
           if controller.action_methods.include?('new') && authorized?(ActiveAdmin::Auth::CREATE, active_admin_config.resource_class)
             link_to I18n.t('active_admin.new_model', model: active_admin_config.resource_label), new_resource_path
           end
         end
 
         # Edit link on show
-        add_action_item only: :show do
+        add_action_item :show, only: :show do
           if controller.action_methods.include?('edit') && authorized?(ActiveAdmin::Auth::UPDATE, resource)
             link_to I18n.t('active_admin.edit_model', model: active_admin_config.resource_label), edit_resource_path(resource)
           end
         end
 
         # Destroy link on show
-        add_action_item only: :show do
+        add_action_item :destroy, only: :show do
           if controller.action_methods.include?('destroy') && authorized?(ActiveAdmin::Auth::DESTROY, resource)
             link_to I18n.t('active_admin.delete_model', model: active_admin_config.resource_label), resource_path(resource),
               method: :delete, data: {confirm: I18n.t('active_admin.delete_confirmation')}
@@ -80,10 +85,12 @@ module ActiveAdmin
   class ActionItem
     include ActiveAdmin::OptionalDisplay
 
-    attr_accessor :block
+    attr_accessor :block, :name
 
-    def initialize(options = {}, &block)
-      @options, @block = options, block
+    def initialize(name, options = {}, &block)
+      @name = name
+      @options = options
+      @block = block
       normalize_display_options!
     end
   end

--- a/spec/unit/dsl_spec.rb
+++ b/spec/unit/dsl_spec.rb
@@ -26,17 +26,35 @@ describe ActiveAdmin::DSL do
 
 
   describe '#action_item' do
-    before { @default_items_count = resource_config.action_items.size }
+    before do
+      @default_items_count = resource_config.action_items.size
 
-    it "add action_item to the action_items of config" do
       dsl.run_registration_block do
-        action_item only: :show do
+        action_item :awesome, only: :show do
           "Awesome ActionItem"
         end
       end
+    end
+
+    it "adds action_item to the action_items of config" do
       expect(resource_config.action_items.size).to eq(@default_items_count + 1)
     end
 
+    context 'DEPRECATED: when used without a name' do
+      before do
+        dsl.run_registration_block do
+          action_item only: :edit do
+            "Awesome ActionItem"
+          end
+        end
+      end
+
+      it "is configured for only the show action" do
+        item = resource_config.action_items.last
+        expect(item.display_on?(:edit)).to be true
+        expect(item.display_on?(:index)).to be false
+      end
+    end
   end
 
   describe "#menu" do

--- a/spec/unit/resource/action_items_spec.rb
+++ b/spec/unit/resource/action_items_spec.rb
@@ -11,7 +11,7 @@ describe ActiveAdmin::Resource::ActionItems do
 
     before do
       resource.clear_action_items!
-      resource.add_action_item do
+      resource.add_action_item :empty do
         # Empty ...
       end
     end
@@ -34,10 +34,10 @@ describe ActiveAdmin::Resource::ActionItems do
 
     before do
       resource.clear_action_items!
-      resource.add_action_item only: :index do
+      resource.add_action_item :new, only: :index do
         raise StandardError
       end
-      resource.add_action_item only: :show do
+      resource.add_action_item :edit, only: :show do
         # Empty ...
       end
     end
@@ -52,11 +52,14 @@ describe ActiveAdmin::Resource::ActionItems do
   end
 
   describe "default action items" do
-
     it "should have 3 action items" do
       expect(resource.action_items.size).to eq 3
     end
 
+    it 'can be removed by name' do
+      resource.remove_action_item :new
+      expect(resource.action_items.size).to eq 2
+    end
   end
 
 end


### PR DESCRIPTION
As discussed in #760, this allows for customizing what of the default action items are shown. It could also be used to allow for [customizing action items per request](https://github.com/gregbell/active_admin/issues/760#issuecomment-14012672), but that is beyond the scope of this pull-request.
