### PR TITLE
Optional Boilerplate Generation

### DIFF
--- a/lib/active_admin/generators/boilerplate.rb
+++ b/lib/active_admin/generators/boilerplate.rb
@@ -1,0 +1,37 @@
+module ActiveAdmin
+  module Generators
+    class Boilerplate
+      def initialize(class_name)
+        @class_name = class_name
+      end
+
+      def attributes
+        @class_name.constantize.new.attributes.keys
+      end
+
+      def rows
+        attributes.map { |a| row(a) }.join("\n")
+      end
+
+      def row(name)
+        "#   row :#{name.gsub(/_id$/, '')}"
+      end
+
+      def columns
+        attributes.map { |a| column(a) }.join("\n")
+      end
+
+      def column(name)
+        "#   column :#{name.gsub(/_id$/, '')}"
+      end
+
+      def filters
+        attributes.map { |a| filter(a) }.join("\n")
+      end
+
+      def filter(name)
+        "# filter :#{name.gsub(/_id$/, '')}"
+      end
+    end
+  end
+end

--- a/lib/generators/active_admin/resource/resource_generator.rb
+++ b/lib/generators/active_admin/resource/resource_generator.rb
@@ -5,10 +5,13 @@ module ActiveAdmin
     class ResourceGenerator < Rails::Generators::NamedBase
       desc "Registers resources with Active Admin"
 
+      class_option :include_boilerplate, type: :boolean, default: false,
+        desc: "Generate boilerplate code for your resource."
+
       source_root File.expand_path("../templates", __FILE__)
 
       def generate_config_file
-        @formatter = ActiveAdmin::Generators::Boilerplate.new(class_name)
+        @boilerplate = ActiveAdmin::Generators::Boilerplate.new(class_name)
         template "admin.rb", "app/admin/#{file_path.tr('/', '_')}.rb"
       end
 

--- a/lib/generators/active_admin/resource/resource_generator.rb
+++ b/lib/generators/active_admin/resource/resource_generator.rb
@@ -1,3 +1,5 @@
+require 'active_admin/generators/boilerplate'
+
 module ActiveAdmin
   module Generators
     class ResourceGenerator < Rails::Generators::NamedBase
@@ -6,6 +8,7 @@ module ActiveAdmin
       source_root File.expand_path("../templates", __FILE__)
 
       def generate_config_file
+        @formatter = ActiveAdmin::Generators::Boilerplate.new(class_name)
         template "admin.rb", "app/admin/#{file_path.tr('/', '_')}.rb"
       end
 

--- a/lib/generators/active_admin/resource/templates/admin.rb
+++ b/lib/generators/active_admin/resource/templates/admin.rb
@@ -1,17 +1,26 @@
 ActiveAdmin.register <%= class_name %> do
 
-# Available Filters
-#<% class_name.constantize.new.attributes.keys.each do |attr| %>
-# filter :<%= attr.gsub(/_id$/, '') %><% end %>
+# Limit actions available to your users by adding them to the 'except' array
+# actions :all, except: []
 
-# Sample Index
-#
+# Add or remove filters (you can use any ActiveRecord scope) to toggle their
+# visibility in the sidebar
+<%= @formatter.filters %>
+
+# Add or remove columns to toggle their visiblity in the index action
 # index do
 #   selectable_column
-#   id_column<% class_name.constantize.new.attributes.keys.each do |attr| %>
-#   column :<%= attr.gsub(/_id$/, '') %><% end %>
+#   id_column
+<%= @formatter.columns %>
 #   actions
 # end
+
+# Add or remove rows to toggle their visiblity in the show action
+# show do |<%= class_name.downcase %>|
+<%= @formatter.rows %>
+# end
+
+# Add or remove fields to toggle their visibility in the form
 
 <% if Rails::VERSION::MAJOR == 4 || defined?(ActionController::StrongParameters) %>
   # See permitted parameters documentation:
@@ -27,6 +36,4 @@ ActiveAdmin.register <%= class_name %> do
   #   permitted
   # end
 <% end %>
-
-
 end

--- a/lib/generators/active_admin/resource/templates/admin.rb
+++ b/lib/generators/active_admin/resource/templates/admin.rb
@@ -1,5 +1,18 @@
 ActiveAdmin.register <%= class_name %> do
 
+# Available Filters
+#<% class_name.constantize.new.attributes.keys.each do |attr| %>
+# filter :<%= attr.gsub(/_id$/, '') %><% end %>
+
+# Sample Index
+#
+# index do
+#   selectable_column
+#   id_column<% class_name.constantize.new.attributes.keys.each do |attr| %>
+#   column :<%= attr.gsub(/_id$/, '') %><% end %>
+#   actions
+# end
+
 <% if Rails::VERSION::MAJOR == 4 || defined?(ActionController::StrongParameters) %>
   # See permitted parameters documentation:
   # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
@@ -14,5 +27,6 @@ ActiveAdmin.register <%= class_name %> do
   #   permitted
   # end
 <% end %>
+
 
 end

--- a/lib/generators/active_admin/resource/templates/admin.rb
+++ b/lib/generators/active_admin/resource/templates/admin.rb
@@ -1,4 +1,18 @@
 ActiveAdmin.register <%= class_name %> do
+<% if Rails::VERSION::MAJOR == 4 || defined?(ActionController::StrongParameters) %>
+  # See permitted parameters documentation:
+  # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
+  #
+  # permit_params :list, :of, :attributes, :on, :model
+  #
+  # or
+  #
+  # permit_params do
+  #   permitted = [:permitted, :attributes]
+  #   permitted << :other if resource.something?
+  #   permitted
+  # end
+<% end %>
 <% if options.include_boilerplate? %>
 # Limit actions available to your users by adding them to the 'except' array
 # actions :all, except: []
@@ -21,19 +35,5 @@ ActiveAdmin.register <%= class_name %> do
 # end
 
 # Add or remove fields to toggle their visibility in the form
-<% end %>
-<% if Rails::VERSION::MAJOR == 4 || defined?(ActionController::StrongParameters) %>
-  # See permitted parameters documentation:
-  # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
-  #
-  # permit_params :list, :of, :attributes, :on, :model
-  #
-  # or
-  #
-  # permit_params do
-  #   permitted = [:permitted, :attributes]
-  #   permitted << :other if resource.something?
-  #   permitted
-  # end
 <% end %>
 end

--- a/lib/generators/active_admin/resource/templates/admin.rb
+++ b/lib/generators/active_admin/resource/templates/admin.rb
@@ -1,27 +1,27 @@
 ActiveAdmin.register <%= class_name %> do
-
+<% if options.include_boilerplate? %>
 # Limit actions available to your users by adding them to the 'except' array
 # actions :all, except: []
 
 # Add or remove filters (you can use any ActiveRecord scope) to toggle their
 # visibility in the sidebar
-<%= @formatter.filters %>
+<%= @boilerplate.filters %>
 
 # Add or remove columns to toggle their visiblity in the index action
 # index do
 #   selectable_column
 #   id_column
-<%= @formatter.columns %>
+<%= @boilerplate.columns %>
 #   actions
 # end
 
 # Add or remove rows to toggle their visiblity in the show action
 # show do |<%= class_name.downcase %>|
-<%= @formatter.rows %>
+<%= @boilerplate.rows %>
 # end
 
 # Add or remove fields to toggle their visibility in the form
-
+<% end %>
 <% if Rails::VERSION::MAJOR == 4 || defined?(ActionController::StrongParameters) %>
   # See permitted parameters documentation:
   # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters


### PR DESCRIPTION
Proof of concept branch for #3807 

@timoschilling Is this something we want to pursue? Will output the following (as-is, I imagine we would want to change the copy):

``` RUBY
ActiveAdmin.register Post do

# Available Filters
#
# filter :id
# filter :title
# filter :body
# filter :published_at
# filter :author
# filter :position
# filter :custom_category
# filter :starred
# filter :foo
# filter :created_at
# filter :updated_at

# Sample Index
#
# index do
#   selectable_column
#   id_column
#   column :id
#   column :title
#   column :body
#   column :published_at
#   column :author
#   column :position
#   column :custom_category
#   column :starred
#   column :foo
#   column :created_at
#   column :updated_at
#   actions
# end
end
```

Of course, this wouldn't be enabled by default. The syntax could be something like `rails g active_admin:resource --include-boilerplate`