### PR TITLE
Lock shoulda matchers to 2.8.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ group :test do
   gem 'rspec'
   gem 'rspec-rails', '~> 3.1.0'
   gem 'i18n-spec'
-  gem 'shoulda-matchers'
+  gem 'shoulda-matchers', '<= 2.8.0'
   gem 'sqlite3', platforms: :mri
   gem 'activerecord-jdbcsqlite3-adapter', platforms: :jruby
   gem 'poltergeist'


### PR DESCRIPTION
shoulda-matchers 3 drops suport for Rails 3.x and Ruby 1.9,
making it incompatible with the ActiveAdmin test matrix