### PR TITLE
favicon_link_tag doesn't require the /assets prefix anymore

### DIFF
--- a/lib/generators/active_admin/install/templates/active_admin.rb.erb
+++ b/lib/generators/active_admin/install/templates/active_admin.rb.erb
@@ -142,7 +142,7 @@ ActiveAdmin.setup do |config|
 
   # == Setting a Favicon
   #
-  # config.favicon = '/assets/favicon.ico'
+  # config.favicon = 'favicon.ico'
 
   # == Removing Breadcrumbs
   #


### PR DESCRIPTION
Fixes the following error: Asset names passed to helpers should not include the "/assets/" prefix. Instead of "/assets/favicon.ico", use "favicon.ico"