### PR TITLE
Add parens to method calls used as arg defaults for Ruby 2.2, fix #3733

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ script: bundle exec rake test
 rvm:
   - 1.9.3
   - 2.0.0
+  - 2.2.0
 before_install:
   - gem update --system
   - gem --version
@@ -11,5 +12,8 @@ env:
   - RAILS=3.1.12
   - RAILS=3.2.14
 matrix:
-  allow_failures:
+  exclude:
     - rvm: 2.0.0
+      env: RAILS=3.0.20
+    - rvm: 2.2.0
+      env: RAILS=3.0.20

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ when /^3\.(1|2)/
   # These are the gems you have to have for Rails 3.1 to be happy
   gem 'sass-rails'
   gem 'uglifier'
+  gem "test-unit", "~>3.0" # a rails 3.2 on ruby 2.2 requirement
 else
   raise "Rails #{rails_version} is not supported yet"
 end

--- a/lib/active_admin/helpers/collection.rb
+++ b/lib/active_admin/helpers/collection.rb
@@ -7,7 +7,7 @@ module ActiveAdmin
       # the ORDER statement mentions a column defined in the SELECT statement.
       #
       # We remove the ORDER statement to work around this issue.
-      def collection_size(collection=collection)
+      def collection_size(collection=collection())
         size = collection.reorder("").count
         # when GROUP BY is used, AR returns Hash instead of Fixnum for .size
         size = size.size if size.kind_of?(Hash)
@@ -15,7 +15,7 @@ module ActiveAdmin
         size
       end
 
-      def collection_is_empty?(collection=collection)
+      def collection_is_empty?(collection=collection())
         collection_size(collection) == 0
       end
     end


### PR DESCRIPTION
Ruby 2.2 included a [bug fix](https://bugs.ruby-lang.org/issues/9593) that impacts methods which call other methods as defaults for some of their arguments, e.g., `def bar(foo=foo)`. The fix is to include parenthesis on the method call, `def bar(foo=foo())`. A similar patch was [recently made](https://github.com/rails/rails/commit/e88da370f190cabd1e9750c5b3531735950ab415) to Rails to support Ruby 2.2.

I only found two instances of method calls that used the problematic syntax. Failing tests revealed these methods; the following regex did not find other instances: `def.+\((\S+)\s*=\s*\1\)`.

Additionally, because test-unit is not included with Ruby 2.2 (and is required for ActiveSupport 3.2.x), it has been explicitly included in the Gemfile in the Rails 3.1|2 section.

Tests pass; tested against Rails 3.2.16 & 3-2-stable branch on both Ruby 2.1.5 and 2.2. The JSLint test was not executed because I did not have a JRE set up; I don't think this test is relevant to the issue at hand.

Note that my branch is based off of the 0-6-stable branch, but I suspect this same change is probably relevant to master.