### PR TITLE
Use `status_tag` in AttributesTable#content_for to display booleans

### DIFF
--- a/lib/active_admin/views/components/attributes_table.rb
+++ b/lib/active_admin/views/components/attributes_table.rb
@@ -79,8 +79,21 @@ module ActiveAdmin
       end
 
       def content_for(record, attr)
-        value = pretty_format find_attr_value(record, attr)
+        value = find_attr_value(record, attr)
+        if is_boolean?(attr, record)
+          value = status_tag(value)
+        else
+          value = pretty_format(value)
+        end
         value.blank? && current_arbre_element.children.to_s.empty? ? empty_value : value
+      end
+
+      def is_boolean?(data, item)
+        if item.respond_to? :has_attribute?
+          item.has_attribute?(data) &&
+            item.column_for_attribute(data) &&
+            item.column_for_attribute(data).type == :boolean
+        end
       end
 
       def find_attr_value(record, attr)


### PR DESCRIPTION
This makes it work nearly the same as in `ActiveAdmin::Views::TableFor`.

It's a bit duplicated code though. Maybe we should move it to `pretty_format` function?

P.S. If someone wants this change in his current rails app, u can implement it without changing the activeadmin gem using this gist: https://gist.github.com/fred/2574969 .