### PR TITLE
Ambiguous coffeescript leading to occasional javascript errors

### DIFF
--- a/app/assets/javascripts/active_admin/lib/checkbox-toggler.js.coffee
+++ b/app/assets/javascripts/active_admin/lib/checkbox-toggler.js.coffee
@@ -1,7 +1,7 @@
 class ActiveAdmin.CheckboxToggler
   constructor: (@options, @container)->
     defaults = {}
-    @options = $.extend defaults, options
+    @options = $.extend defaults, @options
     @_init()
     @_bind()
 

--- a/app/assets/javascripts/active_admin/lib/dropdown-menu.js.coffee
+++ b/app/assets/javascripts/active_admin/lib/dropdown-menu.js.coffee
@@ -9,7 +9,7 @@ class ActiveAdmin.DropdownMenu
       onClickActionItemCallback: null
     }
 
-    @options = $.extend defaults, options
+    @options = $.extend defaults, @options
     @isOpen  = false
 
     @$menuButton = @$element.find '.dropdown_menu_button'


### PR DESCRIPTION
I'be been running into an occasional problem where suddenly my javascript checkboxes and batch actions will stop working. I traced this to the fact that the coffeescript appears to be ambiguous in it's use of the "options" variable. This leads to the coffeescript compiler sometimes producing the correct javascript and sometimes producing javascript that results in an "unknown variable" error.