### PR TITLE
Fix pagination_total index option to prevent SELECT count(*) queries

### DIFF
--- a/features/index/pagination.feature
+++ b/features/index/pagination.feature
@@ -43,17 +43,21 @@ Feature: Index Pagination
     When I am on the index page for posts
     Then I should not see pagination
 
-    Scenario: Viewing index with pagination_total set to false
-      Given an index configuration of:
-      """
-        ActiveAdmin.register Post do
-          index :pagination_total => false do
-          end
+  Scenario: Viewing index with pagination_total set to false
+    Given an index configuration of:
+    """
+      ActiveAdmin.register Post do
+        config.per_page = 10
+        index :pagination_total => false do
         end
-      """
-      Given 100 posts exist
-      When I am on the index page for posts
-      Then I should see pagination with 4 pages
-      Then I should see "Displaying Posts 1 - 30"
-      And I should not see "Displaying Posts 1 - 30 of 100 in total"
+      end
+    """
+    Given 11 posts exist
+    When I am on the index page for posts
+    Then I should see "Displaying Posts 1 - 10"
+    And I should not see "11 in total"
+    And I should see the pagination "Next" link
 
+    When I follow "Next"
+    Then I should see "Displaying Posts 11 - 11"
+    And I should not see the pagination "Next" link

--- a/features/step_definitions/pagination_steps.rb
+++ b/features/step_definitions/pagination_steps.rb
@@ -5,3 +5,11 @@ end
 Then /^I should see pagination with (\d+) pages$/ do |count|
   expect(page).to have_css '.pagination span.page', count: count
 end
+
+Then /^I should see the pagination "Next" link/ do
+  expect(page).to have_css "a", text: "Next"
+end
+
+Then /^I should not see the pagination "Next" link/ do
+  expect(page).to_not have_css "a", text: "Next"
+end

--- a/lib/active_admin/views/components/paginated_collection.rb
+++ b/lib/active_admin/views/components/paginated_collection.rb
@@ -97,6 +97,17 @@ module ActiveAdmin
         options = {}
         options[:param_name] = @param_name if @param_name
 
+        if !@display_total
+          # The #paginate method in kaminari will query the resource with a
+          # count(*) to determine how many pages there should be unless
+          # you pass in the :total_pages option. We issue a query to determine
+          # if there is another page or not, but the limit/offset make this
+          # query fast.
+          offset = collection.offset(collection.current_page * @per_page.to_i).limit(1).count
+          options[:total_pages] = collection.current_page + offset
+          options[:right] = 0
+        end
+
         text_node paginate collection, options
       end
 
@@ -117,22 +128,30 @@ module ActiveAdmin
           entries_name = I18n.translate key, count: collection.size, default: entry_name.pluralize
         end
 
-        if collection.num_pages < 2
-          case collection_size
-          when 0; I18n.t('active_admin.pagination.empty',    model: entries_name)
-          when 1; I18n.t('active_admin.pagination.one',      model: entry_name)
-          else;   I18n.t('active_admin.pagination.one_page', model: entries_name, n: collection.total_count)
+        if @display_total
+          if collection.num_pages < 2
+            case collection_size
+            when 0; I18n.t("active_admin.pagination.empty",    model: entries_name)
+            when 1; I18n.t("active_admin.pagination.one",      model: entry_name)
+            else;   I18n.t("active_admin.pagination.one_page", model: entries_name, n: collection.total_count)
+            end
+          else
+            offset = (collection.current_page - 1) * collection.limit_value
+            total  = collection.total_count
+            I18n.t "active_admin.pagination.multiple",
+                   model: entries_name,
+                   total: total,
+                   from: offset + 1,
+                   to: offset + collection_size
           end
         else
+          # Do not display total count, in order to prevent a `SELECT count(*)`.
+          # To do so we must not call `collection.num_pages`
           offset = (collection.current_page - 1) * collection.limit_value
-          if @display_total
-            total  = collection.total_count
-            I18n.t 'active_admin.pagination.multiple', model: entries_name, total: total,
-              from: offset + 1, to: offset + collection_size
-          else
-            I18n.t 'active_admin.pagination.multiple_without_total', model: entries_name,
-              from: offset + 1, to: offset + collection_size
-          end
+          I18n.t "active_admin.pagination.multiple_without_total",
+                 model: entries_name,
+                 from: offset + 1,
+                 to: offset + collection_size
         end
       end
 

--- a/spec/unit/views/components/paginated_collection_spec.rb
+++ b/spec/unit/views/components/paginated_collection_spec.rb
@@ -198,9 +198,10 @@ describe ActiveAdmin::Views::PaginatedCollection do
       end
 
       describe "set to false" do
-        let(:pagination) { paginated_collection(collection, pagination_total: false) }
-
         it "should not show the total item counts" do
+          expect(collection).not_to receive(:num_pages)
+          expect(collection).not_to receive(:total_pages)
+          pagination = paginated_collection(collection, pagination_total: false)
           info = pagination.find_by_class('pagination_information').first.content.gsub('&nbsp;',' ')
           expect(info).to eq "Displaying posts <b>1 - 30</b>"
         end


### PR DESCRIPTION
Addresses https://github.com/activeadmin/activeadmin/issues/3847.

The `pagination_total` option is supposed to prevent expensive `SELECT count(*)` queries from being performed when viewing a resource's index page.

However, while this option was hiding the display of the total number of pages, it did not actually prevent the query from being performed.

There were two reasons:

First, in `#build_pagination`, the line: `text_node paginate collection, options` would trigger Kaminari to call `#total_pages` on the collection, which would trigger the query. Excerpt of kaminari code:

``` ruby
def paginate(scope, options = {}, &block)
  options[:total_pages] ||= options[:num_pages] || scope.total_pages
```

By passing in the `:total_pages` option, we short circuit this assignment and avoid the query.

The downside is we do so by hardcoding in an essentially random total pages count of 100. I chose the number 100, because I wanted to ensure ellipses would appear in Kaminari's "Page 1, 2, 3, ..., Next, Last" links, no matter how many links are configured to be displayed. However, if the resource only had 2 pages worth of items, then clicking the "3" would result in an empty page. That said, without querying the resource, there's no way to know how many pages there should be.

Second, in `#page_entries_info`, the call `collection.num_pages` also triggered a `SELECT count(*)`. I re-arranged the conditionals to avoid that call if `@display_total` is false, while trying to keep the behavior the same.