### PR TITLE
Form Builder has_many doesn't work with has_one relationship

### DIFF
--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -61,7 +61,7 @@ module ActiveAdmin
         end
         
         template.assign(has_many_block: true)
-        contents = without_wrapper { inputs(options, &form_block) }
+        contents = without_wrapper { inputs(options, &form_block) } || "".html_safe
 
         if builder_options[:new_record]
           contents << js_for_has_many(assoc, form_block, template, builder_options[:new_record], options[:class])

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -38,13 +38,20 @@ inject_into_file 'app/models/blog/post.rb', %q{
 }, after: 'class Blog::Post < ActiveRecord::Base'
 
 
+generate :model, "profile user_id:integer bio:text"
 generate :model, "user type:string first_name:string last_name:string username:string age:integer"
 inject_into_file 'app/models/user.rb', %q{
   has_many :posts, foreign_key: 'author_id'
+  has_one :profile
+  accepts_nested_attributes_for :profile, allow_destroy: true
   def display_name
     "#{first_name} #{last_name}"
   end
 }, after: 'class User < ActiveRecord::Base'
+
+inject_into_file 'app/models/profile.rb', %q{
+  belongs_to :user
+}, after: 'class Profile < ActiveRecord::Base'
 
 generate :model, 'publisher --migration=false --parent=User'
 generate :model, 'category name:string description:text'

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -277,6 +277,43 @@ describe ActiveAdmin::FormBuilder do
 
   end
 
+  context "with a has_one relation on an author's profile" do
+    let :body do
+      author = user()
+      build_form do |f|
+        f.inputs do
+          f.input :title
+          f.input :body
+        end
+        f.form_builder.instance_eval do
+          @object.author = author
+        end
+        f.inputs name: 'Author', for: :author do |author|
+          author.has_many :profile, allow_destroy: true do |profile|
+            profile.input :bio
+          end
+        end
+      end
+    end
+
+    it "should see the button to add profile" do
+      def user
+        User.new
+      end
+      expect(body).to have_selector("a[contains(data-html,'post[author_attributes][profile_attributes][bio]')]")
+    end
+
+    it "should see the profile fields for an existing profile" do
+      def user
+        u = User.new
+        u.profile = Profile.new
+        u
+      end
+      expect(body).to have_selector("[id='post_author_attributes_profile_attributes_bio']", count: 1)
+      expect(body).to have_selector("textarea[name='post[author_attributes][profile_attributes][bio]']")
+    end
+  end
+
   shared_examples :inputs_with_for_expectation do
     it "should generate a nested text input once" do
       expect(body).to have_selector("[id=post_author_attributes_first_name_input]", count: 1)


### PR DESCRIPTION
The documentation for forms (5-forms.md) says a has_many can be used with a has_one relationship, and shows f.has_many :comment as an example. As far as I can tell, this doesn't work at all when creating a new record.

You'll get an exception `undefined method '<<' for nil:NilClass` when you make the `f.has_many` call. This exception is from lib/active_admin/form_builder.rb:67, because `contents` variable is nil. `contents` is the result of formtastic/helpers/inputs_helper.rb `inputs_for_nested_attributes`, whose last line is a call to action_view/helpers/form_helper.rb's `field_for` with only one parameter (the second parameter, `record_object`, is nil). `fields_for` calls  `fields_for_with_nested_attributes` which ends up failing because the `association` parameter is nil.

....

It's broken and I'm tired. It works if I use a has_many relationship. If it's not supposed to work then the documentation needs to be updated.
