### PR TITLE
WIP fixed form behaviour when using has_many with inputs block

### DIFF
--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -55,10 +55,12 @@ module ActiveAdmin
       end
 
       html << template.capture do
-        contents = "".html_safe
         form_block = proc do |has_many_form|
           index    = parent_child_index options[:parent] if options[:parent]
-          block.call has_many_form, index
+          block_contents = template.capture do
+            block.call(has_many_form, index)
+          end
+          template.concat(block_contents)
           template.concat has_many_actions(has_many_form, builder_options, "".html_safe)
         end
 

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -59,6 +59,10 @@ RUBY
 create_file 'app/models/profile.rb', <<-RUBY.strip_heredoc, force: true
   class Profile < ActiveRecord::Base
     belongs_to :user
+
+    unless Rails::VERSION::MAJOR > 3 && !defined? ProtectedAttributes
+      attr_accessible :bio
+    end
   end
 RUBY
 

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -284,6 +284,36 @@ describe ActiveAdmin::FormBuilder do
 
   end
 
+  context "with inputs component inside has_many" do
+
+    def user
+      u = User.new
+      u.profile = Profile.new(bio: 'bio')
+      u
+    end
+
+    let :body do
+      author = user()
+      build_form do |f|
+        f.form_builder.instance_eval do
+          @object.author = author
+        end
+        f.inputs name: 'Author', for: :author do |author|
+          author.has_many :profile, allow_destroy: true do |profile|
+            profile.inputs  "inputs for profile #{profile.object.bio}" do
+              profile.input :bio
+            end
+          end
+        end
+      end
+    end
+
+    it "should see the profile fields for an existing profile" do
+      expect(body).to have_selector("[id='post_author_attributes_profile_attributes_bio']", count: 1)
+      expect(body).to have_selector("textarea[name='post[author_attributes][profile_attributes][bio]']")
+    end
+  end
+
   context "with a has_one relation on an author's profile" do
     let :body do
       author = user()


### PR DESCRIPTION
fixes #3834 
(https://github.com/activeadmin/activeadmin/issues/3834#issuecomment-77440079)

this change allows to use such syntax
```ruby

....
        f.inputs 'Prices in price.inputs' do
          f.has_many :prices, heading: false, allow_destroy: true , new_record: true do |price|
            price.inputs "#{price.object.try!(:city).try!(:name)}" do
              price.input :amount
            end
          end
        end
....
```


before this fix , activeadmin doesn't render content inside inputs block.


HTML structure looks valid, but looks like there are problems with css (I'm not a css guy so help needed)

Feedback needed.

ping @senid231 , @timoschilling , @varyonic , @seanlinsley  
