### PR TITLE
fix site title of namespaces

### DIFF
--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -22,7 +22,7 @@ module ActiveAdmin
 
         def build_active_admin_head
           within @head do
-            insert_tag Arbre::HTML::Title, [title, render_or_call_method_or_proc_on(self, active_admin_application.site_title)].join(" | ")
+            insert_tag Arbre::HTML::Title, [title, render_or_call_method_or_proc_on(self, active_admin_namespace.site_title)].join(" | ")
             active_admin_application.stylesheets.each do |style, options|
               text_node stylesheet_link_tag(style, options).html_safe
             end


### PR DESCRIPTION
Bug:
With this configuration:

``` ruby
ActiveAdmin.setup do |config|
  config.site_title = "Root"
  config.namespace :sub do |sub|
    sub.site_title = "Sub"
  end
end
```

The site title (`<title>` tag), keeps "Root" for all namespaces. Now it's "Root" for root namespace and "Sub" for sub namespace.
