### PR TITLE
Enable pretty_format to handle Symbols

### DIFF
--- a/lib/active_admin/view_helpers/display_helper.rb
+++ b/lib/active_admin/view_helpers/display_helper.rb
@@ -43,7 +43,7 @@ module ActiveAdmin
       # Attempts to create a human-readable string for any object
       def pretty_format(object)
         case object
-        when String, Numeric, Arbre::Element
+        when String, Numeric, Symbol, Arbre::Element
           object.to_s
         when Date, Time
           localize object, format: :long

--- a/spec/unit/pretty_format_spec.rb
+++ b/spec/unit/pretty_format_spec.rb
@@ -7,7 +7,7 @@ describe "#pretty_format" do
     mock_action_view.send *args, &block
   end
 
-  {String: 'hello', Fixnum: 23, Float: 5.67, Bignum: 10**30,
+  {String: 'hello', Fixnum: 23, Float: 5.67, Bignum: 10**30, Symbol: :foo,
     'Arbre::Element' => Arbre::Element.new.br(:foo)
   }.each do |klass, obj|
     it "should call `to_s` on #{klass}s" do


### PR DESCRIPTION
Very basic solution to https://github.com/activeadmin/activeadmin/issues/3914 - if the model returns a Symbol, just call to_s on it as we do for numbers and strings.