### PR TITLE
Update 0-installation.md

### DIFF
--- a/docs/0-installation.md
+++ b/docs/0-installation.md
@@ -3,7 +3,7 @@
 Active Admin is a Ruby Gem.
 
 ```ruby
-gem 'activeadmin'
+gem 'activeadmin', github: 'activeadmin'
 
 # Plus integrations with:
 gem 'devise'


### PR DESCRIPTION
Documentation have a little missing part.
If your rails version equal or bigger than 4.0.0, bundler throw an error like this: 
"Your Gemfile requires gems that depend on each other, creating an infinite loop. Please remove gem 'meta_search' and try again. "

And then i fetched activeadmin from master and solved the problem.