### PR TITLE
Better defaults for the Show page

### DIFF
--- a/lib/active_admin/views/components/attributes_table.rb
+++ b/lib/active_admin/views/components/attributes_table.rb
@@ -7,12 +7,12 @@ module ActiveAdmin
       def build(obj, *attrs)
         @collection     = is_array?(obj) ? obj : [obj]
         @resource_class = @collection.first.class
-        options = { }
+        options = attrs.extract_options!
         options[:for] = @collection.first if single_record?
         super(options)
         @table = table
         build_colgroups
-        rows(*attrs)
+        rows(*display_rows(*attrs, options))
       end
 
       def rows(*attrs)
@@ -46,6 +46,25 @@ module ActiveAdmin
 
       def default_id_for_prefix
         'attributes_table'
+      end
+
+      def default_rows
+        if @resource_class.respond_to? :attribute_names
+          @resource_class.attribute_names
+        elsif @resource_class.respond_to? :keys
+          @resource_class.keys
+        elsif @resource_class.respond_to? :each
+          @resource_class.first
+        else
+          raise "can't detect default_rows"
+        end
+      end
+
+      def display_rows(*attrs, options)
+        attrs = default_rows if attrs.empty?
+        attrs.map!(&:to_s)
+        attrs += [*options[:with]].map(&:to_s)
+        attrs -= [*options[:expect]].map(&:to_s)
       end
 
       # Build Colgroups

--- a/spec/unit/views/components/attributes_table_spec.rb
+++ b/spec/unit/views/components/attributes_table_spec.rb
@@ -236,24 +236,6 @@ describe ActiveAdmin::Views::AttributesTable do
       end # describe rendering rows
     end # with a collection
 
-
-    context "when using a single Hash" do
-      let(:table) do
-        render_arbre_component nil, helpers do
-          attributes_table_for foo: 1, bar: 2 do
-            row :foo
-            row :bar
-          end
-        end
-      end
-      it "should render" do
-        expect(table.find_by_tag("th")[0].content).to eq "Foo"
-        expect(table.find_by_tag("th")[1].content).to eq "Bar"
-        expect(table.find_by_tag("td")[0].content).to eq "1"
-        expect(table.find_by_tag("td")[1].content).to eq "2"
-      end
-    end
-
     context "when using an Array of Hashes" do
       let(:table) do
         render_arbre_component nil, helpers do


### PR DESCRIPTION
I'll turn this into a PR once there's code to go along with the idea.

This replaces the stale #1077.

``` ruby
# Renders the default table
show do
  attributes_table
end

# Removes specific attributes
show do
  attributes_table except: [:foo, :bar]
end

# Adds extra (virtual) attributes
show do
  attributes_table with: :baz
end
```
