### PR TITLE
Prevent not to define unnecessary path

### DIFF
--- a/lib/active_admin/router.rb
+++ b/lib/active_admin/router.rb
@@ -56,6 +56,10 @@ module ActiveAdmin
           # Add on the namespace if required
           unless config.namespace.root?
             nested = routes
+
+            # Do not define unnecessary path
+            return if config.resource_name.route_key == 'comments' && ActiveAdmin.application.comments == false
+
             routes = Proc.new do
               namespace config.namespace.name do
                 instance_exec &nested


### PR DESCRIPTION
I configured ActiveAdmin to `config.comments = false`.
And does not create active_admin_comments table.
But /admin/comments had defined.
When accessing to the admin_comments_path, raise a Mysql2::Error.

So I create a patch.
Please review this.
(Sorry it does not wrote a test. Please taught a suitable place)

related #3766 


