### PR TITLE
Allow pagination to be controller with dynamic per_page

### DIFF
--- a/app/assets/javascripts/active_admin/lib/per_page.js.coffee
+++ b/app/assets/javascripts/active_admin/lib/per_page.js.coffee
@@ -1,0 +1,26 @@
+class ActiveAdmin.PerPage
+  constructor: (@options, @element)->
+    @$element = $(@element)
+    @_init()
+    @_bind()
+
+  _init: ->
+    @$params = @_queryParams()
+
+  _bind: ->
+    @$element.change =>
+      @$params['per_page'] = @$element.val()
+      location.search = $.param(@$params)
+
+  _queryParams: ->
+    query = window.location.search.substring(1)
+    params = {}
+    re = /([^&=]+)=([^&]*)/g
+    while m = re.exec(query)
+      params[decodeURIComponent(m[1])] = decodeURIComponent(m[2])
+    params
+
+$.widget.bridge 'perPage', ActiveAdmin.PerPage
+
+$ ->
+  $('.pagination_per_page select').perPage()

--- a/app/assets/stylesheets/active_admin/components/_pagination.scss
+++ b/app/assets/stylesheets/active_admin/components/_pagination.scss
@@ -32,3 +32,13 @@
 .download_links {
   float: left;
 }
+
+.pagination_per_page {
+  float: right;
+  margin-left: 4px;
+  select {
+    @include light-button;
+    @include rounded(0px);
+    padding: 1px 5px;
+  }
+}

--- a/lib/active_admin/resource_controller/data_access.rb
+++ b/lib/active_admin/resource_controller/data_access.rb
@@ -276,9 +276,21 @@ module ActiveAdmin
 
       def per_page
         if active_admin_config.paginate
-          @per_page || active_admin_config.per_page
+          dynamic_per_page || configured_per_page
         else
           max_per_page
+        end
+      end
+
+      def dynamic_per_page
+        params[:per_page] || @per_page
+      end
+
+      def configured_per_page
+        if active_admin_config.per_page.is_a?(Array)
+          active_admin_config.per_page[0]
+        else
+          active_admin_config.per_page
         end
       end
 

--- a/lib/active_admin/views/components/paginated_collection.rb
+++ b/lib/active_admin/views/components/paginated_collection.rb
@@ -40,6 +40,7 @@ module ActiveAdmin
         @param_name     = options.delete(:param_name)
         @download_links = options.delete(:download_links)
         @display_total  = options.delete(:pagination_total) { true }
+        @per_page       = options.delete(:per_page)
 
         unless collection.respond_to?(:num_pages)
           raise(StandardError, "Collection is not a paginated scope. Set collection.page(params[:page]).per(10) before calling :paginated_collection.")
@@ -63,6 +64,7 @@ module ActiveAdmin
 
       def build_pagination_with_formats(options)
         div id: "index_footer" do
+          build_per_page_select if @per_page.is_a?(Array)
           build_pagination
           div(page_entries_info(options).html_safe, class: "pagination_information")
 
@@ -72,6 +74,21 @@ module ActiveAdmin
             build_download_format_links download_links
           else
             build_download_format_links unless download_links == false
+          end
+        end
+      end
+
+      def build_per_page_select
+        div class: "pagination_per_page" do
+          text_node "Per page:"
+          select do
+            @per_page.each do |per_page|
+              option(
+                per_page,
+                value: per_page,
+                selected: collection.limit_value == per_page ? "selected" : nil
+              )
+            end
           end
         end
       end

--- a/lib/active_admin/views/pages/index.rb
+++ b/lib/active_admin/views/pages/index.rb
@@ -127,11 +127,13 @@ module ActiveAdmin
           paginator        = config.fetch(:paginator, true)
           download_links   = config.fetch(:download_links, active_admin_config.namespace.download_links)
           pagination_total = config.fetch(:pagination_total, true)
+          per_page         = config.fetch(:per_page, active_admin_config.per_page)
 
           paginated_collection(collection, entry_name:       active_admin_config.resource_label,
                                            entries_name:     active_admin_config.plural_resource_label(count: collection_size),
                                            download_links:   download_links,
                                            paginator:        paginator,
+                                           per_page:         per_page,
                                            pagination_total: pagination_total) do
             div class: 'index_content' do
               insert_tag(renderer_class, config, collection)
@@ -159,4 +161,3 @@ module ActiveAdmin
     end
   end
 end
-

--- a/spec/unit/views/components/paginated_collection_spec.rb
+++ b/spec/unit/views/components/paginated_collection_spec.rb
@@ -216,5 +216,21 @@ describe ActiveAdmin::Views::PaginatedCollection do
       end
     end
 
+    context "when specifying per_page: array option" do
+      let(:collection) do
+        posts = 10.times.map { Post.new }
+        Kaminari.paginate_array(posts).page(1).per(5)
+      end
+
+      let(:pagination) { paginated_collection(collection, per_page: [1, 2, 3]) }
+      let(:pagination_html) { pagination.find_by_class("pagination_per_page").first }
+      let(:pagination_node) { Capybara.string(pagination_html.to_s) }
+
+      it "should render per_page select tag" do
+        expect(pagination_html.content).to match(/Per page:/)
+        expect(pagination_node).to have_css("select option", count: 3)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
First of all, I know there were issues and feature requests to support per_page configuration. In one of my project I needed this functionality: allow user to change number of results on one page. And I succeed, but it looked kinda hackish. I know you can do before_filter to set `@per_page` based on some parameter. But: you need to amend each resource, inject some extra html, and ... Maybe it's good idea to deliver that feature out of the box? 

If that sounds like a good candidate to merge, here's how it could word:
* global config from initializer `config.default_per_page` could be set to ether integer or array.
* it could be overwritten in resource controller register `config.per_page`, just like it was before, but now accepting also arrays
* when `per_page` is an array, and pagination on, resource#index adds select with array of options next to pagination links
* selecting some option preserves current query string, manipulating only per_page param

Here's how it would look like:
![screenshot from 2015-01-17 21 39 20](https://cloud.githubusercontent.com/assets/1257520/5790390/fa20d8f6-9e95-11e4-9c8c-3bf9295d5084.png)

What do you guys think?