### PR TITLE
Fix postgres NULL sorting

### DIFF
--- a/lib/active_admin/order_clause.rb
+++ b/lib/active_admin/order_clause.rb
@@ -3,6 +3,8 @@ module ActiveAdmin
     attr_reader :field, :order
 
     def initialize(clause)
+      @@postgres ||= ActiveRecord::Base.connection.instance_of?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
+
       clause =~ /^([\w\_\.]+)(->'\w+')?_(desc|asc)$/
       @column = $1
       @op = $2
@@ -20,7 +22,10 @@ module ActiveAdmin
       table_column = (@column =~ /\./) ? @column :
         [table, active_admin_config.resource_quoted_column_name(@column)].compact.join(".")
 
-      [table_column, @op, ' ', @order].compact.join
+      order = @order
+      order = "desc nulls last" if order == "desc" and @@postgres
+
+      [table_column, @op, ' ', order].compact.join
     end
   end
 end


### PR DESCRIPTION
Hello!

This is a tiny patch to fix issue #1590.

I used the ``@@postgres`` class variable to store the result of the check for the PostgreSQL ActiveRecord adapter. This might be a pointless optimization. I can switch it back to the `instance_of?` check. The only reason it might cause a problem is if people switch database adapters while the process is running. I don't know if that's ever actually done, however.