### PR TITLE
Update to the newest inherited_resources

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'coffee-rails'
   s.add_dependency 'formtastic',          '~> 3.0'
   s.add_dependency 'formtastic_i18n'
-  s.add_dependency 'inherited_resources', '~> 1.4.1'
+  s.add_dependency 'inherited_resources', '~> 1.4', '!= 1.5.0'
   s.add_dependency 'jquery-rails'
   s.add_dependency 'jquery-ui-rails',     '~> 5.0'
   s.add_dependency 'kaminari',            '~> 0.15'


### PR DESCRIPTION
The 1.5.0 version of inherited_resources was causing issues with belongs_to associations in a controller.  See the discussion here - https://github.com/activeadmin/activeadmin/pull/3193

Version 1.5.1 was released to fix this issue.  This PR updates AA to require version 1.5.1 or higher of inherited_resources.
