### PR TITLE
Add ability to pass columns names as argument to table_for helper

### DIFF
--- a/lib/active_admin/views/components/table_for.rb
+++ b/lib/active_admin/views/components/table_for.rb
@@ -7,7 +7,8 @@ module ActiveAdmin
         'table'
       end
 
-      def build(obj, options = {})
+      def build(obj, *attrs)
+        options         = attrs.extract_options!
         @sortable       = options.delete(:sortable)
         @resource_class = options.delete(:i18n)
         @collection     = obj.respond_to?(:each) && !obj.is_a?(Hash) ? obj : [obj]
@@ -16,6 +17,11 @@ module ActiveAdmin
 
         build_table
         super(options)
+        columns(*attrs)
+      end
+
+      def columns(*attrs)
+        attrs.each {|attr| column(attr) }
       end
 
       def column(*args, &block)

--- a/spec/unit/views/components/table_for_spec.rb
+++ b/spec/unit/views/components/table_for_spec.rb
@@ -10,6 +10,92 @@ describe ActiveAdmin::Views::TableFor do
     let(:assigns){ { collection: collection } }
     let(:helpers){ mock_action_view }
 
+    context "when creating a column using symbol argument" do
+      let(:table) do
+        render_arbre_component assigns, helpers do
+          table_for(collection, :title)
+        end
+      end
+
+      it "should create a table header based on the symbol" do
+        expect(table.find_by_tag("th").first.content).to eq "Title"
+      end
+
+      it "should create a table row for each element in the collection" do
+        expect(table.find_by_tag("tr").size).to eq 4 # 1 for head, 3 for rows
+      end
+
+      ["First Post", "Second Post", "Third Post"].each_with_index do |content, index|
+        it "should create a cell with #{content}" do
+          expect(table.find_by_tag("td")[index].content).to eq content
+        end
+      end
+    end
+
+    context "when creating many columns using symbol arguments" do
+      let(:table) do
+        render_arbre_component assigns, helpers do
+          table_for(collection, :title, :created_at)
+        end
+      end
+
+      it "should create a table header based on the symbol" do
+        expect(table.find_by_tag("th").first.content).to eq "Title"
+        expect(table.find_by_tag("th").last.content).to eq "Created At"
+      end
+
+      it "should add a class to each table header based on the col name" do
+        expect(table.find_by_tag("th").first.class_list.to_a.join(' ')).to eq "col col-title"
+        expect(table.find_by_tag("th").last.class_list.to_a.join(' ')).to eq "col col-created_at"
+      end
+
+      it "should create a table row for each element in the collection" do
+        expect(table.find_by_tag("tr").size).to eq 4 # 1 for head, 3 for rows
+      end
+
+      it "should create a cell for each column" do
+        expect(table.find_by_tag("td").size).to eq 6
+      end
+
+      it "should add a class for each cell based on the col name" do
+        expect(table.find_by_tag("td").first.class_list.to_a.join(' ')).to eq "col col-title"
+        expect(table.find_by_tag("td").last.class_list.to_a.join(' ')).to eq "col col-created_at"
+      end
+    end
+
+    context "when creating a column using symbol arguments and another using block" do
+      let(:table) do
+        render_arbre_component assigns, helpers do
+          table_for(collection, :title) do
+            column :created_at
+          end
+        end
+      end
+
+      it "should create a table header based on the symbol" do
+        expect(table.find_by_tag("th").first.content).to eq "Title"
+        expect(table.find_by_tag("th").last.content).to eq "Created At"
+      end
+
+      it "should add a class to each table header based on the col name" do
+        expect(table.find_by_tag("th").first.class_list.to_a.join(' ')).to eq "col col-title"
+        expect(table.find_by_tag("th").last.class_list.to_a.join(' ')).to eq "col col-created_at"
+      end
+
+      it "should create a table row for each element in the collection" do
+        expect(table.find_by_tag("tr").size).to eq 4 # 1 for head, 3 for rows
+      end
+
+      it "should create a cell for each column" do
+        expect(table.find_by_tag("td").size).to eq 6
+      end
+
+      it "should add a class for each cell based on the col name" do
+        expect(table.find_by_tag("td").first.class_list.to_a.join(' ')).to eq "col col-title"
+        expect(table.find_by_tag("td").last.class_list.to_a.join(' ')).to eq "col col-created_at"
+      end
+    end
+
     context "when creating a column with a symbol" do
       let(:table) do
         render_arbre_component assigns, helpers do


### PR DESCRIPTION
``` ruby
table_for user.posts, :title, :created_at do
  column :actions do |post|
    link_to 'Approve', approve_admin_posts_path(post, method: :post)
  end
end
```
