### PR TITLE
Don't pass encoding_options to CSV

### DIFF
--- a/lib/active_admin/csv_builder.rb
+++ b/lib/active_admin/csv_builder.rb
@@ -49,13 +49,17 @@ module ActiveAdmin
       end
 
       if options.delete(:column_names) { true }
-        receiver << CSV.generate_line(columns.map{ |c| encode c.name, options }, options)
+        receiver << CSV.generate_line(
+          columns.map { |c| encode c.name, options },
+          options.except(:encoding_options))
       end
 
       (1..paginated_collection.total_pages).each do |page_no|
         paginated_collection(page_no).each do |resource|
-           resource = controller.send :apply_decorator, resource
-           receiver << CSV.generate_line(build_row(resource, columns, options), options)
+          resource = controller.send :apply_decorator, resource
+          receiver << CSV.generate_line(
+            build_row(resource, columns, options),
+            options.except(:encoding_options))
         end
       end
     end


### PR DESCRIPTION
CSV will raise an error when you pass it an unrecognized key, but it's
used in #encode.

This patch filters the encoding_options CSV option out of the hash that is passed to CSV.