### PR TITLE
Compression removes em if 1.0 used

### DIFF
--- a/app/assets/stylesheets/active_admin/mixins/_sections.scss
+++ b/app/assets/stylesheets/active_admin/mixins/_sections.scss
@@ -5,7 +5,7 @@
   @include border-colors(#e6e6e6, #d4d4d4, #cdcdcd);
   box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 0 1px #FFF inset;
 
-  font-size: 1.0em;
+  font-size: 1em;
   font-weight: bold;
   line-height: 18px;
   margin-bottom: 0.5em;


### PR DESCRIPTION
The default css compressor in Rails is sass.  Sass removes em on compression when 1.0em is used, thus resulting in invalid css that is ignored by the browser.
I'm not sure if this will be fixed in sass, but others suggest using 1em to resolve the issue.
I tested and this resolves the issue for us.