### PR TITLE
Sort load path files in ruby

### DIFF
--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -217,7 +217,7 @@ module ActiveAdmin
 
     # Returns ALL the files to be loaded
     def files
-      load_paths.flatten.compact.uniq.flat_map{ |path| Dir["#{path}/**/*.rb"] }
+      load_paths.flatten.compact.uniq.flat_map{ |path| Dir["#{path}/**/*.rb"].sort }.uniq
     end
 
     def router

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -121,6 +121,42 @@ describe ActiveAdmin::Application do
       FileUtils.touch(test_file)
       expect(application.files).to include(test_file)
     end
+
+    context "given a complex admin directory" do
+      before(:each) do
+        @tmpdir = Dir.mktmpdir
+        @ordered_directory = [
+          "#{@tmpdir}/app/admin/a.rb",
+          "#{@tmpdir}/app/admin/b.rb",
+          "#{@tmpdir}/app/admin/concerns/d.rb",
+          "#{@tmpdir}/app/admin/concerns/e.rb",
+          "#{@tmpdir}/app/admin/v.rb",
+          "#{@tmpdir}/app/admin/w.rb",
+          "#{@tmpdir}/app/admin/x.rb",
+          "#{@tmpdir}/app/admin/y.rb"
+        ]
+        FileUtils.mkdir_p "#{@tmpdir}/app/admin/concerns"
+        FileUtils.touch @ordered_directory
+      end
+      after(:each) { FileUtils.rm_rf @tmpdir }
+
+      context "with a single entry in load_paths" do
+        it "should return the files in alphabetical order" do
+          application.load_paths = ["#{@tmpdir}/app/admin"]
+          expect(application.files).to eq(@ordered_directory)
+        end
+      end
+
+      context "with multiple entries in load_paths" do
+
+        it "should return the files in alphabetical order, grouped by the order defined in load_paths" do
+          file_group1 = @ordered_directory.select {|f| f.include? 'concerns'}
+          file_group2 = @ordered_directory.reject {|f| f.include? 'concerns'}
+          application.load_paths = ["#{@tmpdir}/app/admin/concerns", "#{@tmpdir}/app/admin"]
+          expect(application.files).to eq(file_group1 + file_group2)
+        end
+      end
+    end
   end
 
   describe "#namespace" do


### PR DESCRIPTION
Description
-----------
Different OS/OS Versions return a different ordering for the same directory contents.  Because of this, we can't rely on the given operating system when autoloading files in the same order we expect in different environments, which can lead to startup issues between development and production.  

A full example of these inconsistencies can be found in the following gist:  https://gist.github.com/NickLaMuro/dd35ea9241bfb7e651037ec3bae7f8b3


Changes
-------
By first sorting the result of `Dir["#{path}/**/*.rb"]`, we make sure that the files are returned in the same order for each environment, regardless of OS inconsistancies.

We are also `uniq`ing the files returned after the sort, which retains the order defined in the `load_paths`, but removes any duplicates from entire list.  It is possible that doing that will lead to potentially unintendened concequences for the user, so that might be something that is not wanted.

I ran the tests locally, but a few tests were failing `rake spec` and `rake cucumber` before and after my changes were applied.  Because it seemed unrelated to what I was doing, I have left them failing for now since it seemed to be unrelated to my changes, and my additions don't seem to cause new failures.