### PR TITLE
Add a new option `:download_url_options` to paginated_collection()

### DIFF
--- a/lib/active_admin/view_helpers/download_format_links_helper.rb
+++ b/lib/active_admin/view_helpers/download_format_links_helper.rb
@@ -7,9 +7,13 @@ module ActiveAdmin
         div class: "download_links" do
           span I18n.t('active_admin.download')
           formats.each do |format|
-            a format.upcase, href: url_for(params: params, format: format)
+            a format.upcase, href: download_url_for(params: params, format: format)
           end
         end
+      end
+
+      def download_url_for(options = {})
+        url_for(options)
       end
 
       def self.included base

--- a/lib/active_admin/views/components/paginated_collection.rb
+++ b/lib/active_admin/views/components/paginated_collection.rb
@@ -41,6 +41,7 @@ module ActiveAdmin
         @params         = options.delete(:params)
         @param_name     = options.delete(:param_name)
         @download_links = options.delete(:download_links)
+        @download_url_options = options.delete(:download_url_options) || {}
         @display_total  = options.delete(:pagination_total) { true }
         @per_page       = options.delete(:per_page)
 
@@ -60,6 +61,10 @@ module ActiveAdmin
         else
           super
         end
+      end
+
+      def download_url_for(options = {})
+        url_for(options.merge(@download_url_options))
       end
 
       protected

--- a/lib/active_admin/views/components/paginated_collection.rb
+++ b/lib/active_admin/views/components/paginated_collection.rb
@@ -41,7 +41,7 @@ module ActiveAdmin
         @params         = options.delete(:params)
         @param_name     = options.delete(:param_name)
         @download_links = options.delete(:download_links)
-        @download_url_options = options.delete(:download_url_options) || {}
+        @download_url_options = options.delete(:download_url_options) { {} }
         @display_total  = options.delete(:pagination_total) { true }
         @per_page       = options.delete(:per_page)
 

--- a/spec/unit/views/components/paginated_collection_spec.rb
+++ b/spec/unit/views/components/paginated_collection_spec.rb
@@ -91,6 +91,32 @@ describe ActiveAdmin::Views::PaginatedCollection do
       end
     end
 
+    context "when specifying download_url_options" do
+      let(:view) do
+        view = mock_action_view
+        allow(view.request).to receive(:query_parameters).and_return details: '1'
+        allow(view.request).to receive(:path_parameters).and_return  controller: 'admin/users', action: 'show', id: 1
+        view
+      end
+
+      let(:collection) do
+        posts = 10.times.map{ Post.new }
+        Kaminari.paginate_array(posts).page(1).per(5)
+      end
+
+      let(:pagination) { paginated_collection(collection,
+                                              download_url_options: {
+                                                controller: 'admin/posts',
+                                                action: 'index',
+                                                params: { user_id: 1 }
+                                              },
+                                              download_links: [:csv]) }
+
+      it "should generate download link URLs using download_url_options" do
+        expect(pagination.find_by_tag('a').last.attr(:href)).to eq('/admin/posts.csv?user_id=1')
+      end
+    end
+
     context "when specifying :entry_name option with a single item" do
       let(:collection) do
         posts = [Post.new]


### PR DESCRIPTION
Suppose you are building a user show page with a panel that lists a paginated collection of the user's posts.  In this case, `paginated_collection()` will generate download links with URLs based on the user show page, which do not work.

Using this new option, you can make them work by specifying the correct controller, action and parameters to download the collection.

```
ActiveAdmin.register User do
  show do |user|
    # ...
    panel Post.model_name.human, id: :posts do
      paginated_collection(user.posts.page(params[:posts_page]).per(10),
                           param_name: :posts_page,
                           params: { anchor: 'posts' },
                           download_url_options: {
                             controller: 'admin/posts',
                             action: 'index',
                             params: { user_id: user.id }
                           }) do
      # ...
    end
  end
end
```