### PR TITLE
Add the ability to customize the footer.

### DIFF
--- a/docs/1-general-configuration.md
+++ b/docs/1-general-configuration.md
@@ -169,3 +169,11 @@ ActiveAdmin.setup do |config|
   end
 end
 ```
+
+## Footer Customization
+
+By default, Active Admin displays a "Powered by ActiveAdmin" message on every
+page. You can override this message and show domain-specific messaging:
+```ruby
+config.footer = "MyApp Revision v1.3"
+```

--- a/features/footer.feature
+++ b/features/footer.feature
@@ -1,0 +1,28 @@
+Feature: Site title
+
+  As a developer
+  In order to customize the site footer
+  I want to set it in the configuration
+
+  Background:
+    Given I am logged in
+
+  Scenario: No footer is set in the configuration (default)
+    When I am on the dashboard
+    And I should see the default footer
+
+  Scenario: Set the footer in the configuration
+    Given a configuration of:
+    """
+      ActiveAdmin.application.footer = "MyApp Revision 123"
+    """
+    When I am on the dashboard
+    And I should see the footer "MyApp Revision 123"
+
+  Scenario: Set the footer to a proc
+    Given a configuration of:
+    """
+      ActiveAdmin.application.footer = proc { "Enjoy MyApp Revision 123, #{controller.current_admin_user.try(:email)}!" }
+    """
+    When I am on the dashboard
+    And I should see the footer "Enjoy MyApp Revision 123, admin@example.com!"

--- a/features/step_definitions/footer_steps.rb
+++ b/features/step_definitions/footer_steps.rb
@@ -1,0 +1,11 @@
+Then /^I should see the default footer$/ do
+  expect(page).to have_css '#footer', text: "Powered by Active Admin #{ActiveAdmin::VERSION}"
+end
+
+Then /^I should see the footer "([^"]*)"$/ do |footer|
+  expect(page).to have_css '#footer', text: footer
+end
+
+Then /^I should not see the footer "([^"]*)"$/ do |footer|
+  expect(page).to_not have_css '#footer', text: footer
+end

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -41,6 +41,9 @@ module ActiveAdmin
     # Set the site title image displayed in the main layout (has precendence over :site_title)
     inheritable_setting :site_title_image, ""
 
+    # Set the site footer text (defaults to Powered by ActiveAdmin text with version)
+    inheritable_setting :footer, ""
+
     # Set a favicon
     inheritable_setting :favicon, false
 

--- a/lib/active_admin/views/footer.rb
+++ b/lib/active_admin/views/footer.rb
@@ -2,15 +2,29 @@ module ActiveAdmin
   module Views
     class Footer < Component
 
-      def build
+      def build(namespace)
         super id: "footer"
-        powered_by_message
+        @namespace = namespace
+
+        if footer?
+          para footer_text
+        else
+          para powered_by_message
+        end
+      end
+
+      def footer?
+        @namespace.footer.present?
       end
 
       private
 
+      def footer_text
+        helpers.render_or_call_method_or_proc_on(self, @namespace.footer)
+      end
+
       def powered_by_message
-        para I18n.t('active_admin.powered_by',
+        I18n.t('active_admin.powered_by',
           active_admin: link_to("Active Admin", "http://www.activeadmin.info"),
           version: ActiveAdmin::VERSION).html_safe
       end

--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -138,7 +138,7 @@ module ActiveAdmin
 
         # Renders the content for the footer
         def build_footer
-          insert_tag view_factory.footer
+          insert_tag view_factory.footer, active_admin_namespace
         end
 
       end

--- a/lib/generators/active_admin/install/templates/active_admin.rb.erb
+++ b/lib/generators/active_admin/install/templates/active_admin.rb.erb
@@ -269,4 +269,11 @@ ActiveAdmin.setup do |config|
   # of those filters by default here.
   #
   # config.include_default_association_filters = true
+
+  # == Footer
+  #
+  # By default, the footer shows the current Active Admin version. You can
+  # override the content of the footer here.
+  #
+  # config.footer = 'my custom footer text'
 end


### PR DESCRIPTION
By default, it will still default to the "Powered by Active Admin `<version>`", but this allows folks to customize that message.

We wanted to append additional environmental information to better understand bug reports from our internal customers. To accomplish this today, I created `app/admin/footer.rb`, but it would be nice to set this as a configuration value.

In determining how to do this with my app, I found several resources ([stack overflow](http://stackoverflow.com/questions/20464690/how-do-i-edit-or-override-the-footer-of-activeadmin), [gists](https://gist.github.com/pcreux/3058773), [blog posts](http://reverbhq.com/blog/2012/08/building-web-apps-with-activeadmin/)) which indicated to me that this would be a useful feature for people.
