### PR TITLE
Upgrade Capybara version and fix failing matchers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ group :development do
 end
 
 group :test do
-  gem 'capybara', '= 1.1.2'
+  gem 'capybara'
   gem 'simplecov', require: false # Test coverage generator. Go to /coverage/ after running tests
   gem 'coveralls', require: false # Test coverage website. Go to https://coveralls.io
   gem 'cucumber-rails', require: false

--- a/features/favicon.feature
+++ b/features/favicon.feature
@@ -1,7 +1,7 @@
 Feature: Favicon
-  
+
   Configuring a Favicon file
-  
+
   Background:
     Given a configuration of:
     """
@@ -13,7 +13,7 @@ Feature: Favicon
     Given I am logged out
     When I am on the login page
     Then I should see the favicon "a/favicon.ico"
-  
+
   Scenario: Logged in views show Favicon
     Given I am logged in
     When I am on the dashboard

--- a/features/index/index_as_blog.feature
+++ b/features/index/index_as_blog.feature
@@ -12,7 +12,7 @@ Feature: Index as Blog
       """
     And I am logged in
     When I am on the index page for posts
-    Then I should see "Hello World" within "h3"
+    Then I should see a blog header "Hello World"
     And I should see a link to "Hello World"
 
   Scenario: Viewing the blog with a resource as a simple configuration
@@ -26,7 +26,7 @@ Feature: Index as Blog
         end
       end
       """
-    Then I should see "Hello World" within "h3"
+    Then I should see a blog header "Hello World"
     And I should see a link to "Hello World"
     And I should see "My great post body" within ".post"
 
@@ -45,7 +45,7 @@ Feature: Index as Blog
         end
       end
       """
-    Then I should see "Hello World From Block" within "h3"
+    Then I should see a blog header "Hello World From Block"
     And I should see a link to "Hello World From Block"
     And I should see "My great post body From Block" within ".post"
 

--- a/features/index/pagination.feature
+++ b/features/index/pagination.feature
@@ -53,7 +53,7 @@ Feature: Index Pagination
       """
       Given 100 posts exist
       When I am on the index page for posts
-      Then I should see pagination with 2 pages
+      Then I should see pagination with 4 pages
       Then I should see "Displaying Posts 1 - 30"
       And I should not see "Displaying Posts 1 - 30 of 100 in total"
 

--- a/features/step_definitions/additional_web_steps.rb
+++ b/features/step_definitions/additional_web_steps.rb
@@ -77,5 +77,5 @@ Then /^I should see a validation error "([^"]*)"$/ do |error_message|
 end
 
 Then /^I should see a table with id "([^"]*)"$/ do |dom_id|
-  expect(page).to have_css 'table', id: dom_id
+  page.find("table##{dom_id}")
 end

--- a/features/step_definitions/asset_steps.rb
+++ b/features/step_definitions/asset_steps.rb
@@ -3,13 +3,13 @@ Then /^I should see the css file "([^"]*)"$/ do |path|
 end
 
 Then /^I should see the css file "([^"]*)" of media "([^"]*)"$/ do |path, media|
-  expect(page).to have_xpath "//link[contains(@href, /stylesheets/#{path}) and contains(@media, #{media})]"
+  expect(page).to have_xpath("//link[contains(@href, /stylesheets/#{path}) and contains(@media, #{media})]", visible: false)
 end
 
 Then /^I should see the js file "([^"]*)"$/ do |path|
-  expect(page).to have_xpath "//script[contains(@src, /javascripts/#{path})]"
+  expect(page).to have_xpath("//script[contains(@src, /javascripts/#{path})]", visible: false)
 end
 
 Then /^I should see the favicon "([^"]*)"$/ do |path|
-  expect(page).to have_xpath "//link[contains(@href, \"#{path}\")]"
+  expect(page).to have_xpath("//link[contains(@href, path)]", visible: false)
 end

--- a/features/step_definitions/blog_steps.rb
+++ b/features/step_definitions/blog_steps.rb
@@ -1,0 +1,3 @@
+Then /^I should see a blog header "([^"]*)"$/ do |header_text|
+  expect(page).to have_css 'h3', text: header_text
+end

--- a/features/step_definitions/factory_steps.rb
+++ b/features/step_definitions/factory_steps.rb
@@ -27,8 +27,8 @@ Given /^a store named "([^"]*)" exists$/ do |name|
 end
 
 Given /^I create a new post with the title "([^"]*)"$/ do |title|
-  click_link "Posts"
+  first(:link, 'Posts').click
   click_link "New Post"
-  fill_in :title, with: title
+  fill_in 'post_title', with: title
   click_button "Create Post"
 end

--- a/features/step_definitions/pagination_steps.rb
+++ b/features/step_definitions/pagination_steps.rb
@@ -3,6 +3,5 @@ Then /^I should not see pagination$/ do
 end
 
 Then /^I should see pagination with (\d+) pages$/ do |count|
-  step %{I should see "#{count}" within ".pagination a"}
-  step %{I should not see "#{count.to_i + 1}" within ".pagination a"}
+  expect(page).to have_css '.pagination span.page', count: count
 end

--- a/features/step_definitions/site_title_steps.rb
+++ b/features/step_definitions/site_title_steps.rb
@@ -7,9 +7,11 @@ Then /^I should not see the site title "([^"]*)"$/ do |title|
 end
 
 Then /^I should see the site title image "([^"]*)"$/ do |image|
-  expect(page).to have_css 'h1#site_title img', src: image
+  img = page.find('h1#site_title img')
+  expect(img[:src]).to eq(image)
 end
 
 Then /^I should see the site title image linked to "([^"]*)"$/ do |url|
-  expect(page).to have_css 'h1#site_title a', href: url
+  link = page.find('h1#site_title a')
+  expect(link[:href]).to eq(url)
 end

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -31,11 +31,15 @@ Given /^an admin user "([^"]*)" exists$/ do |email|
   ensure_user_created(email)
 end
 
-Given /^"([^"]*)" requests a pasword reset with token "([^"]*)"( but it expires)?$/ do |email, token, expired|
+Given /^"([^"]*)" requests a password reset with token "([^"]*)"( but it expires)?$/ do |email, token, expired|
   visit new_admin_user_password_path
   fill_in 'Email', with: email
   Devise.stub(:friendly_token){ token }
   click_button "Reset My Password"
 
   AdminUser.where(email: email).first.update_attribute :reset_password_sent_at, 1.month.ago if expired
+end
+
+When /^I fill in the password field with "([^"]*)"$/ do |password|
+  fill_in 'admin_user_password', with: password
 end

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -36,7 +36,7 @@ When /^(?:I )press "([^"]*)"$/ do |button|
 end
 
 When /^(?:I )follow "([^"]*)"$/ do |link|
-  click_link(link)
+  first(:link, link).click
 end
 
 When /^(?:I )fill in "([^"]*)" with "([^"]*)"$/ do |field, value|

--- a/features/users/resetting_password.feature
+++ b/features/users/resetting_password.feature
@@ -18,17 +18,17 @@ Feature: User Resetting Password
     Then I should see "You will receive an email with instructions on how to reset your password in a few minutes."
 
   Scenario: Changing password after resetting
-    When "admin@example.com" requests a pasword reset with token "foobarbaz"
+    When "admin@example.com" requests a password reset with token "foobarbaz"
     When I go to the admin password reset form with token "foobarbaz"
-    And I fill in "Password" with "password"
+    And I fill in the password field with "password"
     And I fill in "Password confirmation" with "password"
     And I press "Change my password"
     Then I should see "success"
 
   Scenario: Changing password after resetting with errors
-    When "admin@example.com" requests a pasword reset with token "foobarbaz" but it expires
+    When "admin@example.com" requests a password reset with token "foobarbaz" but it expires
     When I go to the admin password reset form with token "foobarbaz"
-    And I fill in "Password" with "password"
+    And I fill in the password field with "password"
     And I fill in "Password confirmation" with "wrong"
     And I press "Change my password"
     Then I should see "expired"

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -290,12 +290,17 @@ describe ActiveAdmin::FormBuilder do
       end
 
       it "should add a link to remove new nested records" do
-        expect(Capybara.string(body)).to have_css '.has_many_container > fieldset > ol > li > a', href: '#',
-          content: 'Remove', class: 'button has_many_remove', data: {placeholder: 'NEW_POST_RECORD'}
+        link = Capybara.string(body).find('.has_many_container > fieldset > ol > li > a.button.has_many_remove', text: 'Remove')
+        expect(link[:class]).to eq('button has_many_remove')
+        expect(link.text).to eq('Remove')
+        expect(link[:href]).to eq('#')
       end
 
       it "should add a link to add new nested records" do
-        expect(Capybara.string(body)).to have_css(".has_many_container > fieldset > ol > li > a", class: "button", href: "#", content: "Add New Post")
+        link = Capybara.string(body).find('.has_many_container > a.button.has_many_add')
+        expect(link[:class]).to eq('button has_many_add')
+        expect(link.text).to eq('Add New Post')
+        expect(link[:href]).to eq('#')
       end
     end
 

--- a/spec/unit/views/components/panel_spec.rb
+++ b/spec/unit/views/components/panel_spec.rb
@@ -13,11 +13,13 @@ describe ActiveAdmin::Views::Panel do
   let(:panel_html) { Capybara.string(arbre_panel.to_s) }
 
   it "should have a title h3" do
-    expect(panel_html).to have_css 'h3', content: "My Title"
+    expect(panel_html).to have_css 'h3', text: "My Title"
   end
 
   it "should add panel actions to the panel header" do
-    expect(panel_html).to have_css 'h3 > div.header_action a', content: 'My Link', href: "https://www.github.com/gregbell/active_admin"
+    link = panel_html.find('h3 > div.header_action a')
+    expect(link.text).to eq('My Link')
+    expect(link[:href]).to eq("https://www.github.com/gregbell/active_admin")
   end
 
   it "should have a contents div" do
@@ -25,7 +27,7 @@ describe ActiveAdmin::Views::Panel do
   end
 
   it "should add children to the contents div" do
-    expect(panel_html).to have_css 'div.panel_contents > span', content: "Hello World"
+    expect(panel_html).to have_css 'div.panel_contents > span', text: "Hello World"
   end
 
   it "should set the icon" do
@@ -41,8 +43,8 @@ describe ActiveAdmin::Views::Panel do
     end
 
     it "should allow a html_safe title" do
-      expect(panel_html).to have_css "h3", content: "Title with HTML"
-      expect(panel_html).to have_css "h3 > abbr", content: "HTML"
+      expect(panel_html).to have_css "h3", text: "Title with HTML"
+      expect(panel_html).to have_css "h3 > abbr", text: "HTML"
     end
   end
 


### PR DESCRIPTION
1. Upgraded Capybara to latest
2. Fixed specs by updating syntax and replacing matchers where necessary.
3. Fixed a bad page count in an existing matcher (which should have been failing)

No specs were made pending, and everything runs green.  Fixes issue #2750
