### PR TITLE
Integrate ActiveAdmin with reform

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'cancan'
 gem 'devise'
 gem 'draper'
 gem 'pundit'
+gem 'reform'
 
 # Utility gems used in both development & test environments
 gem 'rake', require: false

--- a/docs/15-forms.md
+++ b/docs/15-forms.md
@@ -1,0 +1,31 @@
+# Form Objects
+
+Active Admin allows you to use the form objects to provide ActiveAdmin-specific
+validations of a resource. [Reform](https://github.com/apotonick/reform)
+
+## Example usage
+
+```ruby
+# app/models/post.rb
+class Post < ActiveRecord::Base
+  # has title, content, and image_url
+end
+
+# app/forms/post_form.rb
+class PostForm < Reform::Form
+  property :title, validates: { presence: true, length: { minimum: 10 } }
+  property :content, validates: { presence: true }
+  property :image_url, validates: { presence: true }
+end
+
+# app/admin/post.rb
+ActiveAdmin.register Post do
+  form_class PostForm
+
+  index do
+    column :title
+    column :image
+    actions
+  end
+end
+```

--- a/features/edit_page.feature
+++ b/features/edit_page.feature
@@ -123,7 +123,7 @@ Feature: Edit Page
 
       ActiveAdmin.register Post do
         form_class PostForm
-        permit_params :title, :body
+        permit_params :title, :body if Rails::VERSION::MAJOR == 4
 
         form do |f|
           f.inputs do

--- a/features/edit_page.feature
+++ b/features/edit_page.feature
@@ -115,3 +115,28 @@ Feature: Edit Page
     Then I should see "Post was successfully updated."
     And I should see the attribute "Title" with "Hello World from update"
     And I should see the attribute "Author" with "John Doe"
+
+  Scenario: Use form object
+    Given a configuration of:
+    """
+      require 'post_form'
+
+      ActiveAdmin.register Post do
+        form_class PostForm
+        permit_params :title, :body
+
+        form do |f|
+          f.inputs do
+            f.input :title
+          end
+          f.actions
+        end
+      end
+    """
+    Given I follow "Edit"
+    And I fill in "Title" with ""
+    Then I press "Update Post"
+    When I should see "can't be blank"
+    And I fill in "Title" with "Hello World"
+    And I press "Update Post"
+    And I should see the attribute "Title" with "Hello World"

--- a/features/new_page.feature
+++ b/features/new_page.feature
@@ -107,3 +107,27 @@ Feature: New Page
     Given I follow "New Post"
     Then I should not see "Title"
     And I should see "Body"
+
+  Scenario: Use form object
+    Given a configuration of:
+    """
+      require 'post_form'
+
+      ActiveAdmin.register Post do
+        form_class PostForm
+        permit_params :title, :body
+
+        form do |f|
+          f.inputs do
+            f.input :title
+          end
+          f.actions
+        end
+      end
+    """
+    And I follow "New Post"
+    Then I press "Create Post"
+    When I should see "can't be blank"
+    And I fill in "Title" with "Hello World"
+    And I press "Update Post"
+    And I should see the attribute "Title" with "Hello World"

--- a/features/new_page.feature
+++ b/features/new_page.feature
@@ -115,7 +115,7 @@ Feature: New Page
 
       ActiveAdmin.register Post do
         form_class PostForm
-        permit_params :title, :body
+        permit_params :title, :body if Rails::VERSION::MAJOR == 4
 
         form do |f|
           f.inputs do

--- a/lib/active_admin/dsl.rb
+++ b/lib/active_admin/dsl.rb
@@ -169,5 +169,9 @@ module ActiveAdmin
       # us to handle a string or a class.
       config.decorator_class_name = "::#{ decorator_class }"
     end
+
+    def form_class(form_class)
+      config.form_class_name = "::#{ form_class }"
+    end
   end
 end

--- a/lib/active_admin/dsl.rb
+++ b/lib/active_admin/dsl.rb
@@ -171,7 +171,7 @@ module ActiveAdmin
     end
 
     def form_class(form_class)
-      config.form_class_name = "::#{ form_class }"
+      config.form_class_name = "::#{form_class}"
     end
   end
 end

--- a/lib/active_admin/resource.rb
+++ b/lib/active_admin/resource.rb
@@ -96,7 +96,9 @@ module ActiveAdmin
     end
 
     def form_class
-      ActiveSupport::Dependencies.constantize(form_class_name) if form_class_name
+      if form_class_name
+        ActiveSupport::Dependencies.constantize(form_class_name)
+      end
     end
 
     def resource_table_name

--- a/lib/active_admin/resource.rb
+++ b/lib/active_admin/resource.rb
@@ -57,6 +57,8 @@ module ActiveAdmin
     # nil to not decorate.
     attr_accessor :decorator_class_name
 
+    attr_accessor :form_class_name
+
     module Base
       def initialize(namespace, resource_class, options = {})
         @namespace = namespace
@@ -91,6 +93,10 @@ module ActiveAdmin
 
     def decorator_class
       ActiveSupport::Dependencies.constantize(decorator_class_name) if decorator_class_name
+    end
+
+    def form_class
+      ActiveSupport::Dependencies.constantize(form_class_name) if form_class_name
     end
 
     def resource_table_name

--- a/lib/active_admin/resource_controller.rb
+++ b/lib/active_admin/resource_controller.rb
@@ -1,6 +1,7 @@
 require 'active_admin/resource_controller/action_builder'
 require 'active_admin/resource_controller/data_access'
 require 'active_admin/resource_controller/decorators'
+require 'active_admin/resource_controller/forms'
 require 'active_admin/resource_controller/scoping'
 require 'active_admin/resource_controller/streaming'
 require 'active_admin/resource_controller/sidebars'
@@ -17,6 +18,7 @@ module ActiveAdmin
 
     include ActionBuilder
     include Decorators
+    include Forms
     include DataAccess
     include Scoping
     include Streaming

--- a/lib/active_admin/resource_controller.rb
+++ b/lib/active_admin/resource_controller.rb
@@ -1,7 +1,7 @@
 require 'active_admin/resource_controller/action_builder'
 require 'active_admin/resource_controller/data_access'
 require 'active_admin/resource_controller/decorators'
-require 'active_admin/resource_controller/forms'
+require "active_admin/resource_controller/forms"
 require 'active_admin/resource_controller/scoping'
 require 'active_admin/resource_controller/streaming'
 require 'active_admin/resource_controller/sidebars'

--- a/lib/active_admin/resource_controller/data_access.rb
+++ b/lib/active_admin/resource_controller/data_access.rb
@@ -148,7 +148,6 @@ module ActiveAdmin
       def create_resource(object)
         run_create_callbacks object do
           if object.is_a?(Reform::Form)
-            object.model.restore_attributes
             object.validate(*resource_params)
           end
           save_resource(object)

--- a/lib/active_admin/resource_controller/data_access.rb
+++ b/lib/active_admin/resource_controller/data_access.rb
@@ -183,7 +183,7 @@ module ActiveAdmin
         when object.respond_to?(:attributes=)
           object.attributes = attributes[0]
         when object.is_a?(Reform::Form)
-           object.validate(*attributes)
+          object.validate(*attributes)
         end
 
         run_update_callbacks object do

--- a/lib/active_admin/resource_controller/data_access.rb
+++ b/lib/active_admin/resource_controller/data_access.rb
@@ -91,6 +91,7 @@ module ActiveAdmin
           authorize_resource! resource
 
           resource = apply_decorator resource
+          resource = apply_form resource
           set_resource_ivar resource
         end
       end
@@ -123,6 +124,7 @@ module ActiveAdmin
           authorize_resource! resource
 
           resource = apply_decorator resource
+          resource = apply_form resource
           set_resource_ivar resource
         end
       end
@@ -145,6 +147,10 @@ module ActiveAdmin
       # @return [void]
       def create_resource(object)
         run_create_callbacks object do
+          if object.is_a?(Reform::Form)
+            object.model.restore_attributes
+            object.validate(*resource_params)
+          end
           save_resource(object)
         end
       end
@@ -171,10 +177,13 @@ module ActiveAdmin
       #
       # @return [void]
       def update_resource(object, attributes)
-        if object.respond_to?(:assign_attributes)
+        case
+        when object.respond_to?(:assign_attributes)
           object.assign_attributes(*attributes)
-        else
+        when object.respond_to?(:attributes=)
           object.attributes = attributes[0]
+        when object.is_a?(Reform::Form)
+           object.validate(*attributes)
         end
 
         run_update_callbacks object do
@@ -277,7 +286,7 @@ module ActiveAdmin
       def collection_applies(options = {})
         only = Array(options.fetch(:only, COLLECTION_APPLIES))
         except = Array(options.fetch(:except, []))
-        
+
         # see #4074 for code reasons
         COLLECTION_APPLIES.select { |applier| only.include? applier }
                           .reject { |applier| except.include? applier }

--- a/lib/active_admin/resource_controller/forms.rb
+++ b/lib/active_admin/resource_controller/forms.rb
@@ -1,0 +1,25 @@
+module ActiveAdmin
+  class ResourceController < BaseController
+    module Forms
+
+    protected
+
+      def apply_form(resource)
+        apply_form? ? form_class.new(resource) : resource
+      end
+
+    private
+
+      def apply_form?
+        case action_name
+        when 'new', 'edit', 'update', 'create'
+          form_class.present?
+        end
+      end
+
+      def form_class
+        active_admin_config.form_class
+      end
+    end
+  end
+end

--- a/lib/active_admin/resource_controller/forms.rb
+++ b/lib/active_admin/resource_controller/forms.rb
@@ -1,18 +1,17 @@
 module ActiveAdmin
   class ResourceController < BaseController
     module Forms
-
-    protected
+      protected
 
       def apply_form(resource)
         apply_form? ? form_class.new(resource) : resource
       end
 
-    private
+      private
 
       def apply_form?
         case action_name
-        when 'new', 'edit', 'update', 'create'
+        when "new", "edit", "update", "create"
           form_class.present?
         end
       end

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -26,7 +26,10 @@ inject_into_file 'app/models/post.rb', %q{
   attr_accessible :author, :position unless Rails::VERSION::MAJOR > 3 && !defined? ProtectedAttributes
 }, after: 'class Post < ActiveRecord::Base'
 copy_file File.expand_path('../templates/post_decorator.rb', __FILE__), "app/models/post_decorator.rb"
-copy_file File.expand_path('../templates/post_form.rb', __FILE__), "app/models/post_form.rb"
+copy_file(
+  File.expand_path("../templates/post_form.rb", __FILE__),
+  "app/models/post_form.rb"
+)
 
 generate :model, "blog/post title:string body:text published_at:datetime author_id:integer position:integer custom_category_id:integer starred:boolean foo_id:integer"
 inject_into_file 'app/models/blog/post.rb', %q{

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -26,6 +26,7 @@ inject_into_file 'app/models/post.rb', %q{
   attr_accessible :author, :position unless Rails::VERSION::MAJOR > 3 && !defined? ProtectedAttributes
 }, after: 'class Post < ActiveRecord::Base'
 copy_file File.expand_path('../templates/post_decorator.rb', __FILE__), "app/models/post_decorator.rb"
+copy_file File.expand_path('../templates/post_form.rb', __FILE__), "app/models/post_form.rb"
 
 generate :model, "blog/post title:string body:text published_at:datetime author_id:integer position:integer custom_category_id:integer starred:boolean foo_id:integer"
 inject_into_file 'app/models/blog/post.rb', %q{

--- a/spec/support/templates/post_form.rb
+++ b/spec/support/templates/post_form.rb
@@ -1,0 +1,5 @@
+require 'reform/form'
+
+class PostForm < Reform::Form
+  property :title, validates: { presence: true }
+end

--- a/spec/support/templates/post_form.rb
+++ b/spec/support/templates/post_form.rb
@@ -1,4 +1,4 @@
-require 'reform/form'
+require "reform/form"
 
 class PostForm < Reform::Form
   property :title, validates: { presence: true }

--- a/spec/unit/resource_controller/forms_spec.rb
+++ b/spec/unit/resource_controller/forms_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe ActiveAdmin::ResourceController::Forms do
   let(:controller_class) do
@@ -16,27 +16,29 @@ describe ActiveAdmin::ResourceController::Forms do
   let(:controller) { controller_class.new }
   let(:active_admin_config) { double(form_class: form_class) }
   before do
-    allow(controller).to receive(:active_admin_config).and_return(active_admin_config)
+    allow(controller).to(
+      receive(:active_admin_config).and_return(active_admin_config)
+    )
     allow(controller).to receive(:action_name).and_return(action)
   end
 
-  describe '#apply_form' do
-    let(:action) { 'edit' }
+  describe "#apply_form" do
+    let(:action) { "edit" }
     let(:resource) { Post.new }
     subject(:applied) { controller.apply_form(resource) }
 
-    context 'with a form class configured' do
+    context "with a form class configured" do
       let(:form_class) { PostForm }
       it { is_expected.to be_kind_of(PostForm) }
     end
 
-    context 'with a form class configured on show action' do
+    context "with a form class configured on show action" do
       let(:form_class) { PostForm }
-      let(:action) { 'show' }
+      let(:action) { "show" }
       it { is_expected.to be_kind_of(Post) }
     end
 
-    context 'with no form class configured' do
+    context "with no form class configured" do
       let(:form_class) { nil }
       it { is_expected.to be_kind_of(Post) }
     end

--- a/spec/unit/resource_controller/forms_spec.rb
+++ b/spec/unit/resource_controller/forms_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+describe ActiveAdmin::ResourceController::Forms do
+  let(:controller_class) do
+    Class.new do
+      def self.name
+        "Test Controller using Forms"
+      end
+
+      include ActiveAdmin::ResourceController::Forms
+
+      public :apply_form
+    end
+  end
+
+  let(:controller) { controller_class.new }
+  let(:active_admin_config) { double(form_class: form_class) }
+  before do
+    allow(controller).to receive(:active_admin_config).and_return(active_admin_config)
+    allow(controller).to receive(:action_name).and_return(action)
+  end
+
+  describe '#apply_form' do
+    let(:action) { 'edit' }
+    let(:resource) { Post.new }
+    subject(:applied) { controller.apply_form(resource) }
+
+    context 'with a form class configured' do
+      let(:form_class) { PostForm }
+      it { is_expected.to be_kind_of(PostForm) }
+    end
+
+    context 'with a form class configured on show action' do
+      let(:form_class) { PostForm }
+      let(:action) { 'show' }
+      it { is_expected.to be_kind_of(Post) }
+    end
+
+    context 'with no form class configured' do
+      let(:form_class) { nil }
+      it { is_expected.to be_kind_of(Post) }
+    end
+  end
+end


### PR DESCRIPTION
In order to provide ability to perform ActiveAdmin specific validations, I integrated ActiveAdmin with reform gem, which implements form object.

Usage:

```ruby
# app/models/post.rb
class Post < ActiveRecord::Base
  # has title, content, and image_url
end

# app/forms/post_form.rb
class PostForm < Reform::Form
  property :title, validates: { presence: true, length: { minimum: 10 } }
  property :content, validates: { presence: true }
  property :image_url, validates: { presence: true }
end

# app/admin/post.rb
ActiveAdmin.register Post do
  form_class PostForm

  index do
    column :title
    column :image
    actions
  end
end
```