### PR TITLE
Add MIT license compatibility badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Active Admin is a Ruby on Rails framework for creating elegant backends for webs
 [![Quality         ](http://img.shields.io/codeclimate/github/activeadmin/activeadmin.svg)      ](https://codeclimate.com/github/activeadmin/activeadmin)
 [![Coverage        ](http://img.shields.io/coveralls/activeadmin/activeadmin.svg)               ](https://coveralls.io/r/activeadmin/activeadmin)
 [![Inch CI         ](http://inch-ci.org/github/activeadmin/activeadmin.svg?branch=master)       ](http://inch-ci.org/github/activeadmin/activeadmin)
+[![git.legal](https://git.legal/projects/1362/badge.svg "Number of libraries approved")](https://git.legal/projects/1362)
 
 ## State of the project
 


### PR DESCRIPTION
I just ran Git.legal's license compatibility scan on all the included gems.  All checkout as compatible with the MIT license.  There was just one LGPL license, which checks-out as truly being used a library, so no problems there.

The badge here gives a quick indicator that the license is MIT, and that the libraries used are compliant with that.
