### PR TITLE
inline deletion of comments

### DIFF
--- a/config/locales/de-CH.yml
+++ b/config/locales/de-CH.yml
@@ -72,6 +72,8 @@
       title: "Kommentar"
       resource: "Resource"
       add: "Kommentar hinzufügen"
+      delete: "Löschen"
+      delete_confirmation: "Sind Sie sicher dass sie diesen Kommentar löschen wollen?"
       no_comments_yet: "Es gibt noch keine Kommentare."
       title_content: "Kommentare (%{count})"
       errors:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -73,6 +73,8 @@ de:
       author: "Autor"
       title: "Kommentar"
       add: "Kommentar hinzufügen"
+      delete: "Löschen"
+      delete_confirmation: "Sind Sie sicher dass sie diesen Kommentar löschen wollen?"
       resource: "Res­sour­ce"
       no_comments_yet: "Es gibt noch keine Kommentare."
       author_missing: "Unbekannt"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,8 @@ en:
       author: "Author"
       title: "Comment"
       add: "Add Comment"
+      delete: "Delete Comment"
+      delete_confirmation: "Are you sure you want to delete these comment?"
       resource: "Resource"
       no_comments_yet: "No comments yet."
       author_missing: "Anonymous"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -71,6 +71,8 @@ es:
       author: "Autor"
       title: "Comentario"
       add: "Comentar"
+      delete: "Borrar Comentario"
+      delete_confirmation: "¿Está seguro que desea borrar este comentario?"
       resource: "Recurso"
       no_comments_yet: "Aún sin comentarios."
       title_content: "Comentarios (%{count})"

--- a/lib/active_admin/orm/active_record/comments.rb
+++ b/lib/active_admin/orm/active_record/comments.rb
@@ -20,7 +20,7 @@ ActiveAdmin.autoload :Comment, 'active_admin/orm/active_record/comments/comment'
 ActiveAdmin.after_load do |app|
   app.namespaces.each do |namespace|
     namespace.register ActiveAdmin::Comment, as: namespace.comments_registration_name do
-      actions :index, :show, :create
+      actions :index, :show, :create, :destroy
 
       menu false unless namespace.comments && namespace.show_comments_in_menu
 
@@ -58,6 +58,13 @@ ActiveAdmin.after_load do |app|
             failure.html do
               flash[:error] = I18n.t 'active_admin.comments.errors.empty_text'
               redirect_to :back
+            end
+          end
+
+          def destroy
+            destroy! do |success, failure|
+              success.html { redirect_to :back }
+              failure.html { redirect_to :back }
             end
           end
         end

--- a/lib/active_admin/orm/active_record/comments/views/active_admin_comments.rb
+++ b/lib/active_admin/orm/active_record/comments/views/active_admin_comments.rb
@@ -35,6 +35,9 @@ module ActiveAdmin
                 comment.author ? auto_link(comment.author) : I18n.t('active_admin.comments.author_missing')
               end
               span pretty_format comment.created_at
+              if authorized?(ActiveAdmin::Auth::DESTROY, comment)
+                text_node link_to I18n.t('active_admin.comments.delete'), comments_url(comment.id), method: :delete, data: { confirm: I18n.t('active_admin.comments.delete_confirmation') }
+              end
             end
             div class: 'active_admin_comment_body' do
               simple_format comment.body
@@ -44,6 +47,14 @@ module ActiveAdmin
 
         def build_empty_message
           span I18n.t('active_admin.comments.no_comments_yet'), class: 'empty'
+        end
+
+        def comments_url(*args)
+          parts = []
+          parts << active_admin_namespace.name unless active_admin_namespace.root?
+          parts << active_admin_namespace.comments_registration_name.underscore
+          parts << 'path'
+          send parts.join('_'), *args
         end
 
         def comment_form_url


### PR DESCRIPTION
this is a part implementation of @seanlinsley's https://github.com/activeadmin/activeadmin/issues/1903#issuecomment-13637169
![delete comment](https://cloud.githubusercontent.com/assets/165599/4910367/9f45ae3a-647e-11e4-9263-8174c050601c.jpg)
