### PR TITLE
Bump formastic to 2.3.x

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'arbre',               '~> 1.0', '>= 1.0.2'
   s.add_dependency 'bourbon'
   s.add_dependency 'coffee-rails'
-  s.add_dependency 'formtastic',          '~> 2.3.0.rc3' # change to 2.3 when stable is released
+  s.add_dependency 'formtastic',          '~> 2.3.0'
   s.add_dependency 'inherited_resources', '~> 1.4.1'
   s.add_dependency 'jquery-rails'
   s.add_dependency 'jquery-ui-rails',     '~> 5.0'


### PR DESCRIPTION
Formtastic just recently released a stable version of 2.3 (https://github.com/justinfrench/formtastic/commit/2654b2d6baef60611fb411575bf8b1a76ebc3c86) so bumping it up from the release candidate to the stable version of 2.3 
