### PR TITLE
WIP: DataAccess module impovements

### DIFF
--- a/docs/9-batch-actions.md
+++ b/docs/9-batch-actions.md
@@ -21,7 +21,7 @@ your desired batch action on all of them:
 ```ruby
 ActiveAdmin.register Post do
   batch_action :flag do |ids|
-    Post.find(ids).each do |post|
+    batch_action_collection.find(ids).each do |post|
       post.flag! :hot
     end
     redirect_to collection_path, alert: "The posts have been flagged."

--- a/lib/active_admin/batch_actions/controller.rb
+++ b/lib/active_admin/batch_actions/controller.rb
@@ -25,8 +25,16 @@ module ActiveAdmin
         active_admin_config.batch_actions.detect{ |action| action.sym.to_s == params[:batch_action] }
       end
 
+      COLLECTION_APPLIES = [
+        :authorization_scope,
+        :collection_decorator,
+        :filtering,
+        :scoping,
+        :includes
+      ].freeze
+
       def batch_action_collection
-        find_collection(only: [:authorization_scope, :collection_decorator, :filtering, :scoping])
+        find_collection(only: COLLECTION_APPLIES)
       end
     end
   end

--- a/lib/active_admin/batch_actions/controller.rb
+++ b/lib/active_admin/batch_actions/controller.rb
@@ -25,6 +25,9 @@ module ActiveAdmin
         active_admin_config.batch_actions.detect{ |action| action.sym.to_s == params[:batch_action] }
       end
 
+      def batch_action_collection
+        find_collection(only: [:authorization_scope, :collection_decorator, :filtering, :scoping])
+      end
     end
   end
 end

--- a/lib/active_admin/batch_actions/controller.rb
+++ b/lib/active_admin/batch_actions/controller.rb
@@ -33,8 +33,8 @@ module ActiveAdmin
         :includes
       ].freeze
 
-      def batch_action_collection
-        find_collection(only: COLLECTION_APPLIES)
+      def batch_action_collection(only = COLLECTION_APPLIES)
+        find_collection(only: only)
       end
     end
   end

--- a/lib/active_admin/batch_actions/resource_extension.rb
+++ b/lib/active_admin/batch_actions/resource_extension.rb
@@ -67,7 +67,10 @@ module ActiveAdmin
         }
 
         add_batch_action :destroy, proc { I18n.t('active_admin.delete') }, destroy_options do |selected_ids|
-          active_admin_config.resource_class.find(selected_ids).each { |r| r.destroy }
+          batch_action_collection.find(selected_ids).each do |record|
+            authorize! ActiveAdmin::Auth::DESTROY, record
+            destroy_resource(record)
+          end
 
           redirect_to active_admin_config.route_collection_path(params),
                       notice: I18n.t("active_admin.batch_actions.succesfully_destroyed",

--- a/lib/active_admin/csv_builder.rb
+++ b/lib/active_admin/csv_builder.rb
@@ -40,7 +40,7 @@ module ActiveAdmin
     end
 
     def build(controller, receiver)
-      @collection = controller.send(:collection)
+      @collection = controller.send(:find_collection, except: :pagination)
       options = ActiveAdmin.application.csv_options.merge self.options
       columns = exec_columns controller.view_context
 

--- a/lib/active_admin/resource_controller/data_access.rb
+++ b/lib/active_admin/resource_controller/data_access.rb
@@ -274,7 +274,7 @@ module ActiveAdmin
         chain.public_send(page_method_name, page).per(per_page)
       end
 
-      def collection_applies(options)
+      def collection_applies(options = {})
         only = Array(options.fetch(:only, COLLECTION_APPLIES))
         except = Array(options.fetch(:except, []))
         COLLECTION_APPLIES && only - except

--- a/lib/active_admin/resource_controller/data_access.rb
+++ b/lib/active_admin/resource_controller/data_access.rb
@@ -19,6 +19,16 @@ module ActiveAdmin
 
       protected
 
+      COLLECTION_APPLIES = [
+        :authorization_scope,
+        :sorting,
+        :filtering,
+        :scoping,
+        :includes,
+        :pagination,
+        :collection_decorator
+      ].freeze
+
       # Retrieve, memoize and authorize the current collection from the db. This
       # method delegates the finding of the collection to #find_collection.
       #
@@ -41,22 +51,12 @@ module ActiveAdmin
       # some additional db # work before your controller returns and
       # authorizes the collection.
       #
-      # @return [ActiveRecord::Relation] The collectin for the index
-      def find_collection
+      # @return [ActiveRecord::Relation] The collection for the index
+      def find_collection(options = {})
         collection = scoped_collection
-
-        collection = apply_authorization_scope(collection)
-        collection = apply_sorting(collection)
-        collection = apply_filtering(collection)
-        collection = apply_scoping(collection)
-        collection = apply_includes(collection)
-
-        unless request.format == 'text/csv'
-          collection = apply_pagination(collection)
+        collection_applies(options).each do |applyer|
+          collection = send("apply_#{applyer}", collection)
         end
-
-        collection = apply_collection_decorator(collection)
-
         collection
       end
 
@@ -272,6 +272,12 @@ module ActiveAdmin
         page = params[Kaminari.config.param_name]
 
         chain.public_send(page_method_name, page).per(per_page)
+      end
+
+      def collection_applies(options)
+        only = Array(options.fetch(:only, COLLECTION_APPLIES))
+        except = Array(options.fetch(:except, []))
+        COLLECTION_APPLIES && only - except
       end
 
       def per_page

--- a/spec/unit/csv_builder_spec.rb
+++ b/spec/unit/csv_builder_spec.rb
@@ -192,6 +192,10 @@ describe ActiveAdmin::CSVBuilder do
     end
     let(:dummy_controller) {
       class DummyController
+        def find_collection(*)
+          collection
+        end
+
         def collection
           Post.order('published_at DESC')
         end
@@ -218,6 +222,15 @@ describe ActiveAdmin::CSVBuilder do
       expect(builder).to receive(:build_row).and_return([]).once.ordered { |post| expect(post.id).to eq @post1.id }
       builder.build dummy_controller, []
     end
+
+    it "should generate data ignoring pagination" do
+      expect(dummy_controller).to receive(:find_collection).
+                                      with(except: :pagination).once.
+                                      and_call_original
+      expect(builder).to receive(:build_row).and_return([]).twice
+      builder.build dummy_controller, []
+    end
+
   end
 
   skip '#exec_columns'

--- a/spec/unit/csv_builder_spec.rb
+++ b/spec/unit/csv_builder_spec.rb
@@ -225,8 +225,8 @@ describe ActiveAdmin::CSVBuilder do
 
     it "should generate data ignoring pagination" do
       expect(dummy_controller).to receive(:find_collection).
-                                      with(except: :pagination).once.
-                                      and_call_original
+        with(except: :pagination).once.
+        and_call_original
       expect(builder).to receive(:build_row).and_return([]).twice
       builder.build dummy_controller, []
     end


### PR DESCRIPTION
Goal of this PR is to provide flexible access to collection in different scopes of request livecycle.
DataAccess#find_collection  becomes more generic and can return different result depends on ```options``` argument.
Can be used in batch actions (no sorting,pagination needed), csv exports(no pagination needed), etc

