### PR TITLE
Update gem requirements for Rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,19 +18,19 @@ env:
   matrix:
     - RAILS=3.2.22
     - RAILS=4.2.5
-    - RAILS="> 5.x"
+    - RAILS=5.0.0
   global:
     - JRUBY_OPTS="-J-Xmx1024m --debug"
 matrix:
   fast_finish: true
   exclude:
     - rvm: 1.9
-      env: RAILS="> 5.x"
+      env: RAILS=5.0.0
   allow_failures:
     - rvm: 2.3.0
-      env: RAILS="> 5.x"
+      env: RAILS=5.0.0
     - rvm: jruby-9.0.5.0
-      env: RAILS="> 5.x"
+      env: RAILS=5.0.0
 branches:
   only:
     - master

--- a/Gemfile
+++ b/Gemfile
@@ -5,30 +5,26 @@ gemspec
 require File.expand_path 'spec/support/detect_rails_version', File.dirname(__FILE__)
 
 rails_version = detect_rails_version
+rails_major   = rails_version[0]
+
 gem 'rails', rails_version
 
-gem 'jquery-ui-rails', rails_version[0] == '3' ? '~> 4.0' : '~> 5.0'
+gem 'jquery-ui-rails', rails_major == '3' ? '~> 4.0' : '~> 5.0'
 
-gem 'test-unit', '~> 3.0' if rails_version[0] == '3'
+gem 'test-unit', '~> 3.0' if rails_major == '3'
 
-if rails_version == '> 5.x'
+if rails_major == '5'
   # Note: when updating this list, be sure to also update the README
-  gem 'ransack',    github: 'activerecord-hackery/ransack'
-  gem 'kaminari',   github: 'amatsuda/kaminari', branch: '0-17-stable'
-  gem 'draper',     github: 'audionerd/draper', branch: 'rails5', ref: 'e816e0e587'
-  gem 'formtastic', github: 'justinfrench/formtastic'
-  gem 'activemodel-serializers-xml', github: 'rails/activemodel-serializers-xml' # drapergem/draper#697
-  gem 'rack-mini-profiler', github: 'MiniProfiler/rack-mini-profiler'
-  gem 'database_cleaner',  github: 'DatabaseCleaner/database_cleaner'
-  gem 'activerecord-jdbc-adapter', github: 'jruby/activerecord-jdbc-adapter', platforms: :jruby
+  gem 'inherited_resources', github: 'activeadmin/inherited_resources'
+  gem 'ransack',             github: 'activerecord-hackery/ransack'
 end
 
 gem 'mime-types', '< 3' # Remove this line when we drop support for Ruby 1.9
 
 # Optional dependencies
 gem 'cancan'
-gem 'devise', rails_version == '> 5.x' ? '> 4.x' : '~> 3.5'
-gem 'draper' if rails_version != '> 5.x'
+gem 'devise', rails_major == '5' ? '> 4.x' : '~> 3.5'
+gem 'draper', rails_major == '5' ? '> 3.x' : '~> 2.1'
 gem 'pundit'
 
 # Utility gems used in both development & test environments
@@ -44,7 +40,7 @@ group :development do
   gem 'binding_of_caller', platforms: :mri  # Retrieve the binding of a method's caller in MRI Ruby >= 1.9.2
 
   # Performance
-  gem 'rack-mini-profiler' if rails_version != '> 5.x' # Inline app profiler. See ?pp=help for options.
+  gem 'rack-mini-profiler'                  # Inline app profiler. See ?pp=help for options.
   gem 'flamegraph', platforms: :mri         # Flamegraph visualiztion: ?pp=flamegraph
 
   # Documentation
@@ -59,7 +55,7 @@ group :test do
   gem 'coveralls', require: false           # Test coverage website. Go to https://coveralls.io
   gem 'cucumber-rails', require: false
   gem 'cucumber', '1.3.20'
-  gem 'database_cleaner' if rails_version != '> 5.x'
+  gem 'database_cleaner'
   gem 'guard-rspec', require: false
   gem 'listen', '~> 2.7', platforms: :ruby_19
   gem 'jasmine'
@@ -71,6 +67,6 @@ group :test do
   gem 'i18n-spec'
   gem 'shoulda-matchers', '<= 2.8.0'
   gem 'sqlite3', platforms: :mri
-  gem 'activerecord-jdbcsqlite3-adapter', platforms: :jruby if rails_version != '> 5.x'
+  gem 'activerecord-jdbcsqlite3-adapter', platforms: :jruby
   gem 'poltergeist'
 end

--- a/README.md
+++ b/README.md
@@ -33,18 +33,8 @@ Active Admin master has preliminary support for Rails 5. To give it a try, these
 
 ```ruby
 gem 'inherited_resources', github: 'activeadmin/inherited_resources'
-gem 'devise',      '> 4.x'
-gem 'rspec-rails', '>= 3.5.0.beta1'
-gem 'ransack',    github: 'activerecord-hackery/ransack'
-gem 'formtastic', github: 'justinfrench/formtastic'
-gem 'draper',     github: 'audionerd/draper', branch: 'rails5', ref: 'e816e0e587'
-# To fix a Draper deprecation error
-gem 'activemodel-serializers-xml', github: 'rails/activemodel-serializers-xml'
-# Optional -- only if you already include these gems
-gem 'rack-mini-profiler',          github: 'MiniProfiler/rack-mini-profiler'
-gem 'database_cleaner',            github: 'pschambacher/database_cleaner', branch: 'rails5.0', ref: '8dd9fa4'
-# Only for JRuby:
-gem 'activerecord-jdbc-adapter',   github: 'jruby/activerecord-jdbc-adapter', platforms: :jruby
+gem 'ransack',             github: 'activerecord-hackery/ransack'
+gem 'draper',              '> 3.x'
 ```
 
 If something isn't working for you please report it on [#4177](https://github.com/activeadmin/activeadmin/issues/4177).

--- a/features/step_definitions/table_steps.rb
+++ b/features/step_definitions/table_steps.rb
@@ -59,8 +59,6 @@ class HtmlTableToTextHelper
 end
 
 module TableMatchHelper
-
-
   # @param table [Array[Array]]
   # @param expected_table [Array[Array[String]]]
   # The expected_table values are String. They are converted to
@@ -97,11 +95,9 @@ module TableMatchHelper
       expect((cell || "").strip).to eq expected_cell
     end
   end
-
-end # module TableMatchHelper
+end
 
 World(TableMatchHelper)
-
 
 # Usage:
 #

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -123,12 +123,14 @@ ActiveAdmin.application.current_user_method = false
 RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.use_instantiated_fixtures = false
-  config.include Devise::Test::ControllerHelpers, type: :controller
   config.render_views = false
   config.filter_run focus: true
   config.filter_run_excluding skip: true
   config.run_all_when_everything_filtered = true
   config.color = true
+
+  devise = ActiveAdmin::Dependency.devise >= '4.2' ? Devise::Test::ControllerHelpers : Devise::TestHelpers
+  config.include devise, type: :controller
 
   require 'support/active_admin_request_helpers'
   config.include ActiveAdminRequestHelpers, type: :request

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -86,7 +86,6 @@ module ActiveAdminIntegrationSpecHelper
   ensure
     I18n.backend.reload!
   end
-
 end
 
 ENV['RAILS_ENV'] = 'test'
@@ -121,27 +120,18 @@ reload_routes!
 ActiveAdmin.application.authentication_method = false
 ActiveAdmin.application.current_user_method = false
 
-# Don't add asset cache timestamps. Makes it easy to integration
-# test for the presence of an asset file
-ENV["RAILS_ASSET_ID"] = ''
-
 RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.use_instantiated_fixtures = false
-  config.include Devise::TestHelpers, type: :controller
+  config.include Devise::Test::ControllerHelpers, type: :controller
   config.render_views = false
   config.filter_run focus: true
   config.filter_run_excluding skip: true
   config.run_all_when_everything_filtered = true
   config.color = true
-end
 
-# All RSpec configuration needs to happen before any examples
-# or else it whines.
-require "support/active_admin_request_helpers"
-RSpec.configure do |c|
-  c.include ActiveAdminRequestHelpers, type: :request
-  c.include Devise::TestHelpers, type: :controller
+  require 'support/active_admin_request_helpers'
+  config.include ActiveAdminRequestHelpers, type: :request
 end
 
 # Force deprecations to raise an exception.


### PR DESCRIPTION
Currently Travis is still using Rails release candidates. This updates it to use the proper release. It also gets it back in sync with the README.

I released Draper 3.0.0.pre1.

A lot of other gems have published Rails 5 compatible versions to Rubygems.

This fixes a Devise deprecation warning:

> including `Devise::TestHelpers` is deprecated and will be removed from Devise. For controller tests, please include `Devise::Test::ControllerHelpers` instead.