### PR TITLE
Fix issue with model attribute matching metasearch method name

### DIFF
--- a/lib/active_admin/inputs/filter_string_input.rb
+++ b/lib/active_admin/inputs/filter_string_input.rb
@@ -9,7 +9,7 @@ module ActiveAdmin
       # If the filter method includes a search condition, build a normal string search field.
       # Else, build a search field with a companion dropdown to choose a search condition from.
       def to_html
-        if @object.respond_to? method
+        if @object.methods.exclude?(method) && @object.respond_to?(method)
           input_wrapping do
             label_html <<
             builder.text_field(method, input_html_options)


### PR DESCRIPTION
Not sure if you're still accepting PRs fixing 0.6 only issues. This is a fix for the case when an attribute on a model matches a method on the metasearch search object. In my case, it was a string attribute called `size`. I was expecting it to create a standard string filter, but got something like this instead:

![screen shot 2014-12-16 at 3 26 03 pm](https://cloud.githubusercontent.com/assets/495973/5464059/05391e0a-8538-11e4-81d9-a2efaaedef9a.png)

(757 is the actual count of records of this model).

After this fix, it looks like you'd expect:

![screen shot 2014-12-16 at 3 40 08 pm](https://cloud.githubusercontent.com/assets/495973/5464194/e01bd390-8539-11e4-9ac9-0afe23fba6a7.png)

I checked metasearch's docs to see if there were a better method for determining what methods are actually search methods but didn't see anything, so this seemed like the simplest fix.