### PR TITLE
Fix broken datepicker specs

### DIFF
--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -592,16 +592,16 @@ describe ActiveAdmin::FormBuilder do
                                     max_date: "2013-12-31" }
           end
         end
-        it 'should generate a datepicker text input with data min and max dates' do
-          expect(body).to have_tag("input", attributes: { type: "text",
-                                                            class: "datepicker",
-                                                            name: "post[created_at]",
-                                                            data: { datepicker_options: {
-                                                              minDate: "2013-10-18",
-                                                              maxDate: "2013-12-31" }.to_json }})
-        end
+      end
+
+      it 'should generate a datepicker text input with data min and max dates' do
+        expect(body).to have_tag("input", attributes: { type: "text",
+                                                        class: "datepicker",
+                                                        name: "post[created_at]",
+                                                        "data-datepicker-options" => CGI::escapeHTML({
+                                                          minDate: "2013-10-18",
+                                                          maxDate: "2013-12-31" }.to_json) })
       end
     end
   end
-
 end


### PR DESCRIPTION
Noticed this one while working on #3000. This test wasn't actually being run because it was inside a `let` block. Not sure how it wasn't blowing up, but obviously failing changes to it didn't fail. Moved it out of the `let` once I noticed it.

Once I did that, it was failing because the `data` attributes apparently weren't being rendered properly. Escaped them to properly test the expectation.
