### PR TITLE
Adding missing gem nl translations

### DIFF
--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -180,3 +180,13 @@ nl:
       blank: "is afwezig"
       'null': "is null"
       not_null: "is niet null"
+# Locales for the formtastic gem
+  formtastic:
+    :yes: 'Ja'
+    :no: 'Nee'
+    :create: 'Creëer %{model}'
+    :update: 'Wijzig %{model}'
+    :submit: 'Verzend %{model}'
+    :cancel: 'Annuleer %{model}'
+    :reset: 'Herstel %{model}'
+    :required: 'verplicht'


### PR DESCRIPTION
Found these translations missing in the nl locale.
As the gems used do not have nl locales present, default the en locale will be used which is not wanted.
