### PR TITLE
Fix XPath Matchers in Cucumber Asset Steps

### DIFF
--- a/features/registering_assets.feature
+++ b/features/registering_assets.feature
@@ -12,8 +12,7 @@ Feature: Registering Assets
 
   Scenario: Viewing default asset files
     When I am on the index page for posts
-    Then I should see the css file "admin/active_admin.css"
-    Then I should see the js file "active_admin_vendor.js"
+    Then I should see the css file "active_admin.css"
     Then I should see the js file "active_admin.js"
 
   Scenario: Registering a CSS file

--- a/features/step_definitions/asset_steps.rb
+++ b/features/step_definitions/asset_steps.rb
@@ -3,13 +3,13 @@ Then /^I should see the css file "([^"]*)"$/ do |path|
 end
 
 Then /^I should see the css file "([^"]*)" of media "([^"]*)"$/ do |path, media|
-  expect(page).to have_xpath("//link[contains(@href, /stylesheets/#{path}) and contains(@media, #{media})]", visible: false)
+  expect(page).to have_xpath("//link[contains(@href, '#{path}') and contains(@media, '#{media}')]", visible: false)
 end
 
 Then /^I should see the js file "([^"]*)"$/ do |path|
-  expect(page).to have_xpath("//script[contains(@src, /javascripts/#{path})]", visible: false)
+  expect(page).to have_xpath("//script[contains(@src, '#{path}')]", visible: false)
 end
 
 Then /^I should see the favicon "([^"]*)"$/ do |path|
-  expect(page).to have_xpath("//link[contains(@href, path)]", visible: false)
+  expect(page).to have_xpath("//link[contains(@href, '#{path}')]", visible: false)
 end


### PR DESCRIPTION
The step definitions looking for assets in the page head produced false positives since quotes were missing inside the XPath expressions.

XPath expressions of the form `"contains(@href, #{path})"` matched no matter what `path` was supplied. In one case even the string interpolation was missing: `"contains(@href, path)"`. Surrounding the literals with single quotes caused actual checks to be performed and revealed outdated information inside the tests:

* The generated assets paths actually start with `assets/` in some Rails versions instead of `javascripts/` and `stylesheets/`. Remove the prefix to make tests pass.

* The `active_admin.css` does not live inside an `admin` directory.

* `registering_assets.features` asserted presence of a file called
  `active_admin_vendor.js` not mentioned elsewhere in the codebase