### PR TITLE
Change the way of assigning template variables

### DIFF
--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -64,7 +64,7 @@ module ActiveAdmin
           template.concat has_many_actions(has_many_form, builder_options, "".html_safe)
         end
 
-        template.assign(has_many_block: true)
+        template.assigns[:has_many_block] = true
         contents = without_wrapper { inputs(options, &form_block) } || "".html_safe
 
         if builder_options[:new_record]

--- a/lib/active_admin/views/components/active_admin_form.rb
+++ b/lib/active_admin/views/components/active_admin_form.rb
@@ -43,7 +43,7 @@ module ActiveAdmin
 
       def inputs(*args, &block)
         if block_given?
-          form_builder.template.assign(has_many_block: true)
+          form_builder.template.assigns[:has_many_block] = true
         end
         if block_given? && block.arity == 0
           wrapped_block = proc do


### PR DESCRIPTION
`ActionView::Base#assign` method removes all previous view variable assigned from ActionView::Base `assigns` hash if there are any.

For example:

```
template.assigns # => {page_title: "Awesome Title"}
template.assign(has_many_block: true) # this will clear the previous `assigns` hash
template.assigns # => {has_many_block: true}
```

This PR changes the way of assigning template variables, to avoid previously assigned values loss:

```
template.assigns[:has_many_block] = true
```
### One of possible problems that this PR solves (reproduction steps):

1) Add custom action with a custom title to a controller:

```
member_action :custom_action do 
  @page_title = "My custom title"
end
```

2) Add template for this action that contains a form with :has_many

```
semantic_form_for [:admin, Article.new], builder: ActiveAdmin::FormBuilder do |f|
  ....
  f.has_many :comments do |coment_form|
    ....
```

3) When you open the page, you will not see "My custom title". The reason is that `has_many` method calls `template.assign(...)` method, which clears template's `assigns` hash, so `template.assigns[:page_title]` returns nil.
### Note

This way (provided by this PR) of assigning template variables does not add an instance variable to the ActionView::Base object (template). If it is needed to add an instance variable, the solution should be like this:

```
template.assigns[:foo] = 'bar'
template.instance_variable_set("@foo", 'bar')
```

But I think it is not necessary, because in all cases when the assignment is performed the variables are not used as instance variables in the view and are not assigned for this purpose.
