### PR TITLE
Re-enable STI build_association with type on parent resource

### DIFF
--- a/lib/active_admin/resource_controller/data_access.rb
+++ b/lib/active_admin/resource_controller/data_access.rb
@@ -120,7 +120,6 @@ module ActiveAdmin
         get_resource_ivar || begin
           resource = build_new_resource
           resource = apply_decorations(resource)
-          resource = assign_attributes(resource, resource_params)
           run_build_callbacks resource
           authorize_resource! resource
 
@@ -136,7 +135,7 @@ module ActiveAdmin
       #
       # @return [ActiveRecord::Base] An un-saved active record base object
       def build_new_resource
-        scoped_collection.send method_for_build
+        scoped_collection.send method_for_build, *resource_params
       end
 
       # Calls all the appropriate callbacks and then creates the new resource.


### PR DESCRIPTION
Fixes #4424, but without the regression previously seen in #4548.