### PR TITLE
Decorators now receive the action name as context

### DIFF
--- a/lib/active_admin/resource_controller/decorators.rb
+++ b/lib/active_admin/resource_controller/decorators.rb
@@ -5,7 +5,7 @@ module ActiveAdmin
     protected
 
       def apply_decorator(resource)
-        decorate? ? decorator_class.new(resource) : resource
+        decorate? ? decorator_class.new(resource, context: action_name) : resource
       end
 
       def apply_collection_decorator(collection)


### PR DESCRIPTION
I’ve found when using decorators that I often want to decorate a value differently depending on whether it's being displayed in a form or not. For example, dollar amounts might be stored in the database as decimal numbers and displayed on the index and show pages with a dollar sign and cents but should be rendered in the form without the dollar sign and no cents.

Draper supports a context attribute for decorators and this change passes the current action name as the context when decorating resources. This will enable the decorator to decorate attributes differently depending on the page they are being shown on.
