### PR TITLE
use same dsl for actions and actions with dropdown (fix #2625)

### DIFF
--- a/docs/3-index-pages/index-as-table.md
+++ b/docs/3-index-pages/index-as-table.md
@@ -72,7 +72,7 @@ index do
   selectable_column
   column :title
   actions do |post|
-    link_to "Preview", admin_preview_post_path(post), class: "member_link"
+    item "Preview", admin_preview_post_path(post), class: "member_link"
   end
 end
 ```
@@ -83,7 +83,18 @@ Or forego the default links entirely:
 index do
   column :title
   actions defaults: false do |post|
-    link_to "View", admin_post_path(post)
+    item "View", admin_post_path(post)
+  end
+end
+```
+
+Or append custom action with custom html via arbre:
+
+```ruby
+index do
+  column :title
+  actions do |post|
+    a link_to "View", admin_post_path(post)
   end
 end
 ```

--- a/lib/active_admin/views/index_as_table.rb
+++ b/lib/active_admin/views/index_as_table.rb
@@ -69,7 +69,7 @@ module ActiveAdmin
     #   selectable_column
     #   column :title
     #   actions do |post|
-    #     link_to "Preview", admin_preview_post_path(post), class: "member_link"
+    #     item "Preview", admin_preview_post_path(post), class: "member_link"
     #   end
     # end
     # ```
@@ -80,7 +80,18 @@ module ActiveAdmin
     # index do
     #   column :title
     #   actions defaults: false do |post|
-    #     link_to "View", admin_post_path(post)
+    #     item "View", admin_post_path(post)
+    #   end
+    # end
+    # ```
+    #
+    # Or append custom action with custom html via arbre:
+    #
+    # ```ruby
+    # index do
+    #   column :title
+    #   actions do |post|
+    #     a link_to "View", admin_post_path(post)
     #   end
     # end
     # ```
@@ -259,12 +270,18 @@ module ActiveAdmin
         #
         # # Append some actions onto the end of the default actions.
         # actions do |admin_user|
-        #   link_to 'Grant Admin', grant_admin_admin_user_path(admin_user)
+        #   item 'Grant Admin', grant_admin_admin_user_path(admin_user)
+        #   item 'Grant User', grant_user_admin_user_path(admin_user)
+        # end
+        #
+        # # Append some actions onto the end of the default actions using arbre dsl.
+        # actions do |admin_user|
+        #   a link_to 'Grant Admin', grant_admin_admin_user_path(admin_user)
         # end
         #
         # # Custom actions without the defaults.
         # actions defaults: false do |admin_user|
-        #   link_to 'Grant Admin', grant_admin_admin_user_path(admin_user)
+        #   item 'Grant Admin', grant_admin_admin_user_path(admin_user)
         # end
         #
         # # Append some actions onto the end of the default actions displayed in a Dropdown Menu


### PR DESCRIPTION
## Before

Before this PR the index action DSL is quite different and partly very dirty.
### There are two problems:
#### 1. actions _with dropdown_ and custom actions has a different mark up than actions _without dropdown_ and custom actions

``` ruby
actions dropdown: true do |admin_user|
  item 'Grant Admin', grant_admin_admin_user_path(admin_user)
  # here you need to use `item`
end

actions do |admin_user|
  link_to 'Grant Admin', grant_admin_admin_user_path(admin_user)
  # here you need to use a string retuning method
end
```
#### 2. If you want to show two custom actions (without dropdown), you need to do a very dirty thing:

``` ruby
actions do |resource|
  (link_to "Foo", foo_admin_resource_path(resource)) + " " +
  (link_to "Bar", bar_admin_resource_path(resource))
end
```
## After

After this PR both actions types use the same DSL and you don't need to concat strings to display 2 custom actions

``` ruby
actions do |resource|
  item "Foo", foo_admin_resource_path(resource)
  item "Bar", bar_admin_resource_path(resource)
end

actions dropdown: true do |resource|
  item "Foo", foo_admin_resource_path(resource)
  item "Bar", bar_admin_resource_path(resource)
end

# You can use the arbre too:
actions dropdown: true do |resource|
  a "Foo", href: foo_admin_resource_path(resource)
  a "Bar", href: bar_admin_resource_path(resource)
end
```

NOTE: the old way still works, but should be depreciated

This PR fix #2625
