### PR TITLE
Bump to latest rails 4.1.x in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ rvm:
 env:
   matrix:
     - RAILS=3.2.19
-    - RAILS=4.1.4
+    - RAILS=4.1.5
   global:
     secure: lRYUGVUV94eqrR7C0b0hhvp+W76NkLRAn6jkJGCbRCEojbeb3HlgK1P+nTDeIuiDmXksJOG6VD3ZiZAn9Plznj7I/MFh+ijgvk8eWj9QNxA8riaSEPAu5VYtPA+uaw1olUt196U3qXH+SaXB4sx5wdIUXpd9qxWWWsW11ia0Jzs=
 notifications:


### PR DESCRIPTION
Really minor PR but just bumping to the latest version of rails 4.1.x in travis.yml
