### PR TITLE
Feature/attributes table for nil

### DIFF
--- a/lib/active_admin/views/components/attributes_table.rb
+++ b/lib/active_admin/views/components/attributes_table.rb
@@ -7,12 +7,16 @@ module ActiveAdmin
       def build(obj, *attrs)
         @collection     = as_array(obj)
         @resource_class = @collection.first.class
-        options = { }
-        options[:for] = @collection.first if single_record?
-        super(options)
-        @table = table
-        build_colgroups
-        rows(*attrs)
+        if @collection.present?
+          options = { }
+          options[:for] = @collection.first if single_record?
+          super(options)
+          @table = table
+          build_colgroups
+          rows(*attrs)
+        else
+          empty_value
+        end
       end
 
       def rows(*attrs)
@@ -20,6 +24,7 @@ module ActiveAdmin
       end
 
       def row(*args, &block)
+        return unless @collection.present?
         title   = args[0]
         options = args.extract_options!
         classes = [:row]
@@ -108,7 +113,7 @@ module ActiveAdmin
         if obj.respond_to?(:each) && obj.respond_to?(:first) && !obj.is_a?(Hash)
           obj
         else
-          [obj]
+          [obj].compact
         end
       end
     end

--- a/spec/unit/views/components/attributes_table_spec.rb
+++ b/spec/unit/views/components/attributes_table_spec.rb
@@ -236,6 +236,19 @@ describe ActiveAdmin::Views::AttributesTable do
       end # describe rendering rows
     end # with a collection
 
+    context "when using a nil" do
+      let(:table) do
+        render_arbre_component nil, helpers do
+          attributes_table_for nil do
+            row :foo
+            row :bar
+          end
+        end
+      end
+      it "should render" do
+        expect(table.find_by_tag('span')[0].content).to eq 'Empty'
+      end
+    end
 
     context "when using a single Hash" do
       let(:table) do


### PR DESCRIPTION
If you pass `nil` to `attributes_table_for` it raises exception. So app have a lot of boilerplate code:

``` ruby
if user.profile.present?
  attributes_table_for user.profile
else
  span class: 'empty' do 
    'Empty'
  end
end
```

This PR implements such behavior for `attributes_table_for`. So it render Empty tag if `nil` given as attribute
