### PR TITLE
remove ransack version dependency since old ransack version is causin…

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'jquery-ui-rails',     '~> 5.0'
   s.add_dependency 'kaminari',            '~> 0.15'
   s.add_dependency 'rails',               '>= 3.2', '< 5.0'
-  s.add_dependency 'ransack',             '~> 1.3'
+  s.add_dependency 'ransack'           
   s.add_dependency 'sass-rails'
 end


### PR DESCRIPTION
remove ransack version dependency since old ransack version is causing "don know what context to use error": https://github.com/activeadmin/activeadmin/issues/3794

Then specify the ransack version should fix this issue:

    gem "ransack", github: "activerecord-hackery/ransack", branch: "rails-4.2"
