### PR TITLE
Fall back to rspec-rails 3.1.x because of failing tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ group :test do
   gem 'launchy'
   gem 'rails-i18n' # Provides default i18n for many languages
   gem 'rspec'
-  gem 'rspec-rails'
+  gem 'rspec-rails', '~> 3.1.0'
   gem 'i18n-spec'
   gem 'shoulda-matchers'
   gem 'sqlite3'


### PR DESCRIPTION
Should get the tests on travis passing and fix #3781 