### PR TITLE
AA thinks "false" means "empty" in show view

### DIFF
--- a/features/show/default_content.feature
+++ b/features/show/default_content.feature
@@ -3,7 +3,7 @@ Feature: Show - Default Content
   Viewing the show page for a resource
 
   Background:
-    Given a post with the title "Hello World" written by "Jane Doe" exists
+    Given a unstarred post with the title "Hello World" written by "Jane Doe" exists
 
   Scenario: Viewing the default show page
     Given a show configuration of:
@@ -14,6 +14,7 @@ Feature: Show - Default Content
     And I should see the attribute "Body" with "Empty"
     And I should see the attribute "Created At" with a nicely formatted datetime
     And I should see the attribute "Author" with "Jane Doe"
+    And I should see the attribute "Starred" with "false"
     And I should see an action item button "Delete Post"
     And I should see an action item button "Edit Post"
 

--- a/features/step_definitions/factory_steps.rb
+++ b/features/step_definitions/factory_steps.rb
@@ -3,14 +3,15 @@ def create_user(name, type = 'User')
   user = type.camelize.constantize.where(first_name: first_name, last_name: last_name).first_or_create(username: name.tr(' ', '').underscore)
 end
 
-Given /^(a|\d+)( published)? posts?(?: with the title "([^"]*)")?(?: and body "([^"]*)")?(?: written by "([^"]*)")?(?: in category "([^"]*)")? exists?$/ do |count, published, title, body, user, category_name|
+Given /^(a|\d+)( published)?( unstarred|starred)? posts?(?: with the title "([^"]*)")?(?: and body "([^"]*)")?(?: written by "([^"]*)")?(?: in category "([^"]*)")? exists?$/ do |count, published, starred, title, body, user, category_name|
   count     = count == 'a' ? 1 : count.to_i
   published = Time.now          if published
+  starred   = starred == " starred" if starred
   author    = create_user(user) if user
   category  = Category.where(name: category_name).first_or_create if category_name
   title   ||= "Hello World %i"
   count.times do |i|
-    Post.create! title: title % i, body: body, author: author, published_at: published, custom_category_id: category.try(:id)
+    Post.create! title: title % i, body: body, author: author, published_at: published, custom_category_id: category.try(:id), starred: starred
   end
 end
 

--- a/lib/active_admin/view_helpers/display_helper.rb
+++ b/lib/active_admin/view_helpers/display_helper.rb
@@ -15,7 +15,7 @@ module ActiveAdmin
       # Attempts to call any known display name methods on the resource.
       # See the setting in `application.rb` for the list of methods and their priority.
       def display_name(resource)
-        render_in_context resource, display_name_method_for(resource) if resource
+        render_in_context resource, display_name_method_for(resource) unless resource.nil?
       end
 
       # Looks up and caches the first available display name method.

--- a/lib/active_admin/view_helpers/method_or_proc_helper.rb
+++ b/lib/active_admin/view_helpers/method_or_proc_helper.rb
@@ -80,7 +80,7 @@ module MethodOrProcHelper
   # passing it the proc. This evaluates the proc in the context of the reciever, thus changing
   # what `self` means inside the proc.
   def render_in_context(context, obj, *args)
-    context ||= self # default to `self`
+    context = self if context.nil? # default to `self` only when nil
     case obj
     when Proc
       context.instance_exec *args, &obj

--- a/spec/unit/view_helpers/display_name_spec.rb
+++ b/spec/unit/view_helpers/display_name_spec.rb
@@ -31,10 +31,12 @@ describe "display_name" do
     expect(display_name subject).to eq 'foo@bar.baz'
   end
 
-  [nil, false].each do |type|
-    it "should return nil when the passed object is #{type.inspect}" do
-      expect(display_name type).to eq nil
-    end
+  it "should return nil when the passed object is nil" do
+    expect(display_name nil).to eq nil
+  end
+
+  it "should return `false` when the passed objct is false" do
+    expect(display_name false).to eq "false"
   end
 
   it "should default to `to_s`" do


### PR DESCRIPTION
Calling render in display name for all resources that are not nil
Self is assigned to render_in_context only when the context is nil
Added Spec to check if false returns a `false` string when display_name is called on it
Added Cucumber specs to cover the same scenarios in the integration testing.

Ref #3867