### PR TITLE
Remove Ruby 1.9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ install:
 script:
   - bundle exec rake test_with_coveralls
 rvm:
-  - 1.9
   - 2.3.0
   - jruby-9.0.5.0
 env:
@@ -23,9 +22,6 @@ env:
     - JRUBY_OPTS="-J-Xmx1024m --debug"
 matrix:
   fast_finish: true
-  exclude:
-    - rvm: 1.9
-      env: RAILS=5.0.0
   allow_failures:
     - rvm: jruby-9.0.5.0
       env: RAILS=5.0.0


### PR DESCRIPTION
Ruby 1.9 support has ended almost two years ago, February 2015 https://www.ruby-lang.org/en/news/2015/02/23/support-for-ruby-1-9-3-has-ended/

I don't think AA should keep the support (also the build keeps failing because of 1.9)