### PR TITLE
Fix in CSV streaming to call passed block

### DIFF
--- a/lib/active_admin/resource_controller/streaming.rb
+++ b/lib/active_admin/resource_controller/streaming.rb
@@ -9,7 +9,10 @@ module ActiveAdmin
     module Streaming
 
       def index
-        super { |format| format.csv { stream_csv } }
+        super do |format|
+          format.csv { stream_csv }
+          yield(format) if block_given?
+        end
       end
 
       protected

--- a/spec/unit/authorization/index_overriding_spec.rb
+++ b/spec/unit/authorization/index_overriding_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe Admin::PostsController, 'Index overriding', type: :controller do
+  before do
+    controller.instance_eval do
+      def index
+        super do
+          render text: 'Rendered from passed block' and return
+        end
+      end
+    end
+    load_defaults!
+    # HACK: the AA config is missing, so we throw it in here
+    controller.class.active_admin_config = ActiveAdmin.application.namespace(:admin).resources['Post'].controller.active_admin_config
+  end
+
+  it 'should call block passed to overridden index' do
+    get :index
+    expect(response.body).to eq 'Rendered from passed block'
+  end
+
+end


### PR DESCRIPTION
New streaming module overrides resource controller's index method and passes block to it.

This change broke custom format responses customization.

Example: 

``` ruby
module ActiveAdmin
  class ResourceController
    def index
      super do |format|
        format.file do
          # this code won't be called
        end
      end
    end
  end
end
```
