### PR TITLE
Support default Pundit policy class.

### DIFF
--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -79,6 +79,8 @@ module ActiveAdmin
     # The authorization adapter to use
     inheritable_setting :authorization_adapter, ActiveAdmin::AuthorizationAdapter
 
+    inheritable_setting :pundit_default_policy, nil
+
     # A proc to be used when a user is not authorized to view the current resource
     inheritable_setting :on_unauthorized_access, :rescue_active_admin_access_denied
 

--- a/lib/generators/active_admin/install/templates/active_admin.rb.erb
+++ b/lib/generators/active_admin/install/templates/active_admin.rb.erb
@@ -65,6 +65,11 @@ ActiveAdmin.setup do |config|
   # CanCanAdapter or make your own. Please refer to documentation.
   # config.authorization_adapter = ActiveAdmin::CanCanAdapter
 
+  # In case you prefer Pundit over other solutions you can here pass
+  # the name of default policy class. This policy will be used in every
+  # case when Pundit is unable to find suitable policy.
+  # config.pundit_default_policy = MyDefaultPunditPolicy
+
   # You can customize your CanCan Ability class name here.
   # config.cancan_ability_class = "Ability"
 

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -66,6 +66,10 @@ describe ActiveAdmin::Application do
     expect(application.allow_comments).to eq true
   end
 
+  it "should set default Pundit policy class" do
+    application.default_pundit_policy = policy_klass
+  end
+
   describe "authentication settings" do
 
     it "should have no default current_user_method" do

--- a/spec/unit/pundit_adapter_spec.rb
+++ b/spec/unit/pundit_adapter_spec.rb
@@ -8,6 +8,25 @@ describe ActiveAdmin::PunditAdapter do
     let(:namespace) { ActiveAdmin::Namespace.new(application, "Admin") }
     let(:resource) { namespace.register(Post) }
     let(:auth) { namespace.authorization_adapter.new(resource, double) }
+    let(:default_policy_klass) do
+      class DefaultPolicy < ApplicationPolicy
+        class Scope
+
+          attr_reader :user, :scope
+
+          def initialize(user, scope)
+            @user = user
+            @scope = scope
+          end
+
+          def resolve
+            scope
+          end
+        end
+      end
+
+      DefaultPolicy
+    end
 
     before do
       namespace.authorization_adapter = ActiveAdmin::PunditAdapter
@@ -30,6 +49,31 @@ describe ActiveAdmin::PunditAdapter do
       collection = double
       auth.scope_collection(collection, :read)
       expect(collection).to eq collection
+    end
+
+    context 'when Pundit is unable to find policy scope' do
+      let(:collection) { double("collection", to_sym: :collection) }
+      subject(:scope) { auth.scope_collection(collection, :read) }
+
+      before do
+        allow(ActiveAdmin.application).to receive(:pundit_default_policy).and_return default_policy_klass
+        allow(Pundit).to receive(:policy_scope!) { raise Pundit::NotDefinedError.new }
+      end
+
+      it("should return default policy's scope if defined") { is_expected.to eq(collection) }
+    end
+
+    context "when Pundit is unable to find policy" do
+      let(:record) { double }
+
+      subject(:policy) { auth.retrieve_policy(record) }
+
+      before do
+        allow(ActiveAdmin.application).to receive(:pundit_default_policy).and_return default_policy_klass
+        allow(Pundit).to receive(:policy!) { raise Pundit::NotDefinedError.new }
+      end
+
+      it("should return default policy instance") { is_expected.to be_instance_of(default_policy_klass) }
     end
   end
 


### PR DESCRIPTION
There are situations where to have default Pundit policy defined which will handle all cases here dedicated policy could not be found. Some of those cases I described in issue #3319. This PR introduces new ActiveAdmin setting `pundit_default_policy` which handles authorization when Pundit can't find dedicated Policy class for resource.
