### PR TITLE
Fixed "private method render"-bug when trying to save invalid model under Rails 4.

### DIFF
--- a/lib/active_admin/base_controller.rb
+++ b/lib/active_admin/base_controller.rb
@@ -14,6 +14,9 @@ module ActiveAdmin
     before_filter :only_render_implemented_actions
     before_filter :authenticate_active_admin_user
 
+    # Or render will fail after trying to save invalid model under Rails 4.
+    public :render
+
     class << self
       # Ensure that this method is available for the DSL
       public :actions


### PR DESCRIPTION
Bug occurs when trying to save an invalid model under Rails 4.

Unfortunately I was not able to write a test for it, since I couldn't figure out how you do that in ActiveAdmin :-(

Be here is what I would be going for:

Alter Post-class to validate:

``` ruby
class Post
  validates_presence_of :title
end
```

Controller spec:

``` ruby
describe Admin::PostsController, type: :controller do
  render_views

  it "#create" do
    post :create, post: {title: ""}
    response.should render_template("new")
  end
end
```

Should not throw "private method render..."-error.
