### PR TITLE
#3044: Use `find_by` instead of `find_by_xxx`

### DIFF
--- a/lib/active_admin/resource.rb
+++ b/lib/active_admin/resource.rb
@@ -144,14 +144,20 @@ module ActiveAdmin
     end
 
     def find_resource(id)
-      resource = resource_class.public_send(method_for_find, id)
+      resource = resource_class.public_send *method_for_find(id)
       decorator_class ? decorator_class.new(resource) : resource
     end
 
     private
 
-    def method_for_find
-      resources_configuration[:self][:finder] || :"find_by_#{resource_class.primary_key}"
+    def method_for_find(id)
+      if finder = resources_configuration[:self][:finder]
+        [finder, id]
+      elsif Rails::VERSION::MAJOR >= 4
+        [:find_by, { resource_class.primary_key => id }]
+      else
+        [:"find_by_#{resource_class.primary_key}", id]
+      end
     end
 
     def default_csv_builder

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -232,7 +232,11 @@ module ActiveAdmin
       let(:resource) { namespace.register(Post) }
       let(:post) { double }
       before do
-        allow(Post).to receive(:find_by_id).with('12345') { post }
+        if Rails::VERSION::MAJOR >= 4
+          allow(Post).to receive(:find_by).with("id" => "12345") { post }
+        else
+          allow(Post).to receive(:find_by_id).with("12345") { post }
+        end
       end
 
       it 'can find the resource' do
@@ -250,7 +254,13 @@ module ActiveAdmin
         let(:different_post) { double }
         before do
           allow(Post).to receive(:primary_key).and_return 'something_else'
-          allow(Post).to receive(:find_by_something_else).with('55555') { different_post }
+          if Rails::VERSION::MAJOR >= 4
+            allow(Post).to receive(:find_by).
+              with("something_else" => "55555") { different_post }
+          else
+            allow(Post).to receive(:find_by_something_else).
+              with("55555") { different_post }
+          end
         end
 
         it 'can find the post by the custom primary key' do


### PR DESCRIPTION
By #3044 , #3090 and according to http://guides.rubyonrails.org/4_2_release_notes.html#adequate-record

Also, should help to prevent:

```
NoMethodError - private method `find_by_id' called for #<Class:0x00000110288708>:
  activeadmin (1.0.0.pre1) lib/active_admin/resource.rb:147:in `find_resource'
```


