### PR TITLE
allow proc as parent menu label

### DIFF
--- a/lib/active_admin/menu.rb
+++ b/lib/active_admin/menu.rb
@@ -96,6 +96,8 @@ module ActiveAdmin
           id.to_s.downcase.tr ' ', '_'
         when ActiveAdmin::Resource::Name
           id.param_key
+        when Proc
+          id.call.to_s.downcase.tr ' ', '_'
         else
           raise TypeError, "#{id.class} isn't supported as a Menu ID"
         end

--- a/lib/active_admin/sidebar_section.rb
+++ b/lib/active_admin/sidebar_section.rb
@@ -6,7 +6,7 @@ module ActiveAdmin
     attr_accessor :name, :options, :block
 
     def initialize(name, options = {}, &block)
-      @name, @options, @block = name.to_s, options, block
+      @name, @options, @block = name, options, block
       normalize_display_options!
     end
 
@@ -31,6 +31,10 @@ module ActiveAdmin
 
     def priority
       options[:priority] || 10
+    end
+
+    def name
+      @name.is_a?(Proc) ? @name.call : @name.to_s
     end
   end
 


### PR DESCRIPTION
allow any Proc in menu parent: DSL option, for example you can use in in case of broken I18n
```
menu parent: -> { I18n.t('active_admin.menu_parent') }
```