### PR TITLE
Prevent jquery-ui-rails 5 from breaking AA

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'formtastic',          '~> 2.3.0.rc3' # change to 2.3 when stable is released
   s.add_dependency 'inherited_resources', '~> 1.4.1'
   s.add_dependency 'jquery-rails'
-  s.add_dependency 'jquery-ui-rails'
+  s.add_dependency 'jquery-ui-rails',     '< 5.0.0'
   s.add_dependency 'kaminari',            '~> 0.15'
   s.add_dependency 'rails',               '>= 3.2', '< 4.2'
   s.add_dependency 'ransack',             '~> 1.0'


### PR DESCRIPTION
AA requires specific components from jquery-ui,
eg. `jquery.ui.datepicker` from `base.js.coffee`,
This behavior has changed in jquery-ui-rails 5,
resulting in asset pipeline dysfunction.
