### PR TITLE
Allow numeric status tags

### DIFF
--- a/lib/active_admin/views/components/status_tag.rb
+++ b/lib/active_admin/views/components/status_tag.rb
@@ -60,7 +60,12 @@ module ActiveAdmin
       end
 
       def status_to_class(status)
-        status.to_s.titleize.gsub(/\s/, '').underscore
+        case status
+        when String, Symbol
+          status.to_s.titleize.gsub(/\s/, '').underscore
+        else
+          ''
+        end
       end
     end
   end

--- a/spec/unit/views/components/status_tag_spec.rb
+++ b/spec/unit/views/components/status_tag_spec.rb
@@ -219,12 +219,19 @@ describe ActiveAdmin::Views::StatusTag do
       end
     end
 
-    context "when status set to a Fixnum" do
-      subject { status_tag(1) }
+    context "when status is set to a Fixnum" do
+      subject { status_tag(42) }
 
       describe '#content' do
         subject { super().content }
-        it     { is_expected.to eq '1' }
+        it     { is_expected.to eq '42' }
+      end
+
+      describe '#class_list' do
+        subject { super().class_list }
+        it {
+          is_expected.not_to include('42')
+        }
       end
     end
   end # describe "#status_tag"


### PR DESCRIPTION
When using status_tag it is sometimes useful to use "numeric" tags (for eg. for user rankings to visualize some associated state).

This patch adds simple to_s before titleize calls inside the StatusTag class.
The second commit adds a check into #status_to_class to avoid generating classes names (such as "1") for the non-string status types.

Tests have been added accordingly.
