### PR TITLE
Wrap new has_many items in an <li> tag

### DIFF
--- a/app/assets/javascripts/active_admin/lib/has_many.js.coffee
+++ b/app/assets/javascripts/active_admin/lib/has_many.js.coffee
@@ -39,7 +39,7 @@ $ ->
       regex = new RegExp $(@).data('placeholder'), 'g'
       html  = $(@).data('html').replace regex, index
 
-      fieldset = $(html).insertBefore(@)
+      fieldset = $('<li>').html(html).insertBefore(@)
       recompute_positions parent
       parent.trigger 'has_many_add:after', [fieldset]
 


### PR DESCRIPTION
When adding new items in the has_many JS, the new fieldsets are not being wrapped in <li> tags, so the DOM is technically in an invalid state.
