### PR TITLE
Change the way of assigning template variables

### DIFF
--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -62,7 +62,7 @@ module ActiveAdmin
           template.concat has_many_actions(has_many_form, builder_options, "".html_safe)
         end
 
-        template.assign(has_many_block: true)
+        template.assigns[:has_many_block] = true
         contents = without_wrapper { inputs(options, &form_block) } || "".html_safe
 
         if builder_options[:new_record]

--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -13,6 +13,8 @@ end
 
 module ActiveAdmin
   class FormBuilder < ::Formtastic::FormBuilder
+    include MethodOrProcHelper
+
     self.input_namespaces = [::Object, ::ActiveAdmin::Inputs, ::Formtastic::Inputs]
 
     # TODO: remove both class finders after formtastic 4 (where it will be default)
@@ -59,7 +61,7 @@ module ActiveAdmin
           block.call has_many_form, index
           template.concat has_many_actions(has_many_form, builder_options, "".html_safe)
         end
-        
+
         template.assign(has_many_block: true)
         contents = without_wrapper { inputs(options, &form_block) } || "".html_safe
 
@@ -83,7 +85,10 @@ module ActiveAdmin
         contents << template.content_tag(:li) do
           template.link_to I18n.t('active_admin.has_many_remove'), "#", class: 'button has_many_remove'
         end
-      elsif builder_options[:allow_destroy]
+      elsif call_method_or_proc_on(has_many_form.object,
+                                   builder_options[:allow_destroy],
+                                   exec: false)
+
         has_many_form.input(:_destroy, as: :boolean,
                             wrapper_html: {class: 'has_many_delete'},
                             label: I18n.t('active_admin.has_many_delete'))
@@ -136,6 +141,5 @@ module ActiveAdmin
         html: CGI.escapeHTML(html).html_safe, placeholder: placeholder
       }
     end
-
   end
 end

--- a/lib/active_admin/views/components/active_admin_form.rb
+++ b/lib/active_admin/views/components/active_admin_form.rb
@@ -43,7 +43,7 @@ module ActiveAdmin
 
       def inputs(*args, &block)
         if block_given?
-          form_builder.template.assign(has_many_block: true)
+          form_builder.template.assigns[:has_many_block] = true
         end
         if block_given? && block.arity == 0
           wrapped_block = proc do

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 require "rspec/mocks/standalone"
 
 describe ActiveAdmin::FormBuilder do
-
   # Setup an ActionView::Base object which can be used for
   # generating the form for.
   let(:helpers) do
@@ -510,7 +509,6 @@ describe ActiveAdmin::FormBuilder do
       it "should add a custom header" do
         expect(body).to have_selector("h3", text: "Post")
       end
-
     end
 
     describe "without heading and new record link" do
@@ -549,7 +547,6 @@ describe ActiveAdmin::FormBuilder do
       it "should add a custom header" do
         expect(body).to have_selector("h3", "Test heading")
       end
-
     end
 
     describe "with custom new record link" do
@@ -565,29 +562,20 @@ describe ActiveAdmin::FormBuilder do
       it "should add a custom new record link" do
         expect(body).to have_selector("a", text: "My Custom New Post")
       end
-
     end
 
     describe "with allow destroy" do
-      context "with an existing post" do
-        let :body do
-          s = self
-          build_form({url: '/categories'}, Category.new) do |f|
-            s.instance_exec do
-              allow(f.object.posts.build).to receive(:new_record?).and_return(false)
-            end
-            f.has_many :posts, allow_destroy: true do |p|
-              p.input :title
-            end
-          end
+      shared_examples_for "has many with allow_destroy = true" do |child_num|
+        it "should render the nested form" do
+          expect(body).to have_selector("input[name='category[posts_attributes][#{child_num}][title]']")
         end
 
         it "should include a boolean field for _destroy" do
-          expect(body).to have_selector("input[name='category[posts_attributes][0][_destroy]']")
+          expect(body).to have_selector("input[name='category[posts_attributes][#{child_num}][_destroy]']")
         end
 
         it "should have a check box with 'Remove' as its label" do
-          expect(body).to have_selector("label[for=category_posts_attributes_0__destroy]", text: "Delete")
+          expect(body).to have_selector("label[for=category_posts_attributes_#{child_num}__destroy]", text: "Delete")
         end
 
         it "should wrap the destroy field in an li with class 'has_many_delete'" do
@@ -595,22 +583,143 @@ describe ActiveAdmin::FormBuilder do
         end
       end
 
-      context "with a new post" do
+      shared_examples_for "has many with allow_destroy = false" do |child_num|
+        it "should render the nested form" do
+          expect(body).to have_selector("input[name='category[posts_attributes][#{child_num}][title]']")
+        end
+
+        it "should not have a boolean field for _destroy" do
+          expect(body).not_to have_selector("input[name='category[posts_attributes][#{child_num}][_destroy]']")
+        end
+
+        it "should not have a check box with 'Remove' as its label" do
+          expect(body).not_to have_selector("label[for=category_posts_attributes_#{child_num}__destroy]", text: "Remove")
+        end
+      end
+
+      shared_examples_for "has many with allow_destroy as String, Symbol or Proc" do |allow_destroy_option|
         let :body do
+          s = self
           build_form({url: '/categories'}, Category.new) do |f|
-            f.object.posts.build
-            f.has_many :posts, allow_destroy: true do |p|
+            s.instance_exec do
+              allow(f.object.posts.build).to receive(:foo?).and_return(true)
+              allow(f.object.posts.build).to receive(:foo?).and_return(false)
+
+              f.object.posts.each do |post|
+                allow(post).to receive(:new_record?).and_return(false)
+              end
+            end
+            f.has_many :posts, allow_destroy: allow_destroy_option do |p|
               p.input :title
             end
           end
         end
 
-        it "should not have a boolean field for _destroy" do
-          expect(body).not_to have_selector("input[name='category[posts_attributes][0][_destroy]']")
+        context 'for the child that responds with true' do
+          it_behaves_like "has many with allow_destroy = true", 0
         end
 
-        it "should not have a check box with 'Remove' as its label" do
-          expect(body).not_to have_selector("label[for=category_posts_attributes_0__destroy]", text: "Remove")
+        context 'for the child that responds with false' do
+          it_behaves_like "has many with allow_destroy = false", 1
+        end
+      end
+
+      context "with an existing post" do
+        context "with allow_destroy = true" do
+          let :body do
+            s = self
+            build_form({url: '/categories'}, Category.new) do |f|
+              s.instance_exec do
+                allow(f.object.posts.build).to receive(:new_record?).and_return(false)
+              end
+              f.has_many :posts, allow_destroy: true do |p|
+                p.input :title
+              end
+            end
+          end
+
+          it_behaves_like "has many with allow_destroy = true", 0
+        end
+
+        context "with allow_destroy = false" do
+          let :body do
+            s = self
+            build_form({url: '/categories'}, Category.new) do |f|
+              s.instance_exec do
+                allow(f.object.posts.build).to receive(:new_record?).and_return(false)
+              end
+              f.has_many :posts, allow_destroy: false do |p|
+                p.input :title
+              end
+            end
+          end
+
+          it_behaves_like "has many with allow_destroy = false", 0
+        end
+
+        context "with allow_destroy = nil" do
+          let :body do
+            s = self
+            build_form({url: '/categories'}, Category.new) do |f|
+              s.instance_exec do
+                allow(f.object.posts.build).to receive(:new_record?).and_return(false)
+              end
+              f.has_many :posts, allow_destroy: nil do |p|
+                p.input :title
+              end
+            end
+          end
+
+          it_behaves_like "has many with allow_destroy = false", 0
+        end
+
+        context "with allow_destroy as Symbol" do
+          it_behaves_like("has many with allow_destroy as String, Symbol or Proc", :foo?)
+        end
+
+        context "with allow_destroy as String" do
+          it_behaves_like("has many with allow_destroy as String, Symbol or Proc", "foo?")
+        end
+
+        context "with allow_destroy as proc" do
+          it_behaves_like("has many with allow_destroy as String, Symbol or Proc",
+                          Proc.new { |child| child.foo? })
+        end
+
+        context "with allow_destroy as lambda" do
+          it_behaves_like("has many with allow_destroy as String, Symbol or Proc",
+                          lambda { |child| child.foo? })
+        end
+
+        context "with allow_destroy as any other expression that evaluates to true" do
+          let :body do
+            s = self
+            build_form({url: '/categories'}, Category.new) do |f|
+              s.instance_exec do
+                allow(f.object.posts.build).to receive(:new_record?).and_return(false)
+              end
+              f.has_many :posts, allow_destroy: Object.new do |p|
+                p.input :title
+              end
+            end
+          end
+
+          it_behaves_like "has many with allow_destroy = true", 0
+        end
+      end
+
+      context "with a new post" do
+        context "with allow_destroy = true" do
+          let :body do
+            build_form({url: '/categories'}, Category.new) do |f|
+              f.object.posts.build
+              f.has_many :posts, allow_destroy: true do |p|
+                p.input :title
+              end
+            end
+          end
+
+          it_behaves_like "has many with allow_destroy = false", 0
         end
       end
     end


### PR DESCRIPTION
`ActionView::Base#assign` method removes all previous view variable assignments from ActionView::Base `assigns` hash  if there are any.

For example:

    template.assigns                      # => {page_title: "Awesome Title"}
    template.assign(has_many_block: true) # this will clear the `assigns` hash
    template.assigns                      # => {has_many_block: true}

So, it should not be called when there is a need to add a variable to a template.

This PR changes this:

    template.assign(foo: 'bar')

to this:

    template.assigns[:foo] = 'bar'

### One of possible problems that this PR solves (reproduction steps):

1) Add custom action with a custom title to a controller:

    member_action :custom_action do 
      @page_title = "My custom title"
    end

2) Add template for this action that contains a form with :has_many

    semantic_form_for [:admin, Article.new], builder: ActiveAdmin::FormBuilder do |f|
      ....
      f.has_many :comments do |coment_form|
        ....
3) When you open the page, you will not see "My custom title". The reason is that `has_many` method calls `template.assign()` method, which clears template's `assigns` hash, so `template.assigns[:page_title]` returns nil.