### PR TITLE
Test and fix input missing from inputs :for block.

### DIFF
--- a/lib/active_admin/views/components/active_admin_form.rb
+++ b/lib/active_admin/views/components/active_admin_form.rb
@@ -40,7 +40,10 @@ module ActiveAdmin
           wrapped_block = proc do
             wrap_it = form_builder.already_in_an_inputs_block ? true : false
             form_builder.already_in_an_inputs_block = true
-            content = block.call
+            form_builder.template.assign('has_many_block'=> true)
+            content = form_builder.template.capture do
+              block.call
+            end
             form_builder.already_in_an_inputs_block = wrap_it
             content
           end

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -246,6 +246,33 @@ describe ActiveAdmin::FormBuilder do
     end
     it "should generate a nested text input once" do
       expect(body.scan("post_author_attributes_first_name_input").size).to eq(1)
+      expect(body.scan("post_author_attributes_last_name_input").size).to eq(1)
+    end
+    it "should add author first and last name fields" do
+      expect(body).to have_tag("input", attributes: { name: "post[author_attributes][first_name]"})
+      expect(body).to have_tag("input", attributes: { name: "post[author_attributes][last_name]"})
+    end
+  end
+
+  context "with two input fields 'for'" do
+    let :body do
+      build_form do |f|
+        f.inputs do
+          f.input :title
+          f.input :body
+        end
+        f.form_builder.instance_eval do
+          @object.author = User.new
+        end
+        f.inputs name: 'Author', for: :author do |author|
+          author.input :first_name
+          author.input :last_name
+        end
+      end
+    end
+    it "should generate a nested text input once" do
+      expect(body.scan("post_author_attributes_first_name_input").size).to eq(1)
+      expect(body.scan("post_author_attributes_last_name_input").size).to eq(1)
     end
     it "should add author first and last name fields" do
       expect(body).to have_tag("input", attributes: { name: "post[author_attributes][first_name]"})


### PR DESCRIPTION
Resolves #3548.  This is the problem @fivell added to #3525 but is separate, being incomplete rendering of inputs :for, not has_many  @timoschilling I think we need more complexity in test_rails_app in addition to the improvements to form_builder_spec
