### PR TITLE
Add german translation for the Comments model

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -132,3 +132,8 @@ de:
       block: "Liste"
       grid: "Gitter"
       blog: "Blog"
+  activerecord:
+    models:
+      comment:
+        one: Kommentar
+        other: Kommentare


### PR DESCRIPTION
This translation is used also in the top menu. You could use this also for `de_CH` it should be the same.