### PR TITLE
remove require inherited_resources

### DIFF
--- a/lib/active_admin/base_controller.rb
+++ b/lib/active_admin/base_controller.rb
@@ -1,5 +1,3 @@
-require 'inherited_resources'
-
 require 'active_admin/base_controller/authorization'
 require 'active_admin/base_controller/menu'
 

--- a/lib/active_admin/resource_controller.rb
+++ b/lib/active_admin/resource_controller.rb
@@ -1,4 +1,3 @@
-require 'inherited_resources'
 require 'active_admin/resource_controller/action_builder'
 require 'active_admin/resource_controller/data_access'
 require 'active_admin/resource_controller/decorators'


### PR DESCRIPTION
This requires are not needed, because `inherited_resources` is already required by `lib/active_admin.rb`.
