### PR TITLE
Fix Rails 4.2 failing tests

### DIFF
--- a/lib/active_admin/filters/formtastic_addons.rb
+++ b/lib/active_admin/filters/formtastic_addons.rb
@@ -37,7 +37,7 @@ module ActiveAdmin
       end
 
       def polymorphic_foreign_type?(method)
-        klass.reflections.values.select{ |r| r.macro == :belongs_to && r.options[:polymorphic] }
+        klass.reflect_on_all_associations.select{ |r| r.macro == :belongs_to && r.options[:polymorphic] }
           .map(&:foreign_type).include? method.to_s
       end
 

--- a/lib/active_admin/views/components/table_for.rb
+++ b/lib/active_admin/views/components/table_for.rb
@@ -115,10 +115,10 @@ module ActiveAdmin
       end
 
       def is_boolean?(data, item)
-        if item.respond_to? :type_for_attribute # Rails >= 4.2
-          item.type_for_attribute(data) == :boolean
-        elsif item.respond_to? :column_for_attribute
-          attr = item.column_for_attribute(data) and attr.type == :boolean
+        if item.respond_to? :has_attribute?
+          item.has_attribute?(data) &&
+            item.column_for_attribute(data) &&
+            item.column_for_attribute(data).type == :boolean
         end
       end
 

--- a/spec/unit/filters/filter_form_builder_spec.rb
+++ b/spec/unit/filters/filter_form_builder_spec.rb
@@ -293,8 +293,8 @@ describe ActiveAdmin::Filters::ViewHelper do
     context "when using a custom foreign key" do
       let(:scope) { Post.search }
       let(:body)  { Capybara.string(filter :category) }
-      it "should should ignore that foreign key and let Ransack handle it" do
-        expect(Post.reflections[:category].foreign_key).to eq :custom_category_id
+      it "should ignore that foreign key and let Ransack handle it" do
+        expect(Post.reflect_on_association(:category).foreign_key).to eq :custom_category_id
         expect(body).to have_selector("select[name='q[category_id_eq]']")
       end
     end


### PR DESCRIPTION
This pull request includes fixes for the following tests and corresponding implementations:

- `spec/unit/views/components/table_for_spec.rb:277`
- `spec/unit/filters/filter_form_builder_spec.rb:296`

The implementation of `#is_boolean?` has been changed to use `#has_attribute?` and `#column_for_attribute` instead of `#type_for_attribute`, since the latter was returning an object with a nil `#type` (you can [read more details in the commit](https://github.com/gonzedge/activeadmin/commit/48ccc3db861bea9aa01d4f75c842303096b8697f)).

Additionally, usages of `.reflections` have been changed to `.reflect_on_association` and `.reflect_on_all_associations` to avoid coupling with the reflection internals ([more details](https://github.com/gonzedge/activeadmin/commit/e676fec843c60ac9b72eb35e88daf9d4f40c4f91)).