### PR TITLE
remove old formtastic css class and add new ones

### DIFF
--- a/app/assets/stylesheets/active_admin/_forms.css.scss
+++ b/app/assets/stylesheets/active_admin/_forms.css.scss
@@ -146,7 +146,7 @@ form {
     }
 
     /* Date and Time Fields */
-    &.date, &.time, &.datetime, &.date_select {
+    &.date_select, &.time_select, &.datetime_select {
       fieldset ol li {
         float:left; width:auto; margin:0 0.5em 0 0;
         label { display: none; }


### PR DESCRIPTION
this fixes #2734 

After I read some formtastic, I end up on [`wrapper_classes`](https://github.com/justinfrench/formtastic/blob/d107e18f307f90df60e854c0875d225e330a8854/lib/formtastic/inputs/base/wrapping.rb#L35) which uses [`as`](https://github.com/justinfrench/formtastic/blob/d107e18f307f90df60e854c0875d225e330a8854/lib/formtastic/inputs/base/naming.rb#L6) to generate the class attribute of a input element. `as` reflects the name by the ruby input class name. While formtastic and active admin don't have a `DateInput`, `TimeInput` or `DatetimeInput` we can remove `.date`, `.time` and `.datetime` from css. While formtastic as a `DateSelectInput`, `TimeSelectInput` and `DatetimeSelectInput` we should add css for those.
