### PR TITLE
Add back pretty formatting of non-symbol attributes.

### DIFF
--- a/lib/active_admin/view_helpers/display_helper.rb
+++ b/lib/active_admin/view_helpers/display_helper.rb
@@ -42,9 +42,14 @@ module ActiveAdmin
 
       def format_attribute(resource, attr)
         value = find_value resource, attr
-        value = pretty_format value                    if attr.is_a? Symbol
-        value = Arbre::Context.new{ status_tag value } if boolean_attr? resource, attr
-        value
+
+        if value.is_a?(Arbre::Element)
+          value
+        elsif boolean_attr?(resource, attr)
+          Arbre::Context.new { status_tag value }
+        else
+          pretty_format value
+        end
       end
 
       def find_value(resource, attr)

--- a/spec/unit/view_helpers/display_helper_spec.rb
+++ b/spec/unit/view_helpers/display_helper_spec.rb
@@ -89,7 +89,7 @@ describe ActiveAdmin::ViewHelpers::DisplayHelper do
     it 'calls the provided block to format the value' do
       value = format_attribute double(foo: 2), ->r { r.foo + 1 }
 
-      expect(value).to eq 3
+      expect(value).to eq '3'
     end
 
     it 'finds values as methods' do
@@ -104,7 +104,7 @@ describe ActiveAdmin::ViewHelpers::DisplayHelper do
       expect(value).to eq '100'
     end
 
-    [1, 1.2, :a_symbol, Arbre::Element.new].each do |val|
+    [1, 1.2, :a_symbol].each do |val|
       it "calls to_s to format the value of type #{val.class}" do
         value = format_attribute double(foo: val), :foo
 


### PR DESCRIPTION
3efb3595, switched around a bunch of code, but also scoped `pretty_format`-ing to only
symbol attributes.

This broke formatting in our app. In Active Admin v1.0.0.pre2 code like:

```ruby
show do
  attributes_table do
    row :mobile_subscription do
      subscription # ActiveRecord::Base object.
    end
  end
end
```

would auto link the returned model, but pre4 merely returns an `inspect` like output.

I think scoping `pretty_format` to only symbol attributes was an oversight as the
method clearly knows how to handle lots of different objects.

This refines `format_attribute` so we can still get nice status tags for boolean
fields, but get pretty formatted output for the rest of the values like pre2 and
earlier did.