### PR TITLE
Add number input type to modla dialog form (used for batch actions)

### DIFF
--- a/app/assets/javascripts/active_admin/lib/modal_dialog.js.coffee
+++ b/app/assets/javascripts/active_admin/lib/modal_dialog.js.coffee
@@ -1,7 +1,7 @@
 ActiveAdmin.modal_dialog = (message, inputs, callback)->
   html = """<form id="dialog_confirm" title="#{message}"><ul>"""
   for name, type of inputs
-    if /^(datepicker|checkbox|text)$/.test type
+    if /^(datepicker|checkbox|text|number)$/.test type
       wrapper = 'input'
     else if type is 'textarea'
       wrapper = 'textarea'


### PR DESCRIPTION
I just added the number input type to the modal i used for a batch_action. I think we can even add more input types, i did not test them yet. Number type is working like a charm !
