### PR TITLE
readd ruby 2.0.0 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ script:
   - time bundle exec rake test_with_coveralls
 rvm:
   - 1.9.3
+  - 2.0.0
   - 2.1.2
 env:
   matrix:


### PR DESCRIPTION
since #3094 is merged and has increased the speed of the travis build, we can readd 2.0.
