### PR TITLE
Added tabs dsl for organizing content on active admin pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,9 +17,12 @@ gem 'pundit'
 gem 'rake', require: false
 gem 'parallel_tests'
 
+group :development, :test, :cucumber do
+  gem 'pry'                # Easily debug from your console with `binding.pry`
+end
+
 group :development do
   # Debugging
-  gem 'pry'                # Easily debug from your console with `binding.pry`
   gem 'better_errors'      # Web UI to debug exceptions. Go to /__better_errors to access the latest one
   gem 'binding_of_caller'  # Retrieve the binding of a method's caller in MRI Ruby >= 1.9.2
 

--- a/app/assets/javascripts/active_admin/application.js.coffee
+++ b/app/assets/javascripts/active_admin/application.js.coffee
@@ -22,6 +22,9 @@ $ ->
   $('.filter_form_field.select_and_search select').change ->
     $(@).siblings('input').prop name: "q[#{@value}]"
 
+  # Tab navigation in the show page
+  $('#main_content .tabs').tabs()
+
   # In order for index scopes to overflow properly onto the next line, we have
   # to manually set its width based on the width of the batch action button.
   if (batch_actions_selector = $('.table_tools .batch_actions_selector')).length

--- a/app/assets/javascripts/active_admin/base.js.coffee
+++ b/app/assets/javascripts/active_admin/base.js.coffee
@@ -3,6 +3,7 @@
 #= require jquery-ui/dialog
 #= require jquery-ui/sortable
 #= require jquery-ui/widget
+#= require jquery-ui/tabs
 #= require jquery_ujs
 #
 #= require_self

--- a/app/assets/stylesheets/active_admin/_base.css.scss
+++ b/app/assets/stylesheets/active_admin/_base.css.scss
@@ -26,6 +26,7 @@
 @import "active_admin/components/status_tags";
 @import "active_admin/components/table_tools";
 @import "active_admin/components/index_list";
+@import "active_admin/components/tabs";
 @import "active_admin/pages/logged_out";
 @import "active_admin/structure/footer";
 @import "active_admin/structure/main_structure";

--- a/app/assets/stylesheets/active_admin/components/_tabs.css.scss
+++ b/app/assets/stylesheets/active_admin/components/_tabs.css.scss
@@ -1,0 +1,43 @@
+.ui-tabs-nav {
+  border-bottom: 1px solid #DDD;
+  list-style: none;
+  display: block;
+  width: auto;
+  margin-bottom: 15px;
+  padding-left: 0;
+
+  a {
+    display: block;
+  }
+
+  li {
+    display: inline-block;
+    position: relative;
+    margin-bottom: -1px;
+  }
+
+  li.ui-tabs-active > a, li.ui-tabs-active > a:hover, li.ui-tabs-active > a:focus {
+    color: #555;
+    cursor: default;
+    background-color: #FFF;
+    border: 1px solid #DDD;
+    border-bottom-color: rgba(0, 0, 0, 0);
+  }
+
+  li > a:hover {
+    border-color: #EEE #EEE #DDD;
+  }
+
+  li > a:hover, li > a:focus {
+    text-decoration: none;
+    background-color: #EEE;
+  }
+  li > a {
+    text-decoration: none;
+    padding: 12px 15px;
+    margin-right: 2px;
+    line-height: 1.42857143;
+    border: 1px solid rgba(0, 0, 0, 0);
+    border-radius: 4px 4px 0 0;
+  }
+}

--- a/features/show/tabs.feature
+++ b/features/show/tabs.feature
@@ -1,0 +1,27 @@
+Feature: Show - Tabs
+
+  Add tabs with different content to the page
+
+  Background:
+    Given a post with the title "Hello World" written by "Jane Doe" exists
+
+  Scenario: Set a method to be called on the resource as the title
+    Given a show configuration of:
+    """
+      ActiveAdmin.register Post do
+        show do
+          tabs do
+            tab :overview do
+              span "tab 1"
+            end
+
+            tab :details do
+              span "tab 2"
+            end
+          end
+        end
+      end
+    """
+    Then I should see two tabs "Overview" and "Details"
+    And I should see "tab 1"
+    And I should see "tab 2"

--- a/features/step_definitions/tab_steps.rb
+++ b/features/step_definitions/tab_steps.rb
@@ -1,3 +1,8 @@
 Then /^the "([^"]*)" tab should be selected$/ do |name|
   step %{I should see "#{name}" within "ul#tabs li.current"}
 end
+
+Then(/^I should see two tabs "(.*?)" and "(.*?)"$/) do |tab_1, tab_2|
+  expect(page).to have_link(tab_1)
+  expect(page).to have_link(tab_2)
+end

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -83,3 +83,7 @@ end
 Then /^show me the page$/ do
   save_and_open_page
 end
+
+Then /^pry now$/ do
+  binding.pry
+end

--- a/lib/active_admin/views/components/tabs.rb
+++ b/lib/active_admin/views/components/tabs.rb
@@ -1,0 +1,28 @@
+module ActiveAdmin
+  module Views
+    class Tabs < ActiveAdmin::Component
+      builder_method :tabs
+
+      def tab(title, options = {}, &block)
+        title = title.to_s.titleize if title.is_a? Symbol
+        @menu << build_menu_item(title, options, &block)
+        @tabs_content << build_content_item(title, options, &block)
+      end
+
+      def build(&block)
+        @menu = ul(class: 'nav nav-tabs', role: "tablist")
+        @tabs_content = div(class: 'tab-content')
+      end
+
+      def build_menu_item(title, options, &block)
+        options = options.reverse_merge({})
+        li { link_to title, "##{title.parameterize}", options }
+      end
+
+      def build_content_item(title, options, &block)
+        options = options.reverse_merge(id: title.parameterize)
+        div(options, &block)
+      end
+    end
+  end
+end

--- a/spec/unit/views/components/tabs_spec.rb
+++ b/spec/unit/views/components/tabs_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+describe ActiveAdmin::Views::Tabs do
+  describe "creating with the dsl" do
+    context "when creating tabs with a symbol" do
+      let(:tabs) do
+        render_arbre_component do
+          tabs do
+            tab :overview
+          end
+        end
+      end
+
+      it "should create a tab navigation bar based on the symbol" do
+        expect(tabs.find_by_tag('li').first.content).to include "Overview"
+      end
+    end
+
+    context "when creating a tab with a block" do
+      let(:tabs) do
+        render_arbre_component do
+          tabs do
+            tab :overview do
+              span 'tab 1'
+            end
+          end
+        end
+      end
+
+      it "should create a tab navigation bar based on the symbol" do
+        expect(tabs.find_by_tag('li').first.content).to include "Overview"
+      end
+
+      it "should create a tab with a span inside of it" do
+        expect(tabs.find_by_tag('span').first.content).to eq('tab 1')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added tabs to active admin to enable users to better organize content on different page (e.g. show pages).

This is the result:
![screen shot 2014-09-01 at 12 14 20 am](https://cloud.githubusercontent.com/assets/1386966/4105442/381113e6-31aa-11e4-9d4e-5099d91fc2c4.png)

DSL:

```
tabs do
  tab :overview do
    span 'tab 1'
  end

  tab :details do
    span 'tab 2'
  end
end
```

I figured I will have it reviewed before starting to write documentation for it. Hope we can get this merged quickly. It is a relatively small change, but really useful when a model has too much data on the screen. You can even be cool like github and display a preview for your html/markdown in a tab just like github does :).
