### PR TITLE
Update filter example to use "_action" in name

### DIFF
--- a/lib/generators/active_admin/install/templates/active_admin.rb.erb
+++ b/lib/generators/active_admin/install/templates/active_admin.rb.erb
@@ -145,7 +145,7 @@ ActiveAdmin.setup do |config|
   # You can add before, after and around filters to all of your
   # Active Admin resources and pages from here.
   #
-  # config.before_filter :do_something_awesome
+  # config.before_action :do_something_awesome
 
   # == Localize Date/Time Format
   #


### PR DESCRIPTION
Since this gem supports Rails 4 and 5 now going forward I thought it would be better despite this being commented out that it should use the current accepted filter name `before_action` since anything suffixed with `_filter` is deprecated in Rails 5.