### PR TITLE
DOM ready events not working for non-Turbolinks apps

### DIFF
--- a/app/assets/javascripts/active_admin/initializers/batch_actions.js.coffee
+++ b/app/assets/javascripts/active_admin/initializers/batch_actions.js.coffee
@@ -1,7 +1,11 @@
-$(document).on 'ready page:load turbolinks:load', ->
+onDOMReady = ->
   # In order for index scopes to overflow properly onto the next line, we have
   # to manually set its width based on the width of the batch action button.
   if (batch_actions_selector = $('.table_tools .batch_actions_selector')).length
     batch_actions_selector.next().css
       width: "calc(100% - 10px - #{batch_actions_selector.outerWidth()}px)"
       'float': 'right'
+
+$(document).
+  ready(onDOMReady).
+  on 'page:load turbolinks:load', onDOMReady

--- a/app/assets/javascripts/active_admin/initializers/datepicker.js.coffee
+++ b/app/assets/javascripts/active_admin/initializers/datepicker.js.coffee
@@ -1,4 +1,4 @@
-$(document).on 'ready page:load turbolinks:load', ->
+onDOMReady = ->
   $(document).on 'focus', 'input.datepicker:not(.hasDatepicker)', ->
     input = $(@)
 
@@ -8,3 +8,7 @@ $(document).on 'ready page:load turbolinks:load', ->
     defaults = dateFormat: 'yy-mm-dd'
     options  = input.data 'datepicker-options'
     input.datepicker $.extend(defaults, options)
+
+$(document).
+  ready(onDOMReady).
+  on 'page:load turbolinks:load', onDOMReady

--- a/app/assets/javascripts/active_admin/initializers/filters.js.coffee
+++ b/app/assets/javascripts/active_admin/initializers/filters.js.coffee
@@ -1,4 +1,4 @@
-$(document).on 'ready page:load turbolinks:load', ->
+onDOMReady = ->
   # Clear Filters button
   $('.clear_filters_btn').click (e) ->
     params = window.location.search.slice(1).split('&')
@@ -20,3 +20,7 @@ $(document).on 'ready page:load turbolinks:load', ->
   # a dropdown, apply that choice to the filter input field.
   $('.filter_form_field.select_and_search select').change ->
     $(@).siblings('input').prop name: "q[#{@value}]"
+
+$(document).
+  ready(onDOMReady).
+  on 'page:load turbolinks:load', onDOMReady

--- a/app/assets/javascripts/active_admin/initializers/tabs.js.coffee
+++ b/app/assets/javascripts/active_admin/initializers/tabs.js.coffee
@@ -1,3 +1,7 @@
-$(document).on 'ready page:load turbolinks:load', ->
+onDOMReady = ->
   # Tab navigation
   $('#active_admin_content .tabs').tabs()
+
+$(document).
+  ready(onDOMReady).
+  on 'page:load turbolinks:load', onDOMReady

--- a/app/assets/javascripts/active_admin/lib/batch_actions.js.coffee
+++ b/app/assets/javascripts/active_admin/lib/batch_actions.js.coffee
@@ -1,5 +1,4 @@
-$(document).on 'ready page:load turbolinks:load', ->
-
+onDOMReady = ->
   #
   # Use ActiveAdmin.modal_dialog to prompt user if confirmation is required for current Batch Action
   #
@@ -37,3 +36,7 @@ $(document).on 'ready page:load turbolinks:load', ->
         $(".batch_actions_selector").each -> $(@).aaDropdownMenu("enable")
       else
         $(".batch_actions_selector").each -> $(@).aaDropdownMenu("disable")
+
+$(document).
+  ready(onDOMReady).
+  on 'page:load turbolinks:load', onDOMReady

--- a/app/assets/javascripts/active_admin/lib/dropdown-menu.js.coffee
+++ b/app/assets/javascripts/active_admin/lib/dropdown-menu.js.coffee
@@ -97,5 +97,9 @@ class ActiveAdmin.DropdownMenu
 
 $.widget.bridge 'aaDropdownMenu', ActiveAdmin.DropdownMenu
 
-$(document).on 'ready page:load turbolinks:load', ->
+onDOMReady = ->
   $('.dropdown_menu').aaDropdownMenu()
+
+$(document).
+  ready(onDOMReady).
+  on 'page:load turbolinks:load', onDOMReady

--- a/app/assets/javascripts/active_admin/lib/per_page.js.coffee
+++ b/app/assets/javascripts/active_admin/lib/per_page.js.coffee
@@ -23,7 +23,7 @@ class ActiveAdmin.PerPage
     while m = re.exec(query)
       params[@_decode(m[1])] = @_decode(m[2])
     params
-   
+
   _decode: (value) ->
     #replace "+" before decodeURIComponent
     decodeURIComponent(value.replace(/\+/g, '%20'))
@@ -38,5 +38,9 @@ class ActiveAdmin.PerPage
 
 $.widget.bridge 'perPage', ActiveAdmin.PerPage
 
-$(document).on 'ready page:load turbolinks:load', ->
+onDOMReady = ->
   $('.pagination_per_page select').perPage()
+
+$(document).
+  ready(onDOMReady).
+  on 'page:load turbolinks:load', onDOMReady


### PR DESCRIPTION
Since `$(document).on('ready', handler)` has been deprecated as of jQuery 1.8 and removed in jQuery 3.0, these events have stopped working for apps without Turbolinks:

* selected a filter
<img width="294" alt="screenshot 2016-12-02 18 35 14" src="https://cloud.githubusercontent.com/assets/82270/20853618/d45d683a-b8cb-11e6-961a-69c69ec6d5a6.png">

* it didn't change the parameter
<img width="844" alt="screenshot 2016-12-02 18 35 45" src="https://cloud.githubusercontent.com/assets/82270/20853620/d6528710-b8cb-11e6-806e-040d2ffd51b1.png">

First I thought about using `on('load DOMContentLoaded')`, but the jQuery API says it's safer to use the `.ready()` method because it assures the handler is executed even if the event binding happens after the DOM is ready: https://api.jquery.com/ready.

I know this is not a very elegant solution, but the only other solution that I came up with was extending jQuery's `.ready()` method to bind Turbolinks' events, and I don't know if it's safe (I haven't tried).

Any thoughts?

My app is using:
- Ruby 2.3.1
- Rails 4.2.6
- The latest version of ActiveAdmin (master branch, commit a932d56b156eaf64beb86cb45f8f801b7933c42e)
- jquery-rails 4.0.5, but I have tried others and the problem persisted

