### PR TITLE
Add the possibility to configure the order of comments

### DIFF
--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -105,6 +105,9 @@ module ActiveAdmin
     # Set flash message keys that shouldn't show in ActiveAdmin
     inheritable_setting :flash_keys_to_except, ['timedout']
 
+    # Set the order and column to be used for ordering for comments
+    inheritable_setting :comment_order, 'created_at ASC'
+
     # Active Admin makes educated guesses when displaying objects, this is
     # the list of methods it tries calling in order
     setting :display_name_methods, [ :display_name,

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -105,9 +105,6 @@ module ActiveAdmin
     # Set flash message keys that shouldn't show in ActiveAdmin
     inheritable_setting :flash_keys_to_except, ['timedout']
 
-    # Set the order and column to be used for ordering for comments
-    inheritable_setting :comment_order, "created_at ASC"
-
     # Active Admin makes educated guesses when displaying objects, this is
     # the list of methods it tries calling in order
     setting :display_name_methods, [ :display_name,

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -106,7 +106,7 @@ module ActiveAdmin
     inheritable_setting :flash_keys_to_except, ['timedout']
 
     # Set the order and column to be used for ordering for comments
-    inheritable_setting :comment_order, 'created_at ASC'
+    inheritable_setting :comment_order, "created_at ASC"
 
     # Active Admin makes educated guesses when displaying objects, this is
     # the list of methods it tries calling in order

--- a/lib/active_admin/orm/active_record/comments.rb
+++ b/lib/active_admin/orm/active_record/comments.rb
@@ -7,6 +7,7 @@ require 'active_admin/orm/active_record/comments/resource_helper'
 ActiveAdmin::Application.inheritable_setting :comments,                   true
 ActiveAdmin::Application.inheritable_setting :show_comments_in_menu,      true
 ActiveAdmin::Application.inheritable_setting :comments_registration_name, 'Comment'
+ActiveAdmin::Application.inheritable_setting :comments_order,             "created_at ASC"
 
 # Insert helper modules
 ActiveAdmin::Namespace.send :include, ActiveAdmin::Comments::NamespaceHelper

--- a/lib/active_admin/orm/active_record/comments/comment.rb
+++ b/lib/active_admin/orm/active_record/comments/comment.rb
@@ -29,7 +29,7 @@ module ActiveAdmin
         resource_type: resource_type(resource),
         resource_id:   resource_id_cast(resource),
         namespace:     namespace.to_s
-      ).order('created_at ASC')
+      ).order(ActiveAdmin.application.comment_order)
     end
 
     def self.resource_id_type

--- a/lib/active_admin/orm/active_record/comments/comment.rb
+++ b/lib/active_admin/orm/active_record/comments/comment.rb
@@ -29,7 +29,7 @@ module ActiveAdmin
         resource_type: resource_type(resource),
         resource_id:   resource_id_cast(resource),
         namespace:     namespace.to_s
-      ).order(ActiveAdmin.application.comment_order)
+      ).order(ActiveAdmin.application.namespaces[namespace].comments_order)
     end
 
     def self.resource_id_type

--- a/lib/generators/active_admin/install/templates/active_admin.rb.erb
+++ b/lib/generators/active_admin/install/templates/active_admin.rb.erb
@@ -129,7 +129,7 @@ ActiveAdmin.setup do |config|
   #
   # You can change the order for the comments and you can change the column
   # to be used for ordering
-  # config.comment_order = 'created_at ASC'
+  # config.comments_order = 'created_at ASC'
 
   # == Batch Actions
   #

--- a/lib/generators/active_admin/install/templates/active_admin.rb.erb
+++ b/lib/generators/active_admin/install/templates/active_admin.rb.erb
@@ -126,6 +126,10 @@ ActiveAdmin.setup do |config|
   #
   # You can change the name under which comments are registered:
   # config.comments_registration_name = 'AdminComment'
+  #
+  # You can change the order for the comments and you can change the column
+  # to be used for ordering
+  # config.comment_order = 'created_at ASC'
 
   # == Batch Actions
   #

--- a/spec/unit/comments_spec.rb
+++ b/spec/unit/comments_spec.rb
@@ -57,11 +57,15 @@ describe "Comments" do
       end
 
       it "should return the correctly ordered comments" do
-        ActiveAdmin::Application.inheritable_setting(:comment_order, 'created_at DESC')
-        another_comment = ActiveAdmin::Comment.create! resource: post,
-                                                       body: "Another Comment",
-                                                       namespace: namespace_name,
-                                                       created_at: @comment.created_at + 20.minutes
+        ActiveAdmin::Application.inheritable_setting(
+          :comment_order, "created_at DESC"
+        )
+        another_comment = ActiveAdmin::Comment.create!(
+          resource: post,
+          body: "Another Comment",
+          namespace: namespace_name,
+          created_at: @comment.created_at + 20.minutes
+        )
         expect(comments.size).to eq 2
         expect(comments.first).to eq(another_comment)
         expect(comments.last).to eq(@comment)

--- a/spec/unit/comments_spec.rb
+++ b/spec/unit/comments_spec.rb
@@ -60,12 +60,15 @@ describe "Comments" do
         ActiveAdmin::Application.inheritable_setting(
           :comment_order, "created_at DESC"
         )
+
         another_comment = ActiveAdmin::Comment.create!(
           resource: post,
           body: "Another Comment",
           namespace: namespace_name,
           created_at: @comment.created_at + 20.minutes
         )
+
+        comments = ActiveAdmin::Comment.find_for_resource_in_namespace(post, namespace_name)
         expect(comments.size).to eq 2
         expect(comments.first).to eq(another_comment)
         expect(comments.last).to eq(@comment)

--- a/spec/unit/comments_spec.rb
+++ b/spec/unit/comments_spec.rb
@@ -68,7 +68,9 @@ describe "Comments" do
           created_at: @comment.created_at + 20.minutes
         )
 
-        comments = ActiveAdmin::Comment.find_for_resource_in_namespace(post, namespace_name)
+        comments = ActiveAdmin::Comment.find_for_resource_in_namespace(
+          post, namespace_name
+        )
         expect(comments.size).to eq 2
         expect(comments.first).to eq(another_comment)
         expect(comments.last).to eq(@comment)

--- a/spec/unit/comments_spec.rb
+++ b/spec/unit/comments_spec.rb
@@ -58,7 +58,7 @@ describe "Comments" do
 
       it "should return the correctly ordered comments" do
         ActiveAdmin::Application.inheritable_setting(
-          :comment_order, "created_at DESC"
+          :comments_order, "created_at DESC"
         )
 
         another_comment = ActiveAdmin::Comment.create!(

--- a/spec/unit/comments_spec.rb
+++ b/spec/unit/comments_spec.rb
@@ -39,8 +39,8 @@ describe "Comments" do
 
       it "should return the most recent comment first" do
         ActiveAdmin::Comment.class_eval { attr_accessible :created_at } if Rails::VERSION::MAJOR == 3
-        another_comment = ActiveAdmin::Comment.create! resource: post, 
-                                                       body: "Another Comment", 
+        another_comment = ActiveAdmin::Comment.create! resource: post,
+                                                       body: "Another Comment",
                                                        namespace: namespace_name,
                                                        created_at: @comment.created_at + 20.minutes
 
@@ -54,6 +54,17 @@ describe "Comments" do
         expect(comments.first).to eq(@comment)
         expect(comments.second).to eq(yet_another_comment)
         expect(comments.last).to eq(another_comment)
+      end
+
+      it "should return the correctly ordered comments" do
+        ActiveAdmin::Application.inheritable_setting(:comment_order, 'created_at DESC')
+        another_comment = ActiveAdmin::Comment.create! resource: post,
+                                                       body: "Another Comment",
+                                                       namespace: namespace_name,
+                                                       created_at: @comment.created_at + 20.minutes
+        expect(comments.size).to eq 2
+        expect(comments.first).to eq(another_comment)
+        expect(comments.last).to eq(@comment)
       end
     end
 


### PR DESCRIPTION
This patch introduces a new configuration parameter

  config.comment_order = 'created_at ASC'

The user will be able to configure if the comments
should be displayed ascending or descending. Furthermore
the user is able to choose the column which should be
used for ordering.