### PR TITLE
don't use ARGV in generator

### DIFF
--- a/lib/generators/active_admin/install/install_generator.rb
+++ b/lib/generators/active_admin/install/install_generator.rb
@@ -27,10 +27,10 @@ module ActiveAdmin
       end
 
       def setup_routes
-        if ARGV.include? "--skip-users"
-          route "ActiveAdmin.routes(self)"
-        else # Ensure Active Admin routes occur after Devise routes so that Devise has higher priority
+        if options[:users] # Ensure Active Admin routes occur after Devise routes so that Devise has higher priority
           inject_into_file "config/routes.rb", "\n  ActiveAdmin.routes(self)", after: /devise_for .*, ActiveAdmin::Devise\.config/
+        else
+          route "ActiveAdmin.routes(self)"
         end
       end
 


### PR DESCRIPTION
## Case 1

``` sh
rails generate active_admin:install --skip-users
```

give's:

``` ruby
options = {"skip_namespace"=>false, "users"=>nil}
```
## Case 2

``` sh
rails generate active_admin:install
```

give's:

``` ruby
options = {"skip_namespace"=>false, "users"=>"devise"}
```
## Result

We can simply do this:

``` ruby
options[:users]
```

insted of dealing with ARGV:

``` ruby
if ARGV.include? "--skip-users"
```
