### PR TITLE
add missing require to devise generator

### DIFF
--- a/lib/generators/active_admin/devise/devise_generator.rb
+++ b/lib/generators/active_admin/devise/devise_generator.rb
@@ -1,4 +1,5 @@
 require "active_admin/error"
+require "active_admin/dependency"
 
 module ActiveAdmin
   module Generators


### PR DESCRIPTION
I received the following error when calling the generator:

```
$ rails generate active_admin:install 
      invoke  devise
/Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/activeadmin-7c18de4cbcf5/lib/generators/active_admin/devise/devise_generator.rb:19:in `install_devise': uninitialized constant ActiveAdmin::Generators::DeviseGenerator::Dependency (NameError)
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:133:in `block in invoke_all'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:133:in `each'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:133:in `map'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:133:in `invoke_all'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/group.rb:232:in `dispatch'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:115:in `invoke'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/group.rb:277:in `block in _invoke_for_class_method'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/shell.rb:68:in `with_padding'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/group.rb:266:in `_invoke_for_class_method'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/group.rb:133:in `_invoke_from_option_users'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:133:in `block in invoke_all'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:133:in `each'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:133:in `map'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:133:in `invoke_all'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/group.rb:232:in `dispatch'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/railties-4.2.3/lib/rails/generators.rb:157:in `invoke'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/railties-4.2.3/lib/rails/commands/generate.rb:13:in `<top (required)>'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/backports-3.6.4/lib/backports/std_lib.rb:9:in `require'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/backports-3.6.4/lib/backports/std_lib.rb:9:in `require_with_backports'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/skylight-0.3.21/lib/skylight/probes.rb:81:in `require'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/railties-4.2.3/lib/rails/commands/commands_tasks.rb:123:in `require_command!'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/railties-4.2.3/lib/rails/commands/commands_tasks.rb:130:in `generate_or_destroy'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/railties-4.2.3/lib/rails/commands/commands_tasks.rb:50:in `generate'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/railties-4.2.3/lib/rails/commands/commands_tasks.rb:39:in `run_command!'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/railties-4.2.3/lib/rails/commands.rb:17:in `<top (required)>'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/backports-3.6.4/lib/backports/std_lib.rb:9:in `require'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/backports-3.6.4/lib/backports/std_lib.rb:9:in `require_with_backports'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/skylight-0.3.21/lib/skylight/probes.rb:81:in `require'
  from /Users/me/my-app/bin/rails:8:in `<top (required)>'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
  from /Users/me/.rbenv/versions/2.1.5/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
  from -e:1:in `<main>'
```

The problem is a missing require. When it's added, the error goes away.