### PR TITLE
Lock inherited resources to 1.4.x in gemspec instead of Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,6 @@ gem 'arbre', github: 'gregbell/arbre' # until gregbell/arbre#16 makes it into an
 
 gem 'sass-rails', '4.0.3' if rails_version[0] == '4' # #3005, #3093
 
-gem 'inherited_resources', '~> 1.4.0'
-
 # Optional dependencies
 gem 'cancan'
 gem 'devise'

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'bourbon'
   s.add_dependency 'coffee-rails'
   s.add_dependency 'formtastic',          '~> 2.3.0.rc3' # change to 2.3 when stable is released
-  s.add_dependency 'inherited_resources', '~> 1.3'
+  s.add_dependency 'inherited_resources', '~> 1.4.1'
   s.add_dependency 'jquery-rails'
   s.add_dependency 'jquery-ui-rails'
   s.add_dependency 'kaminari',            '~> 0.15'


### PR DESCRIPTION
Rather than specifying this in the Gemfile, it should be specified in the gemspec so those tracking master don't accidentally pull in an incompatible inherited_resources gem.
