### PR TITLE
Add credential info for the test rails app to the docs.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,10 @@ script/use_rails 4.0.0
 RAILS=4.0.0 script/local server
 ```
 
-You should now be able to open <http://localhost:3000/admin> in your browser.
+You should now be able to open <http://localhost:3000/admin> in your browser. You can log in using:
+
+	User: admin@example.com
+	Password: password
 
 If you need to perform any other commands on the test application, use the
 `local` script. For example to boot the rails console:


### PR DESCRIPTION
It wasn't immediately obvious what credentials I had to use on the test rails app. I now understand this info exist in the official documentation: http://www.activeadmin.info/documentation.html but I had to look in the migration files to find that information. Having it here (contributing.md) too might save someone else some frustration.
