### PR TITLE
Pluralized DSL methods

### DIFF
--- a/lib/active_admin/csv_builder.rb
+++ b/lib/active_admin/csv_builder.rb
@@ -26,17 +26,29 @@ module ActiveAdmin
       end
     end
 
-    attr_reader :columns, :options, :view_context
+    attr_reader :all_columns, :options, :view_context
 
     COLUMN_TRANSITIVE_OPTIONS = [:humanize_name].freeze
 
     def initialize(options={}, &block)
       @resource = options.delete(:resource)
-      @columns, @options, @block = [], options, block
+      @all_columns, @options, @block = [], options, block
+    end
+
+    def columns(*attributes)
+      options = attributes.extract_options!
+
+      attributes.each do |attributes|
+        attributes = {attributes => {}} unless attributes.is_a?(Hash)
+
+        attributes.each do |attribute, attribute_options|
+          column(attribute, options.merge(attribute_options))
+        end
+      end
     end
 
     def column(name, options={}, &block)
-      @columns << Column.new(name, @resource, column_transitive_options.merge(options), block)
+      @all_columns << Column.new(name, @resource, column_transitive_options.merge(options), block)
     end
 
     def build(controller, csv)
@@ -65,9 +77,9 @@ module ActiveAdmin
 
     def exec_columns(view_context = nil)
       @view_context = view_context
-      @columns = [] # we want to re-render these every instance
+      @all_columns = [] # we want to re-render these every instance
       instance_exec &@block if @block.present?
-      columns
+      all_columns
     end
 
     def build_row(resource, columns, options)

--- a/lib/active_admin/filters/dsl.rb
+++ b/lib/active_admin/filters/dsl.rb
@@ -2,6 +2,18 @@ module ActiveAdmin
   module Filters
     module DSL
 
+      def filters(*attributes)
+        options = attributes.extract_options!
+
+        attributes.each do |attributes|
+          attributes = {attributes => {}} unless attributes.is_a?(Hash)
+
+          attributes.each do |attribute, attribute_options|
+            filter(attribute, options.merge(attribute_options))
+          end
+        end
+      end
+
       # For docs, please see ActiveAdmin::Filters::ResourceExtension#add_filter
       def filter(attribute, options = {})
         config.add_filter(attribute, options)

--- a/lib/active_admin/resource_dsl.rb
+++ b/lib/active_admin/resource_dsl.rb
@@ -17,6 +17,20 @@ module ActiveAdmin
       config.scope_to(*args, &block)
     end
 
+    def scopes(*attributes)
+      options = attributes.extract_options!
+      first   = true
+
+      attributes.each do |attributes|
+        attributes = {attributes => {}} unless attributes.is_a?(Hash)
+
+        attributes.each do |attribute, attribute_options|
+          scope(attribute, options.merge(default: first).merge(attribute_options))
+          first = false
+        end
+      end
+    end
+
     # Create a scope
     def scope(*args, &block)
       config.scope(*args, &block)

--- a/lib/active_admin/views/components/active_admin_form.rb
+++ b/lib/active_admin/views/components/active_admin_form.rb
@@ -61,6 +61,18 @@ module ActiveAdmin
         end
       end
 
+      def multiple_inputs(*attributes)
+        options = attributes.extract_options!
+
+        attributes.each do |attributes|
+          attributes = {attributes => {}} unless attributes.is_a?(Hash)
+
+          attributes.each do |attribute, attribute_options|
+            input(attribute, options.merge(attribute_options))
+          end
+        end
+      end
+
       def input(*args)
         proxy_call_to_form :input, *args
       end

--- a/lib/active_admin/views/index_as_table.rb
+++ b/lib/active_admin/views/index_as_table.rb
@@ -244,6 +244,18 @@ module ActiveAdmin
         "table"
       end
 
+      def columns(*attributes)
+        options = attributes.extract_options!
+
+        attributes.each do |attributes|
+          attributes = {attributes => {}} unless attributes.is_a?(Hash)
+
+          attributes.each do |attribute, attribute_options|
+            current_arbre_element.column(attribute, options.merge(attribute_options))
+          end
+        end
+      end
+
       #
       # Extend the default ActiveAdmin::Views::TableFor with some
       # methods for quickly displaying items on the index page


### PR DESCRIPTION
One of my long-standing annoyances with ActiveAdmin is the cruft of multiple invocations of the same DSL method over and over again when defining things like columns, filters, scopes, and form inputs:

``` ruby
index do
  column(:name)
  column(:price)
  column(:enabled)
end

filter(:name)
filter(:description)
filter(:price)
filter(:enabled)

scope(:all)
scope(:enabled)
scope(:new)
```

This drives me insane because I should just be able to do

``` ruby
index do
  columns(:name, :price, :enabled)
end

filters(:name, :description, :price, :enabled)
scopes(:all, :enabled, :new)
```

So this change adds the following pluralized DSL methods:
- `ActiveAdmin::Views::IndexAsTable#columns`
- `ActiveAdmin::CSVBuilder#columns`
- `ActiveAdmin::Filters::DSL#filters`
- `ActiveAdmin::ResourceDSL#scopes`
- `ActiveAdmin::Views::ActiveAdminForm#multiple_inputs`

(I would much prefer to call `multiple_inputs` just `inputs` but since that method is already proxied to Formtastic and it's part of the Formtastic DSL for creating a group of inputs, I left it as is.)

Each method can take a hash of options as the final argument which will be applied to each invocation of the equivalent singular method:

``` ruby
columns(:name,
        :price,
        :enabled,
        sortable: false)
```

In addition, you can pass hashes instead of symbols to specify options for individual attributes:

``` ruby
columns(:name,
        {price:   {sortable: true},
         enabled: {class: :enabled},
        :description,
        sortable: false)
```

Obviously there might be some discussion around a change like this, but if it looks good I will take the time to get the tests passing and write some additional tests for the new functionality.
