### PR TITLE
Fix default delete prompt on Rails 3.0.x

### DIFF
--- a/lib/active_admin/resource/action_items.rb
+++ b/lib/active_admin/resource/action_items.rb
@@ -70,7 +70,7 @@ module ActiveAdmin
           if controller.action_methods.include?("destroy") && authorized?(ActiveAdmin::Auth::DESTROY, resource)
             link_to(I18n.t('active_admin.delete_model', :model => active_admin_config.resource_label),
               resource_path(resource),
-              :method => :delete, :data => {:confirm => I18n.t('active_admin.delete_confirmation')})
+              :method => :delete, 'data-confirm' => I18n.t('active_admin.delete_confirmation'))
           end
         end
       end

--- a/lib/active_admin/views/index_as_table.rb
+++ b/lib/active_admin/views/index_as_table.rb
@@ -194,7 +194,7 @@ module ActiveAdmin
               links << link_to(I18n.t('active_admin.edit'), edit_resource_path(resource), :class => "member_link edit_link")
             end
             if controller.action_methods.include?('destroy') && authorized?(ActiveAdmin::Auth::DESTROY, resource)
-              links << link_to(I18n.t('active_admin.delete'), resource_path(resource), :method => :delete, :data => {:confirm => I18n.t('active_admin.delete_confirmation')}, :class => "member_link delete_link")
+              links << link_to(I18n.t('active_admin.delete'), resource_path(resource), :method => :delete, 'data-confirm' => I18n.t('active_admin.delete_confirmation'), :class => "member_link delete_link")
             end
             links
           end


### PR DESCRIPTION
Comes through in HTML with a data=“{:ruby=>’hash’}”

