### PR TITLE
Detect resource class based on AR collection klass in table_for

### DIFF
--- a/lib/active_admin/views/components/table_for.rb
+++ b/lib/active_admin/views/components/table_for.rb
@@ -10,8 +10,9 @@ module ActiveAdmin
       def build(obj, *attrs)
         options         = attrs.extract_options!
         @sortable       = options.delete(:sortable)
-        @resource_class = options.delete(:i18n)
         @collection     = obj.respond_to?(:each) && !obj.is_a?(Hash) ? obj : [obj]
+        @resource_class = options.delete(:i18n)
+        @resource_class ||= @collection.klass if @collection.respond_to? :klass
         @columns        = []
         @row_class      = options.delete(:row_class)
 

--- a/spec/unit/views/components/table_for_spec.rb
+++ b/spec/unit/views/components/table_for_spec.rb
@@ -301,6 +301,51 @@ describe ActiveAdmin::Views::TableFor do
       end
     end
 
+    context "when i18n option is specified" do
+      before(:each) do
+        I18n.backend.store_translations :en,
+          activerecord: { attributes: { post: { title: "Name" } } }
+      end
+
+      let(:table) do
+        render_arbre_component assigns, helpers do
+          table_for(collection, i18n: Post) do
+            column :title
+          end
+        end
+      end
+
+      it "should use localized column key" do
+        expect(table.find_by_tag("th").first.content).to eq "Name"
+      end
+    end
+
+    context "when i18n option is not specified" do
+      before(:each) do
+        I18n.backend.store_translations :en,
+          activerecord: { attributes: { post: { title: "Name" } } }
+      end
+
+      let(:collection) do
+        Post.create([
+          { title: "First Post", starred: true },
+          { title: "Second Post" },
+        ])
+        Post.where(starred: true)
+      end
+
+      let(:table) do
+        render_arbre_component assigns, helpers do
+          table_for(collection) do
+            column :title
+          end
+        end
+      end
+
+      it "should predict localized key based on AR collection klass" do
+        expect(table.find_by_tag("th").first.content).to eq "Name"
+      end
+    end
   end
 
   describe "column sorting" do


### PR DESCRIPTION
References to the issue #675 
Will work only with AR collections. I think this is OK for most cases. If you use custom array, you will still need to set i18n option.