### PR TITLE
Fix doc for `permitted_params`

### DIFF
--- a/docs/2-resource-customization.md
+++ b/docs/2-resource-customization.md
@@ -70,7 +70,7 @@ ActiveAdmin.register Post do
   controller do
     def create
       # Good
-      @post = Post.new(permitted_params)
+      @post = Post.new(permitted_params[:post])
       # Bad
       @post = Post.new(params[:post])
 


### PR DESCRIPTION
`permitted_params` returns params that contains the resource name as its root key.

Such as:

``` ruby
  {
    'post' => {
      'title' => 'Rails is omakase.',
      'author' => 'DHH'
    }
  }
```

ref: https://github.com/gregbell/active_admin/blob/master/lib/active_admin/resource_dsl.rb#L48
