### PR TITLE
Documented the `:optional` option for belongs_to

### DIFF
--- a/docs/2-resource-customization.md
+++ b/docs/2-resource-customization.md
@@ -386,3 +386,12 @@ ActiveAdmin.register Ticket do
   end
 end
 ```
+
+If you still want your `belongs_to` resources to be available in the default menu
+and through non-nested routes, you can use the `:optional` option. For example:
+
+```ruby
+ActiveAdmin.register Ticket do
+  belongs_to :project, optional: true
+end
+```


### PR DESCRIPTION
I found the `:optional` option very useful for a project to expose nested resources in the global menu ; here's a short proposal to expose it in the documentation.

Thanks for all the good work in activeadmin, you rock!
