### PR TITLE
fixed batch actions when resource is decorated

### DIFF
--- a/features/index/batch_actions.feature
+++ b/features/index/batch_actions.feature
@@ -20,6 +20,23 @@ Feature: Batch Actions
     Then I should see a flash with "Successfully destroyed 2 posts"
     And I should see 8 posts in the table
 
+  Scenario: Use default (destroy) batch action on a decorated resource
+    Given 5 posts exist
+    And an index configuration of:
+    """
+      ActiveAdmin.register Post do
+        decorate_with PostDecorator
+      end
+    """
+    When I check the 2nd record
+    And I check the 4th record
+    And I follow "Batch Actions"
+    Then I should see the batch action :destroy "Delete Selected"
+
+    Given I submit the batch action form with "destroy"
+    Then I should see a flash with "Successfully destroyed 2 posts"
+    And I should see 3 posts in the table
+
   Scenario: Use default (destroy) batch action on a nested resource
     Given I am logged in
     And 5 posts written by "John Doe" exist

--- a/lib/active_admin/batch_actions/controller.rb
+++ b/lib/active_admin/batch_actions/controller.rb
@@ -27,10 +27,10 @@ module ActiveAdmin
 
       COLLECTION_APPLIES = [
         :authorization_scope,
-        :collection_decorator,
         :filtering,
         :scoping,
-        :includes
+        :includes,
+        :collection_decorator
       ].freeze
 
       def batch_action_collection(only = COLLECTION_APPLIES)


### PR DESCRIPTION
collection_decorator should be last method applied to collection.
Without this such error occurs
```
NoMethodError: undefined method `ransack' for #<#<Class:0x007fed6fc58a28>:0x007fed4bf86f20>
./lib/active_admin/resource_controller/data_access.rb:228:in `apply_filtering'
./lib/active_admin/resource_controller/data_access.rb:58:in `block in find_collection'
./lib/active_admin/resource_controller/data_access.rb:57:in `each'
./lib/active_admin/resource_controller/data_access.rb:57:in `find_collection'
./lib/active_admin/batch_actions/controller.rb:37:in `batch_action_collection'
```