### PR TITLE
Set form multipart option automatically.

### DIFF
--- a/lib/active_admin/views/components/active_admin_form.rb
+++ b/lib/active_admin/views/components/active_admin_form.rb
@@ -33,6 +33,12 @@ module ActiveAdmin
 
         @opening_tag, @closing_tag = split_string_on(form_string, "</form>")
         instance_eval(&block) if block_given?
+
+        # Rails 4 sets multipart automatically if a file field is present,
+        # but the form tag has already been rendered before the block eval.
+        if multipart? && @opening_tag !~ /multipart/
+          @opening_tag.sub!(/<form/, '<form enctype="multipart/form-data"')
+        end
       end
 
       def inputs(*args, &block)
@@ -70,6 +76,10 @@ module ActiveAdmin
 
       def has_many(*args, &block)
         insert_tag(HasManyProxy, form_builder, *args, &block)
+      end
+
+      def multipart?
+        form_builder && form_builder.multipart?
       end
 
       def object

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -124,6 +124,20 @@ describe ActiveAdmin::FormBuilder do
     end
   end
 
+  if Rails::VERSION::MAJOR > 3
+    context "file input present" do
+      let :body do
+        build_form do |f|
+          f.input :body, as: :file
+        end
+      end
+
+      it "adds multipart attribute automatically" do
+        expect(body).to have_selector("form[enctype='multipart/form-data']")
+      end
+    end
+  end
+
   context "with actions" do
     it "should generate the form once" do
       body = build_form do |f|


### PR DESCRIPTION
Rails 4 sets multipart automatically if a file field is present, but to build an Arbre proxy the form tag has already been rendered before the file field.  Fixes #3577 