### PR TITLE
Update 11-decorators.md

### DIFF
--- a/docs/11-decorators.md
+++ b/docs/11-decorators.md
@@ -7,6 +7,18 @@ recommended but not required.
 ## Example usage
 
 ```ruby
+# config/application.rb
+module MyApplication
+  class Application < Rails::Application
+    # ...
+    # add path to decorators to autoload, so that ActiveAdmin does not complain.
+    config.autoload_paths += %W(#{Rails.root}/app/decorators)
+    # ...
+  end
+end
+```
+
+```ruby
 # app/models/post.rb
 class Post < ActiveRecord::Base
   # has title, content, and image_url


### PR DESCRIPTION
PR adds example code to show that `app/decorators` needs to be present in the `autloads_path`, so that ActiveAdmin does not complain when loading the configuration about a `NameError`.
