### PR TITLE
Turbolinks error corrections and enhancements

### DIFF
--- a/app/assets/javascripts/active_admin/initializers/filters.js.coffee
+++ b/app/assets/javascripts/active_admin/initializers/filters.js.coffee
@@ -1,13 +1,20 @@
 $(document).on 'ready page:load turbolinks:load', ->
   # Clear Filters button
-  $('.clear_filters_btn').click ->
+  $('.clear_filters_btn').click (e) ->
     params = window.location.search.slice(1).split('&')
     regex = /^(q\[|q%5B|q%5b|page|commit)/
-    window.location.search = (param for param in params when not param.match(regex)).join('&')
+    if typeof Turbolinks != 'undefined'
+      Turbolinks.visit(window.location.href.split('?')[0] + '?' + (param for param in params when not param.match(regex)).join('&'))
+      e.preventDefault()
+    else
+      window.location.search = (param for param in params when not param.match(regex)).join('&')
 
   # Filter form: don't send any inputs that are empty
-  $('.filter_form').submit ->
+  $('.filter_form').submit (e) ->
     $(@).find(':input').filter(-> @value is '').prop 'disabled', true
+    if typeof Turbolinks != 'undefined'
+      Turbolinks.visit(window.location.href.split('?')[0] + '?' + $( this ).serialize())
+      e.preventDefault()
 
   # Filter form: for filters that let you choose the query method from
   # a dropdown, apply that choice to the filter input field.

--- a/app/assets/javascripts/active_admin/lib/checkbox-toggler.js.coffee
+++ b/app/assets/javascripts/active_admin/lib/checkbox-toggler.js.coffee
@@ -33,4 +33,12 @@ class ActiveAdmin.CheckboxToggler
       $(el).prop checked: setting
       @_didChangeCheckbox(el)
 
+  option: (key, value) ->
+    if $.isPlainObject(key)
+      @options = $.extend(true, @options, key)
+    else if key?
+      @options[key]
+    else
+      @options[key] = value
+
 $.widget.bridge 'checkboxToggler', ActiveAdmin.CheckboxToggler

--- a/app/assets/javascripts/active_admin/lib/per_page.js.coffee
+++ b/app/assets/javascripts/active_admin/lib/per_page.js.coffee
@@ -23,9 +23,17 @@ class ActiveAdmin.PerPage
    
   _decode: (value) ->
     #replace "+" before decodeURIComponent
-    decodeURIComponent(value.replace(/\+/g, '%20')) 
+    decodeURIComponent(value.replace(/\+/g, '%20'))
+
+  option: (key, value) ->
+    if $.isPlainObject(key)
+      @options = $.extend(true, @options, key)
+    else if key?
+      @options[key]
+    else
+      @options[key] = value
 
 $.widget.bridge 'perPage', ActiveAdmin.PerPage
 
-$ ->
+$(document).on 'ready page:load turbolinks:load', ->
   $('.pagination_per_page select').perPage()

--- a/app/assets/javascripts/active_admin/lib/per_page.js.coffee
+++ b/app/assets/javascripts/active_admin/lib/per_page.js.coffee
@@ -11,7 +11,10 @@ class ActiveAdmin.PerPage
     @$element.change =>
       @$params['per_page'] = @$element.val()
       delete @$params['page']
-      location.search = $.param(@$params)
+      if typeof Turbolinks != 'undefined'
+        Turbolinks.visit(window.location.href.split('?')[0] + '?' + $.param(@$params))
+      else
+        location.search = $.param(@$params)
 
   _queryParams: ->
     query = window.location.search.substring(1)


### PR DESCRIPTION
I got a few errors when enabling Turbolinks due to missing option methods on the PerPage and CheckboxToggler widgets and the PerPage widget was not loaded correctly.

I have also made both the filters submission form and the per page widget use Turbolinks.visit if available.