### PR TITLE
Replace gsub with tr

### DIFF
--- a/features/step_definitions/additional_web_steps.rb
+++ b/features/step_definitions/additional_web_steps.rb
@@ -43,7 +43,7 @@ Then /^an "([^"]*)" exception should be raised when I follow "([^"]*)"$/ do |err
 end
 
 Then /^I should be in the resource section for (.+)$/ do |resource_name|
-  expect(current_url).to include resource_name.gsub(' ', '').underscore.pluralize
+  expect(current_url).to include resource_name.tr(' ', '').underscore.pluralize
 end
 
 Then /^I should wait and see "([^"]*)"(?: within "([^"]*)")?$/ do |text, selector|

--- a/features/step_definitions/factory_steps.rb
+++ b/features/step_definitions/factory_steps.rb
@@ -1,6 +1,6 @@
 def create_user(name, type = 'User')
   first_name, last_name = name.split(' ')
-  user = type.camelize.constantize.where(first_name: first_name, last_name: last_name).first_or_create(username: name.gsub(' ', '').underscore)
+  user = type.camelize.constantize.where(first_name: first_name, last_name: last_name).first_or_create(username: name.tr(' ', '').underscore)
 end
 
 Given /^(a|\d+)( published)? posts?(?: with the title "([^"]*)")?(?: and body "([^"]*)")?(?: written by "([^"]*)")?(?: in category "([^"]*)")? exists?$/ do |count, published, title, body, user, category_name|

--- a/features/step_definitions/index_scope_steps.rb
+++ b/features/step_definitions/index_scope_steps.rb
@@ -10,12 +10,12 @@ Then /^I should see the scope "([^"]*)" not selected$/ do |name|
 end
 
 Then /^I should see the scope "([^"]*)" with the count (\d+)$/ do |name, count|
-  name = name.gsub(' ','').underscore.downcase
+  name = name.tr(' ','').underscore.downcase
   step %{I should see "#{count}" within ".scopes .#{name} .count"}
 end
 
 Then /^I should see the scope "([^"]*)" with no count$/ do |name|
-  name = name.gsub(" ", "").underscore.downcase
+  name = name.tr(" ", "").underscore.downcase
   expect(page).to     have_css ".scopes .#{name}"
   expect(page).to_not have_css ".scopes .#{name} .count"
 end

--- a/features/step_definitions/sidebar_steps.rb
+++ b/features/step_definitions/sidebar_steps.rb
@@ -3,7 +3,7 @@ Then /^I should see a sidebar titled "([^"]*)"$/ do |title|
 end
 
 Then /^I should not see a sidebar titled "([^"]*)"$/ do |title|
-  title = title.gsub(' ', '').underscore
+  title = title.tr(' ', '').underscore
   sidebars = page.all :css, "##{title}_sidebar_section"
   expect(sidebars.count).to eq 0
 end

--- a/features/support/selectors.rb
+++ b/features/support/selectors.rb
@@ -27,7 +27,7 @@ module HtmlSelectorsHelpers
       [:css, "table.index_grid"]
 
     when /^the "([^"]*)" sidebar$/
-      [:css, "##{$1.gsub(" ", '').underscore}_sidebar_section"]
+      [:css, "##{$1.tr(" ", '').underscore}_sidebar_section"]
 
     # This allows you to provide a quoted selector as the scope
     # for "within" steps as was previously the default for the

--- a/lib/active_admin/abstract_view_factory.rb
+++ b/lib/active_admin/abstract_view_factory.rb
@@ -71,7 +71,7 @@ module ActiveAdmin
     end
 
     def key_from_method_name(method)
-      method.to_s.gsub('=', '').to_sym
+      method.to_s.tr('=', '').to_sym
     end
 
     def get_view_for_key(key)

--- a/lib/active_admin/dsl.rb
+++ b/lib/active_admin/dsl.rb
@@ -100,7 +100,7 @@ module ActiveAdmin
     def batch_action(title, options = {}, &block)
       # Create symbol & title information
       if title.is_a? String
-        sym = title.titleize.gsub(' ', '').underscore.to_sym
+        sym = title.titleize.tr(' ', '').underscore.to_sym
       else
         sym = title
         title = sym.to_s.titleize

--- a/lib/active_admin/menu.rb
+++ b/lib/active_admin/menu.rb
@@ -92,7 +92,7 @@ module ActiveAdmin
       def normalize_id(id)
         case id
         when String, Symbol, ActiveModel::Name
-          id.to_s.downcase.gsub ' ', '_'
+          id.to_s.downcase.tr ' ', '_'
         when ActiveAdmin::Resource::Name
           id.param_key
         else

--- a/lib/active_admin/sidebar_section.rb
+++ b/lib/active_admin/sidebar_section.rb
@@ -30,7 +30,7 @@ module ActiveAdmin
 
     # If a block is not passed in, the name of the partial to render
     def partial_name
-      options[:partial] || "#{name.to_s.downcase.gsub(' ', '_')}_sidebar"
+      options[:partial] || "#{name.to_s.downcase.tr(' ', '_')}_sidebar"
     end
 
     def custom_class

--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -14,7 +14,7 @@ module ActiveAdmin
 
         def add_classes_to_body
           @body.add_class(params[:action])
-          @body.add_class(params[:controller].gsub('/', '_'))
+          @body.add_class(params[:controller].tr('/', '_'))
           @body.add_class("active_admin")
           @body.add_class("logged_in")
           @body.add_class(active_admin_namespace.name.to_s + "_namespace")

--- a/lib/generators/active_admin/page/page_generator.rb
+++ b/lib/generators/active_admin/page/page_generator.rb
@@ -4,7 +4,7 @@ module ActiveAdmin
       source_root File.expand_path('../templates', __FILE__)
 
       def generate_config_file
-        template "page.rb", "app/admin/#{file_path.gsub('/', '_')}.rb"
+        template "page.rb", "app/admin/#{file_path.tr('/', '_')}.rb"
       end
 
     end

--- a/lib/generators/active_admin/resource/resource_generator.rb
+++ b/lib/generators/active_admin/resource/resource_generator.rb
@@ -6,7 +6,7 @@ module ActiveAdmin
       source_root File.expand_path("../templates", __FILE__)
 
       def generate_config_file
-        template "admin.rb", "app/admin/#{file_path.gsub('/', '_')}.rb"
+        template "admin.rb", "app/admin/#{file_path.tr('/', '_')}.rb"
       end
 
     end

--- a/tasks/docs.rake
+++ b/tasks/docs.rake
@@ -10,7 +10,7 @@ namespace :docs do
 EOD
 
   def filename_from_module(mod)
-    mod.name.to_s.underscore.gsub('_', '-')
+    mod.name.to_s.underscore.tr('_', '-')
   end
 
   def write_docstrings_to(path, mods)


### PR DESCRIPTION
Benchmark shows that `gsub` is 6.5x slower than `tr`

``` ruby
require 'benchmark/ips'

Benchmark.ips do |x|
  str = 'The quick brown fox jumps over the lazy dog'
  x.report("gsub") { str.gsub(' ', '_') }
  x.report("tr")   { str.tr(' ', '_') }

  x.compare!
end
```

>    gsub   227386.5 (±2.2%) i/s -    1138138 in   5.007935s
>    tr  1477767.9 (±2.2%) i/s -    7416100 in   5.021170s
>       Comparison:
>    tr:  1477767.9 i/s
>    gsub:   227386.5 i/s - 6.50x slower
