### PR TITLE
Fix Kaminari deprecation message

### DIFF
--- a/lib/active_admin/views/components/paginated_collection.rb
+++ b/lib/active_admin/views/components/paginated_collection.rb
@@ -132,7 +132,7 @@ module ActiveAdmin
         end
 
         if @display_total
-          if collection.num_pages < 2
+          if collection.total_pages < 2
             case collection_size
             when 0; I18n.t("active_admin.pagination.empty",    model: entries_name)
             when 1; I18n.t("active_admin.pagination.one",      model: entry_name)


### PR DESCRIPTION
Fixes the following:

DEPRECATION WARNING: num_pages is deprecated and will be removed in Kaminari 1.0. Please use total_pages instead. (called from page_entries_info at (…)/lib/active_admin/views/components/paginated_collection.rb:135)