### PR TITLE
Add simple documentation for PORO decorators

### DIFF
--- a/docs/11-decorators.md
+++ b/docs/11-decorators.md
@@ -4,6 +4,11 @@ Active Admin allows you to use the decorator pattern to provide view-specific
 versions of a resource. [Draper](https://github.com/drapergem/draper) is
 recommended but not required.
 
+To use decorator support without Draper, your decorator must support a variety
+of collection methods to support pagination, filtering, etc. See
+[this github issue discussion](https://github.com/activeadmin/activeadmin/issues/3600)
+and [this gem](https://github.com/kiote/activeadmin-poro-decorator) for more details.
+
 ## Example usage
 
 ```ruby
@@ -13,7 +18,7 @@ class Post < ActiveRecord::Base
 end
 
 # app/decorators/post_decorator.rb
-class PostDecorator < ApplicationDecorator
+class PostDecorator < Draper::Decorator
   delegate_all
 
   def image


### PR DESCRIPTION
This adds just two small sentences introducing the possibility of PORO decorators
and links to the [github issue](https://github.com/activeadmin/activeadmin/issues/3600) where there is a full discussion with lots of context
and [the gem](https://github.com/kiote/activeadmin-poro-decorator) by @kiote which not only is a solution but also serves as documentation
for what is required to write your own PORO decorators for ActiveAdmin.
