### PR TITLE
remove ActiveAdmin::Config and replace it to ActiveAdmin::Resource

### DIFF
--- a/lib/active_admin/dsl.rb
+++ b/lib/active_admin/dsl.rb
@@ -15,7 +15,7 @@ module ActiveAdmin
       instance_exec &block if block_given?
     end
 
-    # The instance of ActiveAdmin::Config that's being registered
+    # The instance of ActiveAdmin::Resource that's being registered
     # currently. You can use this within your registration blocks to
     # modify options:
     #

--- a/spec/unit/config_shared_examples.rb
+++ b/spec/unit/config_shared_examples.rb
@@ -1,4 +1,4 @@
-shared_examples_for "ActiveAdmin::Config" do
+shared_examples_for "ActiveAdmin::Resource" do
   describe "namespace" do
     it "should return the namespace" do
       expect(config.namespace).to eq(namespace)

--- a/spec/unit/page_spec.rb
+++ b/spec/unit/page_spec.rb
@@ -6,7 +6,7 @@ require File.expand_path('config_shared_examples', File.dirname(__FILE__))
 module ActiveAdmin
   describe Page do
 
-    it_should_behave_like "ActiveAdmin::Config"
+    it_should_behave_like "ActiveAdmin::Resource"
     before { load_defaults! }
 
     let(:application){ ActiveAdmin::Application.new }

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -4,8 +4,7 @@ require File.expand_path('config_shared_examples', File.dirname(__FILE__))
 module ActiveAdmin
   describe Resource do
 
-    it_should_behave_like "ActiveAdmin::Config"
-
+    it_should_behave_like "ActiveAdmin::Resource"
     before { load_defaults! }
 
     let(:application){ ActiveAdmin::Application.new }


### PR DESCRIPTION
ActiveAdmin::Config class was originally created in this [PR](https://github.com/gregbell/active_admin/pull/758) but removed in this [commit](https://github.com/pcreux/active_admin/commit/c68345fc791550db2038f33ccca3057ecdaa9377).
I replaced all `ActiveAdmin::Config` to `ActiveAdmin::Resource`, since that's seems reasonable.
