### PR TITLE
Update and validate CSS vendor prefixes

### DIFF
--- a/app/assets/stylesheets/active_admin/components/_blank_slates.scss
+++ b/app/assets/stylesheets/active_admin/components/_blank_slates.scss
@@ -4,7 +4,6 @@
 
   .blank_slate {
     @include rounded;
-    -webkit-font-smoothing: antialiased;
     border:  $blank-slate-border;
     color: $blank-slate-primary-color;
     display: inline-block;

--- a/app/assets/stylesheets/active_admin/components/_date_picker.scss
+++ b/app/assets/stylesheets/active_admin/components/_date_picker.scss
@@ -1,8 +1,6 @@
 // -------------------------------------- Date Picker
 .ui-datepicker {
   background: #fff;
-  -webkit-background-clip: padding-box;
-  -moz-background-clip: padding-box;
   background-clip: padding-box;
   color: #fff;
   display: none;

--- a/app/assets/stylesheets/active_admin/components/_dropdown_menu.scss
+++ b/app/assets/stylesheets/active_admin/components/_dropdown_menu.scss
@@ -116,7 +116,6 @@
           padding: 7px 16px 5px;
           text-decoration: none;
           text-align: center;
-          -webkit-font-smoothing: antialiased;
           white-space: nowrap;
 
           &:hover {

--- a/app/assets/stylesheets/active_admin/components/_popovers.scss
+++ b/app/assets/stylesheets/active_admin/components/_popovers.scss
@@ -88,7 +88,6 @@
         padding: 7px 16px 5px;
         text-decoration: none;
         text-align: center;
-        -webkit-font-smoothing: antialiased;
 
         &:hover {
           @include highlight-gradient;

--- a/app/assets/stylesheets/active_admin/components/_tables.scss
+++ b/app/assets/stylesheets/active_admin/components/_tables.scss
@@ -27,7 +27,6 @@ table.index_table {
       text-decoration: none;
       display: block;
       white-space: nowrap;
-      -webkit-font-smoothing: antialiased;
     }
 
     &.sortable a {

--- a/app/assets/stylesheets/active_admin/mixins/_buttons.scss
+++ b/app/assets/stylesheets/active_admin/mixins/_buttons.scss
@@ -8,7 +8,6 @@
   margin-right: 3px;
   padding: 7px 16px 6px;
   text-decoration: none;
-  -webkit-font-smoothing: antialiased;
 
   &.disabled {
     opacity: 0.5;

--- a/app/assets/stylesheets/active_admin/mixins/_gradients.scss
+++ b/app/assets/stylesheets/active_admin/mixins/_gradients.scss
@@ -2,10 +2,9 @@ $secondary-gradient-start: #efefef !default;
 $secondary-gradient-stop: #dfe1e2 !default;
 
 @mixin gradient($start, $end){
-  background: $start;
-  background: -webkit-linear-gradient(-90deg, $start, $end);
-  background: -moz-linear-gradient(-90deg, $start, $end);
-  background: linear-gradient(180deg, $start, $end);
+  background-color: $start;
+  background-image: -webkit-linear-gradient(-90deg, $start, $end);
+  background-image: linear-gradient(180deg, $start, $end);
   // IE 6 & 7
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#{ie-hex-str($start)}', endColorstr='#{ie-hex-str($end)}');
   // IE 8
@@ -30,7 +29,7 @@ $secondary-gradient-stop: #dfe1e2 !default;
 }
 
 @mixin no-gradient {
-  background: none;
+  background-color: none;
   // IE 6 & 7
   filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
   // IE 8

--- a/app/assets/stylesheets/active_admin/mixins/_gradients.scss
+++ b/app/assets/stylesheets/active_admin/mixins/_gradients.scss
@@ -3,7 +3,6 @@ $secondary-gradient-stop: #dfe1e2 !default;
 
 @mixin gradient($start, $end){
   background-color: $start;
-  background-image: -webkit-linear-gradient(-90deg, $start, $end);
   background-image: linear-gradient(180deg, $start, $end);
 }
 

--- a/app/assets/stylesheets/active_admin/mixins/_gradients.scss
+++ b/app/assets/stylesheets/active_admin/mixins/_gradients.scss
@@ -5,10 +5,6 @@ $secondary-gradient-stop: #dfe1e2 !default;
   background-color: $start;
   background-image: -webkit-linear-gradient(-90deg, $start, $end);
   background-image: linear-gradient(180deg, $start, $end);
-  // IE 6 & 7
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#{ie-hex-str($start)}', endColorstr='#{ie-hex-str($end)}');
-  // IE 8
-  -ms-filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#{ie-hex-str($start)}', endColorstr='#{ie-hex-str($end)}');
 }
 
 @mixin primary-gradient {
@@ -30,8 +26,4 @@ $secondary-gradient-stop: #dfe1e2 !default;
 
 @mixin no-gradient {
   background-color: none;
-  // IE 6 & 7
-  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
-  // IE 8
-  -ms-filter: "progid:DXImageTransform.Microsoft.gradient(enabled=false)";
 }

--- a/app/assets/stylesheets/active_admin/mixins/_rounded.scss
+++ b/app/assets/stylesheets/active_admin/mixins/_rounded.scss
@@ -1,43 +1,22 @@
 @mixin rounded($radius: 3px) {
-  -webkit-border-radius: $radius;
-  -moz-border-radius: $radius;
   border-radius: $radius;
 }
 
 @mixin rounded-all($top-left:3px, $top-right:3px, $bottom-right:3px, $bottom-left:3px) {
   border-top-right-radius: $top-right;
-  -moz-border-radius-topright: $top-right;
-  -webkit-border-top-right-radius: $top-right;
-
   border-top-left-radius: $top-left;
-  -moz-border-radius-topleft: $top-left;
-  -webkit-border-top-left-radius: $top-left;
-
   border-bottom-right-radius: $bottom-right;
-  -moz-border-radius-bottomright: $bottom-right;
-  -webkit-border-bottom-right-radius: $bottom-right;
-
   border-bottom-left-radius: $bottom-left;
-  -moz-border-radius-bottomleft: $bottom-left;
-  -webkit-border-bottom-left-radius: $bottom-left;
 }
 
 @mixin rounded-top($radius: 3px) {
   @include rounded(0);
   border-top-right-radius: $radius;
   border-top-left-radius: $radius;
-  -moz-border-radius-topright: $radius;
-  -moz-border-radius-topleft: $radius;
-  -webkit-border-top-right-radius: $radius;
-  -webkit-border-top-left-radius: $radius;
 }
 
 @mixin rounded-bottom($radius: 3px) {
   @include rounded(0);
   border-bottom-right-radius: $radius;
   border-bottom-left-radius: $radius;
-  -moz-border-radius-bottomright: $radius;
-  -moz-border-radius-bottomleft: $radius;
-  -webkit-border-bottom-right-radius: $radius;
-  -webkit-border-bottom-left-radius: $radius;
 }

--- a/app/assets/stylesheets/active_admin/mixins/_shadows.scss
+++ b/app/assets/stylesheets/active_admin/mixins/_shadows.scss
@@ -1,22 +1,18 @@
 @mixin shadow($x: 0, $y: 1px, $blur: 2px, $color: rgba(0,0,0,0.37)) {
   box-shadow: $x $y $blur $color;
-  -moz-box-shadow: $x $y $blur $color;
   -webkit-box-shadow: $x $y $blur $color;
 }
 
 @mixin no-shadow {
   box-shadow: none;
-  -moz-box-shadow: none;
   -webkit-box-shadow: none;
 }
 
 @mixin inset-shadow($x: 0, $y: 1px, $blur: 2px, $color: #aaa) {
   box-shadow: inset $x $y $blur $color;
-  -moz-box-shadow: inset $x $y $blur $color;
   -webkit-box-shadow: inset $x $y $blur $color;
 }
 
 @mixin text-shadow($color: #fff, $x: 0, $y: 1px, $blur: 0) {
   text-shadow: $color $x $y $blur;
 }
-

--- a/app/assets/stylesheets/active_admin/mixins/_shadows.scss
+++ b/app/assets/stylesheets/active_admin/mixins/_shadows.scss
@@ -1,16 +1,13 @@
 @mixin shadow($x: 0, $y: 1px, $blur: 2px, $color: rgba(0,0,0,0.37)) {
   box-shadow: $x $y $blur $color;
-  -webkit-box-shadow: $x $y $blur $color;
 }
 
 @mixin no-shadow {
   box-shadow: none;
-  -webkit-box-shadow: none;
 }
 
 @mixin inset-shadow($x: 0, $y: 1px, $blur: 2px, $color: #aaa) {
   box-shadow: inset $x $y $blur $color;
-  -webkit-box-shadow: inset $x $y $blur $color;
 }
 
 @mixin text-shadow($color: #fff, $x: 0, $y: 1px, $blur: 0) {

--- a/app/assets/stylesheets/active_admin/mixins/_utilities.scss
+++ b/app/assets/stylesheets/active_admin/mixins/_utilities.scss
@@ -9,8 +9,6 @@
 }
 
 @mixin box-sizing($value: border-box) {
-  -moz-box-sizing: $value;
-  -webkit-box-sizing: $value;
   box-sizing: $value;
 }
 

--- a/app/assets/stylesheets/active_admin/mixins/_utilities.scss
+++ b/app/assets/stylesheets/active_admin/mixins/_utilities.scss
@@ -11,8 +11,6 @@
 @mixin box-sizing($value: border-box) {
   -moz-box-sizing: $value;
   -webkit-box-sizing: $value;
-  -o-box-sizing: $value;
-  -ms-box-sizing: $value;
   box-sizing: $value;
 }
 


### PR DESCRIPTION
These vendor prefixes were out of date and no longer valid, creating CSS warnings. This pull request removes the unnecessary prefixes, as well as corrects some shortcuts that were not valid CSS. This primarily concerns `background`; you should be using `background-color` and `background-image` when dealing with gradients, as `background` is technically not a valid CSS property to be handling just the gradients.

For reference checking, please see [CSS3Please](http://css3please.com/) for further commentary as to the validity of the changes in this pull request.