### PR TITLE
Uses ransack 1.3

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'jquery-ui-rails',     '~> 5.0'
   s.add_dependency 'kaminari',            '~> 0.15'
   s.add_dependency 'rails',               '>= 3.2', '< 4.2'
-  s.add_dependency 'ransack'
+  s.add_dependency 'ransack',             '~> 1.3'
   s.add_dependency 'sass-rails'
 end


### PR DESCRIPTION
Uses ransack 1.3
This way the active admin will be compatible with the latest squeal which is compatible with rails 4.1 and above.
