### PR TITLE
Fix error with latest activeadmin, rails and nested models from rails pl...

### DIFF
--- a/lib/active_admin/resource/naming.rb
+++ b/lib/active_admin/resource/naming.rb
@@ -31,7 +31,7 @@ module ActiveAdmin
       # custom `resource_name` when the model's been renamed in ActiveAdmin.
       def param_key
         if resource_class.respond_to? :model_name
-          resource_class.model_name.param_key
+          resource_class.model_name.singular
         else
           resource_name.param_key
         end


### PR DESCRIPTION
There was a problem when using activeadmin to create/updates models from rails plugins. In my case model name was **Crm::Customer**, expected  parameter for inherited_resource was _crm_customer_, but active_admin returns just _customer_.
