### PR TITLE
fix Filters::Humanized from wrong predicate detecting

### DIFF
--- a/lib/active_admin/filters/humanized.rb
+++ b/lib/active_admin/filters/humanized.rb
@@ -43,7 +43,7 @@ module ActiveAdmin
       end
 
       def current_predicate
-        @current_predicate ||= predicates.detect { |p| @body.include?(p) }
+        @current_predicate ||= predicates.detect { |p| @body.end_with?("_#{p}") }
       end
 
       def predicates

--- a/spec/unit/filters/humanized_spec.rb
+++ b/spec/unit/filters/humanized_spec.rb
@@ -52,5 +52,13 @@ describe ActiveAdmin::Filters::Humanized do
         expect(humanizer.body).to eq("Name Predicate Does Not Exist")
       end
     end
+
+    context 'when column name similar to predicate' do
+      it 'parses correct predicate' do
+        param = ['time_start_gteq', 'test']
+        humanizer = ActiveAdmin::Filters::Humanized.new(param)
+        expect(humanizer.body).to eq('Time Start greater than or equal to')
+      end
+    end
   end
 end


### PR DESCRIPTION
```ruby
ActiveAdmin::Filters::Humanized.new(['time_start_gteq', '1']).body
```
before PR it returns `"Time starts with"` and it is wrong
after PR it returns correct message `"Time Start greater than or equal to"`

bug fixed and test added