### PR TITLE
Fix a typo in components/columns.rb file

### DIFF
--- a/lib/active_admin/views/components/columns.rb
+++ b/lib/active_admin/views/components/columns.rb
@@ -41,7 +41,7 @@ module ActiveAdmin
     # the first being 2 time bigger than the second.
     #
     #
-    # == Max and Mix Column Sizes
+    # == Max and Min Column Sizes
     #
     # Active Admin is a fluid width layout, which means that columns are all defined
     # using percentages. Sometimes this can cause issues if you don't want a column


### PR DESCRIPTION
There was a small typo in `views/components/columns.rb` file.
This PR fixes that.