### PR TITLE
Custom Controller Actions: Allow create an action with the same name, that handles multiple HTTP verbs  a more natural way

### DIFF
--- a/lib/active_admin/controller_action.rb
+++ b/lib/active_admin/controller_action.rb
@@ -7,8 +7,8 @@ module ActiveAdmin
       @http_verb = resolve_http_verb(options)
     end
 
-    def remove_http_verb(verb)
-      self.http_verb = Array(http_verb) - Array(verb)
+    def remove_http_verbs(verbs)
+      self.http_verb = http_verb - verbs
     end
 
     private
@@ -17,13 +17,9 @@ module ActiveAdmin
 
     def resolve_http_verb(options)
       method = options[:method]
-      return :get unless method
+      return [:get] unless method
 
-      if method.is_a?(Array)
-        method.map(&:to_sym).uniq
-      else
-        method.to_sym
-      end
+      Array(method).map { |m| m.downcase.to_sym }.uniq
     end
   end
 end

--- a/lib/active_admin/controller_action.rb
+++ b/lib/active_admin/controller_action.rb
@@ -1,12 +1,29 @@
 module ActiveAdmin
   class ControllerAction
-    attr_reader :name
+    attr_reader :name, :http_verb
+
     def initialize(name, options = {})
-      @name, @options = name, options
+      @name = name.to_sym
+      @http_verb = resolve_http_verb(options)
     end
 
-    def http_verb
-      @options[:method] ||= :get
+    def remove_http_verb(verb)
+      self.http_verb = Array(http_verb) - Array(verb)
+    end
+
+    private
+
+    attr_writer :http_verb
+
+    def resolve_http_verb(options)
+      method = options[:method]
+      return :get unless method
+
+      if method.is_a?(Array)
+        method.map(&:to_sym).uniq
+      else
+        method.to_sym
+      end
     end
   end
 end

--- a/lib/active_admin/resource.rb
+++ b/lib/active_admin/resource.rb
@@ -10,6 +10,7 @@ require 'active_admin/resource/includes'
 require 'active_admin/resource/scope_to'
 require 'active_admin/resource/sidebars'
 require 'active_admin/resource/belongs_to'
+require 'active_admin/resource/controller_actions'
 
 module ActiveAdmin
 
@@ -63,7 +64,8 @@ module ActiveAdmin
         @resource_class_name = "::#{resource_class.name}"
         @options    = options
         @sort_order = options[:sort_order]
-        @member_actions, @collection_actions = [], []
+        @member_actions = ControllerActions.new
+        @collection_actions = ControllerActions.new
       end
     end
 
@@ -107,11 +109,11 @@ module ActiveAdmin
 
     # Clears all the member actions this resource knows about
     def clear_member_actions!
-      @member_actions = []
+      @member_actions = ControllerActions.new
     end
 
     def clear_collection_actions!
-      @collection_actions = []
+      @collection_actions = ControllerActions.new
     end
 
     # Return only defined resource actions

--- a/lib/active_admin/resource/controller_actions.rb
+++ b/lib/active_admin/resource/controller_actions.rb
@@ -16,7 +16,7 @@ module ActiveAdmin
         actions.each do |action|
           next if action.name != new_action.name
 
-          new_action.remove_http_verb(action.http_verb)
+          new_action.remove_http_verbs(action.http_verb)
           return if new_action.http_verb.blank?
         end
 

--- a/lib/active_admin/resource/controller_actions.rb
+++ b/lib/active_admin/resource/controller_actions.rb
@@ -1,0 +1,43 @@
+module ActiveAdmin
+  class Resource
+    class ControllerActions
+      def initialize
+        @actions = []
+      end
+
+      def items
+        copy
+      end
+
+      # Adds a new action to the collection.
+      # Don't allow add actions with the same name and http method,
+      # in order to avoid routes duplication.
+      def <<(new_action)
+        actions.each do |action|
+          next if action.name != new_action.name
+
+          new_action.remove_http_verb(action.http_verb)
+          return if new_action.http_verb.blank?
+        end
+
+        actions << new_action
+      end
+
+      def each(&block)
+        copy.each(&block)
+      end
+
+      def size
+        actions.size
+      end
+
+      private
+
+      attr_accessor :actions
+
+      def copy
+        actions.dup
+      end
+    end
+  end
+end

--- a/lib/active_admin/resource_controller.rb
+++ b/lib/active_admin/resource_controller.rb
@@ -5,6 +5,7 @@ require 'active_admin/resource_controller/scoping'
 require 'active_admin/resource_controller/streaming'
 require 'active_admin/resource_controller/sidebars'
 require 'active_admin/resource_controller/resource_class_methods'
+require 'active_admin/resource_controller/action_verb_combiner.rb'
 
 module ActiveAdmin
   # All Resources Controller inherits from this controller.
@@ -22,6 +23,7 @@ module ActiveAdmin
     include Streaming
     include Sidebars
     extend  ResourceClassMethods
+    extend  ActionVerbCombiner
 
     def self.active_admin_config=(config)
       if @active_admin_config = config

--- a/lib/active_admin/resource_controller/action_verb_combiner.rb
+++ b/lib/active_admin/resource_controller/action_verb_combiner.rb
@@ -1,0 +1,79 @@
+module ActiveAdmin
+  class ResourceController < BaseController
+    module ActionVerbCombiner
+      private
+
+      # Add behaviour to an existing action, depending on http method,
+      # when the same action name is specified.
+      #
+      # For example:
+      #
+      #   ActiveAdmin.register Post do
+      #     member_action :comments, method: :get do
+      #       @post = Post.find(params[:id]
+      #       @comments = @post.comments
+      #     end
+      #
+      #     member_action :comments, method: :post do
+      #       @post = Post.find(params[:id]
+      #       @post.comments.create!(comment_params)
+      #     end
+      #   end
+      #
+      # Will be equivalent to:
+      #
+      #   ActiveAdmin.register Post do
+      #     member_action :comments, method: [:get, :post] do
+      #       if request.post?
+      #         @post = Post.find(params[:id]
+      #         @post.comments.create!(comment_params)
+      #       else
+      #         @post = Post.find(params[:id]
+      #         @comments = @post.comments
+      #       end
+      #     end
+      #   end
+      #
+      def add_behaviour_to_action(action_name, http_verbs, &block)
+        old_method_name = add_alias_for_old_behaviour(action_name)
+        new_method_name = add_method_for_new_behaviour(action_name, &block)
+
+        define_method(action_name) do
+          if request.method_symbol.in?(http_verbs)
+            send new_method_name
+          else
+            send old_method_name
+          end
+        end
+      end
+
+      def add_alias_for_old_behaviour(action_name)
+        method_name = resolve_method_name(action_name, "old")
+        alias_method method_name, action_name
+
+        private method_name
+
+        method_name
+      end
+
+      def add_method_for_new_behaviour(action_name, &block)
+        method_name = resolve_method_name(action_name, "new")
+        define_method method_name, &block
+
+        private method_name
+
+        method_name
+      end
+
+      def resolve_method_name(action_name, postfix)
+        next_name = "#{action_name}_#{postfix}"
+
+        while private_method_defined?(next_name) || method_defined?(next_name)
+          next_name = "#{next_name}_#{postfix}"
+        end
+
+        next_name
+      end
+    end
+  end
+end

--- a/spec/unit/action_builder_spec.rb
+++ b/spec/unit/action_builder_spec.rb
@@ -1,5 +1,14 @@
 require 'rails_helper'
 
+def app_routes
+  Rails.application.routes.routes.map do |route|
+    {
+      path: route.path.spec.to_s,
+      verb: %W{GET POST PUT PATCH DELETE}.grep(route.verb).first.to_s.downcase.to_sym
+    }
+  end
+end
+
 describe 'defining actions from registration blocks', type: :controller do
   let(:klass){ Admin::PostsController }
   render_views # https://github.com/rspec/rspec-rails/issues/860
@@ -69,6 +78,57 @@ describe 'defining actions from registration blocks', type: :controller do
         expect(controller.instance_variable_get(:@page_title)).to eq 'My Awesome Comment'
       end
     end
+
+    context 'when several actions with the same name' do
+      let(:routes) do
+        app_routes.select do |route|
+          route[:path].starts_with?("/admin/posts/:id/my_action")
+        end
+      end
+
+      context 'with the same http method' do
+        let(:action!) do
+          ActiveAdmin.register Post do
+            member_action :my_action, method: :get
+            member_action :my_action, method: :get
+          end
+        end
+
+        it 'should create only one route' do
+          expect(routes.map { |r| r[:verb] }).to eq [:get]
+        end
+      end
+
+      context 'with different http methods' do
+        let(:action!) do
+          ActiveAdmin.register Post do
+            member_action :my_action, method: :get
+            member_action :my_action, method: :post
+            member_action :my_action, method: [:put, :patch]
+            member_action :my_action, method: :delete
+          end
+        end
+
+        it 'should create a route for each http method' do
+          expect(routes.map { |r| r[:verb] }.sort).to eq [:delete, :get, :patch, :post, :put]
+        end
+      end
+
+      context 'with the same and different http methods' do
+        let(:action!) do
+          ActiveAdmin.register Post do
+            member_action :my_action, method: :get
+            member_action :my_action, method: [:get, :post]
+            member_action :my_action, method: [:post, :put, :patch]
+            member_action :my_action, method: [:post, :delete, :patch]
+          end
+        end
+
+        it 'should create a single route for each unique http method' do
+          expect(routes.map { |r| r[:verb] }.sort).to eq [:delete, :get, :patch, :post, :put]
+        end
+      end
+    end
   end
 
   describe 'creates a collection action' do
@@ -128,6 +188,57 @@ describe 'defining actions from registration blocks', type: :controller do
         get :comments
 
         expect(controller.instance_variable_get(:@page_title)).to eq 'My Awesome Comments'
+      end
+    end
+
+    context 'when several actions with the same name' do
+      let(:routes) do
+        app_routes.select do |route|
+          route[:path].starts_with?("/admin/posts/my_action")
+        end
+      end
+
+      context 'with the same http method' do
+        let(:action!) do
+          ActiveAdmin.register Post do
+            collection_action :my_action, method: :get
+            collection_action :my_action, method: :get
+          end
+        end
+
+        it 'should create only one route' do
+          expect(routes.map { |r| r[:verb] }).to eq [:get]
+        end
+      end
+
+      context 'with different http methods' do
+        let(:action!) do
+          ActiveAdmin.register Post do
+            collection_action :my_action, method: :get
+            collection_action :my_action, method: :post
+            collection_action :my_action, method: [:put, :patch]
+            collection_action :my_action, method: :delete
+          end
+        end
+
+        it 'should create a route for each http method' do
+          expect(routes.map { |r| r[:verb] }.sort).to eq [:delete, :get, :patch, :post, :put]
+        end
+      end
+
+      context 'with the same and different http methods' do
+        let(:action!) do
+          ActiveAdmin.register Post do
+            collection_action :my_action, method: :get
+            collection_action :my_action, method: [:get, :post]
+            collection_action :my_action, method: [:post, :put, :patch]
+            collection_action :my_action, method: [:post, :delete, :patch]
+          end
+        end
+
+        it 'should create a single route for each unique http method' do
+          expect(routes.map { |r| r[:verb] }.sort).to eq [:delete, :get, :patch, :post, :put]
+        end
       end
     end
   end


### PR DESCRIPTION
When somebody wants to create an action, that handles multiple HTTP verbs, they might write code like this:

          ActiveAdmin.register Post do
            member_action :action_name, method: :get do
              # do something on GET request
            end

            member_action :action_name, method: :post do
              # do something on POST request
            end
          end

This looks fine but doesn't work as expected. There is no magic  )
The second declaration will override the first one.

Furthermore, there will be 2 routes generated (GET, POST), that is strange. 
If there are two routes, why one behaviour?
At least, If action is overridden, then previous route should be removed.

This PR adds a lot of magic and automatically turns the above code into something like this:

          ActiveAdmin.register Post do
            member_action :action_name, method: [:get, :post] do
              if request.post?
                # do something on POST request
              else
                # do something on GET request
              end
            end
          end

In case when action name and http verb both the same as previous declared,  the latest declaration overrides the previous ones.

This works for both member and collection actions and with any combination of actions and http verbs.

This PR also fixes a bug. It is described in this commit https://github.com/activeadmin/activeadmin/commit/a7154b2faab4b3d0dbdff95baaef1e840dafb49f