### PR TITLE
Configure button radius via SCSS variables

### DIFF
--- a/app/assets/stylesheets/active_admin/_header.scss
+++ b/app/assets/stylesheets/active_admin/_header.scss
@@ -66,7 +66,7 @@
         text-decoration: none;
         padding: 6px 10px 4px 10px;
         position: relative;
-        @include rounded(10px);
+        @include rounded($tabs-radius);
       }
 
       &.current > a {

--- a/app/assets/stylesheets/active_admin/mixins/_buttons.scss
+++ b/app/assets/stylesheets/active_admin/mixins/_buttons.scss
@@ -1,5 +1,5 @@
 @mixin basic-button {
-  @include rounded(200px);
+  @include rounded($basic-button-radius);
   display: inline-block;
   font-weight: bold;
   font-size: 1.0em;

--- a/app/assets/stylesheets/active_admin/mixins/_variables.scss
+++ b/app/assets/stylesheets/active_admin/mixins/_variables.scss
@@ -30,5 +30,7 @@ $cell-horizontal-padding: 12px !default;
 $section-padding: 15px !default;
 $text-input-horizontal-padding: 10px !default;
 $text-input-total-padding: $text-input-horizontal-padding * 2 + $border-width * 2;
+$basic-button-radius: 200px !default;
+$tabs-radius: 10px !default;
 
 $blank-slate-border: 1px dashed #DADADA !default;


### PR DESCRIPTION
This makes it easy to adjust the rounded corners on the buttons if you're not a fan of the default style.

A user wanting to remove the rounded corners can simply add the following:
```scss
$basic-button-radius: 0px; //all buttons
$tabs-radius: 0px; //navigation tabs
```