### PR TITLE
Relax kaminari dependency for kaminari 1.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ if rails_major == '5'
 end
 
 platform :ruby_19 do # Remove this block when we drop support for Ruby 1.9
+  gem 'kaminari', '~> 0.15'
   gem 'mime-types', '< 3'
   gem 'nokogiri', '< 1.7'
   gem 'public_suffix', '< 1.5'

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'inherited_resources', '~> 1.6'
   s.add_dependency 'jquery-rails'
   s.add_dependency 'jquery-ui-rails'
-  s.add_dependency 'kaminari',            '~> 0.15'
+  s.add_dependency 'kaminari',            '>= 0.15', '< 2.0'
   s.add_dependency 'railties',            '>= 3.2', '< 5.1'
   s.add_dependency 'ransack',             '~> 1.3'
   s.add_dependency 'sass-rails'


### PR DESCRIPTION
kaminari v1.0.0 is released!

* https://rubygems.org/gems/kaminari/versions/1.0.0
* https://github.com/kaminari/kaminari/blob/master/CHANGELOG.md#100

It seems no problem at my environment. (Ruby 2.4.0, Rails 5.0.1)

