### PR TITLE
Fixed unexpected page title behavior on the show page of resources

### DIFF
--- a/lib/active_admin/views/pages/show.rb
+++ b/lib/active_admin/views/pages/show.rb
@@ -35,7 +35,7 @@ module ActiveAdmin
         def default_title
           title = display_name(resource)
 
-          if title.blank? || title == resource.to_s
+          if title.blank?
             title = "#{active_admin_config.resource_label} ##{resource.id}"
           end
 


### PR DESCRIPTION
Fixes #3860.

`title == resource.to_s` prevented a user-defined to_s method on resources from being used as the page title, including any of the other display_name_methods aliased to it.

Currently the only workaround is to add `show title: :to_s`, which goes against the conventional nature of AA that I like so much.

Even with my change, the kernel's to_s will not be used because of the more comprehensive check in [DisplayHelper#display_name_method_for](https://github.com/activeadmin/activeadmin/blob/6bde1f57ec5f9b724c21e5af146678f4ade839bc/lib/active_admin/view_helpers/display_helper.rb#L30).

I can confirm that removing to_s from display_name_methods will not fix the problem, because if a method aliased to to_s is used `title == resource.to_s` will be true and result in the fallback.