### PR TITLE
Improvement of collection_size helper

### DIFF
--- a/lib/active_admin/helpers/collection.rb
+++ b/lib/active_admin/helpers/collection.rb
@@ -4,9 +4,12 @@ module ActiveAdmin
       # 1. removes `select` and `order` to prevent invalid SQL
       # 2. correctly handles the Hash returned when `group by` is used
       def collection_size(c = collection)
-        c = c.except :select, :order
-
-        c.group_values.present? ? c.count.count : c.count
+        if c.loaded?
+          c.size
+        else
+          c = c.except :select, :order
+          c.group_values.present? ? c.count.count : c.count
+        end
       end
 
       def collection_is_empty?(c = collection)

--- a/lib/active_admin/resource_controller/decorators.rb
+++ b/lib/active_admin/resource_controller/decorators.rb
@@ -68,7 +68,7 @@ module ActiveAdmin
           ::Class.new parent do
             delegate :reorder, :page, :current_page, :total_pages, :limit_value,
                      :total_count, :total_pages, :to_key, :group_values, :except,
-                     :find_each, :ransack
+                     :find_each, :ransack, :loaded?, :load
 
             define_singleton_method(:name) { name }
           end

--- a/lib/active_admin/views/pages/index.rb
+++ b/lib/active_admin/views/pages/index.rb
@@ -46,6 +46,7 @@ module ActiveAdmin
         end
 
         def build_collection
+          collection.load if collection.respond_to? :load
           if items_in_collection?
             render_index
           else

--- a/spec/unit/views/components/paginated_collection_spec.rb
+++ b/spec/unit/views/components/paginated_collection_spec.rb
@@ -29,6 +29,7 @@ describe ActiveAdmin::Views::PaginatedCollection do
 
     before do
       allow(collection).to receive(:except) { collection } unless collection.respond_to? :except
+      allow(collection).to receive(:loaded?) { true }      unless collection.respond_to? :loaded?
       allow(collection).to receive(:group_values) { [] }   unless collection.respond_to? :group_values
     end
 


### PR DESCRIPTION
AR count method generates bad sql for relation with limit, like `SELECT COUNT(count_column) FROM (SELECT  1 AS count_column FROM "table" LIMIT 30 OFFSET 0) subquery_for_count` - it is really slow for big tables.
And we can get size of loaded collection without additional query. Loading collection and count entries is a best solution for relations with limit.

On my real DB, "table" has ~ 50_000_000 rows: 

```
explain analyze SELECT count(*) FROM "table" WHERE <some_condition>;
Planning time: 0.393 ms
Execution time: 0.315 ms

explain analyze SELECT COUNT(count_column) FROM (SELECT  1 AS count_column FROM "table" WHERE <some_condition> LIMIT 50 OFFSET 0) subquery_for_count
Planning time: 0.217 ms
Execution time: 18246.767 ms
```
