### PR TITLE
ru locale fix

### DIFF
--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -40,7 +40,7 @@ ru:
       "no": "Нет"
     main_content: "Создайте %{model}#main_content для отображения содержимого."
     logout: "Выйти"
-    powered_by: "Powered by %{active_admin} %{version}"
+    powered_by: "Работает на %{active_admin} %{version}"
     sidebars:
       filters: "Фильтры"
       search_status: "Статус поиска"
@@ -126,7 +126,7 @@ ru:
         resend_unlock_instructions: "Повторная отправка инструкций разблокировки"
         resend_confirmation_instructions: "Повторная отправка инструкций подтверждения"
     unsupported_browser:
-      headline: "Пожалуйста, обратите внимание, что ActiveAdmin больше не поддерживает Internet Explorer 8 версии и старее"
+      headline: "Пожалуйста, обратите внимание, что Active Admin больше не поддерживает старые версии Internet Explorer начиная с версии IE 8"
       recommendation: "Мы рекомендуем обновить версию вашего браузера (<a href=\"http://windows.microsoft.com/ie\">Internet Explorer</a>, <a href=\"https://chrome.google.com/\">Google Chrome</a>, или <a href=\"https://mozilla.org/firefox/\">Firefox</a>)."
       turn_off_compatibility_view: "Если вы используете IE 9 или новее, убедитесь, что <a href=\"http://windows.microsoft.com/en-US/windows7/webpages-look-incorrect-in-Internet-Explorer\">вы выключили опцию \"Просмотр в режиме совместимости\"</a>."
     access_denied:


### PR DESCRIPTION
Hi!

Any reason why ```ru.active_admin.powered_by``` not translated? I just checked out other locales and all of them did translation of this phrase. I translated this and also fixed ```ru.active_admin.unsupported_browser.headline```. Now it sounds grammatically correct.
