### PR TITLE
added created_at to comments/index

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,6 +72,7 @@ en:
       labels:
         destroy: "Delete"
     comments:
+      created_at: "Created"
       resource_type: "Resource Type"
       author_type: "Author Type"
       body: "Body"

--- a/lib/active_admin/orm/active_record/comments.rb
+++ b/lib/active_admin/orm/active_record/comments.rb
@@ -74,6 +74,7 @@ ActiveAdmin.after_load do |app|
         column I18n.t('active_admin.comments.resource'),      :resource
         column I18n.t('active_admin.comments.author'),        :author
         column I18n.t('active_admin.comments.body'),          :body
+        column I18n.t('active_admin.comments.created_at'),    :created_at
         actions
       end
     end


### PR DESCRIPTION
Modified the comments' index table to include the created_at column.

![comments created at](https://cloud.githubusercontent.com/assets/2336088/8500050/3396abba-215e-11e5-9dc5-da321111c813.png)
