### PR TITLE
Do not decorate not found resources (nils)

### DIFF
--- a/lib/active_admin/resource.rb
+++ b/lib/active_admin/resource.rb
@@ -145,7 +145,7 @@ module ActiveAdmin
 
     def find_resource(id)
       resource = resource_class.public_send *method_for_find(id)
-      decorator_class ? decorator_class.new(resource) : resource
+      (decorator_class && resource) ? decorator_class.new(resource) : resource
     end
 
     private

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -234,8 +234,10 @@ module ActiveAdmin
       before do
         if Rails::VERSION::MAJOR >= 4
           allow(Post).to receive(:find_by).with("id" => "12345") { post }
+          allow(Post).to receive(:find_by).with("id" => "54321") { nil }
         else
           allow(Post).to receive(:find_by_id).with("12345") { post }
+          allow(Post).to receive(:find_by_id).with("54321") { nil }
         end
       end
 
@@ -247,6 +249,10 @@ module ActiveAdmin
         let(:resource) { namespace.register(Post) { decorate_with PostDecorator } }
         it 'decorates the resource' do
           expect(resource.find_resource('12345')).to eq PostDecorator.new(post)
+        end
+
+        it 'does not decorate a not found resource' do
+          expect(resource.find_resource('54321')).to equal nil
         end
       end
 


### PR DESCRIPTION
I have found this bug while using `activeadmin` and [`friendly_id`](https://github.com/norman/friendly_id) together. If your model has a numeric slug different from its id, then it is used in a path to the resource. The [`ActiveAdmin::ViewHelpers::BreadcrumbHelper`](https://github.com/activeadmin/activeadmin/blob/master/lib/active_admin/view_helpers/breadcrumb_helper.rb) recognizes the resource as a DB object and tries to locate it using the bugged method. It fails to find the resource, but still decorates it. As the result [`find_resource`](https://github.com/activeadmin/activeadmin/blob/master/lib/active_admin/resource.rb#L146) and, consequently, [`display_name`](https://github.com/activeadmin/activeadmin/blob/2f7703600953b05e629e101a2b4d5a4c8844740c/lib/active_admin/view_helpers/display_helper.rb#L17) helpers return truthy values and someplace later the decorator fails to delegate some of the methods to the `nil`.