### PR TITLE
Fixes #3592: CSV export downloads in Safari

### DIFF
--- a/features/step_definitions/format_steps.rb
+++ b/features/step_definitions/format_steps.rb
@@ -12,8 +12,11 @@ end
 # Check first rows of the displayed CSV.
 Then /^I should download a CSV file with "([^"]*)" separator for "([^"]*)" containing:$/ do |sep, resource_name, table|
   body   = page.driver.response.body
-  header = page.response_headers['Content-Type']
-  expect(header).to eq 'text/csv; charset=utf-8'
+  content_type_header, content_disposition_header = %w[Content-Type Content-Disposition].map do |header_name|
+    page.response_headers[header_name]
+  end
+  expect(content_type_header).to eq 'text/csv; charset=utf-8'
+  expect(content_disposition_header).to match /\Aattachment; filename=".+?\.csv"\z/
 
   begin
     csv = CSV.parse(body, col_sep: sep)

--- a/lib/active_admin/resource_controller/streaming.rb
+++ b/lib/active_admin/resource_controller/streaming.rb
@@ -23,7 +23,12 @@ module ActiveAdmin
         self.response_body = Enumerator.new &block
       end
 
+      def csv_filename
+        "#{resource_collection_name.to_s.gsub('_', '-')}-#{Time.zone.now.to_date.to_s(:default)}.csv"
+      end
+
       def stream_csv
+        headers['Content-Disposition'] = %{attachment; filename="#{csv_filename}"}
         stream_resource &active_admin_config.csv_builder.method(:build).to_proc.curry[self]
       end
 


### PR DESCRIPTION
Content-Disposition header required for Safari to download the file as an attachemnt
