### PR TITLE
Minor spec changes to get specs passing.

### DIFF
--- a/features/users/logging_in.feature
+++ b/features/users/logging_in.feature
@@ -24,7 +24,7 @@ Feature: User Logging In
     And I fill in "Password" with "not-my-password"
     And I press "Login"
     Then I should see "Login"
-    And I should see "Invalid email or password."
+    And I should see "Invalid email address or password."
 
   Scenario: Attempting to log in with an incorrect password
     When I fill in "Email" with "admin@example.com"

--- a/spec/unit/views/components/paginated_collection_spec.rb
+++ b/spec/unit/views/components/paginated_collection_spec.rb
@@ -46,9 +46,10 @@ describe ActiveAdmin::Views::PaginatedCollection do
 
     it 'should preserve custom query params' do
       allow(view.request).to receive(:query_parameters).and_return page: '1', something: 'else'
-      expect(pagination).to include '/admin/posts.csv?page=1&amp;something=else'
-      expect(pagination).to include '/admin/posts.xml?page=1&amp;something=else'
-      expect(pagination).to include '/admin/posts.json?page=1&amp;something=else'
+      pagination_content = pagination.content
+      expect(pagination_content).to include '/admin/posts.csv?page=1&amp;something=else'
+      expect(pagination_content).to include '/admin/posts.xml?page=1&amp;something=else'
+      expect(pagination_content).to include '/admin/posts.json?page=1&amp;something=else'
     end
 
     context "when specifying :param_name option" do


### PR DESCRIPTION
This PR includes two minor changes to get the specs to green:
1. Change the text for the logging_in spec to properly reflect the error text in the locale files.
2. Don't call include? on a PaginatedCollection, but rather call 'content' first to get the stringified contents.

With this PR the specs are green again.
