### PR TITLE
Bump formastic to ~> 3.0

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'arbre',               '~> 1.0', '>= 1.0.2'
   s.add_dependency 'bourbon'
   s.add_dependency 'coffee-rails'
-  s.add_dependency 'formtastic',          '~> 2.3'
+  s.add_dependency 'formtastic',          '~> 3.0'
   s.add_dependency 'inherited_resources', '~> 1.4.1'
   s.add_dependency 'jquery-rails'
   s.add_dependency 'jquery-ui-rails',     '~> 5.0'


### PR DESCRIPTION
Formastic released 3.0 - https://github.com/justinfrench/formtastic/commit/8e7826068b0280d8ff530a0712e4a742258e2a15 so updating the activeadmin gemspec to version 3

Thanks!
