### PR TITLE
Empty check boxes control is not saved

### DIFF
--- a/lib/active_admin/inputs/filters/check_boxes_input.rb
+++ b/lib/active_admin/inputs/filters/check_boxes_input.rb
@@ -34,16 +34,6 @@ module ActiveAdmin
         def choice_wrapping(html_options, &block)
           template.capture(&block)
         end
-
-        # Don't render hidden fields
-        def hidden_field_for_all
-          ""
-        end
-
-        # Don't render hidden fields
-        def hidden_fields?
-          false
-        end
       end
     end
   end


### PR DESCRIPTION
Attempt to fix #4444 

I removed a hidden field suppressor but it still only works with explicit ```:hidden_fields => true```