### PR TITLE
Adding the gemfile instructions for Rails 4.1

### DIFF
--- a/docs/0-installation.md
+++ b/docs/0-installation.md
@@ -6,6 +6,17 @@ Active Admin is a Ruby Gem.
 gem 'activeadmin'
 ```
 
+In case you are using Rails 4.0.X or Rails 4.1,
+
+```ruby
+gem 'activeadmin', github: 'gregbell/active_admin'
+gem 'polyamorous', github: 'activerecord-hackery/polyamorous'
+gem 'ransack', github: 'activerecord-hackery/ransack'
+gem 'formtastic', github: 'justinfrench/formtastic'
+```
+
+As in this [StackOverflow](http://stackoverflow.com/a/16805376/2080089) answer.
+
 More accurately, it's a [Rails Engine](http://guides.rubyonrails.org/engines.html)
 that can be injected into your existing Ruby on Rails application.
 


### PR DESCRIPTION
Adding only `gem 'activeadmin'` in the Gemfile, for Rails 4.1 does not do the job.

The above four lines need to be added to make sure that activeadmin get's added, without any errors, when `bundle install` is run.
