### PR TITLE
Add ransack to delegated methods for collection decorator

### DIFF
--- a/lib/active_admin/resource_controller/decorators.rb
+++ b/lib/active_admin/resource_controller/decorators.rb
@@ -68,7 +68,7 @@ module ActiveAdmin
           ::Class.new parent do
             delegate :reorder, :page, :current_page, :total_pages, :limit_value,
                      :total_count, :num_pages, :to_key, :group_values, :except,
-                     :find_each
+                     :find_each, :ransack
 
             define_singleton_method(:name) { name }
           end


### PR DESCRIPTION
Using AA 1.0.0.pre and Draper 1.4.0.
Seems that ```:ransack``` is missing from the delegated methods for the collection, when it gets decorated.
Failing scenario, add a decorator to a model in you AA application, then try to delete it via the ```:destroy``` batch action.
I get an error message:

```ruby
undefined method `ransack' for #<#<Class:....
activeadmin (1.0.0.pre1) lib/active_admin/resource_controller/data_access.rb:231:in `apply_filtering'
activeadmin (1.0.0.pre1) lib/active_admin/resource_controller/data_access.rb:61:in `block in find_collection'
activeadmin (1.0.0.pre1) lib/active_admin/resource_controller/data_access.rb:58:in `each'
activeadmin (1.0.0.pre1) lib/active_admin/resource_controller/data_access.rb:58:in `find_collection'
activeadmin (1.0.0.pre1) lib/active_admin/batch_actions/controller.rb:37:in `batch_action_collection'
activeadmin (1.0.0.pre1) lib/active_admin/batch_actions/resource_extension.rb:70:in `block in add_default_batch_action'
activeadmin (1.0.0.pre1) lib/active_admin/batch_actions/controller.rb:12:in `instance_exec'
activeadmin (1.0.0.pre1) lib/active_admin/batch_actions/controller.rb:12:in `batch_action'
```
