### PR TITLE
build js flash message via jQuery to escape html

### DIFF
--- a/app/assets/javascripts/active_admin/lib/flash.js.coffee
+++ b/app/assets/javascripts/active_admin/lib/flash.js.coffee
@@ -4,4 +4,4 @@ ActiveAdmin.flash =
   notice: (message) ->
     this.abstract message, 'notice'
   abstract: (message, type) ->
-    $('.flashes').append "<div class='flash flash_#{type}'>#{message}</div>"
+    $('.flashes').append $("<div>").addClass("flash flash_#{type}").text(message)


### PR DESCRIPTION
Bug:
`message = "foo <bla> bar"` results in `foo bar`
