### PR TITLE
Customize Comment Menu

### DIFF
--- a/lib/active_admin/orm/active_record/comments.rb
+++ b/lib/active_admin/orm/active_record/comments.rb
@@ -7,6 +7,7 @@ require 'active_admin/orm/active_record/comments/resource_helper'
 ActiveAdmin::Application.inheritable_setting :comments,                   true
 ActiveAdmin::Application.inheritable_setting :show_comments_in_menu,      true
 ActiveAdmin::Application.inheritable_setting :comments_registration_name, 'Comment'
+ActiveAdmin::Application.inheritable_setting :comments_menu, {}
 
 # Insert helper modules
 ActiveAdmin::Namespace.send :include, ActiveAdmin::Comments::NamespaceHelper
@@ -22,7 +23,11 @@ ActiveAdmin.after_load do |app|
     namespace.register ActiveAdmin::Comment, as: namespace.comments_registration_name do
       actions :index, :show, :create
 
-      menu false unless namespace.comments && namespace.show_comments_in_menu
+      if namespace.comments && namespace.show_comments_in_menu
+        menu namespace.comments_menu
+      elsif !namespace.comments || !namespace.show_comments_in_menu
+        menu false
+      end
 
       config.comments      = false # Don't allow comments on comments
       config.batch_actions = false # The default destroy batch action isn't showing up anyway...

--- a/lib/generators/active_admin/install/templates/active_admin.rb.erb
+++ b/lib/generators/active_admin/install/templates/active_admin.rb.erb
@@ -126,6 +126,9 @@ ActiveAdmin.setup do |config|
   #
   # You can change the name under which comments are registered:
   # config.comments_registration_name = 'AdminComment'
+  #
+  # You can customize the comment menu
+  # config.comments_menu = { parent: 'Admins', priority: 1 }
 
   # == Batch Actions
   #


### PR DESCRIPTION
Instead of Removing the Comments completely, I wanted to control their position in the default menu.

This PR creates a `comments_menu` config option that is passed to the `menu` in `ActiveAdmin::Comment`. This gives users full control over this item's position in the menu.