### PR TITLE
Allow max line length of 120 symbols

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -9,3 +9,6 @@ java_script:
 
 scss:
   enabled: true
+
+Metrics/LineLength:
+  Max: 120


### PR DESCRIPTION
It's a modern value, since most of us are using modern laptops with wide screens, and it seems to be a standard of the active admin's codebase.