### PR TITLE
make namespace route options configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 index download_links: ->{ can?(:view_all_download_links) || [:pdf] }
 ```
 * Comments menu can be customized via configuration passed to `config.comments_menu` [#4187][] by [@drn][]
+* Added `config.route_options` to namespace to customize routes [#4467][] by [@stereoscott[]]
 
 ### Security Fixes
 

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -80,6 +80,9 @@ module ActiveAdmin
     # Options that a passed to root_to.
     inheritable_setting :root_to_options, {}
 
+    # Options passed to the routes, i.e. { path: '/custom' }
+    inheritable_setting :route_options, {}
+
     # Display breadcrumbs
     inheritable_setting :breadcrumb, true
 

--- a/lib/active_admin/router.rb
+++ b/lib/active_admin/router.rb
@@ -23,7 +23,7 @@ module ActiveAdmin
           if namespace.root?
             root namespace.root_to_options.merge(to: namespace.root_to)
           else
-            namespace namespace.name do
+            namespace namespace.name, namespace.route_options.dup do
               root namespace.root_to_options.merge(to: namespace.root_to, as: :root)
             end
           end
@@ -57,7 +57,7 @@ module ActiveAdmin
           unless config.namespace.root?
             nested = routes
             routes = Proc.new do
-              namespace config.namespace.name do
+              namespace config.namespace.name, config.namespace.route_options.dup do
                 instance_exec &nested
               end
             end

--- a/spec/unit/routing_spec.rb
+++ b/spec/unit/routing_spec.rb
@@ -30,6 +30,24 @@ describe ActiveAdmin, "Routing", type: :routing do
     end
   end
 
+  describe "route_options" do
+    context "with a custom path set in route_options" do
+      before(:each) do
+        ActiveAdmin.application.namespaces[:admin].route_options = { path: '/custom-path' }
+        reload_routes!
+      end
+
+      after(:all) do
+        ActiveAdmin.application.namespaces[:admin].route_options = {}
+        reload_routes!
+      end
+
+      it "should route using the custom path" do
+        expect(admin_posts_path).to eq "/custom-path/posts"
+      end
+    end
+  end
+
   describe "standard resources" do
     context "when in admin namespace" do
       it "should route the index path" do


### PR DESCRIPTION
This PR allows you to set options in your namespace config that are passed to the router. For example:

```ruby
  config.namespace :admin do |admin|
    config.route_options = { path: '' }
  end
```

And in your `routes.rb`:
```ruby
constraints :subdomain => "admin" do
  ActiveAdmin.routes(self)
end
```

This would generate routes like:
```
admin_root  GET        /       admin/dashboard#index, { :subdomain => "admin" }
admin_users GET        /users  admin/users/#index, { :subdomain => "admin" }
```

This is nice because you can keep your admin configuration and controllers all namespaced, but you have greater controller over the route generation. This is very useful when you'd like to use a subdomain without the namespace in the path.

Note: We call `.dup` on the options when calling `namespace` because inside of the rails router `options.delete(:path)` is called and subsequent calls to `namespace.route_options` would return the modified hash. 

Closes #4467.

Related: 
 - https://github.com/activeadmin/activeadmin/issues/691
 - http://stackoverflow.com/questions/38954533/how-to-use-subdomain-with-activeadmin-on-rails