### PR TITLE
fix some yard markup

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,7 +1,7 @@
 lib/**/*.rb
 --protected
 --no-private
---exclude features
+--exclude (features|lib\/generators\/active_admin\/.*\/templates)
 -
 README.md
 CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,7 +224,7 @@ index download_links: ->{ can?(:view_all_download_links) || [:pdf] }
 * Developer can pass options for CSV generation. [#1626][] by [@rheaton][]
 ```ruby
     ActiveAdmin.register Post do
-      csv options: {force_quotes: true} do
+      csv options: { force_quotes: true } do
         column :title
       end
     end

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -135,7 +135,7 @@ module ActiveAdmin
     #
     # Yields the namespace if a block is given
     #
-    # @returns [Namespace] the new or existing namespace
+    # @return [Namespace] the new or existing namespace
     def namespace(name)
       name ||= :root
 
@@ -153,7 +153,7 @@ module ActiveAdmin
     # Register a page
     #
     # @param name [String] The page name
-    # @options [Hash] Accepts option :namespace.
+    # @option [Hash] Accepts option :namespace.
     # @&block The registration block.
     #
     def register_page(name, options = {}, &block)

--- a/lib/active_admin/authorization_adapter.rb
+++ b/lib/active_admin/authorization_adapter.rb
@@ -49,7 +49,7 @@ module ActiveAdmin
     #        global navigation. To deal with this nicely in a case statement, take
     #        a look at `#normalized(klasss)`
     #
-    # @returns [Boolean]
+    # @return [Boolean]
     def authorized?(action, subject = nil)
       true
     end
@@ -66,7 +66,7 @@ module ActiveAdmin
     #        one of the `ActiveAdmin::Auth::*` symbols. Defaults to `Auth::READ` if
     #        no action passed in.
     #
-    # @returns [ActiveRecord::Relation] A new collection, scoped to the
+    # @return [ActiveRecord::Relation] A new collection, scoped to the
     #          objects that the current user has access to.
     def scope_collection(collection, action = Auth::READ)
       collection

--- a/lib/active_admin/base_controller/authorization.rb
+++ b/lib/active_admin/base_controller/authorization.rb
@@ -32,7 +32,7 @@ module ActiveAdmin
       # @param [any] subject The subject that the user is trying to perform
       #                 the action on.
       #
-      # @returns [Boolean]
+      # @return [Boolean]
       #
       def authorized?(action, subject = nil)
         active_admin_authorization.authorized?(action, subject)
@@ -49,7 +49,7 @@ module ActiveAdmin
       # @param [any] subject The subject that the user is trying to perform
       #                 the action on.
       #
-      # @returns [Boolean] True if authorized, otherwise raises
+      # @return [Boolean] True if authorized, otherwise raises
       #                 an ActiveAdmin::AccessDenied.
       def authorize!(action, subject = nil)
         unless authorized? action, subject
@@ -69,7 +69,7 @@ module ActiveAdmin
 
       # Retrieve or instantiate the authorization instance for this resource
       #
-      # @returns [ActiveAdmin::AuthorizationAdapter]
+      # @return [ActiveAdmin::AuthorizationAdapter]
       def active_admin_authorization
         @active_admin_authorization ||=
          active_admin_authorization_adapter.new active_admin_config, current_active_admin_user
@@ -77,7 +77,7 @@ module ActiveAdmin
 
       # Returns the class to be used as the authorization adapter
       #
-      # @returns [Class]
+      # @return [Class]
       def active_admin_authorization_adapter
         adapter = active_admin_namespace.authorization_adapter
         if adapter.is_a? String
@@ -93,7 +93,7 @@ module ActiveAdmin
       #
       # @param [String, Symbol] action The controller action name.
       #
-      # @returns [Symbol] The permission name to use.
+      # @return [Symbol] The permission name to use.
       def action_to_permission(action)
         if action && action = action.to_sym
           Authorization::ACTIONS_DICTIONARY[action] || action

--- a/lib/active_admin/batch_actions/resource_extension.rb
+++ b/lib/active_admin/batch_actions/resource_extension.rb
@@ -40,7 +40,7 @@ module ActiveAdmin
 
       # Remove a batch action
       # @param [Symbol] sym
-      # @returns [ActiveAdmin::BatchAction] the batch action, if it was present
+      # @return [ActiveAdmin::BatchAction] the batch action, if it was present
       #
       def remove_batch_action(sym)
         @batch_actions.delete(sym.to_sym)

--- a/lib/active_admin/dsl.rb
+++ b/lib/active_admin/dsl.rb
@@ -50,7 +50,7 @@ module ActiveAdmin
     #
     # @param [Module] mod A module to include
     #
-    # @returns [Nil]
+    # @return [Nil]
     def include(mod)
       mod.included(self)
     end

--- a/lib/active_admin/filters/resource_extension.rb
+++ b/lib/active_admin/filters/resource_extension.rb
@@ -45,7 +45,7 @@ module ActiveAdmin
       # Remove a filter for this resource. If filters are not enabled, this method
       # will raise a RuntimeError
       #
-      # @param [Symbol] attribute The attribute to not filter on
+      # @param [Symbol] attributes The attributes to not filter on
       def remove_filter(*attributes)
         raise Disabled unless filters_enabled?
 

--- a/lib/active_admin/inputs/filter_boolean_input.rb
+++ b/lib/active_admin/inputs/filter_boolean_input.rb
@@ -9,9 +9,8 @@ module ActiveAdmin
         "#{method}_eq"
       end
 
-      # was "#{object_name}[#{association_primary_key}]"
       def input_html_options_name
-        "#{object_name}[#{input_name}]"
+        "#{object_name}[#{input_name}]" # was "#{object_name}[#{association_primary_key}]"
       end
 
       # Provide the AA translation to the blank input field.

--- a/lib/active_admin/inputs/filter_select_input.rb
+++ b/lib/active_admin/inputs/filter_select_input.rb
@@ -24,9 +24,8 @@ module ActiveAdmin
         I18n.t 'active_admin.any' if super
       end
 
-      # was "#{object_name}[#{association_primary_key}]"
       def input_html_options_name
-        "#{object_name}[#{input_name}]"
+        "#{object_name}[#{input_name}]" # was "#{object_name}[#{association_primary_key}]"
       end
 
       # Would normally return true for has_many and HABTM, which would subsequently

--- a/lib/active_admin/namespace.rb
+++ b/lib/active_admin/namespace.rb
@@ -112,7 +112,7 @@ module ActiveAdmin
     # @param [Symbol] name The name of the menu. Default: :default
     # @param [Proc] block The block to be ran when the menu is built
     #
-    # @returns [void]
+    # @return [void]
     def build_menu(name = DEFAULT_MENU, &block)
       @menus.before_build do |menus|
         menus.menu name do |menu|

--- a/lib/active_admin/orm/active_record/comments/comment.rb
+++ b/lib/active_admin/orm/active_record/comments/comment.rb
@@ -14,7 +14,7 @@ module ActiveAdmin
 
     before_create :set_resource_type
 
-    # @returns [String] The name of the record to use for the polymorphic relationship
+    # @return [String] The name of the record to use for the polymorphic relationship
     def self.resource_type(resource)
       ResourceController::Decorators.undecorate(resource).class.name.to_s
     end

--- a/lib/active_admin/resource/page_presenters.rb
+++ b/lib/active_admin/resource/page_presenters.rb
@@ -32,7 +32,7 @@ module ActiveAdmin
       #
       # @param [Symbol, String] action The action to get the config for
       # @param [String] type The string specified in the presenters index_name method
-      # @returns [PagePresenter, nil]
+      # @return [PagePresenter, nil]
       def get_page_presenter(action, type=nil)
 
         if action.to_s == "index" && type && page_presenters[:index].kind_of?(Hash)

--- a/lib/active_admin/resource/routes.rb
+++ b/lib/active_admin/resource/routes.rb
@@ -1,7 +1,7 @@
 module ActiveAdmin
   class Resource
     module Routes
-      # @params params [Hash] of params: {study_id: 3}
+      # @param params [Hash] of params: { study_id: 3 }
       # @return [String] the path to this resource collection page
       # @example "/admin/posts"
       def route_collection_path(params = {})

--- a/lib/active_admin/resource_controller/data_access.rb
+++ b/lib/active_admin/resource_controller/data_access.rb
@@ -26,7 +26,7 @@ module ActiveAdmin
       # either the @collection instance variable or an instance variable named
       # after the resource that the collection is for. eg: Post => @post.
       #
-      # @returns [ActiveRecord::Relation] The collection for the index
+      # @return [ActiveRecord::Relation] The collection for the index
       def collection
         get_collection_ivar || begin
           collection = find_collection
@@ -41,7 +41,7 @@ module ActiveAdmin
       # some additional db # work before your controller returns and
       # authorizes the collection.
       #
-      # @returns [ActiveRecord::Relation] The collectin for the index
+      # @return [ActiveRecord::Relation] The collectin for the index
       def find_collection
         collection = scoped_collection
 
@@ -83,7 +83,7 @@ module ActiveAdmin
       #   * update
       #   * destroy
       #
-      # @returns [ActiveRecord::Base] An active record object
+      # @return [ActiveRecord::Base] An active record object
       def resource
         get_resource_ivar || begin
           resource = find_resource
@@ -101,7 +101,7 @@ module ActiveAdmin
       # ActiveRecord::Associations::CollectionProxy (belongs_to associations)
       # mysteriously returns an Enumerator object.
       #
-      # @returns [ActiveRecord::Base] An active record object.
+      # @return [ActiveRecord::Base] An active record object.
       def find_resource
         scoped_collection.send method_for_find, params[:id]
       end
@@ -114,7 +114,7 @@ module ActiveAdmin
       # This method is used to instantiate and authorize new resources in the
       # new and create controller actions.
       #
-      # @returns [ActiveRecord::Base] An un-saved active record base object
+      # @return [ActiveRecord::Base] An un-saved active record base object
       def build_resource
         get_resource_ivar || begin
           resource = build_new_resource
@@ -132,7 +132,7 @@ module ActiveAdmin
       # Note that public_send can't be used here w/ Rails 3.2 & a belongs_to
       # config, or you'll get undefined method `build' for []:Array.
       #
-      # @returns [ActiveRecord::Base] An un-saved active record base object
+      # @return [ActiveRecord::Base] An un-saved active record base object
       def build_new_resource
         scoped_collection.send method_for_build, *resource_params
       end
@@ -141,7 +141,7 @@ module ActiveAdmin
       #
       # @param [ActiveRecord::Base] object The new resource to create
       #
-      # @returns [void]
+      # @return [void]
       def create_resource(object)
         run_create_callbacks object do
           save_resource(object)
@@ -152,7 +152,7 @@ module ActiveAdmin
       #
       # @param [ActiveRecord::Base] object The new resource to save
       #
-      # @returns [void]
+      # @return [void]
       def save_resource(object)
         run_save_callbacks object do
           object.save
@@ -168,7 +168,7 @@ module ActiveAdmin
       #                           and the Active Record "role" in the second. The role
       #                           may be set to nil.
       #
-      # @returns [void]
+      # @return [void]
       def update_resource(object, attributes)
         if object.respond_to?(:assign_attributes)
           object.assign_attributes(*attributes)
@@ -183,7 +183,7 @@ module ActiveAdmin
 
       # Destroys an object from the database and calls appropriate callbacks.
       #
-      # @returns [void]
+      # @return [void]
       def destroy_resource(object)
         run_destroy_callbacks object do
           object.destroy
@@ -203,7 +203,7 @@ module ActiveAdmin
       #
       # @param [ActiveRecord::Relation] collection The collection to scope
       #
-      # @retruns [ActiveRecord::Relation] a scoped collection of query
+      # @return [ActiveRecord::Relation] a scoped collection of query
       def apply_authorization_scope(collection)
         action_name = action_to_permission(params[:action])
         active_admin_authorization.scope_collection(collection, action_name)

--- a/lib/active_admin/views/components/columns.rb
+++ b/lib/active_admin/views/components/columns.rb
@@ -115,7 +115,7 @@ module ActiveAdmin
 
       # @param [Hash] options An options hash for the column
       #
-      # @options options [Integer] :span The columns this column should span
+      # @option options [Integer] :span The columns this column should span
       def build(options = {})
         options = options.dup
         @span_size = options.delete(:span) || 1

--- a/lib/active_admin/views/components/status_tag.rb
+++ b/lib/active_admin/views/components/status_tag.rb
@@ -12,21 +12,24 @@ module ActiveAdmin
         'status_tag'
       end
 
-      # @method status_tag(status, type = nil, options = {})
+      # @overload status_tag(status, type = nil, options = {})
+      #   @param [String] status the status to display. One of the span classes will be an underscored version of the status.
+      #   @param [Symbol] type type of status. Will become a class of the span. ActiveAdmin provide style for :ok, :warning and :error.
+      #   @param [Hash] options
+      #   @option options [String] :class to override the default class
+      #   @option options [String] :id to override the default id
+      #   @option options [String] :label to override the default label
+      #   @return [ActiveAdmin::Views::StatusTag]
       #
-      # @param [String] status the status to display. One of the span classes will be an underscored version of the status.
-      # @param [Symbol] type type of status. Will become a class of the span. ActiveAdmin provide style for :ok, :warning and :error.
-      # @param [Hash] options such as :class, :id and :label to override the default label
-      #
-      # @return [ActiveAdmin::Views::StatusTag]
-      #
-      # Examples:
+      # @example
       #   status_tag('In Progress')
       #   # => <span class='status_tag in_progress'>In Progress</span>
       #
+      # @example
       #   status_tag('active', :ok)
       #   # => <span class='status_tag active ok'>Active</span>
       #
+      # @example
       #   status_tag('active', :ok, class: 'important', id: 'status_123', label: 'on')
       #   # => <span class='status_tag active ok important' id='status_123'>on</span>
       #


### PR DESCRIPTION
Now we have a clean `rake yard` run

Changes:
Fix @tags:
  @returns > @return
  @options > @option
  @params > @param
  @method > @overload
  'Examples' > @example
Fix attribute names
Fix Hash style
Fix comments
