### PR TITLE
Update filters to work with custom Ransackers

### DIFF
--- a/lib/active_admin/filters/formtastic_addons.rb
+++ b/lib/active_admin/filters/formtastic_addons.rb
@@ -54,7 +54,7 @@ module ActiveAdmin
       end
 
       def seems_searchable?
-        has_predicate? || ransacker? || scope?
+        has_predicate? || scope?
       end
 
       # If the given method has a predicate (like _eq or _lteq), it's pretty

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -46,6 +46,10 @@ create_file 'app/models/user.rb', <<-RUBY.strip_heredoc, force: true
     has_one :profile
     accepts_nested_attributes_for :profile, allow_destroy: true
 
+    ransacker :age_in_five_years, type: :numeric, formatter: proc { |v| v.to_i - 5 } do |parent|
+      parent.table[:age]
+    end
+
     unless Rails::VERSION::MAJOR > 3 && !defined? ProtectedAttributes
       attr_accessible :first_name, :last_name, :username,  :age
     end

--- a/spec/unit/filters/filter_form_builder_spec.rb
+++ b/spec/unit/filters/filter_form_builder_spec.rb
@@ -4,6 +4,9 @@ class Post
   ransacker :custom_searcher do
     # nothing to see here
   end
+  ransacker :custom_searcher_numeric, type: :numeric do
+    # nothing to see here
+  end
 end
 
 describe ActiveAdmin::Filters::ViewHelper do
@@ -403,14 +406,22 @@ describe ActiveAdmin::Filters::ViewHelper do
 
   describe "custom search methods" do
 
+    it "should use the default type of the ransacker" do
+      body = Capybara.string(filter :custom_searcher_numeric)
+      expect(body).to have_selector("option[value=custom_searcher_numeric_equals]")
+      expect(body).to have_selector("option[value=custom_searcher_numeric_greater_than]")
+      expect(body).to have_selector("option[value=custom_searcher_numeric_less_than]")
+    end
+
     it "should work as select" do
       body = Capybara.string(filter :custom_searcher, as: :select, collection: ['foo'])
-      expect(body).to have_selector("select[name='q[custom_searcher]']")
+      expect(body).to have_selector("select[name='q[custom_searcher_eq]']")
     end
 
     it "should work as string" do
       body = Capybara.string(filter :custom_searcher, as: :string)
-      expect(body).to have_selector("input[name='q[custom_searcher]']")
+      expect(body).to have_selector("option[value=custom_searcher_contains]")
+      expect(body).to have_selector("option[value=custom_searcher_starts_with]")
     end
   end
 

--- a/spec/unit/filters/filter_form_builder_spec.rb
+++ b/spec/unit/filters/filter_form_builder_spec.rb
@@ -423,8 +423,8 @@ describe ActiveAdmin::Filters::ViewHelper do
 
     it "should work as string" do
       body = Capybara.string(filter :custom_title_searcher, as: :string)
-      expect(body).to have_selector("option[name='q[custom_title_searcher_contains]']")
-      expect(body).to have_selector("option[name='q[custom_title_searcher_starts_with]']")
+      expect(body).to have_selector("option[value=custom_title_searcher_contains]")
+      expect(body).to have_selector("option[value=custom_title_searcher_starts_with]")
     end
 
     describe "custom date range search" do

--- a/spec/unit/filters/filter_form_builder_spec.rb
+++ b/spec/unit/filters/filter_form_builder_spec.rb
@@ -424,7 +424,7 @@ describe ActiveAdmin::Filters::ViewHelper do
     it "should work as string" do
       body = Capybara.string(filter :custom_title_searcher, as: :string)
       expect(body).to have_selector("input[name='q[custom_title_searcher_contains]']")
-      expect(body).to have_selector("input[name='q[custom_searcher_starts_with]']")
+      expect(body).to have_selector("input[name='q[custom_title_searcher_starts_with]']")
     end
 
     describe "custom date range search" do

--- a/spec/unit/filters/filter_form_builder_spec.rb
+++ b/spec/unit/filters/filter_form_builder_spec.rb
@@ -423,8 +423,8 @@ describe ActiveAdmin::Filters::ViewHelper do
 
     it "should work as string" do
       body = Capybara.string(filter :custom_title_searcher, as: :string)
-      expect(body).to have_selector("input[name='q[custom_title_searcher_contains]']")
-      expect(body).to have_selector("input[name='q[custom_title_searcher_starts_with]']")
+      expect(body).to have_selector("option[name='q[custom_title_searcher_contains]']")
+      expect(body).to have_selector("option[name='q[custom_title_searcher_starts_with]']")
     end
 
     describe "custom date range search" do

--- a/spec/unit/filters/resource_spec.rb
+++ b/spec/unit/filters/resource_spec.rb
@@ -13,7 +13,7 @@ describe ActiveAdmin::Filters::ResourceExtension do
 
   it "should return the defaults if no filters are set" do
     expect(resource.filters.keys).to match_array([
-      :author, :body, :category, :created_at, :custom_searcher, :position, :published_date, :starred, :taggings, :title, :updated_at
+      :author, :body, :category, :created_at, :custom_searcher, :custom_searcher_numeric, :position, :published_date, :starred, :taggings, :title, :updated_at
     ])
   end
 
@@ -35,7 +35,7 @@ describe ActiveAdmin::Filters::ResourceExtension do
   it "should return the defaults without associations if default association filters are disabled on the namespace" do
     resource.namespace.include_default_association_filters = false
     expect(resource.filters.keys).to match_array([
-      :body, :created_at, :custom_searcher, :position, :published_date, :starred, :title, :updated_at
+      :body, :created_at, :custom_searcher, :custom_searcher_numeric, :position, :published_date, :starred, :title, :updated_at
     ])
   end
 
@@ -104,7 +104,7 @@ describe ActiveAdmin::Filters::ResourceExtension do
       resource.add_filter :count, as: :string
 
       expect(resource.filters.keys).to match_array([
-        :author, :body, :category, :count, :created_at, :custom_searcher, :position, :published_date, :starred, :taggings, :title, :updated_at
+        :author, :body, :category, :count, :created_at, :custom_searcher, :custom_searcher_numeric, :position, :published_date, :starred, :taggings, :title, :updated_at
       ])
     end
 


### PR DESCRIPTION
 It seems that ransackers (eg `ransacker :name_reversed`) are _not_ expected to be called without predicates (that is, they **are** called with predicates, eg: `name_reversed_cont`). So a ransacker filter without a predicate should not `seems_searchable?`.

Seems to me that custom ransackers would never have worked as intended with this code — an artifact of converting from metasearch without testing it in a sample application.

[fixes #3510 / #3409]