### PR TITLE
Add Norwegian (nb) translations for search_status

### DIFF
--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -31,6 +31,10 @@ nb:
         ends_with: "Slutter med"
         greater_than: "Større enn"
         less_than: "Mindre enn"
+    search_status:
+      headline: "Søkestatus:"
+      current_filters: "Gjeldende filtre:"
+      no_current_filters: "Ingen"
     status_tag:
       "yes": "Ja"
       "no": "Nei"


### PR DESCRIPTION
I've left the current_scope translation out since there really isn't any good Norwegian translation that fits in this context.