### PR TITLE
Fix example sidebar access to resource usage

### DIFF
--- a/docs/2-resource-customization.md
+++ b/docs/2-resource-customization.md
@@ -364,8 +364,8 @@ ActiveAdmin.register Project do
 
   sidebar "Project Details", only: [:show, :edit] do
     ul do
-      li link_to "Tickets",    admin_project_tickets_path(project)
-      li link_to "Milestones", admin_project_milestones_path(project)
+      li link_to "Tickets",    admin_project_tickets_path(resource)
+      li link_to "Milestones", admin_project_milestones_path(resource)
     end
   end
 end


### PR DESCRIPTION
I couldn't get the example to work with the `project` variable. Looking at the guide for sidebar [https://github.com/activeadmin/activeadmin/blob/master/docs/7-sidebars.md], it seems like the correct variable is `resource`.