### PR TITLE
Fixing 'inputs' - respecing other than :class options

### DIFF
--- a/lib/active_admin/views/components/active_admin_form.rb
+++ b/lib/active_admin/views/components/active_admin_form.rb
@@ -19,7 +19,7 @@ module ActiveAdmin
         opening_tag << children.to_s << closing_tag
       end
     end
-    
+
     class ActiveAdminForm < FormtasticProxy
       builder_method :active_admin_form_for
 
@@ -95,14 +95,15 @@ module ActiveAdmin
 
     class SemanticInputsProxy < FormtasticProxy
       def build(form_builder, *args, &block)
-        options = args.extract_options!
-        legend = args.shift
+        html_options = args.extract_options!
+        html_options[:class] ||= "inputs"
+        legend = args.shift if args.first.is_a?(::String)
+        legend = html_options.delete(:name) if html_options.key?(:name)
         legend_tag = legend ? "<legend><span>#{legend}</span></legend>" : ""
-        klasses = ["inputs"]
-        klasses << options[:class] if options[:class]
-        @opening_tag = "<fieldset class=\"#{klasses.join(" ")}\">#{legend_tag}<ol>"
+        fieldset_attrs = html_options.map {|k,v| %Q{#{k}="#{v}"} }.join(" ")
+        @opening_tag = "<fieldset #{fieldset_attrs}>#{legend_tag}<ol>"
         @closing_tag = "</ol></fieldset>"
-        super(*(args << options), &block)
+        super(*(args << html_options), &block)
       end
     end
 

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -63,7 +63,7 @@ describe ActiveAdmin::FormBuilder do
     context "it with custom settings" do
       let :body do
         build_form do |f|
-          f.inputs class: "custom_class" do
+          f.inputs class: "custom_class", name: 'custom_name', custom_attr: 'custom_attr' do
             f.input :title
             f.input :body
           end
@@ -72,6 +72,14 @@ describe ActiveAdmin::FormBuilder do
 
       it "should generate a fieldset with a inputs and custom class" do
         expect(body).to have_selector("fieldset.custom_class")
+      end
+
+      it "should generate a fieldset with a custom legend" do
+        expect(body).to have_css("legend", text: 'custom_name')
+      end
+
+      it "should generate a fieldset with a custom attributes" do
+        expect(body).to have_selector("fieldset[custom_attr='custom_attr']")
       end
     end
   end

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -71,7 +71,7 @@ describe ActiveAdmin::FormBuilder do
       end
 
       it "should generate a fieldset with a inputs and custom class" do
-        expect(body).to have_selector("fieldset.inputs.custom_class")
+        expect(body).to have_selector("fieldset.custom_class")
       end
     end
   end


### PR DESCRIPTION
This change is supposed to fix this issue: https://github.com/activeadmin/activeadmin/issues/3954