### PR TITLE
Include parent/container in before/after add/remove has_many events

### DIFF
--- a/app/assets/javascripts/active_admin/lib/has_many.js.coffee
+++ b/app/assets/javascripts/active_admin/lib/has_many.js.coffee
@@ -2,8 +2,14 @@ $ ->
   # Provides a before-removal hook:
   # $ ->
   #   # This is a good place to tear down JS plugins to prevent memory leaks.
-  #   $(document).on 'has_many_remove:before', '.has_many_container', (e, fieldset)->
+  #   $(document).on 'has_many_remove:before', '.has_many_container', (e, fieldset, container)->
   #     fieldset.find('.select2').select2 'destroy'
+  #
+  #   # If you need to do anything after removing the items you can use the
+  #   has_many_remove:after hook
+  #   $(document).on 'has_many_remove:after', '.has_many_container', (e, fieldset, container)->
+  #     list_item_count = container.find('.has_many_fields').length
+  #     alert("There are now #{list_item_count} items in the list")
   #
   $(document).on 'click', 'a.button.has_many_remove', (e)->
     e.preventDefault()
@@ -11,26 +17,26 @@ $ ->
     to_remove = $(@).closest 'fieldset'
     recompute_positions parent
 
-    parent.trigger 'has_many_remove:before', [to_remove]
+    parent.trigger 'has_many_remove:before', [to_remove, parent]
     to_remove.remove()
-    parent.trigger 'has_many_remove:after', [ to_remove ]
+    parent.trigger 'has_many_remove:after', [to_remove, parent]
 
   # Provides before and after creation hooks:
   # $ ->
   #   # The before hook allows you to prevent the creation of new records.
-  #   $(document).on 'has_many_add:before', '.has_many_container', (e)->
+  #   $(document).on 'has_many_add:before', '.has_many_container', (e, container)->
   #     if $(@).children('fieldset').length >= 3
   #       alert "you've reached the maximum number of items"
   #       e.preventDefault()
   #
   #   # The after hook is a good place to initialize JS plugins and the like.
-  #   $(document).on 'has_many_add:after', '.has_many_container', (e, fieldset)->
+  #   $(document).on 'has_many_add:after', '.has_many_container', (e, fieldset, container)->
   #     fieldset.find('select').chosen()
   #
   $(document).on 'click', 'a.button.has_many_add', (e)->
     e.preventDefault()
     parent = $(@).closest '.has_many_container'
-    parent.trigger before_add = $.Event 'has_many_add:before'
+    parent.trigger before_add = $.Event('has_many_add:before'), [parent]
 
     unless before_add.isDefaultPrevented()
       index = parent.data('has_many_index') || parent.children('fieldset').length - 1
@@ -41,7 +47,7 @@ $ ->
 
       fieldset = $(html).insertBefore(@)
       recompute_positions parent
-      parent.trigger 'has_many_add:after', [fieldset]
+      parent.trigger 'has_many_add:after', [fieldset, parent]
 
   $(document).on 'change','.has_many_container[data-sortable] :input[name$="[_destroy]"]', ->
     recompute_positions $(@).closest '.has_many'


### PR DESCRIPTION
This stems from the discussion in #3146. `container`, i.e. the `.has_many_container` is now being passed into `has_many_add:before`, `has_many_add:after`, `has_many_remove:before`, `has_many_remove:after`.
