### PR TITLE
run Travis against Rails 3.2 and Ruby 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,6 @@ env:
 matrix:
   fast_finish: true
   exclude:
-    - rvm: 2.2.3
-      env: RAILS=3.2.22
-    - rvm: jruby-9.0.0.0
-      env: RAILS=3.2.22
     - rvm: 1.9
       env: RAILS=master
   allow_failures:

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ gem 'rails', rails_version == 'master' ? {github: 'rails/rails'} : rails_version
 
 gem 'jquery-ui-rails', rails_version[0] == '3' ? '~> 4.0' : '~> 5.0'
 
+gem 'test-unit', '~> 3.0' if rails_version[0] == '3'
+
 if rails_version == 'master'
   gem 'arel',       github: 'rails/arel'
   gem 'sprockets',  github: 'rails/sprockets'


### PR DESCRIPTION
closes #3715

Rails 3.2.22 includes the Ruby 2 fixes. The test suite passed for me locally. I'm only opening a PR to see if JRuby also passes by having Travis run it, because I'm too impatient to install JRuby.