### PR TITLE
The navigation menu name is no longer overwritten by menu options

### DIFF
--- a/lib/active_admin/resource/menu.rb
+++ b/lib/active_admin/resource/menu.rb
@@ -10,7 +10,7 @@ module ActiveAdmin
           @include_in_menu   = false
           @menu_item_options = {}
         else
-          @navigation_menu_name = options[:menu_name]
+          @navigation_menu_name = options[:menu_name] if options.has_key?(:menu_name)
           @menu_item_options    = default_menu_options.merge options
         end
       end


### PR DESCRIPTION
When you create nested resources with `belongs_to` there is no way to specify the order of the nested resources in the navigation menu. The obvious solution actually causes an exception to be raised:

``` ruby
ActiveAdmin.register(Product) do
  belongs_to(:category)

  menu(priority: 1)
end
```

The reason is that `ActiveAdmin::Resource::Menu#menu_item_options=` overwrites the `@navigation_menu_name` instance variable with a `nil` value if the `menu_opion` menu option isn't passed into the method. In this case, `@navigation_menu_name` has already been set on the menu by the nested resources functionality and the call of `menu` in the nested resource causes it to be lost.

Currently the only way to set the menu order in this case is to ensure the `menu_name` option is set to the parent menu name after setting the menu priority with `menu`, which can be done with either

``` ruby
ActiveAdmin.register(Product) do
  belongs_to(:category)

  menu(priority: 1, menu_name: :category)
end
```

or

``` ruby
ActiveAdmin.register(Product) do
  belongs_to(:category)

  menu(priority: 1)
  navigation_menu(:category)
end
```

Neither of these should be necessary and this change ensures that `@navigation_menu_name` is only set if the `menu_option` option is specifically included in the menu options hash.
