### PR TITLE
fix title of pages with active_admin_logged_out layout (fix #3428)

### DIFF
--- a/app/views/active_admin/devise/confirmations/new.html.erb
+++ b/app/views/active_admin/devise/confirmations/new.html.erb
@@ -1,5 +1,5 @@
 <div id="login">
-  <%= content_tag :h2, t('active_admin.devise.resend_confirmation_instructions.title') %>
+  <h2><%= render_or_call_method_or_proc_on(self, active_admin_application.site_title) %> <%= title t('active_admin.devise.resend_confirmation_instructions.title') %></h2>
 
   <%= active_admin_form_for(resource, :as => resource_name, :url => confirmation_path(resource_name), :html => { :method => :post }) do |f|
     f.inputs do

--- a/app/views/active_admin/devise/passwords/edit.html.erb
+++ b/app/views/active_admin/devise/passwords/edit.html.erb
@@ -1,5 +1,5 @@
 <div id="login">
-  <%= content_tag :h2, t('active_admin.devise.change_password.title') %>
+  <h2><%= render_or_call_method_or_proc_on(self, active_admin_application.site_title) %> <%= title t('active_admin.devise.change_password.title') %></h2>
 
   <%= active_admin_form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :put }) do |f| %>
     <%= devise_error_messages! %>

--- a/app/views/active_admin/devise/passwords/new.html.erb
+++ b/app/views/active_admin/devise/passwords/new.html.erb
@@ -1,5 +1,5 @@
 <div id="login">
-  <%= content_tag :h2, t('active_admin.devise.reset_password.title') %>
+  <h2><%= render_or_call_method_or_proc_on(self, active_admin_application.site_title) %> <%= title t('active_admin.devise.reset_password.title') %></h2>
 
   <%= active_admin_form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :post }) do |f|
     f.inputs do

--- a/app/views/active_admin/devise/registrations/new.html.erb
+++ b/app/views/active_admin/devise/registrations/new.html.erb
@@ -1,5 +1,5 @@
 <div id="login">
-  <h2><%= title "#{render_or_call_method_or_proc_on(self, active_admin_application.site_title)} #{t('active_admin.devise.sign_up.title')}" %></h2>
+  <h2><%= render_or_call_method_or_proc_on(self, active_admin_application.site_title) %> <%= title t('active_admin.devise.sign_up.title') %></h2>
 
   <% scope = Devise::Mapping.find_scope!(resource_name) %>
   <%= active_admin_form_for(resource, :as => resource_name, :url => send(:"#{scope}_registration_path"), :html => { :id => "registration_new" }) do |f|

--- a/app/views/active_admin/devise/sessions/new.html.erb
+++ b/app/views/active_admin/devise/sessions/new.html.erb
@@ -1,5 +1,5 @@
 <div id="login">
-  <h2><%= title "#{render_or_call_method_or_proc_on(self, active_admin_application.site_title)} #{t('active_admin.devise.login.title')}" %></h2>
+  <h2><%= render_or_call_method_or_proc_on(self, active_admin_application.site_title) %> <%= title t('active_admin.devise.login.title') %></h2>
 
   <% scope = Devise::Mapping.find_scope!(resource_name) %>
   <%= active_admin_form_for(resource, :as => resource_name, :url => send(:"#{scope}_session_path"), :html => { :id => "session_new" }) do |f|

--- a/app/views/active_admin/devise/unlocks/new.html.erb
+++ b/app/views/active_admin/devise/unlocks/new.html.erb
@@ -1,5 +1,5 @@
 <div id="login">
-  <h2><%= title "#{render_or_call_method_or_proc_on(self, active_admin_application.site_title)} #{t('active_admin.devise.unlock.title')}" %></h2>
+  <h2><%= render_or_call_method_or_proc_on(self, active_admin_application.site_title) %> <%= title t('active_admin.devise.unlock.title') %></h2>
 
   <%= active_admin_form_for(resource, :as => resource_name, :url => unlock_path(resource_name), :html => { :method => :post }) do |f|
     f.inputs do


### PR DESCRIPTION
The title in the `active_admin_logged_out` layout is wrong:

``` html
<title>{site_title} Login | {site_title}</title>
```

now it is:

``` html
<title>Login | {site_title}</title>
```
