### PR TITLE
Remove deprecated Kaminari method num_pages

### DIFF
--- a/lib/active_admin/resource_controller/decorators.rb
+++ b/lib/active_admin/resource_controller/decorators.rb
@@ -67,7 +67,7 @@ module ActiveAdmin
         def self.wrap!(parent, name)
           ::Class.new parent do
             delegate :reorder, :page, :current_page, :total_pages, :limit_value,
-                     :total_count, :num_pages, :to_key, :group_values, :except,
+                     :total_count, :total_pages, :to_key, :group_values, :except,
                      :find_each, :ransack
 
             define_singleton_method(:name) { name }

--- a/lib/active_admin/views/components/paginated_collection.rb
+++ b/lib/active_admin/views/components/paginated_collection.rb
@@ -44,7 +44,7 @@ module ActiveAdmin
         @display_total  = options.delete(:pagination_total) { true }
         @per_page       = options.delete(:per_page)
 
-        unless collection.respond_to?(:num_pages)
+        unless collection.respond_to?(:total_pages)
           raise(StandardError, "Collection is not a paginated scope. Set collection.page(params[:page]).per(10) before calling :paginated_collection.")
         end
 
@@ -132,7 +132,7 @@ module ActiveAdmin
         end
 
         if @display_total
-          if collection.num_pages < 2
+          if collection.total_pages < 2
             case collection_size
             when 0; I18n.t("active_admin.pagination.empty",    model: entries_name)
             when 1; I18n.t("active_admin.pagination.one",      model: entry_name)
@@ -149,7 +149,7 @@ module ActiveAdmin
           end
         else
           # Do not display total count, in order to prevent a `SELECT count(*)`.
-          # To do so we must not call `collection.num_pages`
+          # To do so we must not call `collection.total_pages`
           offset = (collection.current_page - 1) * collection.limit_value
           I18n.t "active_admin.pagination.multiple_without_total",
                  model: entries_name,

--- a/spec/unit/views/components/paginated_collection_spec.rb
+++ b/spec/unit/views/components/paginated_collection_spec.rb
@@ -212,7 +212,6 @@ describe ActiveAdmin::Views::PaginatedCollection do
 
       describe "set to false" do
         it "should not show the total item counts" do
-          expect(collection).not_to receive(:num_pages)
           expect(collection).not_to receive(:total_pages)
           pagination = paginated_collection(collection, pagination_total: false)
           info = pagination.find_by_class('pagination_information').first.content.gsub('&nbsp;',' ')


### PR DESCRIPTION
Replace it with total_pages

Deprecation notice https://github.com/amatsuda/kaminari/blob/9d550c737a72fc1ddee71e979d358704593a5a6f/CHANGELOG.rdoc#0170

This also reduced number of spec failures to only 4, from 23.