### PR TITLE
Available helper methods in custom views

### DIFF
--- a/lib/active_admin/view_helpers.rb
+++ b/lib/active_admin/view_helpers.rb
@@ -14,6 +14,10 @@ module ActiveAdmin
     include FormHelper
     include TitleHelper
     include ViewFactoryHelper
+    include BlankSlateHelper
+    include ColumnsHelper
+    include PanelHelper
+    include StatusTagHelper
 
   end
 end

--- a/lib/active_admin/view_helpers/blank_slate_helper.rb
+++ b/lib/active_admin/view_helpers/blank_slate_helper.rb
@@ -1,0 +1,12 @@
+module ActiveAdmin
+  module ViewHelpers
+    module BlankSlateHelper
+
+      def blank_slate(context)
+        @blank_slate ||= ActiveAdmin::Views::BlankSlate.new
+        @blank_slate.blank_slate(context)
+      end
+
+    end
+  end
+end

--- a/lib/active_admin/view_helpers/columns_helper.rb
+++ b/lib/active_admin/view_helpers/columns_helper.rb
@@ -1,0 +1,21 @@
+module ActiveAdmin
+  module ViewHelpers
+    module ColumnsHelper
+
+      def columns(&block)
+        @columns ||= ActiveAdmin::Views::Columns.new
+        @columns.columns do
+          content_tag(:div, &block) if block_given?
+        end
+      end
+
+      def column(options = {}, &block)
+        @columns ||= ActiveAdmin::Views::Columns.new
+        @columns.column options do
+          content_tag(:div, &block) if block_given?
+        end
+      end
+
+    end
+  end
+end

--- a/lib/active_admin/view_helpers/panel_helper.rb
+++ b/lib/active_admin/view_helpers/panel_helper.rb
@@ -1,0 +1,14 @@
+module ActiveAdmin
+  module ViewHelpers
+    module PanelHelper
+
+      def panel(title, attributes = {}, &block)
+        @panel ||= ActiveAdmin::Views::Panel.new
+        @panel.panel title, attributes do
+          content_tag(:div, &block) if block_given?
+        end
+      end
+
+    end
+  end
+end

--- a/lib/active_admin/view_helpers/status_tag_helper.rb
+++ b/lib/active_admin/view_helpers/status_tag_helper.rb
@@ -1,0 +1,12 @@
+module ActiveAdmin
+  module ViewHelpers
+    module StatusTagHelper
+
+      def status_tag(*args)
+        @status_tag ||= ActiveAdmin::Views::StatusTag.new
+        @status_tag.status_tag(*args)
+      end
+
+    end
+  end
+end

--- a/spec/unit/view_helpers/blank_slate_helper_spec.rb
+++ b/spec/unit/view_helpers/blank_slate_helper_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe ActiveAdmin::ViewHelpers::BlankSlateHelper do
+  let(:view)    { action_view }
+  let(:context) { 'Plain text' }
+
+  context '#blank_slate' do
+    it 'calls ActiveAdmin::Views::BlankSlate#blank_slate with context' do
+      expect_any_instance_of(ActiveAdmin::Views::BlankSlate).to receive(:blank_slate).with(context)
+      view.blank_slate(context)
+    end
+  end
+
+end

--- a/spec/unit/view_helpers/columns_helper_spec.rb
+++ b/spec/unit/view_helpers/columns_helper_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe ActiveAdmin::ViewHelpers::ColumnsHelper do
+  let(:view)    { action_view }
+  let(:options) { { span: 2, max_width: '200px', min_width: '100px' } }
+
+  context '#columns' do
+    it 'calls ActiveAdmin::Views::Columns#columns' do
+      expect_any_instance_of(ActiveAdmin::Views::Columns).to receive(:columns)
+      view.columns {}
+    end
+  end
+
+  context '#column' do
+    it 'calls ActiveAdmin::Views::Columns#column with options' do
+      expect_any_instance_of(ActiveAdmin::Views::Columns).to receive(:column).with(options)
+      view.column(options)
+    end
+  end
+
+end

--- a/spec/unit/view_helpers/panel_helper_spec.rb
+++ b/spec/unit/view_helpers/panel_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe ActiveAdmin::ViewHelpers::PanelHelper do
+  let(:view)        { action_view }
+  let(:title)       { 'Panel title' }
+  let(:attributes)  { {} }
+
+  context '#panel' do
+    it 'calls ActiveAdmin::Views::Panel#panel with title and attributes' do
+      expect_any_instance_of(ActiveAdmin::Views::Panel).to receive(:panel).with(title, attributes)
+      view.panel(title, attributes)
+    end
+  end
+
+end

--- a/spec/unit/view_helpers/status_tag_helper_spec.rb
+++ b/spec/unit/view_helpers/status_tag_helper_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe ActiveAdmin::ViewHelpers::StatusTagHelper do
+  let(:view) { action_view }
+  let(:args) { ['active', :ok, class: 'important', id: 'status_123', label: 'on'] }
+
+  context '#status_tag' do
+    it 'calls ActiveAdmin::Views::StatusTag#status_tag with arguments' do
+      expect_any_instance_of(ActiveAdmin::Views::StatusTag).to receive(:status_tag).with(*args)
+      view.status_tag(*args)
+    end
+  end
+
+end


### PR DESCRIPTION
Available helper methods panel, columns, status_tag and blank_slate in custom views.

Example:

``` haml
-# /app/views/admin/profiles/compare.html.haml
= columns do
  = column do
    = panel '#1' do
      = status_tag('active', :error, label: 'red')
  = column do
    = panel '#2' do
      = status_tag('active', :ok, label: 'green')
  = column do
    = panel '#3' do
      = status_tag('active', :yes, label: 'blue')

= blank_slate 'Blank slate'
```

Result:
![custom_view](https://cloud.githubusercontent.com/assets/700998/4175113/97386f54-35bf-11e4-8ce1-f99df00857ea.png)
