### PR TITLE
add no-default-user option to active_admin:devise generator

### DIFF
--- a/lib/generators/active_admin/devise/devise_generator.rb
+++ b/lib/generators/active_admin/devise/devise_generator.rb
@@ -12,6 +12,9 @@ module ActiveAdmin
 
       RESERVED_NAMES = [:active_admin_user]
 
+      class_option  :default_user, :type => :boolean, :default => true,
+                    :desc => "Should a default user be created inside the migration?"
+
       def install_devise
         require 'devise'
         if File.exists?(File.join(destination_root, "config", "initializers", "devise.rb"))
@@ -44,7 +47,7 @@ module ActiveAdmin
       def add_default_user_to_migration
         # Don't assume that we have a migration!
         devise_migration_file = Dir["db/migrate/*_devise_create_#{table_name}.rb"].first
-        return if devise_migration_file.nil?
+        return if devise_migration_file.nil? || !options[:default_user]
 
         devise_migration_content = File.read(devise_migration_file)
 


### PR DESCRIPTION
When using active admin with a customized User model living in the
main app, it is common to add further validations for profile
attributes etc. Creating a user in the generated migration may fail
then since not all required attributes are present.

In those cases it's better to setup the initial user via a database
seed. This option allows other engines, which bundle active admin, to
invoke default active admin generators while still providing their
default user via a seed.
