### PR TITLE
Update jquery ui references

### DIFF
--- a/app/assets/javascripts/active_admin/base.js.coffee
+++ b/app/assets/javascripts/active_admin/base.js.coffee
@@ -1,5 +1,11 @@
 #= require jquery
-#= require jquery-ui
+#= require jquery-ui/core
+#= require jquery-ui/widget
+#= require jquery-ui/mouse
+#= require jquery-ui/position
+#= require jquery-ui/datepicker
+#= require jquery-ui/dialog
+#= require jquery-ui/sortable
 #= require jquery_ujs
 #
 #= require_self


### PR DESCRIPTION
Updates the 'require' statements to use [jquery-ui-rails v5.0.0](https://github.com/joliss/jquery-ui-rails#require-specific-modules) updated syntax. 
