### PR TITLE
Add configuration for including association filters by default

### DIFF
--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -111,6 +111,9 @@ module ActiveAdmin
     # Set default localize format for Date/Time values
     inheritable_setting :localize_format, :long
 
+    # Include association filters by default
+    inheritable_setting :include_default_association_filters, true
+
     # Active Admin makes educated guesses when displaying objects, this is
     # the list of methods it tries calling in order
     setting :display_name_methods, [ :display_name,

--- a/lib/active_admin/filters/resource_extension.rb
+++ b/lib/active_admin/filters/resource_extension.rb
@@ -107,7 +107,11 @@ module ActiveAdmin
 
       # @return [Array] The array of default filters for this resource
       def default_filters
-        default_association_filters + default_content_filters + custom_ransack_filters
+        [].tap do |result|
+          result.concat default_association_filters if namespace.include_default_association_filters
+          result.concat default_content_filters
+          result.concat custom_ransack_filters
+        end
       end
 
       def custom_ransack_filters

--- a/lib/active_admin/filters/resource_extension.rb
+++ b/lib/active_admin/filters/resource_extension.rb
@@ -107,11 +107,11 @@ module ActiveAdmin
 
       # @return [Array] The array of default filters for this resource
       def default_filters
-        [].tap do |result|
-          result.concat default_association_filters if namespace.include_default_association_filters
-          result.concat default_content_filters
-          result.concat custom_ransack_filters
-        end
+        result = []
+        result.concat default_association_filters if namespace.include_default_association_filters
+        result.concat default_content_filters
+        result.concat custom_ransack_filters
+        result
       end
 
       def custom_ransack_filters

--- a/lib/generators/active_admin/install/templates/active_admin.rb.erb
+++ b/lib/generators/active_admin/install/templates/active_admin.rb.erb
@@ -259,4 +259,11 @@ ActiveAdmin.setup do |config|
   # You can enable or disable them for all resources here.
   #
   # config.filters = true
+  #
+  # By default the filters include associations in a select, which means
+  # that every record will be loaded for each association.
+  # You can enabled or disable the inclusion
+  # of those filters by default here.
+  #
+  # config.include_default_association_filters = true
 end

--- a/spec/unit/filters/resource_spec.rb
+++ b/spec/unit/filters/resource_spec.rb
@@ -32,6 +32,13 @@ describe ActiveAdmin::Filters::ResourceExtension do
     expect(resource.filters).to be_empty
   end
 
+  it "should return the defaults without associations if default association filters are disabled on the namespace" do
+    resource.namespace.include_default_association_filters = false
+    expect(resource.filters.keys).to match_array([
+      :body, :created_at, :custom_searcher, :position, :published_at, :starred, :title, :updated_at
+    ])
+  end
+
   describe "removing a filter" do
     it "should work" do
       expect(resource.filters.keys).to include :author


### PR DESCRIPTION
In many situations loading all records of a model for default association filters is unreasonable.

This change adds a `include_default_association_filters` setting which can be used to disable the inclusion of association filters by default without affecting other default filters.