### PR TITLE
add Namespace::Store

### DIFF
--- a/features/step_definitions/configuration_steps.rb
+++ b/features/step_definitions/configuration_steps.rb
@@ -4,7 +4,7 @@ module ActiveAdminReloading
     eval(config_content)
     ActiveAdmin::Event.dispatch ActiveAdmin::Application::AfterLoadEvent,  ActiveAdmin.application
     Rails.application.reload_routes!
-    ActiveAdmin.application.namespaces.values.each &:reset_menu!
+    ActiveAdmin.application.namespaces.each &:reset_menu!
   end
 end
 

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -17,7 +17,7 @@ module ActiveAdmin
 
     attr_reader :namespaces
     def initialize
-      @namespaces = {}
+      @namespaces = Namespace::Store.new
     end
 
     # Load paths for admin configurations. Add folders to this load path
@@ -174,7 +174,7 @@ module ActiveAdmin
     # Removes all defined controllers from memory. Useful in
     # development, where they are reloaded on each request.
     def unload!
-      namespaces.values.each &:unload!
+      namespaces.each &:unload!
       @@loaded = false
     end
 

--- a/lib/active_admin/namespace.rb
+++ b/lib/active_admin/namespace.rb
@@ -227,5 +227,21 @@ module ActiveAdmin
       PageDSL.new(config).run_registration_block(&block)
     end
 
+    class Store
+      include Enumerable
+      delegate :[], :[]=, :empty?, to: :@namespaces
+
+      def initialize
+        @namespaces = {}
+      end
+
+      def each(&block)
+        @namespaces.values.each(&block)
+      end
+
+      def names
+        @namespaces.keys
+      end
+    end
   end
 end

--- a/lib/active_admin/orm/active_record/comments.rb
+++ b/lib/active_admin/orm/active_record/comments.rb
@@ -18,7 +18,7 @@ ActiveAdmin.autoload :Comment, 'active_admin/orm/active_record/comments/comment'
 
 # Walk through all the loaded namespaces after they're loaded
 ActiveAdmin.after_load do |app|
-  app.namespaces.values.each do |namespace|
+  app.namespaces.each do |namespace|
     namespace.register ActiveAdmin::Comment, as: namespace.comments_registration_name do
       actions :index, :show, :create
 
@@ -30,7 +30,7 @@ ActiveAdmin.after_load do |app|
       scope :all, show_count: false
       # Register a scope for every namespace that exists.
       # The current namespace will be the default scope.
-      app.namespaces.values.map(&:name).each do |name|
+      app.namespaces.map(&:name).each do |name|
         scope name, default: namespace.name == name do |scope|
           scope.where namespace: name.to_s
         end

--- a/lib/active_admin/router.rb
+++ b/lib/active_admin/router.rb
@@ -18,7 +18,7 @@ module ActiveAdmin
     end
 
     def define_root_routes(router)
-      router.instance_exec @application.namespaces.values do |namespaces|
+      router.instance_exec @application.namespaces do |namespaces|
         namespaces.each do |namespace|
           if namespace.root?
             root namespace.root_to_options.merge(to: namespace.root_to)
@@ -34,7 +34,7 @@ module ActiveAdmin
     # Defines the routes for each resource
     def define_resource_routes(router)
       router.instance_exec @application.namespaces, self do |namespaces, aa_router|
-        resources = namespaces.values.flat_map{ |n| n.resources.values }
+        resources = namespaces.flat_map{ |n| n.resources.values }
         resources.each do |config|
           routes = aa_router.resource_routes(config)
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,7 +13,7 @@ module ActiveAdminIntegrationSpecHelper
   end
 
   def reload_menus!
-    ActiveAdmin.application.namespaces.values.each{|n| n.reset_menu! }
+    ActiveAdmin.application.namespaces.each{|n| n.reset_menu! }
   end
 
   # Sometimes we need to reload the routes within

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -121,10 +121,10 @@ describe ActiveAdmin::Application do
     end
 
     it "should not pollute the global app" do
-      expect(application.namespaces.keys).to be_empty
+      expect(application.namespaces).to be_empty
       application.namespace(:brand_new_ns)
-      expect(application.namespaces.keys).to eq [:brand_new_ns]
-      expect(ActiveAdmin.application.namespaces.keys).to eq [:admin]
+      expect(application.namespaces.names).to eq [:brand_new_ns]
+      expect(ActiveAdmin.application.namespaces.names).to eq [:admin]
     end
   end
 

--- a/spec/unit/routing_spec.rb
+++ b/spec/unit/routing_spec.rb
@@ -10,7 +10,7 @@ describe ActiveAdmin, "Routing", type: :routing do
   end
 
   it "should only have the namespaces necessary for route testing" do
-    expect(ActiveAdmin.application.namespaces.keys).to eq [:admin, :root]
+    expect(ActiveAdmin.application.namespaces.names).to eq [:admin, :root]
   end
 
   it "should route to the admin dashboard" do


### PR DESCRIPTION
with `Namespace::Store` we can make `application.namespaces` enumerable, with this we no longer need to do thinks like `application.namespaces.values.each`, we can now do this `application.namespaces.each`