### PR TITLE
Use pre-installed version of phantomjs on CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,7 @@ group :test do
   gem 'guard-rspec', require: false
   gem 'listen', '~> 2.7', platforms: :ruby_19
   gem 'jasmine'
+  gem 'phantomjs', '1.9.8.0'                # Same version as Travis CI's pre-installed version
   gem 'jslint_on_rails'
   gem 'launchy'
   gem 'rails-i18n'                          # Provides default i18n for many languages


### PR DESCRIPTION
In recent build history, many builds randomly failed because of connection issue when trying to download and isntall phantomjs.

Let's just use the one pre-installed on Travis CI build environment.