### PR TITLE
remove TableFor#is_boolean, detect boolean by attribute type

### DIFF
--- a/lib/active_admin/views/components/table_for.rb
+++ b/lib/active_admin/views/components/table_for.rb
@@ -109,19 +109,11 @@ module ActiveAdmin
         elsif item.respond_to? :[]
           item[data]
         end
+        value = status_tag(value.to_s) if [true, false].include?(value)
         value = pretty_format(value) if data.is_a?(Symbol)
-        value = status_tag value     if is_boolean? data, item
         value
       end
-
-      def is_boolean?(data, item)
-        if item.respond_to? :has_attribute?
-          item.has_attribute?(data) &&
-            item.column_for_attribute(data) &&
-            item.column_for_attribute(data).type == :boolean
-        end
-      end
-
+      
       # Returns an array for the current sort order
       #   current_sort[0] #=> sort_key
       #   current_sort[1] #=> asc | desc


### PR DESCRIPTION
 do not use database table column to detect boolean attribute

simplified #2753 
fixes #3838