### PR TITLE
Make status_tag usable with actual booleans

### DIFF
--- a/lib/active_admin/views/components/status_tag.rb
+++ b/lib/active_admin/views/components/status_tag.rb
@@ -57,9 +57,10 @@ module ActiveAdmin
       protected
 
       def convert_to_boolean_status(status)
-        if status == 'true'
+        case status
+        when true, 'true'
           'Yes'
-        elsif ['false', nil].include?(status)
+        when false, 'false', nil
           'No'
         else
           status

--- a/spec/unit/views/components/status_tag_spec.rb
+++ b/spec/unit/views/components/status_tag_spec.rb
@@ -89,8 +89,22 @@ describe ActiveAdmin::Views::StatusTag do
       end
     end
 
-    context "when status is false" do
+    context "when status is 'false'" do
       subject { status_tag('false') }
+
+      describe '#class_list' do
+        subject { super().class_list }
+        it      { is_expected.to include('status_tag') }
+      end
+
+      describe '#content' do
+        subject { super().content }
+        it      { is_expected.to eq('No') }
+      end
+    end
+
+    context "when status is false" do
+      subject { status_tag(false) }
 
       describe '#class_list' do
         subject { super().class_list }


### PR DESCRIPTION
I'd like status_tag(boolean_value) behavior be the same as for boolean active record db columns - localized Yes and No with colors.