### PR TITLE
simplify AA::Devise.config

### DIFF
--- a/lib/active_admin/devise.rb
+++ b/lib/active_admin/devise.rb
@@ -6,18 +6,12 @@ module ActiveAdmin
   module Devise
 
     def self.config
-      config = {
+      {
         path: ActiveAdmin.application.default_namespace || "/",
         controllers: ActiveAdmin::Devise.controllers,
-        path_names: { sign_in: 'login', sign_out: "logout" }
+        path_names: { sign_in: 'login', sign_out: "logout" },
+        sign_out_via: [*::Devise.sign_out_via, ActiveAdmin.application.logout_link_method].uniq
       }
-
-      if ::Devise.respond_to?(:sign_out_via)
-        logout_methods = [::Devise.sign_out_via, ActiveAdmin.application.logout_link_method].flatten.uniq
-        config.merge!( sign_out_via: logout_methods)
-      end
-
-      config
     end
 
     def self.controllers

--- a/spec/unit/devise_spec.rb
+++ b/spec/unit/devise_spec.rb
@@ -76,38 +76,18 @@ describe ActiveAdmin::Devise::Controller do
     let(:config) { ActiveAdmin::Devise.config }
 
     describe ":sign_out_via option" do
+      it "should contain the application.logout_link_method" do
+        expect(::Devise).to receive(:sign_out_via).and_return(:delete)
+        expect(ActiveAdmin.application).to receive(:logout_link_method).and_return(:get)
 
-      subject { config[:sign_out_via] }
-
-      context "when Devise does not implement sign_out_via (version < 1.2)" do
-        before do
-          expect(::Devise).to receive(:respond_to?).with(:sign_out_via).and_return(false)
-        end
-
-        it "should not contain any customization for sign_out_via" do
-          expect(config).to_not have_key(:sign_out_via)
-        end
+        expect(config[:sign_out_via]).to include(:get)
       end
 
-      context "when Devise implements sign_out_via (version >= 1.2)" do
-        before do
-         expect(::Devise).to receive(:respond_to?).with(:sign_out_via).and_return(true)
-          allow(::Devise).to receive(:sign_out_via) { :delete }
-        end
+      it "should contain Devise's logout_via_method(s)" do
+        expect(::Devise).to receive(:sign_out_via).and_return([:delete, :post])
+        expect(ActiveAdmin.application).to receive(:logout_link_method).and_return(:get)
 
-        it "should contain the application.logout_link_method" do
-            expect(::Devise).to receive(:sign_out_via).and_return(:delete)
-            expect(ActiveAdmin.application).to receive(:logout_link_method).and_return(:get)
-
-            expect(config[:sign_out_via]).to include(:get)
-        end
-
-        it "should contain Devise's logout_via_method(s)" do
-            expect(::Devise).to receive(:sign_out_via).and_return([:delete, :post])
-            expect(ActiveAdmin.application).to receive(:logout_link_method).and_return(:get)
-
-            expect(config[:sign_out_via]).to eq [:delete, :post, :get]
-        end
+        expect(config[:sign_out_via]).to eq [:delete, :post, :get]
       end
 
     end # describe ":sign_out_via option"


### PR DESCRIPTION
Devise has `sign_out_via` since v1.2.0 (plataformatec/devise@ab7f3bc1757104c053d3e3c9bf6db2de03dee830), and we have a min (soft) dependency to v3.2.x https://github.com/activeadmin/activeadmin/blob/master/lib/active_admin/dependency.rb#L3
