### PR TITLE
Router rewrite and support of singleton belongs to resources

### DIFF
--- a/lib/active_admin/resource/belongs_to.rb
+++ b/lib/active_admin/resource/belongs_to.rb
@@ -28,6 +28,10 @@ module ActiveAdmin
         @options[:optional]
       end
 
+      def singleton?
+        @options[:singleton]
+      end
+
       def required?
         !optional?
       end

--- a/lib/active_admin/router.rb
+++ b/lib/active_admin/router.rb
@@ -1,5 +1,11 @@
 module ActiveAdmin
   class Router
+    extend ActiveSupport::Autoload
+
+    autoload :ResourceRoutes
+
+    attr_reader :application
+
     def initialize(application)
       @application = application
     end
@@ -13,12 +19,14 @@ module ActiveAdmin
     #   end
     #
     def apply(router)
-      define_root_routes router
-      define_resource_routes router
+      define_root_routes(router)
+      define_resource_routes(router)
     end
 
+    private
+
     def define_root_routes(router)
-      router.instance_exec @application.namespaces.values do |namespaces|
+      router.instance_exec application.namespaces.values do |namespaces|
         namespaces.each do |namespace|
           if namespace.root?
             root to: namespace.root_to
@@ -33,74 +41,13 @@ module ActiveAdmin
 
     # Defines the routes for each resource
     def define_resource_routes(router)
-      router.instance_exec @application.namespaces, self do |namespaces, aa_router|
-        resources = namespaces.values.flat_map{ |n| n.resources.values }
+      router.instance_exec application.namespaces do |namespaces|
+        resources = namespaces.values.flat_map { |n| n.resources.values }
+
         resources.each do |config|
-          routes = aa_router.resource_routes(config)
-
-          # Add in the parent if it exists
-          if config.belongs_to?
-            belongs_to = routes
-            routes     = Proc.new do
-              # If it's optional, make the normal resource routes
-              instance_exec &belongs_to if config.belongs_to_config.optional?
-
-              # Make the nested belongs_to routes
-              # :only is set to nothing so that we don't clobber any existing routes on the resource
-              resources config.belongs_to_config.target.resource_name.plural, only: [] do
-                instance_exec &belongs_to
-              end
-            end
-          end
-
-          # Add on the namespace if required
-          unless config.namespace.root?
-            nested = routes
-            routes = Proc.new do
-              namespace config.namespace.name do
-                instance_exec &nested
-              end
-            end
-          end
-
-          instance_exec &routes
+          ActiveAdmin::Router::ResourceRoutes.new(router, config).call
         end
       end
-    end
-
-    def resource_routes(config)
-      Proc.new do
-        # Builds one route for each HTTP verb passed in
-        build_route  = proc{ |verbs, *args|
-          [*verbs].each{ |verb| send verb, *args }
-        }
-        # Deals with +ControllerAction+ instances
-        build_action = proc{ |action|
-          build_route.call(action.http_verb, action.name)
-        }
-        case config
-        when ::ActiveAdmin::Resource
-          resources config.resource_name.route_key, only: config.defined_actions do
-            member do
-              config.member_actions.each &build_action
-            end
-
-            collection do
-              config.collection_actions.each &build_action
-              post :batch_action if config.batch_actions_enabled?
-            end
-          end
-        when ::ActiveAdmin::Page
-          page = config.underscored_resource_name
-          get "/#{page}" => "#{page}#index"
-          config.page_actions.each do |action|
-            build_route.call action.http_verb, "/#{page}/#{action.name}" => "#{page}##{action.name}"
-          end
-        else
-          raise "Unsupported config class: #{config.class}"
-        end
-      end
-
     end
   end
 end

--- a/lib/active_admin/router/resource_routes.rb
+++ b/lib/active_admin/router/resource_routes.rb
@@ -1,0 +1,102 @@
+module ActiveAdmin
+  class Router
+    class ResourceRoutes
+      attr_reader :route, :config
+
+      def initialize(route, config)
+        @route = route
+        @config = config
+      end
+
+      def call
+        define_namespace do
+          if config.belongs_to?
+            # Add in the parent if it exists
+            define_routes if config.belongs_to_config.optional?
+            define_belongs_to_routes
+          else
+            define_routes
+          end
+        end
+      end
+
+      private
+
+      # Defines all routes: resource and page
+      def define_routes
+        case config
+        when ::ActiveAdmin::Resource
+          route.public_send resource_type, resource_name, only: config.defined_actions do
+            define_actions
+          end
+        when ::ActiveAdmin::Page
+          page = config.underscored_resource_name
+
+          route.get "/#{page}" => "#{page}#index"
+
+          config.page_actions.each do |action|
+            build_route(action.http_verb, "/#{page}/#{action.name}" => "#{page}##{action.name}")
+          end
+        else
+          raise "Unsupported config class: #{config.class}"
+        end
+      end
+
+      # Make the nested belongs_to routes
+      def define_belongs_to_routes
+        # :only is set to nothing so that we don't clobber any existing routes on the resource
+        route.resources config.belongs_to_config.target.resource_name.plural, only: [] do
+          define_routes
+        end
+      end
+
+      # Add on the namespace if required
+      def define_namespace
+        if config.namespace.root?
+          yield
+        else
+          route.namespace config.namespace.name do
+            yield
+          end
+        end
+      end
+
+      def resource_type
+        singleton_belongs_to? ? :resource : :resources
+      end
+
+      def resource_name
+        config.resource_name.public_send(singleton_belongs_to? ? :singular : :plural)
+      end
+
+      # Builds one route for each HTTP verb passed in
+      def build_route(verbs, *args)
+        [*verbs].each { |verb| route.send(verb, *args) }
+      end
+
+      # Deals with +ControllerAction+ instances
+      def build_action(action)
+        build_route(action.http_verb, action.name)
+      end
+
+
+      # Defines member and collection actions
+      def define_actions
+        route.member do
+          config.member_actions.each { |v| build_action(v) }
+        end
+
+        route.collection do
+          config.collection_actions.each { |v| build_action(v) }
+          route.post :batch_action if config.batch_actions_enabled?
+        end
+      end
+
+      # Check if a child route singleton
+      def singleton_belongs_to?
+        config.belongs_to? &&
+          config.belongs_to_config.singleton?
+      end
+    end
+  end
+end

--- a/spec/unit/routing_spec.rb
+++ b/spec/unit/routing_spec.rb
@@ -144,6 +144,32 @@ describe ActiveAdmin, "Routing", type: :routing do
           route_to({ controller: 'admin/users', action: 'do_something'})
       end
     end
+
+    context 'singular child resource' do
+      before do
+        load_resources do
+          ActiveAdmin.register(Post) do
+            belongs_to :user, singleton: true
+            collection_action :collection
+            member_action :member
+          end
+          ActiveAdmin.register(User) do
+          end
+        end
+      end
+
+      it 'should properly route to resource' do
+        expect(admin_user_post_path(1)).to eq "/admin/users/1/post"
+      end
+
+      it 'should property route to member action' do
+        expect(member_admin_user_post_path(1)).to eq "/admin/users/1/post/member"
+      end
+
+      it 'should property route to collection action' do
+        expect(collection_admin_user_post_path(1)).to eq "/admin/users/1/post/collection"
+      end
+    end
   end
 
   describe "page" do


### PR DESCRIPTION
It's WIP branch, which will be squashed and completed, after you give me a green light on it.

- [x] Rewrite of the router definitions
- [x] Add`s ability to define singleton resource

#### Related

- Support multiple belongs_to (https://github.com/gregbell/active_admin/issues/221)
- Support nested belongs_to (#3280)

#### Singleton resource

```ruby
ActiveAdmin.register Place
ActiveAdmin.register Location do
  belongs_to :place, singleton: true
end
```

Generates correct route with `resource` DSL command, instead of `resources`, so it's possible to get access location using the url: `/admin/users/1/location` instead of `/admin/users/1/locations`.