### PR TITLE
Use the yard 0.8.7.6 or greater

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ group :development do
   gem 'flamegraph'         # Flamegraph visualiztion: ?pp=flamegraph
 
   # Documentation
-  gem 'yard', github: 'lsegal/yard' # Documentation generator (until lsegal/yard#765 is in a release)
+  gem 'yard'               # Documentation generator
   gem 'redcarpet'          # Markdown implementation (for yard)
 end
 


### PR DESCRIPTION
We can use the latest release of yard as it contains lsegal/yard#765

I wasn't too sure if I should explicitly require it to use the latest version or not
`gem 'yard' , '>= 0.8.7.6'` vs just `gem 'yard'`

If you guys have a preference, I can change it

Thanks a lot!
