### PR TITLE
Update Gemfile and specs so that everything runs under JRuby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,15 +29,15 @@ group :development do
   # Debugging
   gem 'pry'                # Easily debug from your console with `binding.pry`
   gem 'better_errors'      # Web UI to debug exceptions. Go to /__better_errors to access the latest one
-  gem 'binding_of_caller'  # Retrieve the binding of a method's caller in MRI Ruby >= 1.9.2
+  gem 'binding_of_caller', platforms: [:ruby]  # Retrieve the binding of a method's caller in MRI Ruby >= 1.9.2
 
   # Performance
-  gem 'rack-mini-profiler' # Inline app profiler. See ?pp=help for options.
-  gem 'flamegraph'         # Flamegraph visualiztion: ?pp=flamegraph
+  gem 'rack-mini-profiler', platforms: [:ruby] # Inline app profiler. See ?pp=help for options.
+  gem 'flamegraph', platforms: [:ruby]         # Flamegraph visualiztion: ?pp=flamegraph
 
   # Documentation
-  gem 'yard', github: 'lsegal/yard' # Documentation generator (until lsegal/yard#765 is in a release)
-  gem 'redcarpet'          # Markdown implementation (for yard)
+  gem 'yard', github: 'lsegal/yard', platforms: [:ruby] # Documentation generator (until lsegal/yard#765 is in a release)
+  gem 'redcarpet', platforms: [:ruby]          # Markdown implementation (for yard)
 end
 
 group :test do
@@ -54,5 +54,7 @@ group :test do
   gem 'rspec', '~> 2.99'
   gem 'rspec-rails'
   gem 'shoulda-matchers'
-  gem 'sqlite3'
+  gem 'sqlite3', platforms: [:ruby]
+  gem 'activerecord-jdbcsqlite3-adapter', platforms: [:jruby]
+
 end

--- a/features/step_definitions/batch_action_steps.rb
+++ b/features/step_definitions/batch_action_steps.rb
@@ -28,7 +28,8 @@ When /^I toggle the collection selection$/ do
 end
 
 Then /^I should see that the batch action button is disabled$/ do
-  expect(page).to have_css ".batch_actions_selector .dropdown_menu_button.disabled"
+  dropdown = page.find(".batch_actions_selector .dropdown_menu_button")
+  expect(dropdown[:class]).to eq('disabled dropdown_menu_button')
 end
 
 Then /^I (should|should not) see the batch action (button|selector)$/ do |maybe, type|

--- a/spec/integration/memory_spec.rb
+++ b/spec/integration/memory_spec.rb
@@ -2,21 +2,23 @@ require 'spec_helper'
 
 describe "Memory Leak" do
 
-  def count_instances_of(klass)
-    ObjectSpace.each_object(klass) { }
-  end
+  if (RUBY_PLATFORM != "java")
+    def count_instances_of(klass)
+      ObjectSpace.each_object(klass) { }
+    end
 
-  [ActiveAdmin::Namespace, ActiveAdmin::Resource].each do |klass|
-    it "should not leak #{klass}" do
-      previously_disabled = GC.enable
-      GC.start
-      count = count_instances_of(klass)
+    [ActiveAdmin::Namespace, ActiveAdmin::Resource].each do |klass|
+      it "should not leak #{klass}" do
+        previously_disabled = GC.enable
+        GC.start
+        count = count_instances_of(klass)
 
-      load_defaults!
+        load_defaults!
 
-      GC.start
-      GC.disable if previously_disabled
-      expect(count_instances_of klass).to be <= count
+        GC.start
+        GC.disable if previously_disabled
+        expect(count_instances_of klass).to be <= count
+      end
     end
   end
 


### PR DESCRIPTION
1. Added some platforms restrictions to the Gemfile, so JRuby incompatible gems are not required when using JRuby
2. Blocked out Objectspace related specs under JRuby
3. Changed a failing step in the batch_action_steps.rb

I'm not really sure why I had to make change #3.  The original test and the changed test should be identical, but the former was failing under JRuby.  With the change it passes.  If anyone has any insight, that would be great.

Also, it's likely possible to re-enable Yard on JRuby - I just disabled it entirely because I didn't want to search for and test a JRuby and Yard compatible Markdown parser.
