### PR TITLE
Option to Prevent Devise Pages From Showing Up in Search Engine Results

### DIFF
--- a/app/views/layouts/active_admin_logged_out.html.erb
+++ b/app/views/layouts/active_admin_logged_out.html.erb
@@ -14,6 +14,10 @@
 
   <%= favicon_link_tag ActiveAdmin.application.favicon if ActiveAdmin.application.favicon %>
 
+  <% if ActiveAdmin.application.robots_meta_tag_for_logged_out_pages.present? %>
+    <%= tag(:meta, name: 'robots', content: ActiveAdmin.application.robots_meta_tag_for_logged_out_pages) %>
+  <% end %>
+
   <%= csrf_meta_tag %>
 </head>
 <body class="active_admin logged_out <%= controller.action_name %>">

--- a/features/robots_meta_tag_for_logged_out_pages.feature
+++ b/features/robots_meta_tag_for_logged_out_pages.feature
@@ -1,0 +1,15 @@
+Feature: Robots Meta Tag for Logged Out Pages
+
+  Prevent Devise pages from showing up in search engine results.
+
+  Background:
+    Given a configuration of:
+    """
+      ActiveAdmin.register Post
+      ActiveAdmin.application.robots_meta_tag_for_logged_out_pages = "noindex, nofollow"
+    """
+
+  Scenario: Logged out views show Favicon
+    Given I am logged out
+    When I am on the login page
+    Then the site should contain a meta tag with name "robots" and content "noindex, nofollow"

--- a/features/step_definitions/meta_tag_steps.rb
+++ b/features/step_definitions/meta_tag_steps.rb
@@ -1,0 +1,3 @@
+Then /^the site should contain a meta tag with name "([^"]*)" and content "([^"]*)"$/ do |name, content|
+  expect(page).to have_xpath("//meta[@name='#{name}' and @content='#{content}']", visible: false)
+end

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -40,6 +40,10 @@ module ActiveAdmin
     # Set a favicon
     inheritable_setting :favicon, false
 
+    # Set to "noindex, nofollow" to prevent authentication related
+    # pages to show in search engine result.
+    inheritable_setting :robots_meta_tag_for_logged_out_pages, nil
+
     # The view factory to use to generate all the view classes. Take
     # a look at ActiveAdmin::ViewFactory
     inheritable_setting :view_factory, ActiveAdmin::ViewFactory.new

--- a/lib/generators/active_admin/install/templates/active_admin.rb.erb
+++ b/lib/generators/active_admin/install/templates/active_admin.rb.erb
@@ -144,6 +144,13 @@ ActiveAdmin.setup do |config|
   #
   # config.favicon = 'favicon.ico'
 
+  # == Robots Meta Tag
+  #
+  # Prevent sign up/sign in/recover password pages from showing up in
+  # search engine results.
+  #
+  # config.robots_meta_tag_for_logged_out_pages = 'noindex, nofollow'
+
   # == Removing Breadcrumbs
   #
   # Breadcrumbs are enabled by default. You can customize them for individual

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -54,6 +54,15 @@ describe ActiveAdmin::Application do
     expect(application.favicon).to eq "/a/favicon.ico"
   end
 
+  it "should store robots meta tag content for logged out pages" do
+    expect(application.robots_meta_tag_for_logged_out_pages).to eq nil
+  end
+
+  it "should set robots meta tag content for logged out pages" do
+    application.robots_meta_tag_for_logged_out_pages = "noindex, nofollow"
+    expect(application.robots_meta_tag_for_logged_out_pages).to eq "noindex, nofollow"
+  end
+
   it "should have a view factory" do
     expect(application.view_factory).to be_an_instance_of(ActiveAdmin::ViewFactory)
   end


### PR DESCRIPTION
Some of our customers get nervous when they see the sign-in page of their admin backend in google results. Including a `robots` meta tag with content `"noindex, nofollow"` in the head of the logged out pages prevents search engines from indexing these pages.

Add an application setting called `robots_meta_tag_for_logged_out_pages` to control whether this meta tag should be present.

I could see some alternatives to the route taken in this commit:

* Less control: Turn the setting into a boolean. Not sure though if someone might only want `"noindex"` etc.
* More control: Instead add a `meta_tags_for_logged_out_pages` setting to define arbitrary meta tags. Might be too open though.
* Find a better name for this option since it's a bit long.

Finally, one could argue that this could be handled via `robots.txt`. In our case though, we supply ActiveAdmin along with other Rails engines and this change would allow to settle this question once and for all instead of having to edit files in each individual project every time.

Looking forward to your feedback.