### PR TITLE
Improved layout for boolean fields

### DIFF
--- a/app/assets/stylesheets/active_admin/_forms.scss
+++ b/app/assets/stylesheets/active_admin/_forms.scss
@@ -180,7 +180,7 @@ form {
 
     /* Boolean Field */
     &.boolean {
-      height: 1.1em;
+      min-height: 1.1em;
       label {
         width: 80%;
         padding-left:20%;


### PR DESCRIPTION
When you used a hint text on a boolean field the padding of the field was very narrow.
Using a min-height fixes this, if the field is bigger (because of the hint) it adds some spacing.

![screen_shot_2016-03-21_at_14_05_27](https://cloud.githubusercontent.com/assets/106335/13919527/3ed1c620-ef6e-11e5-8d40-9fac539d931b.png)

![screen_shot_2016-03-21_at_14_05_55](https://cloud.githubusercontent.com/assets/106335/13919528/40749ab6-ef6e-11e5-97ef-510bf928cb29.png)