### PR TITLE
truncate display_name_methods values

### DIFF
--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -101,14 +101,7 @@ module ActiveAdmin
 
     # Active Admin makes educated guesses when displaying objects, this is
     # the list of methods it tries calling in order
-    setting :display_name_methods, [ :display_name,
-                                      :full_name,
-                                      :name,
-                                      :username,
-                                      :login,
-                                      :title,
-                                      :email,
-                                      :to_s ]
+    setting :display_name_methods, [:display_name, :to_s]
 
     # == Deprecated Settings
 

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -24,6 +24,10 @@ inject_into_file 'app/models/post.rb', %q{
   accepts_nested_attributes_for :author
   accepts_nested_attributes_for :taggings
   attr_accessible :author, :position unless Rails::VERSION::MAJOR > 3 && !defined? ProtectedAttributes
+
+  def display_name
+    title
+  end
 }, after: 'class Post < ActiveRecord::Base'
 copy_file File.expand_path('../templates/post_decorator.rb', __FILE__), "app/models/post_decorator.rb"
 
@@ -96,6 +100,12 @@ directory File.expand_path('../templates/policies', __FILE__), 'app/policies'
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 
 generate 'active_admin:install'
+
+inject_into_file 'app/models/admin_user.rb', %q{
+  def display_name
+    email
+  end
+}, after: 'class AdminUser < ActiveRecord::Base'
 
 inject_into_file "config/routes.rb", "\n  root to: redirect('/admin')", after: /.*::Application.routes.draw do/
 remove_file "public/index.html" if File.exists? "public/index.html"

--- a/spec/unit/view_helpers/display_name_spec.rb
+++ b/spec/unit/view_helpers/display_name_spec.rb
@@ -14,8 +14,8 @@ describe "display_name" do
   end
 
   it "should memoize the result for the class" do
-    subject = Class.new.new
-    expect(subject).to receive(:name).twice.and_return "My Name"
+    subject = double(title: "My Name")
+    expect(subject).to receive(:display_name).twice.and_return "My Name"
     expect(display_name subject).to eq "My Name"
     expect(ActiveAdmin.application).to_not receive(:display_name_methods)
     expect(display_name subject).to eq "My Name"
@@ -27,8 +27,9 @@ describe "display_name" do
     allow(klass).to receive(:reflect_on_all_associations).and_return [ double(name: :login) ]
     allow(subject).to receive :login
     expect(subject).to_not receive :login
-    allow(subject).to receive(:email).and_return 'foo@bar.baz'
-    expect(display_name subject).to eq 'foo@bar.baz'
+    allow(ActiveAdmin.application).to receive(:display_name_methods).and_return [:login, :display_name]
+    allow(subject).to receive(:display_name).and_return "foo@bar.baz"
+    expect(display_name subject).to eq "foo@bar.baz"
   end
 
   it "should return `nil` when the passed object is `nil`" do


### PR DESCRIPTION
There are some methods in that list which are to specific for some use cases. We should setup only `display_name` as ActiveAdmin default and `to_s` as fallback.
