### PR TITLE
Fix french i18n login title

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -88,7 +88,7 @@ fr:
       password:
         title: "Mot de passe"
       login:
-        title: "Connection"
+        title: "Connexion"
         remember_me: "Garder ma session ouverte"
         submit: "Se connecter"
       reset_password:


### PR DESCRIPTION
As you can see [here](https://translate.google.com/?ie=UTF-8&hl=en&client=tw-ob#fr/en/connexion) the french login title i18n is not correct.

This is a very small fix but it would be great to have it on master. I've checked the rest of the french i18n and everything else seems fine.
