### PR TITLE
Do not auto link to inaccessible actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Enhancements
 
+* Do not auto link to inaccessible actions [#3686][] by [@pranas][]
 * Allow to enable comments on per-resource basis [#3695][] by [@pranas][]
 * Rename `allow_comments` to `comments` for more consistent naming [#3695][] by [@pranas][]
 * Unify DSL for index `actions` and `actions dropdown: true` [#3463][] by [@timoschilling][]
@@ -984,6 +985,7 @@ of the highlights. 250 commits. Enough said.
 [#3464]: https://github.com/activeadmin/activeadmin/issues/3464
 [#3486]: https://github.com/activeadmin/activeadmin/issues/3486
 [#3519]: https://github.com/activeadmin/activeadmin/issues/3519
+[#3686]: https://github.com/activeadmin/activeadmin/issues/3686
 [#3695]: https://github.com/activeadmin/activeadmin/issues/3695
 [@Bishop]: https://github.com/Bishop
 [@BoboFraggins]: https://github.com/BoboFraggins

--- a/lib/active_admin/namespace.rb
+++ b/lib/active_admin/namespace.rb
@@ -146,8 +146,8 @@ module ActiveAdmin
     def add_current_user_to_menu(menu, priority = 10, html_options = {})
       if current_user_method
         menu.add id: 'current_user', priority: priority, html_options: html_options,
-          label: ->{ display_name current_active_admin_user },
-          url:   ->{ auto_url_for(current_active_admin_user) || '#' },
+          label: -> { display_name current_active_admin_user },
+          url:   -> { auto_url_for(current_active_admin_user) },
           if:    :current_active_admin_user?
       end
     end

--- a/lib/active_admin/resource/routes.rb
+++ b/lib/active_admin/resource/routes.rb
@@ -15,6 +15,10 @@ module ActiveAdmin
         RouteBuilder.new(self).instance_path(resource)
       end
 
+      def route_edit_instance_path(resource)
+        RouteBuilder.new(self).edit_instance_path(resource)
+      end
+
       # Returns the routes prefix for this config
       def route_prefix
         namespace.module_name.try(:underscore)
@@ -36,7 +40,7 @@ module ActiveAdmin
         def collection_path(params)
           route_name = route_name(
             resource.resources_configuration[:self][:route_collection_name],
-            (resource.route_uncountable? ? 'index_path' : 'path')
+            suffix: (resource.route_uncountable? ? "index_path" : "path")
           )
 
           routes.public_send route_name, *route_collection_params(params)
@@ -51,13 +55,25 @@ module ActiveAdmin
           routes.public_send route_name, *route_instance_params(instance)
         end
 
+        # @return [String] the path to the edit page of this resource
+        # @param instance [ActiveRecord::Base] the instance we want the path of
+        # @example "/admin/posts/1/edit"
+        def edit_instance_path(instance)
+          path = resource.resources_configuration[:self][:route_instance_name]
+          route_name = route_name(path, action: :edit)
+
+          routes.public_send route_name, *route_instance_params(instance)
+        end
+
         private
 
         attr_reader :resource
 
-        def route_name(resource_path_name, suffix = 'path')
+        def route_name(resource_path_name, options = {})
+          suffix = options[:suffix] || "path"
           route = []
 
+          route << options[:action]           # "edit" or "new"
           route << resource.route_prefix      # "admin"
           route << belongs_to_name if nested? # "category"
           route << resource_path_name         # "posts" or "post"

--- a/lib/active_admin/view_helpers/auto_link_helper.rb
+++ b/lib/active_admin/view_helpers/auto_link_helper.rb
@@ -21,8 +21,15 @@ module ActiveAdmin
 
       # Like `auto_link`, except that it only returns a URL instead of a full <a> tag
       def auto_url_for(resource)
-        if config = active_admin_resource_for(resource.class)
+        config = active_admin_resource_for(resource.class)
+        return unless config
+
+        if config.controller.action_methods.include?("show") &&
+          authorized?(ActiveAdmin::Auth::READ, resource)
           url_for config.route_instance_path resource
+        elsif config.controller.action_methods.include?("edit") &&
+          authorized?(ActiveAdmin::Auth::UPDATE, resource)
+          url_for config.route_edit_instance_path resource
         end
       end
 

--- a/lib/active_admin/views/tabbed_navigation.rb
+++ b/lib/active_admin/views/tabbed_navigation.rb
@@ -43,7 +43,11 @@ module ActiveAdmin
         li id: item.id do |li|
           li.add_class "current" if item.current? assigns[:current_tab]
 
-          text_node link_to item.label(self), item.url(self), item.html_options
+          if url = item.url(self)
+            text_node link_to item.label(self), url, item.html_options
+          else
+            span item.label(self), item.html_options
+          end
 
           if children = item.items(self).presence
             li.add_class "has_nested"

--- a/spec/unit/auto_link_spec.rb
+++ b/spec/unit/auto_link_spec.rb
@@ -14,6 +14,10 @@ describe "auto linking resources" do
     "/admin/posts/#{post.id}"
   end
 
+  def authorized?(_action, _subject)
+    true
+  end
+
   context "when the resource is not registered" do
     it "should return the display name of the object" do
       expect(auto_link(post)).to eq "Hello World"
@@ -25,10 +29,41 @@ describe "auto linking resources" do
       active_admin_namespace.register Post
     end
     it "should return a link with the display name of the object" do
-      expect(self).to receive(:url_for).and_return admin_post_path(post)
+      expect(self).to receive(:url_for) { |url| url }
       expect(self).to receive(:link_to).with "Hello World", admin_post_path(post)
       auto_link(post)
     end
-  end
 
+    context "but the user doesn't have access" do
+      it "should return the display name of the object" do
+        expect(self).to receive(:authorized?).twice.and_return(false)
+        expect(auto_link(post)).to eq "Hello World"
+      end
+    end
+
+    context "but the show action is disabled" do
+      before do
+        active_admin_namespace.register(Post) { actions :all, except: :show }
+      end
+
+      it "should fallback to edit" do
+        url_path = "/admin/posts/#{post.id}/edit"
+        expect(self).to receive(:url_for) { |url| url }
+        expect(self).to receive(:link_to).with "Hello World", url_path
+        auto_link(post)
+      end
+    end
+
+    context "but the show and edit actions are disabled" do
+      before do
+        active_admin_namespace.register(Post) do
+          actions :all, except: [:show, :edit]
+        end
+      end
+
+      it "should return the display name of the object" do
+        expect(auto_link(post)).to eq "Hello World"
+      end
+    end
+  end
 end

--- a/spec/unit/views/tabbed_navigation_spec.rb
+++ b/spec/unit/views/tabbed_navigation_spec.rb
@@ -48,6 +48,8 @@ describe ActiveAdmin::Views::TabbedNavigation do
                        priority: 10,
                        if: :admin_logged_in?
       end
+
+      menu.add label: "Charles Smith", id: "current_user", url: -> { nil }
     end
 
     it "should generate a ul" do
@@ -93,6 +95,13 @@ describe ActiveAdmin::Views::TabbedNavigation do
 
     it "should not generate the management parent menu" do
       expect(html).to_not have_selector("a[href='#']", text: "Management")
+    end
+
+    context "when url is nil" do
+      it "should generate a span" do
+        selector = "li#current_user > span"
+        expect(html).to have_selector(selector, text: "Charles Smith")
+      end
     end
 
     describe "marking current item" do


### PR DESCRIPTION
Even though show action is disabled for a specific resource or the current user doesn't have access to it, the links are generated in show page table or index table anyway. They lead to either "access denied" or "not found" error pages. The links for default actions in index table are checked for these conditions (see [here](https://github.com/activeadmin/activeadmin/blob/cc6aa1674449f4ae9d7651b214d14e2e82d1b67c/lib/active_admin/views/index_as_table.rb#L328])). I applied the same conditions for links generated by auto linking helper.