### PR TITLE
Depend only on specific Rails components

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'jquery-rails'
   s.add_dependency 'jquery-ui-rails'
   s.add_dependency 'kaminari',            '~> 0.15'
-  s.add_dependency 'rails',               '>= 3.2', '< 5.1'
+  s.add_dependency 'railties',            '>= 3.2', '< 5.1'
   s.add_dependency 'ransack',             '~> 1.3'
   s.add_dependency 'sass-rails'
   s.add_dependency 'sprockets',           '< 4.1'


### PR DESCRIPTION
Rails 5 introduces Action Cable that comes with additional dependencies.
Not all applications use Action Cable, so developers can choose to
include only required Rails components to their Gemfiles to avoid having
unused dependencies.

Removing the dependency on `rails` meta gem will allow using ActiveAdmin
in the applications where the developers decided to opt-out of some of
the Rails components.