### PR TITLE
Style 'date' input type

### DIFF
--- a/app/assets/javascripts/active_admin/application.js.coffee
+++ b/app/assets/javascripts/active_admin/application.js.coffee
@@ -1,10 +1,15 @@
 # Initializers
 $(document).on 'ready page:load', ->
   # jQuery datepickers (also evaluates dynamically added HTML)
-  $(document).on 'focus', '.datepicker:not(.hasDatepicker)', ->
+  $(document).on 'focus', 'input.datepicker:not(.hasDatepicker)', ->
+    $input = $(@)
+
+    # Only applying datepicker to compatible browsers
+    return if $input[0].type is 'date'
+
     defaults = dateFormat: 'yy-mm-dd'
-    options = $(@).data 'datepicker-options'
-    $(@).datepicker $.extend(defaults, options)
+    options = $input.data 'datepicker-options'
+    $input.datepicker $.extend(defaults, options)
 
   # Clear Filters button
   $('.clear_filters_btn').click ->

--- a/app/assets/stylesheets/active_admin/_forms.scss
+++ b/app/assets/stylesheets/active_admin/_forms.scss
@@ -119,7 +119,14 @@ form {
   }
 
   /* Text Fields */
-  input[type=text], input[type=password], input[type=email], input[type=number], input[type=url], input[type=tel], textarea {
+  input[type=text],
+  input[type=password],
+  input[type=email],
+  input[type=number],
+  input[type=url],
+  input[type=tel],
+  input[type=date],
+  textarea {
     width: calc(80% - #{$text-input-total-padding});
     border: $border-width solid #c9d0d6;
     @include rounded;
@@ -132,6 +139,10 @@ form {
       border: $border-width solid #99a2aa;
       @include shadow(0,0,4px,#99a2aa);
     }
+  }
+
+  input[type=date] {
+    width: calc(100% - #{$text-input-total-padding});
   }
 
   fieldset > ol > li {

--- a/lib/active_admin/inputs.rb
+++ b/lib/active_admin/inputs.rb
@@ -9,6 +9,7 @@ module ActiveAdmin
 
       autoload :Base
       autoload :StringInput
+      autoload :DatePickerInput
       autoload :DateRangeInput
       autoload :NumericInput
       autoload :SelectInput

--- a/lib/active_admin/inputs/filters/date_picker_input.rb
+++ b/lib/active_admin/inputs/filters/date_picker_input.rb
@@ -1,0 +1,13 @@
+module ActiveAdmin
+  module Inputs
+    module Filters
+      class DatePickerInput < ::Formtastic::Inputs::DatePickerInput
+        include Base
+
+        def input_html_options
+          super.merge(class: "datepicker")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #3817. Adds logic to skip `datepicker()` call if browser is WebKit and the input type is `date`.

### Code
``` RUBY
ActiveAdmin.register Post do
  filter :published_at, as: :date_picker
  filter :created_at
end
```

### On Chrome
![screen shot 2015-02-25 at 8 52 04 pm](https://cloud.githubusercontent.com/assets/397982/6384861/891a7f0e-bd30-11e4-9586-27549738e578.png)

### On Firefox
![screen shot 2015-02-25 at 8 51 55 pm](https://cloud.githubusercontent.com/assets/397982/6384869/a35da21a-bd30-11e4-9e7b-914f27669283.png)

------------
One thing to note: There's a similarly named class called `datepicker_input`. I think it's fine to rename it into something more descriptive (and less conflicting) but I wanted to check first.