### PR TITLE
remove admin_user locale keys

### DIFF
--- a/config/locales/de-CH.yml
+++ b/config/locales/de-CH.yml
@@ -93,23 +93,3 @@
         sign_in: "Anmeldung"
         forgot_your_password: "Passwort vergessen?"
         sign_in_with_omniauth_provider: "Anmeldung mit %{provider}"
-  activerecord:
-    attributes:
-      admin_user:
-        id: ID
-        email: E-Mail
-        encrypted_Password: Verschlüsseltes Passwort
-        reset_password_token: Passwort-Reset-Token
-        reset_password_sent_at: Passwort-Reset-Anweisungen gesendet am
-        remember_created_at: Passwort merken seit
-        sign_in_count: Anzahl Logins
-        current_sign_in_at: Aktuell angemeldet seit
-        last_sign_in_at: Letzter Login am
-        current_sign_in_ip: Aktuelle IP-Adresse
-        last_sign_in_ip: Letzte IP-Adresse
-        created_at: Erstellt am
-        updated_at: Aktualisiert am
-    models:
-      admin_user:
-        one: Administrator
-        other: Administratoren

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -112,26 +112,6 @@ de:
         sign_in_with_omniauth_provider: "Anmeldung mit %{provider}"
     access_denied:
       message: "Sie haben nicht die Berechtigung um diese Aktion auszuführen."
-  activerecord:
-    attributes:
-      admin_user:
-        id: ID
-        email: E-Mail
-        encrypted_Password: Verschlüsseltes Passwort
-        reset_password_token: Passwort-Reset-Token
-        reset_password_sent_at: Passwort-Reset-Anweisungen gesendet am
-        remember_created_at: Passwort merken seit
-        sign_in_count: Anzahl Logins
-        current_sign_in_at: Aktuell angemeldet seit
-        last_sign_in_at: Letzter Login am
-        current_sign_in_ip: Aktuelle IP-Adresse
-        last_sign_in_ip: Letzte IP-Adresse
-        created_at: Erstellt am
-        updated_at: Aktualisiert am
-    models:
-      admin_user:
-        one: Administrator
-        other: Administratoren
   formtastic:
     yes: "Ja"
     no: "Nein"


### PR DESCRIPTION
Only the German based languages have this keys. The Keys are useless, because the developer can change the name of the 'User' Model.
