### PR TITLE
delegate parameters to controller

### DIFF
--- a/lib/active_admin/dsl.rb
+++ b/lib/active_admin/dsl.rb
@@ -70,8 +70,8 @@ module ActiveAdmin
     #
     #   end
     #
-    def controller(&block)
-      @config.controller.class_exec(&block) if block_given?
+    def controller(*args,&block)
+      @config.controller.class_exec(*args,&block) if block_given?
       @config.controller
     end
 

--- a/lib/active_admin/dsl.rb
+++ b/lib/active_admin/dsl.rb
@@ -71,9 +71,16 @@ module ActiveAdmin
     #   end
     #
     def controller(*args,&block)
-      @config.controller.class_exec(*args,&block) if block_given?
+      if block_given?
+        @config.controller.class_exec(*args) do
+          args_names = block.parameters.map(&:last)
+          args.each_with_index{|value,i| define_method(args_names[i]){ value }}
+        end
+        @config.controller.class_exec(*args,&block)
+      end
       @config.controller
     end
+
 
     # Add a new action item to the resource
     #


### PR DESCRIPTION
Earlier I did not found the way to pass variable to controller, like with this example
```
    ActiveAdmin.register Foo do
      #some code  
      bar = 42
    
      controller do
        def scoped_collection
          # ??? bar
        end
      end
    end
```

and with this patch you can use
```
    ActiveAdmin.register Foo do
      #some code  
      bar = 42
    
      controller(bar) do |bar|
        @bar= bar
        def scoped_collection
          self.class.send :class_eval, '@bar' # 42
        end
      end
    end
```

Maybe there is easier way, I'll be very grateful for it. 