### PR TITLE
Fix the column_for_attribute deprecation warning for the last time

### DIFF
--- a/features/decorators.feature
+++ b/features/decorators.feature
@@ -17,12 +17,14 @@ Feature: Decorators
           column(:id)
           column(:title)
           column(:decorator_method)
+          column(:starred)
         end
       end
     """
     When I am on the index page for posts
     Then I should see "A method only available on the decorator"
     And I should see "A very unique post"
+    And I should see "No"
 
   Scenario: Show page with decorator
     Given a configuration of:

--- a/features/step_definitions/factory_steps.rb
+++ b/features/step_definitions/factory_steps.rb
@@ -5,9 +5,9 @@ end
 
 Given /^(a|\d+)( published)?( unstarred|starred)? posts?(?: with the title "([^"]*)")?(?: and body "([^"]*)")?(?: written by "([^"]*)")?(?: in category "([^"]*)")? exists?$/ do |count, published, starred, title, body, user, category_name|
   count     = count == 'a' ? 1 : count.to_i
-  published = Time.now          if published
+  published = Time.now              if published
   starred   = starred == " starred" if starred
-  author    = create_user(user) if user
+  author    = create_user(user)     if user
   category  = Category.where(name: category_name).first_or_create if category_name
   title   ||= "Hello World %i"
   count.times do |i|

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -106,7 +106,6 @@ After do
 end
 
 Before do
-
   begin
     # We are caching classes, but need to manually clear references to
     # the controllers. If they aren't clear, the router stores references
@@ -119,6 +118,14 @@ Before do
     p $!
     raise $!
   end
+end
+
+# Force deprecations to raise an exception.
+# This would set `behavior = :raise`, but that wasn't added until Rails 4.
+ActiveSupport::Deprecation.behavior = -> message, callstack do
+  e = StandardError.new message
+  e.set_backtrace callstack
+  raise e
 end
 
 # improve the performance of the specs suite by not logging anything

--- a/lib/active_admin/batch_actions/controller.rb
+++ b/lib/active_admin/batch_actions/controller.rb
@@ -30,7 +30,6 @@ module ActiveAdmin
         :filtering,
         :scoping,
         :includes,
-        :collection_decorator
       ].freeze
 
       def batch_action_collection(only = COLLECTION_APPLIES)

--- a/lib/active_admin/resource_controller/data_access.rb
+++ b/lib/active_admin/resource_controller/data_access.rb
@@ -275,12 +275,10 @@ module ActiveAdmin
       end
 
       def collection_applies(options = {})
-        only = Array(options.fetch(:only, COLLECTION_APPLIES))
+        only   = Array(options.fetch(:only, COLLECTION_APPLIES))
         except = Array(options.fetch(:except, []))
-        
-        # see #4074 for code reasons
-        COLLECTION_APPLIES.select { |applier| only.include? applier }
-                          .reject { |applier| except.include? applier }
+
+        COLLECTION_APPLIES & only - except
       end
 
       def per_page

--- a/lib/active_admin/views/components/table_for.rb
+++ b/lib/active_admin/views/components/table_for.rb
@@ -116,10 +116,8 @@ module ActiveAdmin
       end
 
       def is_boolean?(data, item)
-        if item.respond_to? :has_attribute?
-          item.has_attribute?(data) &&
-            item.column_for_attribute(data) &&
-            item.column_for_attribute(data).type == :boolean
+        if item.class.respond_to? :columns_hash
+          column = item.class.columns_hash[data.to_s] and column.type == :boolean
         end
       end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -143,10 +143,17 @@ RSpec.configure do |c|
   c.include Devise::TestHelpers, type: :controller
 end
 
+# Force deprecations to raise an exception.
+# This would set `behavior = :raise`, but that wasn't added until Rails 4.
+ActiveSupport::Deprecation.behavior = -> message, callstack do
+  e = StandardError.new message
+  e.set_backtrace callstack
+  raise e
+end
+
 # improve the performance of the specs suite by not logging anything
 # see http://blog.plataformatec.com.br/2011/12/three-tips-to-improve-the-performance-of-your-test-suite/
 Rails.logger.level = 4
-
 
 # Improves performance by forcing the garbage collector to run less often.
 unless ENV['DEFER_GC'] == '0' || ENV['DEFER_GC'] == 'false'


### PR DESCRIPTION
#3838

Turns out we couldn’t use `type_for_column` since:
- it’s not intended as a public method
- it would return a null object if the column had the default value (nil)

for example:
```
expected: "No"
     got: ""

(compared using ==)
 (RSpec::Expectations::ExpectationNotMetError)
./features/step_definitions/table_steps.rb:96:in `assert_cells_match'
./features/step_definitions/table_steps.rb:79:in `block (2 levels) in assert_tables_match'
./features/step_definitions/table_steps.rb:75:in `each_index'
./features/step_definitions/table_steps.rb:75:in `block in assert_tables_match'
./features/step_definitions/table_steps.rb:74:in `each_index'
./features/step_definitions/table_steps.rb:74:in `assert_tables_match'
./features/step_definitions/table_steps.rb:115:in `/^I should see the "([^"]*)" table:$/'
features/index/index_as_table.feature:252:in `Then I should see the "index_table_posts" table:'

Failing Scenarios:
cucumber features/index/index_as_table.feature:244 # Scenario: Sorting
```