### PR TITLE
Don't stream CSV in development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ env:
   matrix:
     - RAILS=3.2.22
     - RAILS=4.1.13
-    - RAILS=4.2.4
     - RAILS=master
+    - RAILS=4.2.4
   global:
     - JRUBY_OPTS="-J-Xmx1024m --debug"
 matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 #### Minor
 
+* Stream CSV downloads as they're generated [#3038][] by [@craigmcnamara][]
+  * Disable streaming in development for easier debugging [#3535][] by [@seanlinsley][]
 * Improved code reloading [#3783][] by [@chancancode][]
 * Do not auto link to inaccessible actions [#3686][] by [@pranas][]
 * Allow to enable comments on per-resource basis [#3695][] by [@pranas][]

--- a/docs/4-csv-format.md
+++ b/docs/4-csv-format.md
@@ -38,3 +38,21 @@ config.csv_options = { col_sep: ';' }
 # Force the use of quotes
 config.csv_options = { force_quotes: true }
 ```
+
+## Streaming
+
+By default Active Admin streams the CSV response to your browser as it's generated.
+This is good because it prevents request timeouts, for example the infamous H12
+error on Heroku.
+
+However if an exception occurs while generating the CSV, the request will eventually
+time out, with the last line containing the exception message. CSV streaming is
+disabled in development to help debug these exceptions. That lets you use tools like
+better_errors and web-console to debug the issue. If you want to customize the
+environments where CSV streaming is disabled, you can change this setting:
+
+```ruby
+# config/initializers/active_admin.rb
+
+config.disable_streaming_in = ['development', 'staging']
+```

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -125,6 +125,9 @@ module ActiveAdmin
                                       :email,
                                       :to_s ]
 
+    # To make debugging easier, by default don't stream in development
+    setting :disable_streaming_in, ['development']
+
     # == Deprecated Settings
 
     def allow_comments=(*)

--- a/lib/active_admin/csv_builder.rb
+++ b/lib/active_admin/csv_builder.rb
@@ -40,26 +40,23 @@ module ActiveAdmin
     end
 
     def build(controller, csv)
-      @collection = controller.send(:find_collection, except: :pagination)
-      options = ActiveAdmin.application.csv_options.merge self.options
-      columns = exec_columns controller.view_context
+      @collection  = controller.send :find_collection, except: :pagination
+      columns      = exec_columns controller.view_context
+      options      = ActiveAdmin.application.csv_options.merge self.options
+      bom          = options.delete :byte_order_mark
+      column_names = options.delete(:column_names) { true }
+      csv_options  = options.except :encoding_options
 
-      if byte_order_mark = options.delete(:byte_order_mark)
-        csv << byte_order_mark
+      csv << bom if bom
+
+      if column_names
+        csv << CSV.generate_line(columns.map{ |c| encode c.name, options }, csv_options)
       end
 
-      if options.delete(:column_names) { true }
-        csv << CSV.generate_line(
-          columns.map { |c| encode c.name, options },
-          options.except(:encoding_options))
-      end
-
-      (1..paginated_collection.total_pages).each do |page_no|
-        paginated_collection(page_no).each do |resource|
+      (1..paginated_collection.total_pages).each do |page|
+        paginated_collection(page).each do |resource|
           resource = controller.send :apply_decorator, resource
-          csv << CSV.generate_line(
-            build_row(resource, columns, options),
-            options.except(:encoding_options))
+          csv << CSV.generate_line(build_row(resource, columns, options), csv_options)
         end
       end
 

--- a/lib/active_admin/csv_builder.rb
+++ b/lib/active_admin/csv_builder.rb
@@ -39,17 +39,17 @@ module ActiveAdmin
       @columns << Column.new(name, @resource, column_transitive_options.merge(options), block)
     end
 
-    def build(controller, receiver)
+    def build(controller, csv)
       @collection = controller.send(:find_collection, except: :pagination)
       options = ActiveAdmin.application.csv_options.merge self.options
       columns = exec_columns controller.view_context
 
       if byte_order_mark = options.delete(:byte_order_mark)
-        receiver << byte_order_mark
+        csv << byte_order_mark
       end
 
       if options.delete(:column_names) { true }
-        receiver << CSV.generate_line(
+        csv << CSV.generate_line(
           columns.map { |c| encode c.name, options },
           options.except(:encoding_options))
       end
@@ -57,11 +57,13 @@ module ActiveAdmin
       (1..paginated_collection.total_pages).each do |page_no|
         paginated_collection(page_no).each do |resource|
           resource = controller.send :apply_decorator, resource
-          receiver << CSV.generate_line(
+          csv << CSV.generate_line(
             build_row(resource, columns, options),
             options.except(:encoding_options))
         end
       end
+
+      csv
     end
 
     def exec_columns(view_context = nil)

--- a/lib/active_admin/resource_controller/streaming.rb
+++ b/lib/active_admin/resource_controller/streaming.rb
@@ -20,7 +20,12 @@ module ActiveAdmin
       def stream_resource(&block)
         headers['X-Accel-Buffering'] = 'no'
         headers['Cache-Control'] = 'no-cache'
-        self.response_body = Enumerator.new &block
+
+        if ActiveAdmin.application.disable_streaming_in.include? Rails.env
+          self.response_body = block['']
+        else
+          self.response_body = Enumerator.new &block
+        end
       end
 
       def csv_filename


### PR DESCRIPTION
This enables any exceptions to bubble up, instead of waiting until the request times out before sending back any data. This also lets you use in-browser debuggers, like better_errors.

TODO: add tests