### PR TITLE
Make Activeadmin possible inside Rails Engine

### DIFF
--- a/lib/generators/active_admin/devise/devise_generator.rb
+++ b/lib/generators/active_admin/devise/devise_generator.rb
@@ -52,6 +52,8 @@ module ActiveAdmin
       end
 
       def add_default_user_to_seed
+        return unless Rails.application
+        
         seeds_paths = Rails.application.paths["db/seeds.rb"] || Rails.application.paths["db/seeds"] # "db/seeds" => Rails 3.2 fallback
         seeds_file = seeds_paths.existent.first
         return if seeds_file.nil? || !options[:default_user]


### PR DESCRIPTION
Hi,
I'm trying to use Activeadmin inside my Rails Engine plugin, but somethings are not working well =(

When I tried to run the install guide I get this error:

lib/generators/active_admin/devise/devise_generator.rb:55:in `add_default_user_to_seed': undefined method `paths' for nil:NilClass (NoMethodError)
