### PR TITLE
fix exporting csv with frozen attributes

### DIFF
--- a/lib/active_admin/csv_builder.rb
+++ b/lib/active_admin/csv_builder.rb
@@ -75,7 +75,7 @@ module ActiveAdmin
 
     def encode(content, options)
       if options[:encoding]
-        content.to_s.encode! options[:encoding], options[:encoding_options]
+        content.to_s.encode options[:encoding], options[:encoding_options]
       else
         content
       end


### PR DESCRIPTION
String#encode! throws "can't modify frozen String" when called on a frozen string. By using #encode instead, we aren't mutating the string.