### PR TITLE
Fallback to use formtastic inputs

### DIFF
--- a/lib/active_admin/filters/forms.rb
+++ b/lib/active_admin/filters/forms.rb
@@ -3,7 +3,18 @@ module ActiveAdmin
 
     class InputClassFinder < Formtastic::InputClassFinder
       def class_name(as)
-        "Filter#{super}"
+        input_class = "Filter#{super}"
+        if active_admin_input_class?(input_class)
+          input_class
+        else
+          super
+        end
+      end
+
+      private
+
+      def active_admin_input_class?(name)
+        ActiveAdmin::Inputs.const_defined?(name)
       end
     end
 

--- a/spec/unit/filters/filter_form_builder_spec.rb
+++ b/spec/unit/filters/filter_form_builder_spec.rb
@@ -399,6 +399,13 @@ describe ActiveAdmin::Filters::ViewHelper do
     end
   end
 
+  describe "does not support some filter inputs" do
+    it "should fallback to use formtastic inputs" do
+      body = Capybara.string(filter :custom_searcher, as: :text)
+      expect(body).to have_selector("textarea[name='q[custom_searcher]']")
+    end
+  end
+
   describe "blank option" do
     context "for a select filter" do
       it "should be there by default" do


### PR DESCRIPTION
Fix #3678 

We bring the fallback to use formtastic inputs when there is no implementation of filter input class found in ActiveAdmin.
