### PR TITLE
dynamic respond_to in ResourceController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ index download_links: ->{ can?(:view_all_download_links) || [:pdf] }
 ### Security Fixes
 
 * Prevents potential DOS attack via Ruby symbols [#1926][] by [@seanlinsley][]
+* Prevents access to formats that the user not permitted to see [#3542][] by [@timoschilling][]
 
 ### Bug Fixes
 

--- a/lib/active_admin/view_helpers/download_format_links_helper.rb
+++ b/lib/active_admin/view_helpers/download_format_links_helper.rb
@@ -2,6 +2,18 @@ module ActiveAdmin
   module ViewHelpers
     module DownloadFormatLinksHelper
 
+      def build_download_formats(download_links)
+        download_links = instance_exec(&download_links) if download_links.is_a?(Proc)
+
+        if download_links.is_a?(Array) && !download_links.empty?
+          download_links
+        elsif download_links == false
+          []
+        else
+          self.class.formats
+        end
+      end
+
       # TODO: Refactor to new HTML DSL
       def build_download_format_links(formats = self.class.formats)
         params = request.query_parameters.except :format, :commit

--- a/lib/active_admin/views/components/paginated_collection.rb
+++ b/lib/active_admin/views/components/paginated_collection.rb
@@ -66,13 +66,8 @@ module ActiveAdmin
           build_pagination
           div(page_entries_info(options).html_safe, class: "pagination_information")
 
-          download_links = @download_links.is_a?(Proc) ? instance_exec(&@download_links) : @download_links
-
-          if download_links.is_a?(Array) && !download_links.empty?
-            build_download_format_links download_links
-          else
-            build_download_format_links unless download_links == false
-          end
+          formats = build_download_formats @download_links
+          build_download_format_links formats if formats.any?
         end
       end
 


### PR DESCRIPTION
this is a fix for #3539

befor this change, AA respond to html, xml and json on each action, that's a securty problem while the user can view a record as xml and see the raw data.

after this change AA respond only to html on each action and respond to xml, csv, json only it the format is configured for the download links.

Now a user can only see that data he has access to
