### PR TITLE
dynamic labels for modal dialog forms

### DIFF
--- a/app/assets/javascripts/active_admin/lib/modal_dialog.js.coffee
+++ b/app/assets/javascripts/active_admin/lib/modal_dialog.js.coffee
@@ -1,6 +1,14 @@
 ActiveAdmin.modal_dialog = (message, inputs, callback)->
   html = """<form id="dialog_confirm" title="#{message}"><ul>"""
-  for name, type of inputs
+  for name, definition of inputs
+    label = name
+    type = definition
+    if definition.type
+      type = definition.type
+
+    if definition.label
+      label = definition.label
+
     if /^(datepicker|checkbox|text)$/.test type
       wrapper = 'input'
     else if type is 'textarea'
@@ -12,7 +20,7 @@ ActiveAdmin.modal_dialog = (message, inputs, callback)->
 
     klass = if type is 'datepicker' then type else ''
     html += """<li>
-      <label>#{name.charAt(0).toUpperCase() + name.slice(1)}</label>
+      <label>#{label.charAt(0).toUpperCase() + label.slice(1)}</label>
       <#{wrapper} name="#{name}" class="#{klass}" type="#{type}">""" +
         (if opts then (
           for v in opts


### PR DESCRIPTION
extending modal_dialog.js.coffee so that the input definition can include a seperate label option. This allows dynamic server side generated labels with consistent name fields

In particular, we're using this in a situation where some of our batch action forms have a popup with a form where the user can choose to apply the action to all records meeting the current filter criteria, not just the visible ones. The label for the checkbox input, needs to include the total count of records. This change allows us to do that. It's good for any situation where you need dynamic labels, particularly on batch actions.
