### PR TITLE
add localize format to the configuration

### DIFF
--- a/docs/1-general-configuration.md
+++ b/docs/1-general-configuration.md
@@ -48,6 +48,15 @@ to your application's `config/locales` folder and update it. We welcome new/upda
 so feel free to [contribute](https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md)!
 To translate third party gems like devise, use for example devise-i18n.
 
+## Localize Format For Dates and Times
+
+Active Admin sets `:long` as default localize format for dates and times.
+If you want, you can customize it.
+
+```ruby
+config.localize_format = :short
+```
+
 ## Namespaces
 
 When registering resources in Active Admin, they are loaded into a namespace.

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -105,6 +105,9 @@ module ActiveAdmin
     # Set flash message keys that shouldn't show in ActiveAdmin
     inheritable_setting :flash_keys_to_except, ['timedout']
 
+    # Set default localize format for Date/Time values
+    inheritable_setting :localize_format, :long
+
     # Active Admin makes educated guesses when displaying objects, this is
     # the list of methods it tries calling in order
     setting :display_name_methods, [ :display_name,

--- a/lib/active_admin/view_helpers/display_helper.rb
+++ b/lib/active_admin/view_helpers/display_helper.rb
@@ -46,7 +46,7 @@ module ActiveAdmin
         when String, Numeric, Symbol, Arbre::Element
           object.to_s
         when Date, Time
-          localize object, format: :long
+          localize object, format: active_admin_application.localize_format
         else
           if defined?(::ActiveRecord) && object.is_a?(ActiveRecord::Base) ||
              defined?(::Mongoid)      && object.class.include?(Mongoid::Document)
@@ -56,7 +56,6 @@ module ActiveAdmin
           end
         end
       end
-
     end
   end
 end

--- a/lib/generators/active_admin/install/templates/active_admin.rb.erb
+++ b/lib/generators/active_admin/install/templates/active_admin.rb.erb
@@ -140,6 +140,14 @@ ActiveAdmin.setup do |config|
   #
   # config.before_filter :do_something_awesome
 
+  # == Localize Date/Time Format
+  #
+  # Set the localize format to display dates and times.
+  # To understand how to localize your app with I18n, read more at
+  # https://github.com/svenfuchs/i18n/blob/master/lib%2Fi18n%2Fbackend%2Fbase.rb#L52
+  #
+  config.localize_format = :long
+
   # == Setting a Favicon
   #
   # config.favicon = 'favicon.ico'

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -49,6 +49,15 @@ describe ActiveAdmin::Application do
     expect(application.favicon).to eq false
   end
 
+  it "should return default localize format" do
+    expect(application.localize_format).to eq :long
+  end
+
+  it "should set localize format" do
+    application.localize_format = :default
+    expect(application.localize_format).to eq :default
+  end
+
   it "should set the site's favicon" do
     application.favicon = "/a/favicon.ico"
     expect(application.favicon).to eq "/a/favicon.ico"

--- a/spec/unit/pretty_format_spec.rb
+++ b/spec/unit/pretty_format_spec.rb
@@ -29,6 +29,20 @@ describe "#pretty_format" do
         expect(pretty_format(t)).to eq "February 28, 1985 20:15"
       end
 
+      context "apply custom localize format" do
+        before do
+          ActiveAdmin.application.localize_format = :short
+        end
+        after do
+          ActiveAdmin.application = nil
+        end
+        it "should actually do the formatting" do
+          t = Time.utc(1985, "feb", 28, 20, 15, 1)
+
+          expect(pretty_format(t)).to eq "28 Feb 20:15"
+        end
+      end
+
       context "with non-English locale" do
         before(:all) do
           @previous_locale = I18n.locale.to_s


### PR DESCRIPTION
### Localize Format For Dates and Times

Active Admin uses `:long` as default localize format for dates and times.
If you want, you can customize it.

```ruby
config.localize_format = :short
```
