### PR TITLE
fix parallel_tests (close #3162)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,8 @@ gem 'devise'
 gem 'draper'
 gem 'pundit'
 
+gem 'parallel_tests', group: [:development, :test] # #3162
+
 group :development do
   # Debugging
   gem 'pry'                # Easily debug from your console with `binding.pry`
@@ -47,7 +49,6 @@ group :test do
   gem 'jasmine'
   gem 'jslint_on_rails'
   gem 'launchy'
-  gem 'parallel_tests'
   gem 'rails-i18n' # Provides default i18n for many languages
   gem 'rspec-rails'
   gem 'shoulda-matchers'


### PR DESCRIPTION
`parallel_test` need to use in dev and test, to generate rails test app

for #3162
