### PR TITLE
Correct path in active_admin.scss

### DIFF
--- a/lib/generators/active_admin/assets/templates/active_admin.scss
+++ b/lib/generators/active_admin/assets/templates/active_admin.scss
@@ -1,7 +1,7 @@
 // SASS variable overrides must be declared before loading up Active Admin's styles.
 //
 // To view the variables that Active Admin provides, take a look at
-// `app/assets/stylesheets/active_admin/mixins/_variables.css.scss` in the
+// `app/assets/stylesheets/active_admin/mixins/_variables.scss` in the
 // Active Admin source.
 //
 // For example, to change the sidebar width:


### PR DESCRIPTION
In the comments, the path `app/assets/stylesheets/active_admin/mixins/_variables.css.scss` is incorrect and needs to be changed to `app/assets/stylesheets/active_admin/mixins/_variables.scss`