### PR TITLE
Fixes 3100

### DIFF
--- a/app/assets/stylesheets/active_admin/_forms.scss
+++ b/app/assets/stylesheets/active_admin/_forms.scss
@@ -114,7 +114,6 @@ form {
         float: left;
         width: 100%;
         margin: 0;
-        padding: 0;
       }
     }
   }


### PR DESCRIPTION
See https://github.com/activeadmin/activeadmin/issues/3100

The padding set to 0 prevents block from displaying on the right of the title.

Radio and checkboxes have the problem, simply corrected by removing the padding:0 propety.

I checked in simple & nested forms, and visually with browserStack, works well from IE9, works with firefox 3.6+, chrome, safari. 

All tests pass.

I created static pages so that you can visually see the result:

http://davidb583.github.io/activeadmin-static-3100-bugfix-1/
http://davidb583.github.io/activeadmin-static-3100-bugfix-2/