### PR TITLE
Is there any way I can change default sort key order 'desc' to 'asc'?

### DIFF
--- a/lib/active_admin/views/components/table_for.rb
+++ b/lib/active_admin/views/components/table_for.rb
@@ -59,6 +59,7 @@ module ActiveAdmin
       def build_table_header(col)
         classes  = Arbre::HTML::ClassList.new
         sort_key = sortable? && col.sortable? && col.sort_key
+        sort_key_order = col.sort_key_order
         params   = request.query_parameters.except :page, :order, :commit, :format
 
         classes << 'sortable'                         if sort_key
@@ -67,7 +68,7 @@ module ActiveAdmin
 
         if sort_key
           th class: classes do
-            link_to col.pretty_title, params: params, order: "#{sort_key}_#{order_for_sort_key(sort_key)}"
+            link_to col.pretty_title, params: params, order: "#{sort_key}_#{order_for_sort_key(sort_key, sort_key_order)}"
           end
         else
           th col.pretty_title, class: classes
@@ -133,9 +134,9 @@ module ActiveAdmin
       #
       # Default is to use 'desc'. If the current sort key is
       # 'desc' it will return 'asc'
-      def order_for_sort_key(sort_key)
+      def order_for_sort_key(sort_key, sort_key_order)
         current_key, current_order = current_sort
-        return 'desc' unless current_key == sort_key
+        return sort_key_order unless current_key == sort_key
         current_order == 'desc' ? 'asc' : 'desc'
       end
 
@@ -201,6 +202,14 @@ module ActiveAdmin
             @data.to_s
           else
             @options[:sortable].to_s
+          end
+        end
+
+        def sort_key_order
+          if @options[:sort_key_order].nil?
+            @options[:sort_key_order] = :desc
+          else
+            @options[:sort_key_order].to_s
           end
         end
 

--- a/spec/unit/views/components/table_for_spec.rb
+++ b/spec/unit/views/components/table_for_spec.rb
@@ -265,5 +265,14 @@ describe ActiveAdmin::Views::TableFor do
       it { should_not be_sortable }
     end
 
+    context "when a block given with a sort key order" do
+      let(:table_column){ build_column("Username", sort_key_order: :asc){ } }
+      it { should_not be_sortable }
+
+      describe '#sort_key_order' do
+        subject { super().sort_key_order }
+        it{ should == "asc" }
+      end
+    end
   end
 end


### PR DESCRIPTION
Hello, thanks for great library :)

I'm facing a problem of forcing `active_admin` to generate links inside 'th' tags with default `asc` key instead of `desc`.
I have followed source code till  [this point](https://github.com/gregbell/active_admin/blob/a25c9231715a4124bd7a303f29feeb381ec88956/lib/active_admin/views/components/table_for.rb#L136) but it gave no tips how can I override default logic.

``` ruby
# models/post.rb
# Post
# t.text :body
# create_table :posts
# t.string :title

# admin/post.rb
ActiveAdmin.register Post do
  index do
    column :title
    column :body
    actions
  end
end
```

My goal is to see this type of link generated `/admin/posts?order=title_asc` instead of default `/admin/posts?order=title_desc`. So when user clicks on column he wil receive `asc` results.
