### PR TITLE
Issue with ransack delegation fixed

### DIFF
--- a/lib/active_admin/resource_controller/decorators.rb
+++ b/lib/active_admin/resource_controller/decorators.rb
@@ -68,7 +68,7 @@ module ActiveAdmin
           ::Class.new parent do
             delegate :reorder, :page, :current_page, :total_pages, :limit_value,
                      :total_count, :num_pages, :to_key, :group_values, :except,
-                     :find_each
+                     :find_each, :ransack
 
             define_singleton_method(:name) { name }
           end


### PR DESCRIPTION
There is 'undefined ransack method' exception during a default batch action (e.g. delete) on decorated collection. This additional delegation fixes the issue.