### PR TITLE
Bump the rails versions on travis.yml to the latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ rvm:
   - 2.1.4
 env:
   matrix:
-    - RAILS=3.2.20
-    - RAILS=4.1.7
+    - RAILS=3.2.21
+    - RAILS=4.1.8
   global:
     secure: lRYUGVUV94eqrR7C0b0hhvp+W76NkLRAn6jkJGCbRCEojbeb3HlgK1P+nTDeIuiDmXksJOG6VD3ZiZAn9Plznj7I/MFh+ijgvk8eWj9QNxA8riaSEPAu5VYtPA+uaw1olUt196U3qXH+SaXB4sx5wdIUXpd9qxWWWsW11ia0Jzs=
 notifications:


### PR DESCRIPTION
Bumping rails in travis.yml to the latest patch releases - http://weblog.rubyonrails.org/2014/11/17/Rails-3-2-21-4-0-12-and-4-1-8-have-been-released/
