### PR TITLE
Add the ability to specify Symbol and Proc as `allow_destroy` parameter of `f.has_many`

### DIFF
--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -59,7 +59,7 @@ module ActiveAdmin
           block.call has_many_form, index
           template.concat has_many_actions(has_many_form, builder_options, "".html_safe)
         end
-        
+
         template.assign(has_many_block: true)
         contents = without_wrapper { inputs(options, &form_block) } || "".html_safe
 
@@ -83,10 +83,12 @@ module ActiveAdmin
         contents << template.content_tag(:li) do
           template.link_to I18n.t('active_admin.has_many_remove'), "#", class: 'button has_many_remove'
         end
-      elsif builder_options[:allow_destroy]
-        has_many_form.input(:_destroy, as: :boolean,
-                            wrapper_html: {class: 'has_many_delete'},
-                            label: I18n.t('active_admin.has_many_delete'))
+      elsif builder_options.key? :allow_destroy
+        if allow_destroy?(has_many_form.object, builder_options.fetch(:allow_destroy))
+          has_many_form.input(:_destroy, as: :boolean,
+                                wrapper_html: {class: 'has_many_delete'},
+                                label: I18n.t('active_admin.has_many_delete'))
+        end
       end
 
       if builder_options[:sortable]
@@ -137,5 +139,15 @@ module ActiveAdmin
       }
     end
 
+    def allow_destroy?(object, allow_destroy_option)
+      case allow_destroy_option
+      when Symbol
+        object.public_send allow_destroy_option
+      when Proc
+        allow_destroy_option.call(object)
+      else
+        allow_destroy_option
+      end
+    end
   end
 end

--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -85,7 +85,10 @@ module ActiveAdmin
         contents << template.content_tag(:li) do
           template.link_to I18n.t('active_admin.has_many_remove'), "#", class: 'button has_many_remove'
         end
-      elsif has_many_allow_destroy?(has_many_form, builder_options)
+      elsif call_method_or_proc_on(has_many_form.object,
+                                   builder_options[:allow_destroy],
+                                   exec: false)
+
         has_many_form.input(:_destroy, as: :boolean,
                             wrapper_html: {class: 'has_many_delete'},
                             label: I18n.t('active_admin.has_many_delete'))
@@ -137,17 +140,6 @@ module ActiveAdmin
       template.link_to text, '#', class: "button has_many_add", data: {
         html: CGI.escapeHTML(html).html_safe, placeholder: placeholder
       }
-    end
-
-    def has_many_allow_destroy?(has_many_form, builder_options)
-      allow_destroy_option = builder_options[:allow_destroy]
-
-      case allow_destroy_option
-      when nil then false
-      when TrueClass, FalseClass then allow_destroy_option
-      else
-        call_method_or_proc_on(has_many_form.object, allow_destroy_option, exec: false)
-      end
     end
   end
 end

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -578,8 +578,11 @@ describe ActiveAdmin::FormBuilder do
           expect(body).to have_selector("label[for=category_posts_attributes_#{child_num}__destroy]", text: "Delete")
         end
 
-        it "should wrap the destroy field in an li with class 'has_many_delete'" do
-          expect(body).to have_selector(".has_many_container > fieldset > ol > li.has_many_delete > input", count: 1)
+        context "with allow_destroy as lambda" do
+          it_behaves_like(
+            "has many persisted with allow_destroy as Symbol or Proc",
+            -> (child) { child.foo? }
+          )
         end
       end
 

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -565,7 +565,7 @@ describe ActiveAdmin::FormBuilder do
     end
 
     describe "with allow destroy" do
-      shared_examples_for "has many persisted with allow_destroy = true" do |child_num|
+      shared_examples_for "has many with allow_destroy = true" do |child_num|
         it "should render the nested form" do
           expect(body).to have_selector("input[name='category[posts_attributes][#{child_num}][title]']")
         end
@@ -583,7 +583,7 @@ describe ActiveAdmin::FormBuilder do
         end
       end
 
-      shared_examples_for "has many persisted with allow_destroy = false" do |child_num|
+      shared_examples_for "has many with allow_destroy = false" do |child_num|
         it "should render the nested form" do
           expect(body).to have_selector("input[name='category[posts_attributes][#{child_num}][title]']")
         end
@@ -597,7 +597,7 @@ describe ActiveAdmin::FormBuilder do
         end
       end
 
-      shared_examples_for "has many persisted with allow_destroy as Symbol or Proc" do |allow_destroy_option|
+      shared_examples_for "has many with allow_destroy as String, Symbol or Proc" do |allow_destroy_option|
         let :body do
           s = self
           build_form({url: '/categories'}, Category.new) do |f|
@@ -616,11 +616,11 @@ describe ActiveAdmin::FormBuilder do
         end
 
         context 'for the child that responds with true' do
-          it_behaves_like "has many persisted with allow_destroy = true", 0
+          it_behaves_like "has many with allow_destroy = true", 0
         end
 
         context 'for the child that responds with false' do
-          it_behaves_like "has many persisted with allow_destroy = false", 1
+          it_behaves_like "has many with allow_destroy = false", 1
         end
       end
 
@@ -638,7 +638,7 @@ describe ActiveAdmin::FormBuilder do
             end
           end
 
-          it_behaves_like "has many persisted with allow_destroy = true", 0
+          it_behaves_like "has many with allow_destroy = true", 0
         end
 
         context "with allow_destroy = false" do
@@ -654,7 +654,7 @@ describe ActiveAdmin::FormBuilder do
             end
           end
 
-          it_behaves_like "has many persisted with allow_destroy = false", 0
+          it_behaves_like "has many with allow_destroy = false", 0
         end
 
         context "with allow_destroy = nil" do
@@ -670,29 +670,41 @@ describe ActiveAdmin::FormBuilder do
             end
           end
 
-          it_behaves_like "has many persisted with allow_destroy = false", 0
+          it_behaves_like "has many with allow_destroy = false", 0
         end
 
         context "with allow_destroy as Symbol" do
-          it_behaves_like("has many persisted with allow_destroy as Symbol or Proc", :foo?)
+          it_behaves_like("has many with allow_destroy as String, Symbol or Proc", :foo?)
         end
 
         context "with allow_destroy as String" do
-          it_behaves_like("has many persisted with allow_destroy as Symbol or Proc", "foo?")
+          it_behaves_like("has many with allow_destroy as String, Symbol or Proc", "foo?")
         end
 
         context "with allow_destroy as proc" do
-          it_behaves_like(
-            "has many persisted with allow_destroy as Symbol or Proc",
-            Proc.new { |child| child.foo? }
-          )
+          it_behaves_like("has many with allow_destroy as String, Symbol or Proc",
+                          Proc.new { |child| child.foo? })
         end
 
         context "with allow_destroy as lambda" do
-          it_behaves_like(
-            "has many persisted with allow_destroy as Symbol or Proc",
-            -> (child) { child.foo? }
-          )
+          it_behaves_like("has many with allow_destroy as String, Symbol or Proc",
+                          -> (child) { child.foo? })
+        end
+
+        context "with allow_destroy as any other expression that evaluates to true" do
+          let :body do
+            s = self
+            build_form({url: '/categories'}, Category.new) do |f|
+              s.instance_exec do
+                allow(f.object.posts.build).to receive(:new_record?).and_return(false)
+              end
+              f.has_many :posts, allow_destroy: Object.new do |p|
+                p.input :title
+              end
+            end
+          end
+
+          it_behaves_like "has many with allow_destroy = true", 0
         end
       end
 
@@ -707,7 +719,7 @@ describe ActiveAdmin::FormBuilder do
             end
           end
 
-          it_behaves_like "has many persisted with allow_destroy = false", 0
+          it_behaves_like "has many with allow_destroy = false", 0
         end
       end
     end

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -578,11 +578,8 @@ describe ActiveAdmin::FormBuilder do
           expect(body).to have_selector("label[for=category_posts_attributes_#{child_num}__destroy]", text: "Delete")
         end
 
-        context "with allow_destroy as lambda" do
-          it_behaves_like(
-            "has many persisted with allow_destroy as Symbol or Proc",
-            -> (child) { child.foo? }
-          )
+        it "should wrap the destroy field in an li with class 'has_many_delete'" do
+          expect(body).to have_selector(".has_many_container > fieldset > ol > li.has_many_delete > input", count: 1)
         end
       end
 

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -688,7 +688,7 @@ describe ActiveAdmin::FormBuilder do
 
         context "with allow_destroy as lambda" do
           it_behaves_like("has many with allow_destroy as String, Symbol or Proc",
-                          -> (child) { child.foo? })
+                          lambda { |child| child.foo? })
         end
 
         context "with allow_destroy as any other expression that evaluates to true" do


### PR DESCRIPTION
When I generate nested has_many forms, I might whant to set the `allow_destroy` parameter 
depending on the child record.

For example: I want to not allow delete comments, that was created by an admin, 
or I want to not allow delete articles that are published.

I added the ability to specify Symbol and Proc as `allow_destroy` parameter.

If a Symbol is specified, the child object's method will be called. 

    # this will create 'delete' checkbox only for articles which #draft? method returns true
    f.has_many :articles, allow_destroy: :draft? do |a|

If a Proc is specified, the given blok will be calculated  for the child object.
The object is passed as the parameter of the block.

    f.has_many :comments, allow_destroy:  -> (comment) { !comment.author.admin? } do |c|