### PR TITLE
limit execjs to < 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ require File.expand_path 'spec/support/detect_rails_version', File.dirname(__FIL
 rails_version = detect_rails_version
 gem 'rails', rails_version
 
+gem 'execjs', '< 2.0.0'
+
 # Optional dependencies
 gem 'cancan'
 gem 'devise'


### PR DESCRIPTION
execjs >= 2.0.0 runs only on Ruby > 2.0. This fixes the Ruby 1.9 builds https://travis-ci.org/activeadmin/activeadmin/jobs/57738808.