### PR TITLE
add rspec filter 'focus' and 'skip'

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -126,6 +126,9 @@ RSpec.configure do |config|
   config.use_instantiated_fixtures = false
   config.include Devise::TestHelpers, type: :controller
   config.render_views = false
+  config.filter_run focus: true
+  config.filter_run_excluding skip: true
+  config.run_all_when_everything_filtered = true
 end
 
 # All RSpec configuration needs to happen before any examples


### PR DESCRIPTION
It allows you to run only specific tests or exclude some specific tests. This is helpful to focus on the tests for the current working feature. If all focused tests runs, rspec will do a second full run, so it is ensured that no test is broken.

See https://www.relishapp.com/rspec/rspec-core/v/2-0/docs/filtering for more informations
