### PR TITLE
New feature, form extentions

### DIFF
--- a/docs/14-gotchas.md
+++ b/docs/14-gotchas.md
@@ -1,5 +1,11 @@
 #Gotchas
 
+## Security
+
+### Spreadsheet applications vulnerable to unescaped CSV data
+
+If your CSV export includes untrusted data provided by your users, it's possible that they could include an executable formula that could call arbitrary commands on your computer. See [#4256](https://github.com/activeadmin/activeadmin/issues/4256) for more details.
+
 ## Session Commits & Asset Pipeline
 
 When configuring the asset pipeline ensure that the asset prefix 

--- a/lib/generators/active_admin/install/install_generator.rb
+++ b/lib/generators/active_admin/install/install_generator.rb
@@ -11,7 +11,7 @@ module ActiveAdmin
       source_root File.expand_path("../templates", __FILE__)
 
       def copy_initializer
-        @underscored_user_name = name.underscore
+        @underscored_user_name = name.underscore.gsub('/', '_')
         @use_authentication_method = options[:users].present?
         template 'active_admin.rb.erb', 'config/initializers/active_admin.rb'
       end


### PR DESCRIPTION
I think it will be usefull to have extension functionality for resource forms. 
I have created dsl function for this:
```
extend_form do |f|
  f.inputs 'Components' do
    f.has_many :components, allow_destroy: true do |t|
      t.input :name
      t.input :description
    end
  end
end
```
This will add components inputs before you standard form