### PR TITLE
Encode any values for CSV

### DIFF
--- a/app/views/active_admin/resource/index.csv.erb
+++ b/app/views/active_admin/resource/index.csv.erb
@@ -9,11 +9,15 @@
   encoding_options = options.delete(:encoding_options) || {}
 
   csv_output = CSV.generate(options) do |csv|
-    csv << columns.map(&:name)
+    csv << columns.map do |column|
+      s = column.name
+      s = String(s).encode(encoding, encoding_options) if !encoding.nil?
+      s
+    end
     collection.each do |resource|
       csv << columns.map do |column|
         s = call_method_or_proc_on resource, column.data
-        s.encode!(encoding, encoding_options) if !encoding.nil? && s.respond_to?(:encode!)
+        s = String(s).encode(encoding, encoding_options) if !encoding.nil?
         s
       end
     end


### PR DESCRIPTION
Hi,

Thank you for merging the PR about CSV encoding. I found a bug in an edge case after it was merged.

If a model has columns with serialized object, they don't respond to "encode!" but can include strings to encode.

e.g.
`{a: "a", b: "あいうえお"}`

`["a", "あいうえお"]`

So my solution here is encode any values after convert it to string since the values are converted sooner or later in [CSV lib](https://github.com/ruby/ruby/blob/trunk/lib/csv.rb#L2021).
Could you consider to merge this fix?
