### PR TITLE
Fix breadcrumb link when path passed without leading slash

### DIFF
--- a/lib/active_admin/view_helpers/breadcrumb_helper.rb
+++ b/lib/active_admin/view_helpers/breadcrumb_helper.rb
@@ -4,8 +4,9 @@ module ActiveAdmin
 
       # Returns an array of links to use in a breadcrumb
       def breadcrumb_links(path = request.path)
-        parts = path[1..-1].split('/') # remove leading "/" and split up the URL
-        parts.pop                      # remove last since it's used as the page title
+        # remove leading "/" and split up the URL
+        # and remove last since it's used as the page title
+        parts = path.split('/').select(&:present?)[0..-2]
 
         parts.each_with_index.map do |part, index|
           # 1. try using `display_name` if we can locate a DB object

--- a/spec/unit/view_helpers/breadcrumbs_spec.rb
+++ b/spec/unit/view_helpers/breadcrumbs_spec.rb
@@ -32,6 +32,18 @@ describe "Breadcrumbs" do
       end
     end
 
+    context "when path 'admin/users'" do
+      let(:path) { 'admin/users' }
+
+      it 'should have one item' do
+        expect(trail.size).to eq 1
+      end
+      it 'should have a link to /admin' do
+        expect(trail[0][:name]).to eq 'Admin'
+        expect(trail[0][:path]).to eq '/admin'
+      end
+    end
+
     context "when path '/admin/users'" do
       let(:path) { "/admin/users" }
 


### PR DESCRIPTION
Fixes https://github.com/activeadmin/activeadmin/issues/3481
