### PR TITLE
Fix select input name concatenation

### DIFF
--- a/lib/active_admin/inputs/filters/select_input.rb
+++ b/lib/active_admin/inputs/filters/select_input.rb
@@ -7,7 +7,7 @@ module ActiveAdmin
         def input_name
           return method if seems_searchable?
 
-          searchable_method_name.concat multiple? ? '_in' : '_eq'
+          searchable_method_name + (multiple? ? '_in' : '_eq')
         end
 
         def searchable_method_name


### PR DESCRIPTION
Do not modify the source string when appending '_in' or '_eq' to
searchable_method_name otherwise it gets appended at each call.

Example: `payment_type_code_eq_eq_eq_eq_eq_eq_eq_eq_eq_eq`

Fixes #4121.