### PR TITLE
use most recent Rails version by default

### DIFF
--- a/spec/support/detect_rails_version.rb
+++ b/spec/support/detect_rails_version.rb
@@ -10,7 +10,7 @@ unless defined? TRAVIS_CONFIG
   TRAVIS_RAILS_VERSIONS = TRAVIS_CONFIG['env']['matrix'].grep(/RAILS=(.*)/){ $1 }
 end
 
-DEFAULT_RAILS_VERSION ||= TRAVIS_RAILS_VERSIONS.first
+DEFAULT_RAILS_VERSION ||= TRAVIS_RAILS_VERSIONS.last
 
 def detect_rails_version
   version = version_from_file || ENV['RAILS'] || DEFAULT_RAILS_VERSION


### PR DESCRIPTION
What say you @timoschilling? Since the Rails team is starting work on Rails 5, it seems wrong to have our development environment default to Rails 3.2.