### PR TITLE
Rails 5: In fields_for, use to_unsafe_h on params before flat_map if necessary

### DIFF
--- a/lib/active_admin/view_helpers/fields_for.rb
+++ b/lib/active_admin/view_helpers/fields_for.rb
@@ -17,6 +17,7 @@ module ActiveAdmin
         namespace = options[:namespace]
         except = options[:except].is_a?(Array) ? options[:except] : [options[:except]]
 
+        params = params.to_unsafe_h if params.respond_to?(:to_unsafe_h)
         params.flat_map do |k, v|
           next if namespace.nil? && %w(controller action commit utf8).include?(k.to_s)
           next if except.map(&:to_s).include?(k.to_s)


### PR DESCRIPTION
See http://eileencodes.com/posts/actioncontroller-parameters-now-returns-an-object-instead-of-a-hash/