### PR TITLE
Setting with questionmark

### DIFF
--- a/lib/active_admin/helpers/settings.rb
+++ b/lib/active_admin/helpers/settings.rb
@@ -45,6 +45,15 @@ module ActiveAdmin
             read_default_setting name.to_sym
           end
         end
+
+        define_method "#{name}?" do
+          value = public_send(name)
+          if value.is_a? Array
+            value.any?
+          else
+            value.present?
+          end
+        end
       end
 
       def deprecated_setting(name, default, message = nil)

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -94,6 +94,25 @@ describe ActiveAdmin::Settings::Inheritance do
         expect(heir.new.left).to eq :right
       end
     end
+
+    describe "the getter with question-mark `config.left?`" do
+      {
+        "nil" => [nil, false],
+        "false" => [false, false],
+        "true" => [true, true],
+        "string" => ["string", true],
+        "empty string" => ["", false],
+        "array" => [[1, 2], true],
+        "empty array" => [[], false]
+      }.each do |context, (value, result)|
+        context "with a #{context} value" do
+          before{ subject.inheritable_setting :left, value }
+          it "should be #{result}" do
+            expect(heir.new.left?).to eq result
+          end
+        end
+      end
+    end
   end
 
 end


### PR DESCRIPTION
add support for `config.setting_name?`

This adds a ActiveModel like questionmark attr checker:

``` ruby
  inheritable_setting :foo, true
  config.foo? # => true

  inheritable_setting :foo, false
  config.foo? # => false

  inheritable_setting :foo, ""
  config.foo? # => false

  inheritable_setting :foo, "bar"
  config.foo? # => true
```
