### PR TITLE
allow CSV pagination to be customizable

### DIFF
--- a/docs/4-csv-format.md
+++ b/docs/4-csv-format.md
@@ -56,3 +56,25 @@ environments where CSV streaming is disabled, you can change this setting:
 
 config.disable_streaming_in = ['development', 'staging']
 ```
+
+# Pagination
+
+By default we use `find_each` to paginate through your records because it's the
+best option made available by Rails. Note that it relies on the table's primary
+key, and orders the collection by ID. If you would like to configure either of
+those, you can use the `paginate_with` option.
+
+```ruby
+ActiveAdmin.register Post do
+  controller do
+    def collection
+      Post.order created_at: :desc
+    end
+  end
+
+  csv paginate_with: :kaminari
+end
+```
+
+You can also provide any custom pagination by passing a proc/lambda. The only
+requirement is that it needs to respond to `each`.

--- a/lib/active_admin/csv_builder.rb
+++ b/lib/active_admin/csv_builder.rb
@@ -63,6 +63,8 @@ module ActiveAdmin
       csv
     end
 
+  private
+
     def exec_columns(view_context = nil)
       @view_context = view_context
       @columns = [] # we want to re-render these every instance
@@ -92,6 +94,18 @@ module ActiveAdmin
       end
     end
 
+    def column_transitive_options
+      @column_transitive_options ||= @options.slice(*COLUMN_TRANSITIVE_OPTIONS)
+    end
+
+    def paginated_collection(page_no = 1)
+      @collection.public_send(Kaminari.config.page_method_name, page_no).per(batch_size)
+    end
+
+    def batch_size
+      1000
+    end
+
     class Column
       attr_reader :name, :data, :options
 
@@ -110,20 +124,6 @@ module ActiveAdmin
           name.to_s
         end
       end
-    end
-
-    private
-
-    def column_transitive_options
-      @column_transitive_options ||= @options.slice(*COLUMN_TRANSITIVE_OPTIONS)
-    end
-
-    def paginated_collection(page_no = 1)
-      @collection.public_send(Kaminari.config.page_method_name, page_no).per(batch_size)
-    end
-
-    def batch_size
-      1000
     end
   end
 end

--- a/lib/active_admin/csv_builder.rb
+++ b/lib/active_admin/csv_builder.rb
@@ -26,7 +26,7 @@ module ActiveAdmin
       end
     end
 
-    attr_reader :columns, :options, :byte_order_mark, :column_names, :csv_options
+    attr_reader :columns, :options, :paginate_with, :byte_order_mark, :column_names, :csv_options
 
     COLUMN_TRANSITIVE_OPTIONS = [:humanize_name].freeze
 
@@ -34,6 +34,7 @@ module ActiveAdmin
       @resource = options.delete(:resource)
       @block    = block
       @options  = ActiveAdmin.application.csv_options.merge options
+      @paginate_with   = @options.delete(:paginate_with) { :find_each }
       @byte_order_mark = @options.delete :byte_order_mark
       @column_names    = @options.delete(:column_names) { true }
       @csv_options     = @options.except :encoding_options
@@ -47,17 +48,15 @@ module ActiveAdmin
       @collection = controller.send :find_collection, except: :pagination
       columns     = exec_columns controller.view_context
 
-      csv << byte_order_mark if byte_order_mark
+      csv << encode(byte_order_mark) if byte_order_mark
 
       if column_names
-        csv << CSV.generate_line(columns.map{ |c| encode c.name, options }, csv_options)
+        csv << CSV.generate_line(columns.map{ |c| encode c.name }, csv_options)
       end
 
-      (1..paginated_collection.total_pages).each do |page|
-        paginated_collection(page).each do |resource|
-          resource = controller.send :apply_decorator, resource
-          csv << CSV.generate_line(build_row(resource, columns, options), csv_options)
-        end
+      each_resource do |resource|
+        resource = controller.send :apply_decorator, resource
+        csv << CSV.generate_line(build_row(resource, columns), csv_options)
       end
 
       csv
@@ -72,13 +71,13 @@ module ActiveAdmin
       @columns
     end
 
-    def build_row(resource, columns, options)
+    def build_row(resource, columns)
       columns.map do |column|
-        encode call_method_or_proc_on(resource, column.data), options
+        encode call_method_or_proc_on(resource, column.data)
       end
     end
 
-    def encode(content, options)
+    def encode(content)
       if options[:encoding]
         content.to_s.encode options[:encoding], options[:encoding_options]
       else
@@ -98,12 +97,23 @@ module ActiveAdmin
       @column_transitive_options ||= @options.slice(*COLUMN_TRANSITIVE_OPTIONS)
     end
 
-    def paginated_collection(page_no = 1)
-      @collection.public_send(Kaminari.config.page_method_name, page_no).per(batch_size)
+    def each_resource
+      case paginate_with
+      when :find_each
+        @collection.find_each{ |resource| yield resource }
+      when :kaminari
+        (1..kaminari_collection.total_pages).each do |page|
+          kaminari_collection(page).each{ |resource| yield resource }
+        end
+      when Proc
+        paginate_with.call(@collection).each{ |resource| yield resource }
+      else
+        fail "unexpected argument for paginate_with: #{paginate_with}"
+      end
     end
 
-    def batch_size
-      1000
+    def kaminari_collection(page = 1)
+      @collection.public_send(Kaminari.config.page_method_name, page).per 1000
     end
 
     class Column

--- a/spec/unit/csv_builder_spec.rb
+++ b/spec/unit/csv_builder_spec.rb
@@ -166,7 +166,7 @@ describe ActiveAdmin::CSVBuilder do
     end
 
     it "should have proper separator" do
-      expect(builder.options).to eq({force_quotes: true})
+      expect(builder.options).to eq col_sep: ',', force_quotes: true
     end
   end
 

--- a/spec/unit/csv_builder_spec.rb
+++ b/spec/unit/csv_builder_spec.rb
@@ -3,186 +3,173 @@
 require 'rails_helper'
 
 describe ActiveAdmin::CSVBuilder do
-
-  describe '.default_for_resource using Post' do
-    let(:csv_builder) { ActiveAdmin::CSVBuilder.default_for_resource(Post).tap(&:exec_columns) }
-
-    it 'returns a default csv_builder for Post' do
-      expect(csv_builder).to be_a(ActiveAdmin::CSVBuilder)
-    end
-
-    it 'defines Id as the first column' do
-      expect(csv_builder.columns.first.name).to eq 'Id'
-      expect(csv_builder.columns.first.data).to eq :id
-    end
-
-    it "has Post's content_columns" do
-      csv_builder.columns[1..-1].each_with_index do |column, index|
-        expect(column.name).to eq Post.content_columns[index].name.humanize
-        expect(column.data).to eq Post.content_columns[index].name.to_sym
-      end
-    end
-
-    context 'when column has a localized name' do
-      let(:localized_name) { 'Titulo' }
-
-      before do
-        allow(Post).to receive(:human_attribute_name).and_call_original
-        allow(Post).to receive(:human_attribute_name).with(:title){ localized_name }
-      end
-
-      it 'gets name from I18n' do
-        title_index = Post.content_columns.map(&:name).index('title') + 1 # First col is always id
-        expect(csv_builder.columns[title_index].name).to eq localized_name
-      end
-    end
-  end
+  let(:builder) { ActiveAdmin::CSVBuilder.new options, &block }
+  let(:options) { {} }
+  let(:block)   { ->{} }
+  before{ |ex| builder.send :exec_columns unless ex.metadata[:skip_exec] }
 
   context 'when empty' do
-    let(:builder){ ActiveAdmin::CSVBuilder.new.tap(&:exec_columns) }
-
-    it "should have no columns" do
+    it "has no columns" do
       expect(builder.columns).to eq []
     end
   end
 
   context "with a symbol column (:title)" do
-    let(:builder) do
-      ActiveAdmin::CSVBuilder.new do
-        column :title
-      end.tap(&:exec_columns)
-    end
+    let(:block) {
+      ->{ column :title }
+    }
 
-    it "should have one column" do
+    it "has one column" do
       expect(builder.columns.size).to eq 1
     end
 
     describe "the column" do
       let(:column){ builder.columns.first }
 
-      it "should have a name of 'Title'" do
+      it "has a name of 'Title'" do
         expect(column.name).to eq "Title"
       end
 
-      it "should have the data :title" do
+      it "has the data :title" do
         expect(column.data).to eq :title
       end
     end
   end
 
   context "with a block and title" do
-    let(:builder) do
-      ActiveAdmin::CSVBuilder.new do
-        column "My title" do
+    let(:block) {
+      -> {
+        column 'My title' do
           # nothing
         end
-      end.tap(&:exec_columns)
-    end
+      }
+    }
 
-    it "should have one column" do
+    it "has one column" do
       expect(builder.columns.size).to eq 1
     end
 
     describe "the column" do
       let(:column){ builder.columns.first }
 
-      it "should have a name of 'My title'" do
+      it "has a name of 'My title'" do
         expect(column.name).to eq "My title"
       end
 
-      it "should have the data :title" do
+      it "has the data :title" do
         expect(column.data).to be_an_instance_of(Proc)
       end
     end
   end
 
-  context "with a humanize_name column option" do
-    context "with symbol column name" do
-      let(:builder) do
-        ActiveAdmin::CSVBuilder.new do
+  describe ":humanize_name" do
+    context "set on column with symbol column name" do
+      let(:block) {
+        -> {
           column :my_title, humanize_name: false
-        end.tap(&:exec_columns)
-      end
+        }
+      }
 
       describe "the column" do
         let(:column){ builder.columns.first }
 
-        it "should have a name of 'my_title'" do
+        it "has a name of 'my_title'" do
           expect(column.name).to eq "my_title"
         end
       end
     end
 
-    context "with string column name" do
-      let(:builder) do
-        ActiveAdmin::CSVBuilder.new do
+    context "set on column with string column name" do
+      let(:block) {
+        -> {
           column "my_title", humanize_name: false
-        end.tap(&:exec_columns)
-      end
+        }
+      }
 
       describe "the column" do
         let(:column){ builder.columns.first }
 
-        it "should have a name of 'my_title'" do
+        it "has a name of 'my_title'" do
+          expect(column.name).to eq "my_title"
+        end
+      end
+    end
+
+    context "set on builder" do
+      let(:options) { {humanize_name: false} }
+      let(:block)   { ->{ column :my_title } }
+
+      describe "the column" do
+        let(:column){ builder.columns.first }
+
+        it "has humanize_name option set" do
+          expect(column.options).to eq humanize_name: false
+        end
+
+        it "has a name of 'my_title'" do
           expect(column.name).to eq "my_title"
         end
       end
     end
   end
 
-  context "with a separator" do
-    let(:builder) do
-      ActiveAdmin::CSVBuilder.new(col_sep: ";").tap(&:exec_columns)
-    end
+  describe ":col_sep" do
+    let(:options) { {col_sep: ';'} }
 
-    it "should have proper separator" do
-      expect(builder.options).to eq({col_sep: ";"})
+    it "uses the proper separator" do
+      expect(builder.options).to eq col_sep: ';'
     end
   end
 
-  context "with humanize_name option" do
-    let(:builder) do
-      ActiveAdmin::CSVBuilder.new(humanize_name: false) do
-        column :my_title
-      end.tap(&:exec_columns)
-    end
+  describe "CSV options" do
+    let(:options) { {force_quotes: true} }
 
-    describe "the column" do
-      let(:column){ builder.columns.first }
-
-      it "should have humanize_name option set" do
-        expect(column.options).to eq humanize_name: false
-      end
-
-      it "should have a name of 'my_title'" do
-        expect(column.name).to eq "my_title"
-      end
-    end
-  end
-
-  context "with csv_options" do
-    let(:builder) do
-      ActiveAdmin::CSVBuilder.new(force_quotes: true).tap(&:exec_columns)
-    end
-
-    it "should have proper separator" do
+    it "are kept around" do
       expect(builder.options).to eq col_sep: ',', force_quotes: true
     end
   end
 
-  context "with access to the controller" do
-    let(:dummy_view_context) { double(controller: dummy_controller) }
-    let(:dummy_controller) { double(names: %w(title summary updated_at created_at))}
-    let(:builder) do
-      ActiveAdmin::CSVBuilder.new do
-        column "id"
-        controller.names.each do |name|
-          column(name)
-        end
-      end.tap{ |b| b.exec_columns(dummy_view_context) }
+  describe '.default_for_resource using Post' do
+    let(:builder) { ActiveAdmin::CSVBuilder.default_for_resource Post }
+
+    it 'defines Id as the first column' do
+      expect(builder.columns.first.name).to eq 'Id'
+      expect(builder.columns.first.data).to eq :id
     end
 
-    it "should build columns provided by the controller" do
+    it "has Post's content_columns" do
+      builder.columns[1..-1].each_with_index do |column, index|
+        expect(column.name).to eq Post.content_columns[index].name.humanize
+        expect(column.data).to eq Post.content_columns[index].name.to_sym
+      end
+    end
+
+    context 'when column has a localized name', skip_exec: true do
+      before do
+        allow(Post).to receive(:human_attribute_name).and_call_original
+        allow(Post).to receive(:human_attribute_name).with(:title){ 'Titulo' }
+        builder.send :exec_columns
+      end
+
+      it 'gets name from I18n' do
+        title_index = Post.content_columns.map(&:name).index('title')
+        expect(builder.columns[title_index + 1].name).to eq 'Titulo'
+      end
+    end
+  end
+
+  context "with access to the controller", skip_exec: true do
+    let(:dummy_view_context) { double(controller: dummy_controller) }
+    let(:dummy_controller) { double(names: %w(title summary updated_at created_at))}
+    let(:block) {
+      -> {
+        column "id"
+        controller.names.each{ |name| column name }
+      }
+    }
+    before{ builder.send :exec_columns, dummy_view_context }
+
+    it "builds columns provided by the controller" do
       expect(builder.columns.map(&:data)).to match_array([:id, :title, :summary, :updated_at, :created_at])
     end
   end
@@ -211,21 +198,21 @@ describe ActiveAdmin::CSVBuilder do
       end
       DummyController.new
     }
-    let(:builder) do
-      ActiveAdmin::CSVBuilder.new do
+    let(:block) {
+      -> {
         column "id"
         column "title"
         column "published_date"
-      end
-    end
+      }
+    }
 
-    it "should generate data with the supplied order" do
+    it "generates data with the supplied order" do
       expect(builder).to receive(:build_row).and_return([]).once.ordered { |post| expect(post.id).to eq @post2.id }
       expect(builder).to receive(:build_row).and_return([]).once.ordered { |post| expect(post.id).to eq @post1.id }
       builder.build dummy_controller, []
     end
 
-    it "should generate data ignoring pagination" do
+    it "generates data ignoring pagination" do
       expect(dummy_controller).to receive(:find_collection).
         with(except: :pagination).once.
         and_call_original
@@ -256,17 +243,18 @@ describe ActiveAdmin::CSVBuilder do
       DummyController.new
     end
     let(:encoding) { Encoding::ASCII }
-    let(:opts) { {} }
-    let(:builder) do
-      ActiveAdmin::CSVBuilder.new(encoding: encoding, encoding_options: opts) do
+    let(:encoding_options) { {} }
+    let(:options) { {encoding: encoding, encoding_options: encoding_options} }
+    let(:block) {
+      -> {
         column "おはようございます"
         column "title"
-      end
-    end
+      }
+    }
 
     context "Shift-JIS with options" do
       let(:encoding) { Encoding::Shift_JIS }
-      let(:opts) { { invalid: :replace, undef: :replace, replace: "?" } }
+      let(:encoding_options) { {invalid: :replace, undef: :replace, replace: "?"} }
 
       it "encodes the CSV" do
         receiver = []
@@ -278,9 +266,7 @@ describe ActiveAdmin::CSVBuilder do
 
     context "ASCII with options" do
       let(:encoding) { Encoding::ASCII }
-      let(:opts) do
-        { invalid: :replace, undef: :replace, replace: "__REPLACED__" }
-      end
+      let(:encoding_options) { {invalid: :replace, undef: :replace, replace: "__REPLACED__"} }
 
       it "encodes the CSV without errors" do
         receiver = []
@@ -291,6 +277,8 @@ describe ActiveAdmin::CSVBuilder do
       end
     end
   end
+
+  skip '#build'
 
   skip '#exec_columns'
 

--- a/spec/unit/csv_builder_spec.rb
+++ b/spec/unit/csv_builder_spec.rb
@@ -8,10 +8,9 @@ describe ActiveAdmin::CSVBuilder do
   let(:block)   { ->{} }
 
   let(:view_context) {
-    context = double
-    method = MethodOrProcHelper.instance_method(:call_method_or_proc_on).bind(context)
-    allow(context).to receive(:call_method_or_proc_on){ |*args| method.call *args }
-    context
+    context = Class.new
+    context.send :include, MethodOrProcHelper
+    context.new
   }
   let(:controller) {
     controller = double view_context: view_context, find_collection: collection

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -195,7 +195,7 @@ module ActiveAdmin
     describe "#csv_builder" do
       context "when no csv builder set" do
         it "should return a default column builder with id and content columns" do
-          expect(config.csv_builder.exec_columns.size).to eq Category.content_columns.size + 1
+          expect(config.csv_builder.send(:exec_columns).size).to eq Category.content_columns.size + 1
         end
       end
 


### PR DESCRIPTION
This fixes the performance issues that #3375 introduced by switching from `find_each` to Kaminari, since Kaminari has to do a SQL count. For those that want that behavior they can enable it by setting `paginate_with: :kaminari`, but the fastest option should be the default for Active Admin.

I chose this approach instead of #4082 because databases don’t guarantee any particular order when requesting records, so it’s possible that the resulting CSV won’t include all records.
