### PR TITLE
FormBuilder#has_many does not support multiple inputs

### DIFF
--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -558,6 +558,23 @@ describe ActiveAdmin::FormBuilder do
       end
     end
 
+    describe "with two inputs" do
+      let :body do
+        build_form({url: '/categories'}, Category.new) do |f|
+          f.object.posts.build
+          f.has_many :posts do |p|
+            p.input :body
+            p.input :title
+          end
+        end
+      end
+
+      it "should have both inputs" do
+        expect(body).to have_tag('input', attributes: { name: 'category[posts_attributes][0][title]'})
+        expect(body).to have_tag('textarea', attributes: { name: 'category[posts_attributes][0][body]'})
+      end
+    end
+
     skip "should render the block if it returns nil" do
       body = build_form({url: '/categories'}, Category.new) do |f|
         f.object.posts.build


### PR DESCRIPTION
I was actually using it and it makes sense to do so. By bisecting I've found the commit where it was introduced (#3486):

```
6afaf58357f9606835b3d3b17356a85abcb54cae is the first bad commit
commit 6afaf58357f9606835b3d3b17356a85abcb54cae
Author: Piers Chambers <piers@varyonic.com>
Date:   Sun Sep 21 20:12:40 2014 -0400

    Refactor FormBuilder, replacing form_buffers with Arbre components.  See PR #3486 for discussion.

:040000 040000 dfe2c2b07bd7269df5bf153e0dd14441704b1be8 61297dea084b349b70c13e5f9782166a7cbe9285 M  lib
:040000 040000 a3852ad0ef3ad4e6c8f88c3f9b1d1431cf61a833 1e0c445a3193c923b9ce0fbf4ee0a16b9dc95add M  spec
```

I was using https://gist.github.com/mikz/c00d57f879221b949411 as the test file.

Also this PR has the failing test.

Ideas how to fix it? /cc @varyonic
