### PR TITLE
fix favicon namespace

### DIFF
--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -31,8 +31,8 @@ module ActiveAdmin
               text_node(javascript_include_tag(path))
             end
 
-            if active_admin_application.favicon
-              text_node(favicon_link_tag(active_admin_application.favicon))
+            if active_admin_namespace.favicon
+              text_node(favicon_link_tag(active_admin_namespace.favicon))
             end
 
             text_node csrf_meta_tag


### PR DESCRIPTION
favicon setting in namespace is not working

```
ActiveAdmin.setup do |config|
  config.namespace :admin2 do |admin2|
    # this setting is not working
    admin2.favicon = '/favicon2.ico'
  end
end
```
