### PR TITLE
Fix cases where events bound to document were 'rebounding'

### DIFF
--- a/app/assets/javascripts/active_admin/lib/batch_actions.js.coffee
+++ b/app/assets/javascripts/active_admin/lib/batch_actions.js.coffee
@@ -32,8 +32,8 @@ $ ->
     else
       $(".paginated_collection").checkboxToggler()
 
-    $(document).on 'change', '.paginated_collection :checkbox', ->
-      if $(".paginated_collection :checkbox:checked").length
-        $(".batch_actions_selector").each -> $(@).aaDropdownMenu("enable")
-      else
-        $(".batch_actions_selector").each -> $(@).aaDropdownMenu("disable")
+$(document).on 'change', '.paginated_collection :checkbox', ->
+  if $(".paginated_collection :checkbox:checked").length
+    $(".batch_actions_selector").each -> $(@).aaDropdownMenu("enable")
+  else
+    $(".batch_actions_selector").each -> $(@).aaDropdownMenu("disable")

--- a/app/assets/javascripts/active_admin/lib/has_many.js.coffee
+++ b/app/assets/javascripts/active_admin/lib/has_many.js.coffee
@@ -1,59 +1,55 @@
-$ ->
-  # Provides a before-removal hook:
-  # $ ->
-  #   # This is a good place to tear down JS plugins to prevent memory leaks.
-  #   $(document).on 'has_many_remove:before', '.has_many_container', (e, fieldset, container)->
-  #     fieldset.find('.select2').select2 'destroy'
-  #
-  #   # If you need to do anything after removing the items you can use the
-  #   has_many_remove:after hook
-  #   $(document).on 'has_many_remove:after', '.has_many_container', (e, fieldset, container)->
-  #     list_item_count = container.find('.has_many_fields').length
-  #     alert("There are now #{list_item_count} items in the list")
-  #
-  $(document).on 'click', 'a.button.has_many_remove', (e)->
-    e.preventDefault()
-    parent    = $(@).closest '.has_many_container'
-    to_remove = $(@).closest 'fieldset'
+# Provides a before-removal hook:
+#   # This is a good place to tear down JS plugins to prevent memory leaks.
+#   $(document).on 'has_many_remove:before', '.has_many_container', (e, fieldset, container)->
+#     fieldset.find('.select2').select2 'destroy'
+#
+#   # If you need to do anything after removing the items you can use the
+#   has_many_remove:after hook
+#   $(document).on 'has_many_remove:after', '.has_many_container', (e, fieldset, container)->
+#     list_item_count = container.find('.has_many_fields').length
+#     alert("There are now #{list_item_count} items in the list")
+#
+$(document).on 'click', 'a.button.has_many_remove', (e)->
+  e.preventDefault()
+  parent    = $(@).closest '.has_many_container'
+  to_remove = $(@).closest 'fieldset'
+  recompute_positions parent
+
+  parent.trigger 'has_many_remove:before', [to_remove, parent]
+  to_remove.remove()
+  parent.trigger 'has_many_remove:after', [to_remove, parent]
+
+# Provides before and after creation hooks:
+#   # The before hook allows you to prevent the creation of new records.
+#   $(document).on 'has_many_add:before', '.has_many_container', (e, container)->
+#     if $(@).children('fieldset').length >= 3
+#       alert "you've reached the maximum number of items"
+#       e.preventDefault()
+#
+#   # The after hook is a good place to initialize JS plugins and the like.
+#   $(document).on 'has_many_add:after', '.has_many_container', (e, fieldset, container)->
+#     fieldset.find('select').chosen()
+#
+$(document).on 'click', 'a.button.has_many_add', (e)->
+  e.preventDefault()
+  parent = $(@).closest '.has_many_container'
+  parent.trigger before_add = $.Event('has_many_add:before'), [parent]
+
+  unless before_add.isDefaultPrevented()
+    index = parent.data('has_many_index') || parent.children('fieldset').length - 1
+    parent.data has_many_index: ++index
+
+    regex = new RegExp $(@).data('placeholder'), 'g'
+    html  = $(@).data('html').replace regex, index
+
+    fieldset = $(html).insertBefore(@)
     recompute_positions parent
+    parent.trigger 'has_many_add:after', [fieldset, parent]
 
-    parent.trigger 'has_many_remove:before', [to_remove, parent]
-    to_remove.remove()
-    parent.trigger 'has_many_remove:after', [to_remove, parent]
+$(document).on 'change','.has_many_container[data-sortable] :input[name$="[_destroy]"]', ->
+  recompute_positions $(@).closest '.has_many'
 
-  # Provides before and after creation hooks:
-  # $ ->
-  #   # The before hook allows you to prevent the creation of new records.
-  #   $(document).on 'has_many_add:before', '.has_many_container', (e, container)->
-  #     if $(@).children('fieldset').length >= 3
-  #       alert "you've reached the maximum number of items"
-  #       e.preventDefault()
-  #
-  #   # The after hook is a good place to initialize JS plugins and the like.
-  #   $(document).on 'has_many_add:after', '.has_many_container', (e, fieldset, container)->
-  #     fieldset.find('select').chosen()
-  #
-  $(document).on 'click', 'a.button.has_many_add', (e)->
-    e.preventDefault()
-    parent = $(@).closest '.has_many_container'
-    parent.trigger before_add = $.Event('has_many_add:before'), [parent]
-
-    unless before_add.isDefaultPrevented()
-      index = parent.data('has_many_index') || parent.children('fieldset').length - 1
-      parent.data has_many_index: ++index
-
-      regex = new RegExp $(@).data('placeholder'), 'g'
-      html  = $(@).data('html').replace regex, index
-
-      fieldset = $(html).insertBefore(@)
-      recompute_positions parent
-      parent.trigger 'has_many_add:after', [fieldset, parent]
-
-  $(document).on 'change','.has_many_container[data-sortable] :input[name$="[_destroy]"]', ->
-    recompute_positions $(@).closest '.has_many'
-
-  init_sortable()
-  $(document).on 'has_many_add:after', '.has_many_container', init_sortable
+$(document).on 'has_many_add:after', '.has_many_container', init_sortable
 
 
 init_sortable = ->
@@ -77,3 +73,6 @@ recompute_positions = (parent)->
 
     if sortable_input.length
       sortable_input.val if destroy_input.is ':checked' then '' else position++
+
+$ ->
+  init_sortable()


### PR DESCRIPTION
This PR will fix cases dealing with Turbolinks or anything messing with the ready event. Events bound to the 'document' object were being triggered twice (or more).

Since this method of event binding is independent of the target object existing in the DOM at the moment of its runtime, it is actually better to leave them out of the ready function.