### PR TITLE
Specifying kaminari version for Rails 5 is no longer needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ gem 'inherited_resources', github: 'activeadmin/inherited_resources'
 gem 'devise',      '> 4.x'
 gem 'rspec-rails', '>= 3.5.0.beta1'
 gem 'ransack',    github: 'activerecord-hackery/ransack'
-gem 'kaminari',   github: 'amatsuda/kaminari', branch: '0-17-stable'
 gem 'formtastic', github: 'justinfrench/formtastic'
 gem 'draper',     github: 'audionerd/draper', branch: 'rails5', ref: 'e816e0e587'
 # To fix a Draper deprecation error


### PR DESCRIPTION
Specifying the branch of kaminari for using Active Admin with Rails 5 seems to be no longer needed since kaminari 0.17 is released.