### PR TITLE
Make CI green again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script:
 rvm:
   - 1.9
   - 2.3.0
-  - jruby-9.0.4.0
+  - jruby-9.0.5.0
 env:
   matrix:
     - RAILS=3.2.22
@@ -29,7 +29,7 @@ matrix:
   allow_failures:
     - rvm: 2.3.0
       env: RAILS="> 5.x"
-    - rvm: jruby-9.0.4.0
+    - rvm: jruby-9.0.5.0
       env: RAILS="> 5.x"
 branches:
   only:

--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,7 @@ group :test do
   gem 'cucumber', '1.3.20'
   gem 'database_cleaner' if rails_version != '> 5.x'
   gem 'guard-rspec', require: false
+  gem 'listen', '~> 2.7', platforms: :ruby_19
   gem 'jasmine'
   gem 'jslint_on_rails'
   gem 'launchy'

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -58,6 +58,9 @@ Capybara.javascript_driver = :poltergeist
 # steps to use the XPath syntax.
 Capybara.default_selector = :css
 
+# Make input type=hidden visible
+Capybara.ignore_hidden_elements = false
+
 # If you set this to false, any error raised from within your app will bubble
 # up to your step definition and out to cucumber unless you catch it somewhere
 # on the way. You can make Rails rescue errors and render error pages on a

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -164,3 +164,6 @@ unless ENV['DEFER_GC'] == '0' || ENV['DEFER_GC'] == 'false'
     config.after(:all)  { DeferredGarbageCollection.reconsider }
   end
 end
+
+# Make input type=hidden visible
+Capybara.ignore_hidden_elements = false


### PR DESCRIPTION
There're 4 major issues:

1. Ruby 1.9 fails to bundle because `guard` now depends on `ruby_dep` which only supports ~> Ruby 2.0
2. Like 1, `listen` also depends on JRuby 9.0.5.0
3. Kaminari deprecated num_pages
4. Capybara now treats hidden form tag as hidden elements

Not quite sure about ActiveAdmin's version support policy. Any idea?