### PR TITLE
Support jquery-ui-rails version 4.* and 5.*

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,9 @@ require File.expand_path 'spec/support/detect_rails_version', File.dirname(__FIL
 rails_version = detect_rails_version
 gem 'rails', rails_version
 
+jquery_ui_rails_version = rails_version > "4" ? "~> 5.0" : "~> 4.0"
+gem 'jquery-ui-rails', jquery_ui_rails_version
+
 gem 'execjs', '~> 2.4.0' # ~> 2.5.0 works only for Ruby > 2.0
 
 # Optional dependencies

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'formtastic_i18n'
   s.add_dependency 'inherited_resources', '~> 1.6'
   s.add_dependency 'jquery-rails'
-  s.add_dependency 'jquery-ui-rails',     '~> 5.0'
+  s.add_dependency 'jquery-ui-rails'
   s.add_dependency 'kaminari',            '~> 0.15'
   s.add_dependency 'rails',               '>= 3.2', '< 5.0'
   s.add_dependency 'ransack',             '~> 1.3'

--- a/app/assets/javascripts/active_admin/base.js.coffee
+++ b/app/assets/javascripts/active_admin/base.js.coffee
@@ -1,11 +1,6 @@
 #= require jquery
-#= require jquery-ui/datepicker
-#= require jquery-ui/dialog
-#= require jquery-ui/sortable
-#= require jquery-ui/widget
-#= require jquery-ui/tabs
+#= require ./jquery_ui
 #= require jquery_ujs
-#
 #= require_self
 #= require_tree ./lib
 #= require_tree ./ext

--- a/app/assets/javascripts/active_admin/jquery_ui.js.erb
+++ b/app/assets/javascripts/active_admin/jquery_ui.js.erb
@@ -1,0 +1,11 @@
+<% jquery_ui_path = if Jquery::Ui::Rails::VERSION >= "5"
+                      "jquery-ui/"
+                    else
+                      "jquery.ui."
+                    end
+%>
+<% require_asset "#{jquery_ui_path}datepicker" %>
+<% require_asset "#{jquery_ui_path}dialog" %>
+<% require_asset "#{jquery_ui_path}sortable" %>
+<% require_asset "#{jquery_ui_path}widget" %>
+<% require_asset "#{jquery_ui_path}tabs" %>


### PR DESCRIPTION
I came across several apps where the main pain point adding ActiveAdmin was to upgrade to the latest `jquery-ui-rails` as it was affecting the front-end. I believe that removing the version of `jquery-ui-rails` ActiveAdmin depends on makes it easier to add ActiveAdmin to an existing app.

Looking at https://github.com/activeadmin/activeadmin/commit/7b9ad75a93f5edaacdfef09cbf5e1d999826a952 I figured that we lock the dependency to `jquery-ui-rails` version **5+** because the load path is different from **4+**. Looking at the discusion on https://github.com/sstephenson/sprockets/issues/90 I figured that we can support `jquery-ui-rails` **4.*** and **5.*** by taking advantage of the `require_asset` method.

Here are two screenshots where I run ActiveAdmin on `jquery-ui-rails` **4.*** and **5.***:

**jquery-ui-rails 4.***
<img width="761" alt="screen shot 2015-09-21 at 12 06 32 pm" src="https://cloud.githubusercontent.com/assets/45299/10002192/a31d0728-605a-11e5-8b44-c6938188ac80.png">

**jquery-ui-rails 5.***
<img width="698" alt="screen shot 2015-09-21 at 12 05 40 pm" src="https://cloud.githubusercontent.com/assets/45299/10002203/ab6efd0a-605a-11e5-8a93-6d0311f909d7.png">


I also changed the test suite to run against `jquery-ui-rails 4.0+` on Rails 3.2 and `jquery-ui-rails 5.0+` on Rails 4.* to ensure that we support both versions.