### PR TITLE
support for full range of JSON and JSONB operators in PostgreSQL

### DIFF
--- a/lib/active_admin/order_clause.rb
+++ b/lib/active_admin/order_clause.rb
@@ -3,9 +3,9 @@ module ActiveAdmin
     attr_reader :field, :order
 
     def initialize(clause)
-      clause =~ /^([\w\_\.]+)(->'\w+')?_(desc|asc)$/
+      clause =~ /^([\w\_\.]+)([-#]>>?'\w+')?_(desc|asc)$/
       @column = $1
-      @op = $2
+      @op = $2.to_s.strip
       @order = $3
 
       @field = [@column, @op].compact.join

--- a/spec/unit/order_clause_spec.rb
+++ b/spec/unit/order_clause_spec.rb
@@ -67,6 +67,26 @@ describe ActiveAdmin::OrderClause do
     end
   end
 
+  describe "hstore_col#>>'field'_asc" do
+    let(:clause) { "hstore_col->>'field'_asc" }
+
+    it { is_expected.to be_valid }
+
+    describe '#field' do
+      subject { super().field }
+      it { is_expected.to eq("hstore_col->>'field'") }
+    end
+
+    describe '#order' do
+      subject { super().order }
+      it { is_expected.to eq('asc') }
+    end
+
+    it 'converts to sql' do
+      expect(subject.to_sql(config)).to eq %Q("hstore_col"->>'field' asc)
+    end
+  end
+
   describe '_asc' do
     let(:clause) { '_asc' }
 


### PR DESCRIPTION
Based on this http://www.postgresql.org/docs/9.4/static/functions-json.html#FUNCTIONS-JSON-OP-TABLE there are 6 operators for JSON and JSONB columns in PostgreSQL. ActiveAdmin currently supports only 2 of those operators. Just small modification in ActiveAdmin::OrderClause's regular expression gives us support for remaining 4 operators.

It only partially resolves #3085.