### PR TITLE
using AUTH constants for menu generation

### DIFF
--- a/lib/active_admin/resource/menu.rb
+++ b/lib/active_admin/resource/menu.rb
@@ -27,7 +27,7 @@ module ActiveAdmin
           id: resource_name.plural,
           label: proc{ resource.plural_resource_label },
           url:   proc{ resource.route_collection_path(params) },
-          if:    proc{ authorized?(:read, menu_resource_class) }
+          if:    proc{ authorized?(Auth::READ, menu_resource_class) }
         }
       end
 


### PR DESCRIPTION
closes #4297 

Admittedly, I can't 100% say this doesn't break something.  I pulled the latest down from master, and it seems the spec suite is in a weird state. I'm getting errors simply from the randomization of the suite.  Fixing the specs is outside the scope of this PR and this reallllly shouldn't change anything. It's also used in our application as a monkey-patch and hasn't failed us. 