### PR TITLE
add i18n specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ group :test do
   gem 'rails-i18n' # Provides default i18n for many languages
   gem 'rspec'
   gem 'rspec-rails'
+  gem 'i18n-spec'
   gem 'shoulda-matchers'
   gem 'sqlite3'
 end

--- a/spec/unit/i18n_spec.rb
+++ b/spec/unit/i18n_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+Dir.glob('config/locales/*.yml') do |locale_file|
+  describe locale_file do
+    it { is_expected.to be_parseable }
+    it { is_expected.to have_one_top_level_namespace }
+    it { is_expected.to be_named_like_top_level_namespace }
+    it { is_expected.to_not have_legacy_interpolations }
+    it { is_expected.to have_a_valid_locale }
+    it { is_expected.to be_a_subset_of 'config/locales/en.yml' }
+  end
+end


### PR DESCRIPTION
I same test for the i18n locales, this test are failing until #3518 and #3524 are merged.

The tests validates each locale file and checking it against the en file.

The benefit of this test are that we can see this things:
- a developer add some keys for thirdparty gems
- the locales are invalid
- have the wrong namespace / iso
- a developer add some keys for a feature only in his language and not in english
