### PR TITLE
3280 added nested belongs to rebased

### DIFF
--- a/features/belongs_to.feature
+++ b/features/belongs_to.feature
@@ -52,6 +52,24 @@ Feature: Belongs To
     When I follow "Posts"
     Then the "Posts" tab should be selected
 
+  Scenario: When the belongs to is nested
+    Given a configuration of:
+    """
+      ActiveAdmin.register User
+      ActiveAdmin.register Post do
+        belongs_to :user
+      end
+      ActiveAdmin.register Tagging do
+        belongs_to :user
+        belongs_to :post
+      end
+    """
+    When I go to the last author's last post's taggings
+    Then I should see a link to "Users" in the breadcrumb
+    And I should see a link to "Jane Doe" in the breadcrumb
+    And I should see a link to "Posts" in the breadcrumb
+    And I should see a link to "Hello World" in the breadcrumb
+
   Scenario: Displaying belongs to resources in main menu
     Given a configuration of:
     """

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -48,6 +48,9 @@ module NavigationHelpers
     when /^the last post's show page$/
       admin_post_path(Post.last)
 
+    when /^the last author's last post's taggings$/
+      admin_user_post_taggings_path(User.last, Post.where(author_id: User.last.id).last)
+
     when /^the last post's edit page$/
       edit_admin_post_path(Post.last)
 

--- a/lib/active_admin/base_controller/menu.rb
+++ b/lib/active_admin/base_controller/menu.rb
@@ -22,7 +22,7 @@ module ActiveAdmin
       # Get's called through a before filter
       def set_current_tab
         @current_tab = if current_menu && active_admin_config.belongs_to? && parent?
-          parent_item = active_admin_config.belongs_to_config.target.menu_item
+          parent_item = active_admin_config.belongs_to_config.first.target.menu_item
           if current_menu.include? parent_item
             parent_item
           else

--- a/lib/active_admin/resource.rb
+++ b/lib/active_admin/resource.rb
@@ -120,18 +120,19 @@ module ActiveAdmin
     end
 
     def belongs_to(target, options = {})
-      @belongs_to = Resource::BelongsTo.new(self, target, options)
-      self.navigation_menu_name = target unless @belongs_to.optional?
+      this_belongs_to = Resource::BelongsTo.new(self, target, options)
+      self.navigation_menu_name = target unless this_belongs_to.optional?
+      belongs_to_config << this_belongs_to
       controller.send :belongs_to, target, options.dup
     end
 
     def belongs_to_config
-      @belongs_to
+      @belongs_to ||= []
     end
 
     # Do we belong to another resource?
     def belongs_to?
-      !!belongs_to_config
+      belongs_to_config.length > 0
     end
 
     # The csv builder for this resource

--- a/lib/active_admin/resource/routes.rb
+++ b/lib/active_admin/resource/routes.rb
@@ -75,7 +75,7 @@ module ActiveAdmin
 
           route << options[:action]           # "edit" or "new"
           route << resource.route_prefix      # "admin"
-          route << belongs_to_name if nested? # "category"
+          route += belongs_to_names
           route << resource_path_name         # "posts" or "post"
           route << suffix                     # "path" or "index path"
 
@@ -85,25 +85,25 @@ module ActiveAdmin
 
         # @return params to pass to instance path
         def route_instance_params(instance)
-          if nested?
-            [instance.public_send(belongs_to_name).to_param, instance.to_param]
-          else
-            instance.to_param
-          end
+          belongs_to_names.reverse.reduce([instance]) do |arr,name| 
+            arr + [arr.last.public_send(name)]
+          end.map{|i| i.to_param }.reverse
         end
 
         def route_collection_params(params)
-          if nested?
-            params[:"#{belongs_to_name}_id"]
+          belongs_to_names.map{|name| params[:"#{name}_id"]}
+        end
+
+        def belongs_to_names
+          required_belongs_to.map{|bc| bc.target.resource_name.singular }
+        end
+
+        def required_belongs_to
+          if resource.belongs_to?
+            resource.belongs_to_config.select{|bc| bc.required?} 
+          else
+            []
           end
-        end
-
-        def nested?
-          resource.belongs_to? && resource.belongs_to_config.required?
-        end
-
-        def belongs_to_name
-          resource.belongs_to_config.target.resource_name.singular if nested?
         end
 
         def routes

--- a/lib/active_admin/view_helpers/breadcrumb_helper.rb
+++ b/lib/active_admin/view_helpers/breadcrumb_helper.rb
@@ -13,9 +13,10 @@ module ActiveAdmin
           # 2. try using the model name translation
           # 3. default to calling `titlecase` on the URL fragment
           if part =~ /\A(\d+|[a-f0-9]{24})\z/ && parts[index-1]
-            parent = active_admin_config.belongs_to_config.try :target
-            config = parent && parent.resource_name.route_key == parts[index-1] ? parent : active_admin_config
-            name   = display_name config.find_resource part
+            config = active_admin_config.belongs_to_config.map(&:target).select do |parent|
+              parent.resource_name.route_key == parts[index-1]
+            end.first || active_admin_config
+            name = display_name config.find_resource part
           end
           name ||= I18n.t "activerecord.models.#{part.singularize}", count: ::ActiveAdmin::Helpers::I18n::PLURAL_MANY_COUNT, default: part.titlecase
 

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -21,6 +21,12 @@ create_file 'app/models/post.rb', <<-RUBY.strip_heredoc, force: true
 RUBY
 copy_file File.expand_path('../templates/post_decorator.rb', __FILE__), 'app/models/post_decorator.rb'
 
+generate :model, "post_comment message:string post_id:integer"
+inject_into_file 'app/models/post_comment.rb', %q{
+   belongs_to :post
+   attr_accessible :message, :post unless Rails::VERSION::MAJOR > 3 && !defined? ProtectedAttributes
+ }, after: 'class PostComment < ActiveRecord::Base'
+
 generate :model, 'blog/post title:string body:text published_date:date author_id:integer ' +
   'position:integer custom_category_id:integer starred:boolean foo_id:integer'
 create_file 'app/models/blog/post.rb', <<-RUBY.strip_heredoc, force: true

--- a/spec/unit/belongs_to_spec.rb
+++ b/spec/unit/belongs_to_spec.rb
@@ -4,7 +4,7 @@ describe ActiveAdmin::Resource::BelongsTo do
 
   let(:user_config){ ActiveAdmin.register User }
   let(:post_config){ ActiveAdmin.register Post do belongs_to :user end }
-  let(:belongs_to){ post_config.belongs_to_config }
+  let(:belongs_to){ post_config.belongs_to_config.first }
 
   it "should have an owner" do
     expect(belongs_to.owner).to eq post_config

--- a/spec/unit/resource/routes_spec.rb
+++ b/spec/unit/resource/routes_spec.rb
@@ -1,9 +1,9 @@
-require 'rails_helper' 
+require 'rails_helper'
 
 module ActiveAdmin
   describe Resource::Routes do
 
-    after :all do
+    after do
       load_defaults!
       reload_routes!
     end
@@ -70,6 +70,35 @@ module ActiveAdmin
 
         it "should nest the instance path" do
           expect(config.route_instance_path(post)).to eq "/admin/categories/1/posts/3"
+        end
+      end
+
+      context "when the resources belongs to two other resources" do
+        let! :config do
+          ActiveAdmin.register Tagging do
+            belongs_to :category
+            belongs_to :post
+          end
+        end
+
+        let :tagging do
+          Tagging.new do |t|
+            t.id = 4
+            t.post = Post.new do |p|
+              p.id = 3
+              p.category = Category.new{ |c| c.id = 1 }
+            end
+          end
+        end
+
+        before{ reload_routes! }
+
+        it "should nest the collection path" do
+          expect(config.route_collection_path(category_id: 1, post_id: 3)).to eq "/admin/categories/1/posts/3/taggings"
+        end
+
+        it "should nest the instance path" do
+          expect(config.route_instance_path(tagging)).to eq "/admin/categories/1/posts/3/taggings/4"
         end
       end
     end

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -80,9 +80,9 @@ module ActiveAdmin
     describe "#belongs_to" do
 
       it "should build a belongs to configuration" do
-        expect(config.belongs_to_config).to eq nil
+        expect(config.belongs_to_config.length).to eq 0
         config.belongs_to :posts
-        expect(config.belongs_to_config).to_not eq nil
+        expect(config.belongs_to_config.length).to eq 1
       end
 
       it "should set the target menu to the belongs to target" do

--- a/spec/unit/routing_spec.rb
+++ b/spec/unit/routing_spec.rb
@@ -169,6 +169,31 @@ describe ActiveAdmin, "Routing", type: :routing do
     end
   end
 
+  describe "nested belongs to resource" do
+    before do
+      ActiveAdmin.register(Tagging) do
+        belongs_to :user, optional: true
+        belongs_to :post
+      end
+      reload_routes!
+    end
+    it "should route the nested index path" do
+      expect(admin_user_post_taggings_path(1,2)).to eq "/admin/users/1/posts/2/taggings"
+    end
+
+    it "should route the nested show path" do
+      expect(admin_user_post_tagging_path(1,2,3)).to eq "/admin/users/1/posts/2/taggings/3"
+    end
+
+    it "should route the nested skipping optional index path" do
+      expect(admin_post_taggings_path(1)).to eq "/admin/posts/1/taggings"
+    end
+
+    it "should route the nested skipping optional show path" do
+      expect(admin_post_tagging_path(1,2)).to eq "/admin/posts/1/taggings/2"
+    end
+  end
+
   describe "page" do
     context "when default namespace" do
       before(:each) do

--- a/spec/unit/view_helpers/breadcrumbs_spec.rb
+++ b/spec/unit/view_helpers/breadcrumbs_spec.rb
@@ -16,7 +16,7 @@ describe "Breadcrumbs" do
                                defined_actions: actions }
     let(:post)        { double display_name: 'Hello World' }
     let(:post_config) { double find_resource: post, resource_name: double(route_key: 'posts'),
-                               defined_actions: actions, belongs_to_config: double(target: user_config) }
+                               defined_actions: actions, belongs_to_config: [double(target: user_config)] }
 
     let :active_admin_config do
       post_config
@@ -193,7 +193,7 @@ describe "Breadcrumbs" do
     context "when the 'show' action is disabled" do
       let(:post_config) { double find_resource: post, resource_name: double(route_key: 'posts'),
                                  defined_actions: actions - [:show], # this is the change
-                                 belongs_to_config: double(target: user_config) }
+                                 belongs_to_config: [double(target: user_config)] }
 
       let(:path) { "/admin/posts/1/edit" }
 


### PR DESCRIPTION
This is a rebase of #3280 against the current master. We need this functionality and we're keen to see the PR merged. I understand the original author may not have had time to complete the rebase.

This commit also:
- Removes the extraneous `PostComment` model from the original PR and uses the existing `Tagging` model for specs
- Adds a feature spec for the breadcrumb links with nested `belongs_to` resources
