### PR TITLE
fix resource collection lookup

### DIFF
--- a/lib/active_admin/resource_collection.rb
+++ b/lib/active_admin/resource_collection.rb
@@ -33,7 +33,9 @@ module ActiveAdmin
     # Finds a resource based on the resource name, resource class, or base class.
     def find_resource(obj)
       resources.detect do |r|
-        r.resource_name.to_s == obj.to_s || r.resource_class.to_s == obj.to_s
+        r.resource_name.to_s == obj.to_s
+      end || resources.detect do |r|
+        r.resource_class.to_s == obj.to_s
       end ||
       if obj.respond_to? :base_class
         resources.detect{ |r| r.resource_class.to_s == obj.base_class.to_s }

--- a/spec/unit/resource_collection_spec.rb
+++ b/spec/unit/resource_collection_spec.rb
@@ -151,6 +151,23 @@ describe ActiveAdmin::ResourceCollection do
         expect(collection[name]).to eq renamed_resource
       end
     end
+
+    context "with a resource and a renamed resource added in disorder" do
+      let(:resource) { ActiveAdmin::Resource.new namespace, resource_class }
+      let(:renamed_resource) do
+        ActiveAdmin::Resource.new namespace, resource_class, as: name
+      end
+      let(:name) { "Administrators" }
+
+      before do
+        collection.add renamed_resource
+        collection.add resource
+      end
+
+      it "should find a resource by class when there are two resources with that class" do
+        expect(collection[resource_class]).to eq resource
+      end
+    end
   end
 
   skip "specs for subclasses of Page and Resource"


### PR DESCRIPTION
This PRs solves a very specific problem with the implementation of `ActiveAdmin::ResourceCollection#find_resource`. The problem arised when i had the following admin resources:

```ruby
# app/admin/prospect.rb
ActiveAdmin.register Prospect do
  # ...
end

# app/admin/prospect_report.rb
ActiveAdmin.register Prospect, as: 'ProspectReport' do
  # ...
end

# app/admin/visits.rb
ActiveAdmin.register Visit do
  belongs_to :prospect
  # ...
end
```

I thought the visit resource was expected to be available on `/admin/prospects/:id/visits` but in practice, the route was on `/admin/prospects/:id/visits`.

The problem was that `find_resource` was doing this:

```ruby
resources.detect do |r|
  r.resource_name.to_s == obj.to_s || r.resource_class.to_s == obj.to_s
end
```

I thought the purpose was to find a resource by the resource name and then by class name, but this was doing another thing: It was finding a resource by resource name or class name. I think the `belongs_to` method should be looking for a resource with the name 'Prospect', and that resource should be the first one defined (not `ProsspectReport`), but, in practice, `find_resource` stopped its search when it found another resource with the same class associated due to just iterating once.

The fix i'm proposing is just to make two lookups: one for the resource name, **and** then one for the class:

```ruby
resources.detect do |r|
  r.resource_name.to_s == obj.to_s
end ||
resources.detect do |r|
  r.resource_class.to_s == obj.to_s
end
```
