### PR TITLE
ActiveAdmin.modal_dialog fire events before_open and after_open

### DIFF
--- a/app/assets/javascripts/active_admin/lib/modal_dialog.js.coffee
+++ b/app/assets/javascripts/active_admin/lib/modal_dialog.js.coffee
@@ -28,8 +28,14 @@ ActiveAdmin.modal_dialog = (message, inputs, callback)->
     [wrapper, elem, opts, type, klass] = [] # unset any temporary variables
 
   html += "</ul></form>"
-  $(html).appendTo('body').dialog
+
+  form = $(html).appendTo('body')
+  $('body').trigger 'modal_dialog:before_open', [form]
+
+  form.dialog
     modal: true
+    open: (event, ui) ->
+      $('body').trigger 'modal_dialog:after_open', [form]
     dialogClass: 'active_admin_dialog'
     buttons:
       OK: ->


### PR DESCRIPTION
Fixes #3991 

With this PR every time when ActiveAdmin.modal_dialog shows, it fires up two events on "body" tag:
1. 'modal_dialog:before_open'
2. 'modal_dialog:after_open'

Here is demo app which demonstrates usage of new events
https://github.com/workgena/demo.activeadmin.info/tree/modal_dialog (Branch modal_dialog)