### PR TITLE
force usage of jQuery 2 from jquery-rails

### DIFF
--- a/app/assets/javascripts/active_admin/base.js.coffee
+++ b/app/assets/javascripts/active_admin/base.js.coffee
@@ -1,4 +1,4 @@
-#= require jquery
+#= require jquery2
 #= require ./jquery_ui
 #= require jquery_ujs
 #= require_self


### PR DESCRIPTION
was debugging weir behavior of active admin what was caused by requiring jquery 3
I would suggest explicitly to require jquery 2 until jquery 3 is fully supported.