### PR TITLE
change modal dialog css for more than button

### DIFF
--- a/app/assets/stylesheets/active_admin/components/_modal_dialog.scss
+++ b/app/assets/stylesheets/active_admin/components/_modal_dialog.scss
@@ -25,7 +25,7 @@
     padding: 7px 15px 13px
   }
   .ui-dialog-buttonpane button {
-    &:first-child { @include dark-button } // OK
+    & { @include dark-button } // OK
     &:last-child { @include light-button } // Cancel
   }
 }


### PR DESCRIPTION
the old style keep the same, but no it works vor more than 2 buttons

befor:
![before](https://cloud.githubusercontent.com/assets/165599/3078174/ac50d95e-e460-11e3-85e6-119024f5496c.jpg)

after:
![after](https://cloud.githubusercontent.com/assets/165599/3078178/c9768344-e460-11e3-8b65-82b30603d6d9.jpg)
