### PR TITLE
Fixes #4342 Corrects missing filters in #index when using a filter. (…

### DIFF
--- a/lib/active_admin/filters/active.rb
+++ b/lib/active_admin/filters/active.rb
@@ -16,7 +16,7 @@ module ActiveAdmin
       private
 
       def build_filters
-        filters = @params[:q] || []
+        filters = @params[:q] || @params["q"] || []
         filters.map{ |param| Humanized.new(param) }
       end
 


### PR DESCRIPTION
@timoschilling -- Re my other PR -- this is just the one feature. 

Previously: Filters applied would say 'none' even if filters were applied, due to mismatch in params hash expectation :q vs. 'q'.