### PR TITLE
Updated resource-customization.md with a working permit example

### DIFF
--- a/docs/2-resource-customization.md
+++ b/docs/2-resource-customization.md
@@ -30,9 +30,11 @@ end
 Any form field that sends multiple values (such as a HABTM association, or an array attribute)
 needs to pass an empty array to `permit_params`:
 
+If your HABTM is `roles`, you should permit `role_ids: []`
+
 ```ruby
 ActiveAdmin.register Post do
-  permit_params :title, :content, :publisher_id, roles: []
+  permit_params :title, :content, :publisher_id, role_ids: []
 end
 ```
 


### PR DESCRIPTION
For a HABTM, just permitting :roles doesn't do anything.

Say that I have a model `User` and `Page`. `User` has HABTM `pages` relationship.

When I update the User's pages, the ActiveAdmin User controller receives parameter `page_ids: ['0', '1', '2']` and etc.

Permitting `:pages` in this case won't solve the problem. However permitting `page_ids: []` will do so.