### PR TITLE
Not removing action_items container when empty

### DIFF
--- a/lib/active_admin/views/title_bar.rb
+++ b/lib/active_admin/views/title_bar.rb
@@ -47,7 +47,7 @@ module ActiveAdmin
       end
 
       def build_action_items
-        insert_tag(view_factory.action_items, @action_items) if @action_items.any?
+        insert_tag(view_factory.action_items, @action_items)
       end
 
     end


### PR DESCRIPTION
I am using Javascript to add buttons to the `action_items` bar `inside titlebar_right`.

Removing `action_items` completely when there are no action items generated by the backend is not a good idea where action_item buttons are added on the client side, as the script would need to check for the existence of the container every time.

Example JS/jQuery to add a print button:

```js
function addPrintButton() {
    $('.action_items').prepend('<span class="action_item"><a href="#" class="print_button">Print</a></span>');
    $('.print_button').click(function(e) {
        e.preventDefault();
        window.print();
    });
}

$(document).on('ready page:load', function(event) {
    addPrintButton();
});
```