### PR TITLE
Add unit test to dsl_spec

### DIFF
--- a/spec/unit/dsl_spec.rb
+++ b/spec/unit/dsl_spec.rb
@@ -8,11 +8,10 @@ end
 
 describe ActiveAdmin::DSL do
 
-  let(:config){ double }
   let(:application) { ActiveAdmin::Application.new }
   let(:namespace) { ActiveAdmin::Namespace.new application, :admin }
   let(:resource_config) { ActiveAdmin::Resource.new namespace, Post }
-  let(:dsl){ ActiveAdmin::DSL.new(config) }
+  let(:dsl){ ActiveAdmin::DSL.new(resource_config) }
 
   describe "#include" do
 
@@ -25,10 +24,25 @@ describe ActiveAdmin::DSL do
 
   end
 
+
+  describe '#action_item' do
+    before { @default_items_count = resource_config.action_items.size }
+
+    it "add action_item to the action_items of config" do
+      dsl.run_registration_block do
+        action_item only: :show do
+          "Awesome ActionItem"
+        end
+      end
+      expect(resource_config.action_items.size).to eq(@default_items_count + 1)
+    end
+
+  end
+
   describe "#menu" do
 
     it "should set the menu_item_options on the configuration" do
-      expect(config).to receive(:menu_item_options=).with({parent: "Admin"})
+      expect(resource_config).to receive(:menu_item_options=).with({parent: "Admin"})
       dsl.run_registration_block do
         menu parent: "Admin"
       end
@@ -39,21 +53,18 @@ describe ActiveAdmin::DSL do
   describe "#navigation_menu" do
 
     it "should set the navigation_menu_name on the configuration" do
-      expect(config).to receive(:navigation_menu_name=).with(:admin)
+      expect(resource_config).to receive(:navigation_menu_name=).with(:admin)
       dsl.run_registration_block do
         navigation_menu :admin
       end
     end
 
     it "should accept a block" do
-
       dsl = ActiveAdmin::DSL.new(resource_config)
       dsl.run_registration_block do
         navigation_menu { :dynamic_menu }
       end
-
       expect(resource_config.navigation_menu_name).to eq :dynamic_menu
-
     end
 
   end
@@ -61,15 +72,14 @@ describe ActiveAdmin::DSL do
   describe "#sidebar" do
 
     before do
-      allow(config).to receive(:sidebar_sections).and_return([])
       dsl.config.sidebar_sections << ActiveAdmin::SidebarSection.new(:email)
     end
 
-    it "add sidebar_section to the sidebar_sections on the configuration" do
+    it "add sidebar_section to the sidebar_sections of config" do
       dsl.run_registration_block do
         sidebar :help
       end
-      expect(config.sidebar_sections.map(&:name)).to match_array([:email, :help])
+      expect(dsl.config.sidebar_sections.map(&:name)).to match_array([:filters, :email, :help])
     end
 
   end


### PR DESCRIPTION
I add a new example for `#action_item` method in `ActiveAdmin::DSL`.
Also contains a bit fix for way of using double.
