### PR TITLE
Update installation instructions for Rails >= 4.0

### DIFF
--- a/docs/0-installation.md
+++ b/docs/0-installation.md
@@ -12,6 +12,12 @@ gem 'draper'
 gem 'pundit'
 ```
 
+For Rails >= 4.0, you will need to use ActiveAdmin from github:
+
+```ruby
+gem 'activeadmin', github: 'activeadmin'
+```
+
 More accurately, it's a [Rails Engine](http://guides.rubyonrails.org/engines.html)
 that can be injected into your existing Ruby on Rails application.
 


### PR DESCRIPTION
I found the wrong resources first and was lead astray. Would greatly appreciated links or references to current installation instructions where they occur. Thanks!