### PR TITLE
remove unnecessary check from attributes_table_for

### DIFF
--- a/lib/active_admin/views/components/attributes_table.rb
+++ b/lib/active_admin/views/components/attributes_table.rb
@@ -79,9 +79,8 @@ module ActiveAdmin
       end
 
       def content_for(record, attr)
-        previous = current_arbre_element.to_s
         value    = pretty_format find_attr_value(record, attr)
-        value.blank? && previous == current_arbre_element.to_s ? empty_value : value
+        value.blank? ? empty_value : value
       end
 
       def find_attr_value(record, attr)


### PR DESCRIPTION
1. the check of `previous == current_arbre_element.to_s` dosen't make any sense!
2. the value of current_arbre_element can't change!
