### PR TITLE
If the search result value is an array, then show the comma-separated…

### DIFF
--- a/lib/active_admin/filters/humanized.rb
+++ b/lib/active_admin/filters/humanized.rb
@@ -10,7 +10,7 @@ module ActiveAdmin
       end
 
       def value
-        @value
+        @value.is_a?(::Array) ? @value.compact.join(', ') : @value
       end
 
       def body

--- a/spec/unit/filters/humanized_spec.rb
+++ b/spec/unit/filters/humanized_spec.rb
@@ -1,19 +1,31 @@
 require 'rails_helper'
 
 describe ActiveAdmin::Filters::Humanized do
-  let(:param) { ['category_id_eq', '1'] }
-
-  subject { ActiveAdmin::Filters::Humanized.new(param) }
-
   describe '#value' do
-    it 'should equal query string parameter' do
+    it 'should equal query string parameter if not an Array' do
+      param = ['category_id_eq', '1']
+      subject = ActiveAdmin::Filters::Humanized.new(param)
       expect(subject.value).to eq('1')
+    end
+
+    it 'should equal query string parameters separated by commas if an Array' do
+      param = ['category_id_eq', ['1', '2']]
+      subject = ActiveAdmin::Filters::Humanized.new(param)
+      expect(subject.value).to eq("1, 2")
+    end
+
+    it 'should remove nil values before joining equal query string parameters separated by commas if an Array' do
+      param = ['category_id_eq', ['1', nil, '2']]
+      subject = ActiveAdmin::Filters::Humanized.new(param)
+      expect(subject.value).to eq("1, 2")
     end
   end
 
   describe '#body' do
     context 'when Ransack predicate' do
       it 'parses language from Ransack' do
+        param = ['category_id_eq', '1']
+        subject = ActiveAdmin::Filters::Humanized.new(param)
         expect(subject.body).to eq('Category ID equals')
       end
 


### PR DESCRIPTION
… entries in the search results section.