### PR TITLE
Missing style for datetime selects

### DIFF
--- a/app/assets/stylesheets/active_admin/_forms.css.scss
+++ b/app/assets/stylesheets/active_admin/_forms.css.scss
@@ -146,7 +146,7 @@ form {
     }
 
     /* Date and Time Fields */
-    &.date, &.time, &.datetime, &.date_select {
+    &.date, &.time, &.datetime, &.date_select, &.datetime_select {
       fieldset ol li {
         float:left; width:auto; margin:0 0.5em 0 0;
         label { display: none; }


### PR DESCRIPTION
Style is not applied to `datetime_select` formtastic inputs
