### PR TITLE
Fixes #3583: Associates comments with STI base classes

### DIFF
--- a/features/comments/commenting.feature
+++ b/features/comments/commenting.feature
@@ -143,8 +143,6 @@ Feature: Commenting
     When I add a comment "Hello World"
     Then I should see a flash with "Comment was successfully created"
     And I should be in the resource section for publishers
-    When I am on the index page for comments
-    Then I should see the content "Publisher"
     And I should see "Hello World"
 
   Scenario: Commenting on a class with string id

--- a/lib/active_admin/orm/active_record/comments/comment.rb
+++ b/lib/active_admin/orm/active_record/comments/comment.rb
@@ -16,7 +16,7 @@ module ActiveAdmin
 
     # @return [String] The name of the record to use for the polymorphic relationship
     def self.resource_type(resource)
-      ResourceController::Decorators.undecorate(resource).class.name.to_s
+      ResourceController::Decorators.undecorate(resource).class.base_class.name.to_s
     end
 
     # Postgres adapters won't compare strings to numbers (issue 34)

--- a/spec/unit/comments_spec.rb
+++ b/spec/unit/comments_spec.rb
@@ -126,7 +126,7 @@ describe "Comments" do
           namespace: namespace_name)
 
         expect(ActiveAdmin::Comment.find_for_resource_in_namespace(publisher, namespace_name).last.resource_type).
-          to eq('Publisher')
+          to eq("User")
       end
     end
   end


### PR DESCRIPTION
The Rails convention of a polymorphic belongs_to is to associate with the base class
not the subclass.  The makes the association more durable, in the case that a model instance
changes its type (switches subclasses).  In addition, all comments through 0.6.x were
associated with the resource base class.  The change to associate with the subclass has
orphaned those Comments.  This change fixes those problems.