### PR TITLE
#2753 - status_tag supports boolean status (fix)

### DIFF
--- a/app/assets/stylesheets/active_admin/components/_status_tags.scss
+++ b/app/assets/stylesheets/active_admin/components/_status_tags.scss
@@ -6,11 +6,11 @@
   padding: 3px 5px 2px 5px;
   font-size: 0.8em;
 
-  &.ok, &.published, &.complete, &.completed, &.green { background: #8daa92; }
-  &.warn, &.warning, &.orange { background: #e29b20; }
-  &.error, &.errored, &.red { background: #d45f53; }
-
+  /** default colors first */
   &.yes { background: #6090DB }
   &.no  { background: grey }
 
+  &.ok, &.published, &.complete, &.completed, &.green { background: #8daa92; }
+  &.warn, &.warning, &.orange { background: #e29b20; }
+  &.error, &.errored, &.red { background: #d45f53; }
 }

--- a/lib/active_admin/views/components/status_tag.rb
+++ b/lib/active_admin/views/components/status_tag.rb
@@ -39,7 +39,7 @@ module ActiveAdmin
         type = args[1]
         label = options.delete(:label)
         classes = options.delete(:class)
-        status = convert_to_boolean_status(status)
+        status = status_from_boolean(status)
 
         if status
           content = label || if s = status.to_s and s.present?
@@ -56,10 +56,10 @@ module ActiveAdmin
 
       protected
 
-      def convert_to_boolean_status(status)
-        if status == 'true'
+      def status_from_boolean(status)
+        if status == true
           'Yes'
-        elsif ['false', nil].include?(status)
+        elsif [false, nil].include?(status)
           'No'
         else
           status

--- a/lib/active_admin/views/components/table_for.rb
+++ b/lib/active_admin/views/components/table_for.rb
@@ -109,8 +109,8 @@ module ActiveAdmin
         elsif item.respond_to? :[]
           item[data]
         end
-        value = pretty_format(value) if data.is_a?(Symbol)
         value = status_tag value     if is_boolean? data, item
+        value = pretty_format(value) if data.is_a?(Symbol)
         value
       end
 

--- a/spec/unit/views/components/status_tag_spec.rb
+++ b/spec/unit/views/components/status_tag_spec.rb
@@ -90,7 +90,7 @@ describe ActiveAdmin::Views::StatusTag do
     end
 
     context "when status is false" do
-      subject { status_tag('false') }
+      subject { status_tag(false) }
 
       describe '#class_list' do
         subject { super().class_list }


### PR DESCRIPTION
Hi guys,

I fixed this issue little bit. Previous version didn't worked for me. It had been accepting only boolean value in a string which I think made no sense.