### PR TITLE
Add has_many input config option for setting the start index

### DIFF
--- a/app/assets/javascripts/active_admin/lib/has_many.js.coffee
+++ b/app/assets/javascripts/active_admin/lib/has_many.js.coffee
@@ -67,7 +67,7 @@ init_sortable = ->
 recompute_positions = (parent)->
   parent     = if parent instanceof jQuery then parent else $(@)
   input_name = parent.data 'sortable'
-  position   = 0
+  position   = parseInt(parent.data('sortable-start') || 0, 10)
 
   parent.children('fieldset').each ->
     # We ignore nested inputs, so when defining your has_many, be sure to keep

--- a/docs/5-forms.md
+++ b/docs/5-forms.md
@@ -79,7 +79,7 @@ ActiveAdmin.register Post do
       end
     end
     f.inputs do
-      f.has_many :taggings, sortable: :position do |t|
+      f.has_many :taggings, sortable: :position, sortable_start: 1 do |t|
         t.input :tag
       end
     end
@@ -105,6 +105,8 @@ If you pass a string, it will be used as the text for the new record button.
 
 The `:sortable` option adds a hidden field and will enable drag & drop sorting of the children. It 
 expects the name of the column that will store the index of each child.
+
+The `:sortable_start` option sets the value (0 by default) of the first position in the list.
 
 ## Datepicker
 

--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -34,13 +34,15 @@ module ActiveAdmin
 
     def has_many(assoc, options = {}, &block)
       # remove options that should not render as attributes
-      custom_settings = :new_record, :allow_destroy, :heading, :sortable
+      custom_settings = :new_record, :allow_destroy, :heading, :sortable, :sortable_start
       builder_options = {new_record: true}.merge! options.slice  *custom_settings
       options         = {for: assoc      }.merge! options.except *custom_settings
       options[:class] = [options[:class], "inputs has_many_fields"].compact.join(' ')
+      sortable_column = builder_options[:sortable]
+      sortable_start  = builder_options.fetch(:sortable_start, 0)
 
-      if (column = builder_options[:sortable])
-        options[:for] = [assoc, sorted_children(assoc, column)]
+      if sortable_column
+        options[:for] = [assoc, sorted_children(assoc, sortable_column)]
       end
 
       html = "".html_safe
@@ -69,7 +71,7 @@ module ActiveAdmin
       end
 
       tag = @already_in_an_inputs_block ? :li : :div
-      html = template.content_tag(tag, html, class: "has_many_container #{assoc}", 'data-sortable' => builder_options[:sortable])
+      html = template.content_tag(tag, html, class: "has_many_container #{assoc}", 'data-sortable' => sortable_column, 'data-sortable-start' => sortable_start)
       template.concat(html) if template.output_buffer
       html
     end

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -584,7 +584,36 @@ describe ActiveAdmin::FormBuilder do
         it "shows the nested fields for saved and unsaved records" do
           expect(body).to have_selector("fieldset.inputs.has_many_fields")
         end
+      end
 
+      context "without sortable_start set" do
+        let :body do
+          build_form({url: '/categories'}, Category.new) do |f|
+            f.object.posts.build
+            f.has_many :posts, sortable: :position do |p|
+              p.input :title
+            end
+          end
+        end
+
+        it "defaults to 0" do
+          expect(body).to have_selector("div.has_many_container[data-sortable-start='0']")
+        end
+      end
+
+      context "with sortable_start set" do
+        let :body do
+          build_form({url: '/categories'}, Category.new) do |f|
+            f.object.posts.build
+            f.has_many :posts, sortable: :position, sortable_start: 15 do |p|
+              p.input :title
+            end
+          end
+        end
+
+        it "sets the data attribute" do
+          expect(body).to have_selector("div.has_many_container[data-sortable-start='15']")
+        end
       end
     end
 


### PR DESCRIPTION
This PR addresses #3680 by adding a `sortable_start` option to set the start index in a `has_many` input. If the option isn't provided, it defaults to 0 to preserve the existing behavior.

The syntax looks like this:

```ruby
f.has_many :things, sortable: :position, sortable_start: 1 do |t|
  ...
end
```

