### PR TITLE
Include params when building IndexList link URLs

### DIFF
--- a/lib/active_admin/views/components/index_list.rb
+++ b/lib/active_admin/views/components/index_list.rb
@@ -36,7 +36,10 @@ module ActiveAdmin
       # @param [Class] index_class The class on which to build the link and html classes
       def build_index_list(index_class)
         li class: classes_for_index(index_class) do
-          a href: url_for(as: index_class.index_name.to_sym), class: "table_tools_button" do
+          params = request.query_parameters.except :page, :commit, :format
+          url_with_params = url_for(params.merge(as: index_class.index_name.to_sym))
+
+          a href: url_with_params, class: "table_tools_button" do
             name = index_class.index_name
             I18n.t("active_admin.index_list.#{name}", default: name.to_s.titleize)
           end

--- a/spec/unit/views/components/index_list_spec.rb
+++ b/spec/unit/views/components/index_list_spec.rb
@@ -4,13 +4,19 @@ describe ActiveAdmin::Views::IndexList do
 
   describe "#index_list_renderer" do
 
-
     let(:index_classes) { [ActiveAdmin::Views::IndexAsTable, ActiveAdmin::Views::IndexAsBlock] }
+
+    let(:collection) {
+      Post.create(title: 'First Post', starred: true)
+      Post.where(nil)
+    }
 
     let(:helpers) do
       helpers = mock_action_view
-      allow(helpers).to receive(:url_for).and_return("/")
-      allow(helpers).to receive(:params).and_return as: "table"
+      allow(helpers).to receive(:url_for) { |url| "/?#{ url.to_query }" }
+      allow(helpers.request).to receive(:query_parameters).and_return as: "table", q: { title_contains: "terms" }
+      allow(helpers).to receive(:params).and_return as: "table", q: { title_contains: "terms" }
+      allow(helpers).to receive(:collection).and_return(collection)
       helpers
     end
 
@@ -30,6 +36,14 @@ describe ActiveAdmin::Views::IndexList do
       expect(a_tags.size).to eq 2
       expect(a_tags.first.to_s).to include("Table")
       expect(a_tags.last.to_s).to include("List")
+    end
+
+    it "should maintain index filter parameters" do
+      a_tags = subject.find_by_tag("a")
+      expect(a_tags.first.attributes[:href])
+        .to eq("/?#{ { as: "table", q: { title_contains: "terms" } }.to_query }")
+      expect(a_tags.last.attributes[:href])
+        .to eq("/?#{ { as: "block", q: { title_contains: "terms" } }.to_query }")
     end
   end
 end


### PR DESCRIPTION
Links for IndexList would remove all parameters except `:as` which would cause search filters to be lost when changing index types from Table to Block (as an example).
- Add test to prevent regressions
- Reverts https://github.com/activeadmin/activeadmin/commit/4f2916bef684c695afd6346e2365e4d0bdc25927

Tests required creating a single Post record due to how the [Collection](https://github.com/activeadmin/activeadmin/blob/f8926831429fe635d26ac8043ea5d676fb6ee637/lib/active_admin/helpers/collection.rb#L7) helper modifies the ActiveRecord relation. Testing URLs and routes in general is rather complex in these situations.
