### PR TITLE
4230 search status name on filter sidebar

### DIFF
--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -32,7 +32,7 @@ ar:
         greater_than: "أكبر من"
         less_than: "أقل من"
     search_status:
-      headline: "المجال:"
+      current_scope: "المجال:"
       current_filters: "المُرشحات الحاليّة:"
       no_current_filters: "بدون"
     status_tag:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -32,7 +32,7 @@ de:
         greater_than: "Größer als"
         less_than: "Kleiner als"
     search_status:
-      headline: "Anwendungsbereich:"
+      current_scope: "Anwendungsbereich:"
       current_filters: "Aktuelle Filter:"
       no_current_filters: "Keine"
     status_tag:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,7 +32,7 @@ en:
         greater_than: "Greater than"
         less_than: "Less than"
     search_status:
-	  headline: "Search status:"
+      headline: "Search status:"
       current_scope: "Scope:"
       current_filters: "Current filters:"
       no_current_filters: "None"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,7 @@ en:
         greater_than: "Greater than"
         less_than: "Less than"
     search_status:
+	  search_status_name: "Search status:"
       headline: "Scope:"
       current_filters: "Current filters:"
       no_current_filters: "None"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,8 +32,8 @@ en:
         greater_than: "Greater than"
         less_than: "Less than"
     search_status:
-	  search_status_name: "Search status:"
-      headline: "Scope:"
+	  headline: "Search status:"
+      current_scope: "Scope:"
       current_filters: "Current filters:"
       no_current_filters: "None"
     status_tag:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -32,7 +32,7 @@ es:
         greater_than: "Mayor que"
         less_than: "Menor que"
     search_status:
-      headline: "Alcance:"
+      current_scope: "Alcance:"
       current_filters: "Filtros actuales:"
       no_current_filters: "Ninguno"
     status_tag:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -32,7 +32,7 @@ fr:
         greater_than: "Plus grand que"
         less_than: "Plus petit que"
     search_status:
-      headline: "Etendu du filtre :"
+      current_scope: "Etendu du filtre :"
       current_filters: "Filtres actuels :"
       no_current_filters: "Aucun filtres"
     status_tag:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -32,7 +32,7 @@ id:
         greater_than: "Lebih besar dari"
         less_than: "Lebih kecil dari"
     search_status:
-      headline: "Scope:"
+      current_scope: "Scope:"
       current_filters: "Filter kini:"
       no_current_filters: "Tidak ada"
     status_tag:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -32,6 +32,7 @@ it:
         greater_than: "Maggiore di"
         less_than: "Minore di"
     search_status:
+	  search_status_name: "Situazione filtri:"
       headline: "Contesto:"
       current_filters: "Filtri attivi:"
       no_current_filters: "Nessuno"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -32,8 +32,8 @@ it:
         greater_than: "Maggiore di"
         less_than: "Minore di"
     search_status:
-	  search_status_name: "Situazione filtri:"
-      headline: "Contesto:"
+	  headline: "Situazione filtri:"
+      current_scope: "Contesto selezionato:"
       current_filters: "Filtri attivi:"
       no_current_filters: "Nessuno"
     status_tag:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -32,7 +32,7 @@ it:
         greater_than: "Maggiore di"
         less_than: "Minore di"
     search_status:
-	  headline: "Situazione filtri:"
+      headline: "Situazione filtri:"
       current_scope: "Contesto selezionato:"
       current_filters: "Filtri attivi:"
       no_current_filters: "Nessuno"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -32,7 +32,7 @@ ja:
         greater_than: "より大きい"
         less_than: "より小さい"
     search_status:
-      headline: "範囲:"
+      current_scope: "範囲:"
       current_filters: "現在の絞り込み:"
       no_current_filters: "なし"
     status_tag:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -32,7 +32,7 @@ ko:
         greater_than: "초과"
         less_than: "미만"
     search_status:
-      headline: "검색 범위:"
+      current_scope: "검색 범위:"
       current_filters: "적용된 필터:"
       no_current_filters: "현재 적용된 필터가 없습니다"
     status_tag:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -32,7 +32,7 @@ nl:
         greater_than: "Groter dan"
         less_than: "Kleiner dan"
     search_status:
-      headline: "Scope:"
+      current_scope: "Scope:"
       current_filters: "Huidige filters:"
       no_current_filters: "Geen"
     status_tag:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -32,7 +32,7 @@ pt-BR:
         greater_than: "Maior Que"
         less_than: "Menor Que"
     search_status:
-      headline: "Em:"
+      current_scope: "Em:"
       current_filters: "Filtros escolhidos:"
       no_current_filters: "Nenhum"
     status_tag:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -32,7 +32,7 @@ ru:
         greater_than: "больше"
         less_than: "меньше"
     search_status:
-      headline: "Область:"
+      current_scope: "Область:"
       current_filters: "Текущий фильтр:"
       no_current_filters: "Ни один"
     status_tag:

--- a/config/locales/sv-SE.yml
+++ b/config/locales/sv-SE.yml
@@ -32,7 +32,7 @@
         greater_than: "Större än"
         less_than: "Mindre än"
     search_status:
-      headline: "Scope:"
+      current_scope: "Scope:"
       current_filters: "Nuvarande filter:"
       no_current_filters: "Inga"
     status_tag:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -32,7 +32,7 @@ uk:
         greater_than: "більше"
         less_than: "меньше"
     search_status:
-      headline: "Область:"
+      current_scope: "Область:"
       current_filters: "Поточний фільтр:"
       no_current_filters: "Жоден"
     status_tag:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -32,7 +32,7 @@
         greater_than: "大于"
         less_than: "小于"
     search_status:
-      headline: "搜索范围："
+      current_scope: "搜索范围："
       current_filters: "过滤条件："
       no_current_filters: "无"
     status_tag:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -32,7 +32,7 @@
         greater_than: "大於"
         less_than: "小於"
     search_status:
-      headline: "子集："
+      current_scope: "子集："
       current_filters: "目前篩選條件："
       no_current_filters: "無"
     status_tag:

--- a/lib/active_admin/filters/resource_extension.rb
+++ b/lib/active_admin/filters/resource_extension.rb
@@ -163,7 +163,7 @@ module ActiveAdmin
       end
 
       def search_status_section
-        ActiveAdmin::SidebarSection.new I18n.t("active_admin.search_status.headline", :default => 'Search status'), only: :index, if: -> { params[:q] || params[:scope] } do
+        ActiveAdmin::SidebarSection.new I18n.t("active_admin.search_status.headline"), only: :index, if: -> { params[:q] || params[:scope] } do
           active = ActiveAdmin::Filters::Active.new(resource_class, params)
 
           span do

--- a/lib/active_admin/filters/resource_extension.rb
+++ b/lib/active_admin/filters/resource_extension.rb
@@ -163,7 +163,7 @@ module ActiveAdmin
       end
 
       def search_status_section
-        ActiveAdmin::SidebarSection.new :search_status, only: :index, if: -> { params[:q] || params[:scope] } do
+        ActiveAdmin::SidebarSection.new I18n.t("active_admin.search_status.search_status_name", :default => 'Search status'), only: :index, if: -> { params[:q] || params[:scope] } do
           active = ActiveAdmin::Filters::Active.new(resource_class, params)
 
           span do

--- a/lib/active_admin/filters/resource_extension.rb
+++ b/lib/active_admin/filters/resource_extension.rb
@@ -163,11 +163,11 @@ module ActiveAdmin
       end
 
       def search_status_section
-        ActiveAdmin::SidebarSection.new I18n.t("active_admin.search_status.search_status_name", :default => 'Search status'), only: :index, if: -> { params[:q] || params[:scope] } do
+        ActiveAdmin::SidebarSection.new I18n.t("active_admin.search_status.headline", :default => 'Search status'), only: :index, if: -> { params[:q] || params[:scope] } do
           active = ActiveAdmin::Filters::Active.new(resource_class, params)
 
           span do
-            h4 I18n.t("active_admin.search_status.headline"), style: 'display: inline'
+            h4 I18n.t("active_admin.search_status.current_scope"), style: 'display: inline'
             b active.scope, style: "display: inline"
 
             div style: "margin-top: 10px" do

--- a/spec/unit/dsl_spec.rb
+++ b/spec/unit/dsl_spec.rb
@@ -97,7 +97,7 @@ describe ActiveAdmin::DSL do
       dsl.run_registration_block do
         sidebar :help
       end
-      expect(dsl.config.sidebar_sections.map(&:name)).to match_array %w{filters search_status email help}
+      expect(dsl.config.sidebar_sections.map(&:name)).to match_array %w{filters search status email help}
     end
 
   end

--- a/spec/unit/dsl_spec.rb
+++ b/spec/unit/dsl_spec.rb
@@ -97,7 +97,7 @@ describe ActiveAdmin::DSL do
       dsl.run_registration_block do
         sidebar :help
       end
-      expect(dsl.config.sidebar_sections.map(&:name)).to match_array %w{filters search status email help}
+      expect(dsl.config.sidebar_sections.map(&:name)).to match_array ['filters', 'Search status:', 'email', 'help']
     end
 
   end


### PR DESCRIPTION
 Add search status panel name in I18n #4230 

- [x] refactor `search_status.headline` to `search_status.current_scope` (all yml )
- [x] added new tag `search_status.headline` to :gb: and :it: yml