### PR TITLE
Fix compatibility with Inherited Resources 1.5.x

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'bourbon'
   s.add_dependency 'coffee-rails'
   s.add_dependency 'formtastic',          '~> 3.0'
-  s.add_dependency 'inherited_resources', '~> 1.4.1'
+  s.add_dependency 'inherited_resources', '>= 1.4.1'
   s.add_dependency 'jquery-rails'
   s.add_dependency 'jquery-ui-rails',     '~> 5.0'
   s.add_dependency 'kaminari',            '~> 0.15'

--- a/lib/active_admin/resource.rb
+++ b/lib/active_admin/resource.rb
@@ -119,6 +119,7 @@ module ActiveAdmin
 
     def belongs_to(target, options = {})
       @belongs_to = Resource::BelongsTo.new(self, target, options)
+      options[:parent_class] = target.to_s.classify.constantize unless options[:parent_class]
       self.navigation_menu_name = target unless @belongs_to.optional?
       controller.send :belongs_to, target, options.dup
     end

--- a/spec/unit/namespace/register_resource_spec.rb
+++ b/spec/unit/namespace/register_resource_spec.rb
@@ -124,7 +124,7 @@ describe ActiveAdmin::Namespace, "registering a resource" do
       context "when not optional" do
         before do
           namespace.register Post do
-            belongs_to :author
+            belongs_to :author, parent_class: User
           end
         end
         it "should not show up in the menu" do
@@ -134,7 +134,7 @@ describe ActiveAdmin::Namespace, "registering a resource" do
       context "when optional" do
         before do
           namespace.register Post do
-            belongs_to :author, optional: true
+            belongs_to :author, parent_class: User, optional: true
           end
         end
         it "should show up in the menu" do


### PR DESCRIPTION
Specs (and app behavior) were failing for the belongs_to association in a Controller.  This was failing because Inherited Resources was no longer inferring the parent_class from the parameters passed in (as it was in 1.4.1).  So when find was called on the parent_class, this was resulting in a NPE.

I fixed this by doing this inference ourselves, classifying and then constantizing the belongs_to :target.  Unfortunately this means that if the target name is not a class name, then the parent_class will need to be explicitly set.

I'm not 100% sure this is the right fix - I'd love to get some other opinions.
