### PR TITLE
Lock jquery-ui-rails dependency to '~> 5.0'

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'formtastic_i18n'
   s.add_dependency 'inherited_resources', '~> 1.6'
   s.add_dependency 'jquery-rails'
-  s.add_dependency 'jquery-ui-rails'
+  s.add_dependency 'jquery-ui-rails',     '~> 5.0'
   s.add_dependency 'kaminari',            '~> 0.15'
   s.add_dependency 'railties',            '>= 3.2', '< 5.1'
   s.add_dependency 'ransack',             '~> 1.3'


### PR DESCRIPTION
The new jquery-ui-rails 6.0 version breaks Active Admin, so I've locked it to the ~> 5.0 version for now.