### PR TITLE
Thread-unsafe use of url_helpers

### DIFF
--- a/lib/active_admin/devise.rb
+++ b/lib/active_admin/devise.rb
@@ -36,10 +36,8 @@ module ActiveAdmin
         namespace = ActiveAdmin.application.default_namespace.presence
         root_path_method = [namespace, :root_path].compact.join('_')
 
-        url_helpers = Rails.application.routes.url_helpers
-
-        path = if url_helpers.respond_to? root_path_method
-                 url_helpers.send root_path_method
+        path = if Helpers::Routes.respond_to? root_path_method
+                 Helpers::Routes.send root_path_method
                else
                  # Guess a root_path when url_helpers not helpful
                  "/#{namespace}"

--- a/lib/active_admin/engine.rb
+++ b/lib/active_admin/engine.rb
@@ -8,5 +8,9 @@ module ActiveAdmin
         app.config.assets.precompile << path
       end
     end
+
+    initializer 'active_admin.routes' do
+      require 'active_admin/helpers/routes/url_helpers'
+    end
   end
 end

--- a/lib/active_admin/helpers/routes/url_helpers.rb
+++ b/lib/active_admin/helpers/routes/url_helpers.rb
@@ -1,0 +1,15 @@
+module ActiveAdmin
+  module Helpers
+    module Routes
+      module UrlHelpers
+        include Rails.application.routes.url_helpers
+      end
+
+      extend UrlHelpers
+
+      def self.default_url_options
+        Rails.application.config.action_mailer.default_url_options || {}
+      end
+    end
+  end
+end

--- a/lib/active_admin/resource/routes.rb
+++ b/lib/active_admin/resource/routes.rb
@@ -107,7 +107,7 @@ module ActiveAdmin
         end
 
         def routes
-          Rails.application.routes.url_helpers
+          Helpers::Routes
         end
       end
     end


### PR DESCRIPTION
There are two files that are thread unsafe by virtue of using `Rails.application.routes.url_helpers` in threaded code: 

1. [lib/active_admin/devise.rb:39](https://github.com/activeadmin/activeadmin/blob/master/lib/active_admin/devise.rb#L39)
2. [lib/active_admin/resource/routes:110](https://github.com/activeadmin/activeadmin/blob/master/lib/active_admin/resource/routes.rb#L110)

This is actually due to a bug in MRI (https://github.com/puma/puma/issues/647)