### PR TITLE
WIP: AA Info pages

### DIFF
--- a/app/admin/icons.rb
+++ b/app/admin/icons.rb
@@ -1,4 +1,4 @@
-ActiveAdmin.register_page "Icons", namespace: :active_admin do
+ActiveAdmin.register_page "Icons", namespace: ActiveAdmin.application.infopage_namespace do
   content do
     ul do
       ActiveAdmin::Iconic::ICONS.keys.each do |key|
@@ -13,4 +13,4 @@ ActiveAdmin.register_page "Icons", namespace: :active_admin do
       end
     end
   end
-end
+end if ActiveAdmin.application.use_infopage?

--- a/app/admin/icons.rb
+++ b/app/admin/icons.rb
@@ -1,0 +1,16 @@
+ActiveAdmin.register_page "Icons", namespace: :active_admin do
+  content do
+    ul do
+      ActiveAdmin::Iconic::ICONS.keys.each do |key|
+        li do
+          span do
+            ActiveAdmin::Iconic.icon key, width: 50, height: 50
+          end
+          span do
+            key
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -67,6 +67,12 @@ module ActiveAdmin
     # The namespace root.
     inheritable_setting :root_to, 'dashboard#index'
 
+    # The namespace of the ActiveAdmin Infopage
+    inheritable_setting :infopage_namespace, :active_admin
+
+    # The group which has ActiveAdmin Infopage
+    inheritable_setting :infopage_groups, %w(development)
+
     # Display breadcrumbs
     inheritable_setting :breadcrumb, true
 
@@ -112,6 +118,10 @@ module ActiveAdmin
     def prepare!
       remove_active_admin_load_paths_from_rails_autoload_and_eager_load
       attach_reloader
+    end
+
+    def use_infopage?
+      infopage_namespace && infopage_groups.include?(Rails.env)
     end
 
     # Registers a brand new configuration for the given resource.

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -23,7 +23,7 @@ module ActiveAdmin
     # Load paths for admin configurations. Add folders to this load path
     # to load up other resources for administration. External gems can
     # include their paths in this load path to provide active_admin UIs
-    setting :load_paths, [File.expand_path('app/admin', Rails.root)]
+    setting :load_paths, [File.expand_path('app/admin', Rails.root), File.expand_path("../../../app/admin", __FILE__)]
 
     # The default number of resources to display on index pages
     inheritable_setting :default_per_page, 30

--- a/lib/active_admin/engine.rb
+++ b/lib/active_admin/engine.rb
@@ -7,11 +7,12 @@ module ActiveAdmin
     initializer "ActiveAdmin info page setup" do
       ActiveAdmin.setup do |config|
         config.namespace :active_admin do |active_admin|
+          active_admin.site_title = "ActiveAdmin Infopage"
           active_admin.authorization_adapter = ActiveAdmin::AuthorizationAdapter
           active_admin.authentication_method = false
           active_admin.current_user_method = false
         end
-      end
+      end if ActiveAdmin.application.use_infopage?
     end
   end
 end

--- a/lib/active_admin/engine.rb
+++ b/lib/active_admin/engine.rb
@@ -3,5 +3,15 @@ module ActiveAdmin
     initializer "ActiveAdmin precompile hook", group: :all do |app|
       app.config.assets.precompile += %w(active_admin.js active_admin.css active_admin/print.css)
     end
+
+    initializer "ActiveAdmin info page setup" do
+      ActiveAdmin.setup do |config|
+        config.namespace :active_admin do |active_admin|
+          active_admin.authorization_adapter = ActiveAdmin::AuthorizationAdapter
+          active_admin.authentication_method = false
+          active_admin.current_user_method = false
+        end
+      end
+    end
   end
 end

--- a/lib/generators/active_admin/install/templates/active_admin.rb.erb
+++ b/lib/generators/active_admin/install/templates/active_admin.rb.erb
@@ -112,6 +112,14 @@ ActiveAdmin.setup do |config|
   # Default:
   # config.root_to = 'dashboard#index'
 
+  # == ActiveAdmin Infopage
+  #
+  # Show's a ActiveAdmin Infopage under http://localhost:3000/active_admin
+  # This can be disabled by setting `config.infopage_namespace = false`.
+  #
+  # Defaults:
+  # config.infopage_namespace = :active_admin
+  # config.infopage_groups    = %w(development)
 
   # == Admin Comments
   #


### PR DESCRIPTION
NOTE: this is not a finished PR at the moment, this should be a discussion base at the moment.

Inspired by the Rails Routes (http://localhost:3000/rails/info/routes) and Rails Mailer (http://localhost:3000/rails/mailers) pages, I have build a AA Infopage with use AA himself to show informations about the AA part of the Railsapp.

Possible informations are:
* List of all Namespaces, Resources and Pages (like a Sitemap)
* List of all Icons (already implemented)
* Documentation of the used AA version
* Helppages (for the Enduser)
* Keyboardshortcuts (#614, #3498)
* FAQ
* ...

This will be configurable:
* Turn on/off complied in development and/or production
* Turn on/off single parts / informations
* Ability to control it via CanCan/Pundit