### PR TITLE
Acknowledge relative url root

### DIFF
--- a/lib/active_admin/resource/menu.rb
+++ b/lib/active_admin/resource/menu.rb
@@ -26,7 +26,7 @@ module ActiveAdmin
         {
           id: resource_name.plural,
           label: proc{ resource.plural_resource_label },
-          url:   proc{ resource.route_collection_path(params) },
+          url:   proc{ (controller.config.relative_url_root || '') + resource.route_collection_path(params) },
           if:    proc{ authorized?(:read, menu_resource_class) }
         }
       end


### PR DESCRIPTION
Allows resource URLs to acknowledge the Rails relative_url_root setting.