### PR TITLE
Lock jquery-ui-rails to a version up to 4.2.1

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'formtastic',          '~> 2.3.0.rc3' # change to 2.3 when stable is released
   s.add_dependency 'inherited_resources', '~> 1.4.1'
   s.add_dependency 'jquery-rails'
-  s.add_dependency 'jquery-ui-rails'
+  s.add_dependency 'jquery-ui-rails',     '<= 4.2.1'
   s.add_dependency 'kaminari',            '~> 0.15'
   s.add_dependency 'rails',               '>= 3.2', '< 4.2'
   s.add_dependency 'ransack',             '~> 1.0'


### PR DESCRIPTION
jquery-ui-rails changed the way one must reference a module in their manifests
in v5.0.0 from a `.` to a `/`. Since base.js.coffee uses the dot syntax, we
should set the upper limit of the gem version for now.

See: https://github.com/joliss/jquery-ui-rails/commit/774f8b3e2e5ae8b80515128dd0cdb5cde48dfc01

Fixes #3247.
