### PR TITLE
Add i18n content for date range filter

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,7 +30,9 @@ en:
         starts_with: "Starts with"
         ends_with: "Ends with"
         greater_than: "Greater than"
+        gteq_date: "Greater than or equal to"
         less_than: "Less than"
+        lteq_date: "Less than or equal to"
     search_status:
       headline: "Search status:"
       current_scope: "Scope:"

--- a/features/index/filters.feature
+++ b/features/index/filters.feature
@@ -54,6 +54,22 @@ Feature: Index Filtering
     And I should see 1 posts in the table
     And I should see "Hello World 2" within ".index_table"
 
+  Scenario: Date range - Filtering posts by date range
+    Given 3 post exists
+    And a published post with the title "Hello World" exists
+    And an index configuration of:
+    """
+      ActiveAdmin.register Post do
+        filter :published_at, :as => :date_range
+      end
+    """
+    When I fill in "q_published_at_gteq_date" with today's date
+    When I fill in "q_published_at_lteq_date" with today's date
+    When I press "Filter"
+    Then I should see 1 posts in the table
+    And I should see "Published At greater than or equal to" within "#search-status-_sidebar_section"
+    And I should see "Published At less than or equal to" within "#search-status-_sidebar_section"
+
   Scenario: Checkboxes - Filtering posts written by anyone
     Given 1 post exists
     And a post with the title "Hello World" written by "Jane Doe" exists
@@ -157,5 +173,3 @@ Feature: Index Filtering
     Then I should see 1 categories in the table
     And I should see "Non-Fiction" within ".index_table"
     And the "Jane Doe" checkbox should be checked
-
-

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -43,6 +43,10 @@ When /^(?:I )fill in "([^"]*)" with "([^"]*)"$/ do |field, value|
   fill_in(field, with: value)
 end
 
+When /^(?:I )fill in "([^"]*)" with today's date$/ do |field|
+  fill_in(field, with: Date.today.strftime("%Y-%m-%d"))
+end
+
 When /^(?:I )select "([^"]*)" from "([^"]*)"$/ do |value, field|
   select(value, from: field)
 end


### PR DESCRIPTION
I think this was broken in 1.0.0.pre3 because of the change in
#4505. The Ransack configuration was changed to add gteq_date and

lteq_date as predicates but ActiveAdmin's i18n keys were not updated
with this content. Ransack does not provide default values. Without the
i18n content you get translation errors in the sidebar search status on
a results page.

With translation error:

![screen shot 2016-09-08 at 6 18 25 pm](https://cloud.githubusercontent.com/assets/7151152/18368954/b01dfba6-75f0-11e6-96db-c9d1794e5a37.png)

With addition of i18n values:

![screen shot 2016-09-08 at 5 30 24 pm](https://cloud.githubusercontent.com/assets/7151152/18368925/865d3868-75f0-11e6-9b50-f0f3a9d0e877.png)
