### PR TITLE
Fix ES translations for key 'add_new_association'

### DIFF
--- a/config/locales/es-MX.yml
+++ b/config/locales/es-MX.yml
@@ -19,7 +19,7 @@ es-MX:
     previous: "Anterior"
     next: "Siguiente"
     download: "Descargar:"
-    has_many_new: "Agregar Añadir %{model}"
+    has_many_new: "Añadir %{model}"
     has_many_delete: "Eliminar"
     has_many_remove: "Quitar"
     filters:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -19,7 +19,7 @@ es:
     previous: "Anterior"
     next: "Siguiente"
     download: "Descargar:"
-    has_many_new: "Agregar Añadir %{model}"
+    has_many_new: "Añadir %{model}"
     has_many_delete: "Eliminar"
     has_many_remove: "Quitar"
     filters:


### PR DESCRIPTION
'Agregar' and 'Añadir' are synonims, making it as redundant as would be 'Add Append %{model}"'.
Only one of them is needed.
