### PR TITLE
Method #decorate? should use form.options[:decorate]

### DIFF
--- a/lib/active_admin/resource_controller/decorators.rb
+++ b/lib/active_admin/resource_controller/decorators.rb
@@ -28,7 +28,7 @@ module ActiveAdmin
 
       def decorate?
         case action_name
-        when 'new', 'edit'
+        when 'new', 'edit', 'create', 'update'
           form = active_admin_config.get_page_presenter :form
           form && form.options[:decorate] && decorator_class.present?
         else

--- a/spec/unit/resource_controller/decorators_spec.rb
+++ b/spec/unit/resource_controller/decorators_spec.rb
@@ -28,14 +28,26 @@ describe ActiveAdmin::ResourceController::Decorators do
     context 'with a decorator configured' do
       let(:decorator_class) { PostDecorator }
       it { is_expected.to be_kind_of(PostDecorator) }
+
+      context 'with form' do
+        let(:action) { 'update' }
+
+        it "does not decorate when :decorate is set to false" do 
+          form = double
+          allow(form).to receive(:options).and_return(:decorate => false)
+          allow(active_admin_config).to receive(:get_page_presenter).and_return(form)
+          is_expected.not_to be_kind_of(PostDecorator) 
+        end
+      end
     end
 
     context 'with no decorator configured' do
       let(:decorator_class) { nil }
       it { is_expected.to be_kind_of(Post) }
     end
-  end
 
+  end
+`
   describe '#apply_collection_decorator' do
     before { Post.create! }
     let(:action) { 'index' }

--- a/spec/unit/resource_controller/decorators_spec.rb
+++ b/spec/unit/resource_controller/decorators_spec.rb
@@ -45,9 +45,8 @@ describe ActiveAdmin::ResourceController::Decorators do
       let(:decorator_class) { nil }
       it { is_expected.to be_kind_of(Post) }
     end
-
   end
-`
+
   describe '#apply_collection_decorator' do
     before { Post.create! }
     let(:action) { 'index' }


### PR DESCRIPTION
I noticed that decorators are added to forms in `update` and `create` actions. Consider the following scenario: 
1. User tries to create a record that has a decorator.
2. User visits the `new` page. Record is not decorated.
3. User enters invalid data and submits.
4. Action `create` is fired, a form is rerendered, but this time the record is decorated.

I assume form should be not decorated in `create`/`update` by default. I have prepared a fix for that.

I had problems with running `rake test:major_supported_rails`: specs from  `features/strong_parameters.feature` fails on my machine on my branch and on master. Tried to debug it and I noticed that  `Before('@rails4')` is not executed, therefore specs intended to be run on Rails 4 are run on Rails 3. Do you have any clue what could be wrong on my env?