### PR TITLE
raise an error for bad filters instead of silently failing

### DIFF
--- a/lib/active_admin/filters/forms.rb
+++ b/lib/active_admin/filters/forms.rb
@@ -10,9 +10,13 @@ module ActiveAdmin
       self.input_class_finder = ::Formtastic::InputClassFinder
 
       def filter(method, options = {})
-        if method.present? && options[:as] ||= default_input_type(method)
-          template.concat input(method, options)
+        raise "'method' required" unless method.present?
+
+        unless options[:as] ||= default_input_type(method)
+          raise "Could not determine filter input type for '#{method}'. Try specifing 'as: :something'"
         end
+
+        template.concat input(method, options)
       end
 
       protected


### PR DESCRIPTION
Today I attempted to add a filter on a has-many-through association. The
UI was display nothing for my filter and AFAICS there was nothing
anywhere to tell me what the problem was.

After digging around I found that

    ActiveAdmin::Fitlers::FormBuilder#filter

simply fails quietly (returning nothing) if the type for a filter can't
be determined.

I have updated the method to raise an error instead.

Here is what failed for me (names changed):

I had this class:

```
    class Foo < ActiveRecord::Base
        has_many :bars, though: :something
    end
```

In the corresponding activeadmin resource I had this:

```
  filter :bars_id_in,
      collection: -> { Bar.all },
      as: :select, # <------- I needed to specify this
      multiple: true,
```

I needed to specify `:as`, but I had to dig into the code to figure this
out.

I have not written any specs for this. If this patch is "pre approved"
then I can write specs before you pull if desired.