### PR TITLE
Fix batch action pluralization in Spanish

### DIFF
--- a/config/locales/es-MX.yml
+++ b/config/locales/es-MX.yml
@@ -59,7 +59,7 @@ es-MX:
         other: "Se han destruido %{count} %{plural_model} con éxito"
       selection_toggle_explanation: "(Cambiar selección)"
       link: "Añadir"
-      action_label: "%{title} seleccionado"
+      action_label: "%{title} seleccionados"
       labels:
         destroy: "Borrar"
     comments:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -69,7 +69,7 @@ es:
         other: "Se han destruido %{count} %{plural_model} con éxito"
       selection_toggle_explanation: "(Cambiar selección)"
       link: "Añadir"
-      action_label: "%{title} seleccionado"
+      action_label: "%{title} seleccionados"
       labels:
         destroy: "Borrar"
     comments:


### PR DESCRIPTION
Since batch actions apply to multiple records, Spanish requires the pluralized
form to make sense.