### PR TITLE
fix and implement missing resource controller specs

### DIFF
--- a/spec/unit/resource_controller_spec.rb
+++ b/spec/unit/resource_controller_spec.rb
@@ -225,7 +225,7 @@ describe Admin::PostsController, type: "controller" do
   describe "performing batch_action" do
     let(:controller){ Admin::PostsController.new }
     let(:batch_action) { ActiveAdmin::BatchAction.new :flag, "Flag", &batch_action_block }
-    let(:batch_action_block) { lambda { |*| } }
+    let(:batch_action_block) { proc { } }
     before do
       allow(controller.class.active_admin_config).to receive(:batch_actions).and_return([batch_action])
     end


### PR DESCRIPTION
# Commit 1

The old 2 skipped tests are failing while this overwrites the rspec `post` method:

``` ruby
let(:post) { Post.new title: "An incledibly unique Post Title" }
```

To use a `post` request in a unit spec is not a good choice, while with post you can't expect a internal rised error, you can only expect the external error, so I change it.
# Commit 2

This is not the best way, but it looks like this is the only one and we don't need to test the right behavior of `instance_exec`.
