### PR TITLE
Fix jquery ui asset

### DIFF
--- a/app/assets/javascripts/active_admin/base.js.coffee
+++ b/app/assets/javascripts/active_admin/base.js.coffee
@@ -1,8 +1,8 @@
 #= require jquery
-#= require jquery.ui.datepicker
-#= require jquery.ui.dialog
-#= require jquery.ui.sortable
-#= require jquery.ui.widget
+#= require jquery-ui/datepicker
+#= require jquery-ui/dialog
+#= require jquery-ui/sortable
+#= require jquery-ui/widget
 #= require jquery_ujs
 #
 #= require_self


### PR DESCRIPTION
_Problem:_
I stumbled upon an issue where active admin throws error `couldn't find file 'jquery.ui.datepicker'`, I have looked at issue #2232, and checked the `jquery-ui-rails` gem version in `Gemfile.lock`, it already had the correct version, unfortunately in my case it still throws errors.

_Solution:_
I checked on jquery-ui-rails (https://github.com/joliss/jquery-ui-rails), and noticed that it uses a different way of adding asset, which uses `jquery-ui/datepicker` instead of the one used in `base.js.coffee` which uses `jquery.ui.datepicker`, hopefully this satisfies other users that had the same issue.

_Tested On:_
Mac OSX 10.9.3
Ruby 2.1.2
