### PR TITLE
Use correct way to respond to missing

### DIFF
--- a/lib/active_admin/abstract_view_factory.rb
+++ b/lib/active_admin/abstract_view_factory.rb
@@ -46,8 +46,7 @@ module ActiveAdmin
       set_view_for_key(key, value)
     end
 
-    # Override respond to to include keys
-    def respond_to?(method)
+    def respond_to_missing?(method, include_private)
       key = key_from_method_name(method)
       if has_key?(key)
         true


### PR DESCRIPTION
Hi,

The number of the arguments of `respond_to?` is 2, `name` and `include_private = false`.
Ruby 2.1: http://ruby-doc.org/core-2.1.2/Object.html#method-i-respond_to-3F
Ruby 1.9.3: http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-respond_to-3F
If you use `respond_to?(:foo, true)` on these classes, which I fixed on, it raises `ArgumentError`. 

Furthermore, we should use `respond_to_missing?` instead of `respond_to?` if we want to override the behavior.
Ruby 2.1: http://ruby-doc.org/core-2.1.2/Object.html#method-i-respond_to_missing-3F
Ruby 1.9.3: http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-respond_to_missing-3F

Discussion about `respond_to?` and `respond_to_missing?` is here.
http://robots.thoughtbot.com/always-define-respond-to-missing-when-overriding
