### PR TITLE
Enable caller to pass a scope count to `scope` via `show_count`

### DIFF
--- a/features/index/index_scopes.feature
+++ b/features/index/index_scopes.feature
@@ -77,6 +77,19 @@ Feature: Index Scoping
     And I should see the scope "All" with no count
     And I should see 3 posts in the table
 
+  @scope
+  Scenario: Viewing resources with a scope and scope count provided for a single scope
+    Given 3 posts exist
+    And an index configuration of:
+      """
+      ActiveAdmin.register Post do
+        scope :all, :default => true, :show_count => 100
+      end
+      """
+    Then I should see the scope "All" selected
+    And I should see the scope "All" with the count 100
+    And I should see 3 posts in the table
+
   Scenario: Viewing resources when scoping
     Given 2 posts exist
     And 3 published posts exist

--- a/lib/active_admin/views/components/scopes.rb
+++ b/lib/active_admin/views/components/scopes.rb
@@ -59,7 +59,11 @@ module ActiveAdmin
 
       # Return the count for the scope passed in.
       def get_scope_count(scope)
-        collection_size(scope_chain(scope, collection_before_scope))
+        if scope.show_count.respond_to?(:to_int)
+          scope.show_count.to_int
+        else
+          collection_size(scope_chain(scope, collection_before_scope))
+        end
       end
     end
   end


### PR DESCRIPTION
This is useful in situations where there are multiple scopes and the count
can be generated for all of them in a single query.