### PR TITLE
Fix css issues with rendering date(time) selectors

### DIFF
--- a/app/assets/stylesheets/active_admin/_forms.css.scss
+++ b/app/assets/stylesheets/active_admin/_forms.css.scss
@@ -143,8 +143,8 @@ form {
       float: left;
       position: static;
       width: 20%;
-      span { position: static; width: auto; }
-      &.label label { position: static; width: auto; }
+      span { position: static; width: 100%; }
+      &.label label { position: static; width: 100%; }
     }
     .fragments-group {
       box-sizing: border-box;


### PR DESCRIPTION
Treat fragments and fragment groups separately from other fieldsets and lists.

The problem is that formtastic uses `fieldset`s, `ol`s, and `li`s to display the segmented date/time drop down boxes, and other styles were overriding them, making them behave like normal nested field sets (trying to render the legend absolutely, in the upper left hand corner, for example)

I don't know where this bug got introduced, but this fixes rendering date/datetime fields both in nested and in top level `inputs` groups.

This is a bit of a hack, but I plan on tightening up the CSS in ActiveAdmin so I think this is a good stopgap.

Here is a screenshot of the previous behavior:

![Rendering Bug](https://dl.dropboxusercontent.com/u/473648/ActiveAdmin/Screen%20Shot%202014-09-04%20at%2011.02.23%20AM.png)

And here is the new behavior:

![Fixed](https://dl.dropboxusercontent.com/u/473648/ActiveAdmin/Screen%20Shot%202014-09-04%20at%2012.28.09%20PM.png)

This patch also fixes https://github.com/activeadmin/activeadmin/issues/2734 as seen above
