### PR TITLE
mark activeadmin.info as out of date

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Github [docs folder](https://github.com/activeadmin/activeadmin/tree/master/docs
 
 ## Links
 
-* Website: <http://www.activeadmin.info>
+* Website: <http://www.activeadmin.info> (out of date)
 * Live demo: <http://demo.activeadmin.info/admin>
 * Documentation
   * Guides: <http://activeadmin.info/documentation.html>


### PR DESCRIPTION
@seanlinsley I know we already had this discussion in #3436, but I think we should mark activeadmin.info as out of date, for users like @hakunin in #3513.
