### PR TITLE
Use newest version of inherited resources

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'bourbon'
   s.add_dependency 'coffee-rails'
   s.add_dependency 'formtastic',          '~> 2.3.0.rc3' # change to 2.3 when stable is released
-  s.add_dependency 'inherited_resources', '~> 1.4.1'
+  s.add_dependency 'inherited_resources', '~> 1.5.0'
   s.add_dependency 'jquery-rails'
   s.add_dependency 'jquery-ui-rails',     '~> 5.0'
   s.add_dependency 'kaminari',            '~> 0.15'


### PR DESCRIPTION
Which in turn uses new version of responders. Otherwise we can't use the location responder
