### PR TITLE
Define workflow for PR merging

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,3 +142,16 @@ git checkout 325-add-japanese-translations
 git pull --rebase upstream master
 git push -f 325-add-japanese-translations
 ```
+
+### 9. Merging a PR (maintainers only)
+
+A PR can only be merged into master by a maintainer if:
+
+* It is passing CI.
+* It has been approved by at least another maintainer.
+* It has no requested changes.
+* It is up to date with current master.
+* It has been opened for at least 48h.
+
+Any maintainer is allowed to merge a PR if all of these conditions are
+met.


### PR DESCRIPTION
One of the current problems of `activeadmin` is the little availability of its maintainers. The only person with authority for merging PR's seems to be @timoschilling at the moment but his availability is very small and inconsistent. However, lately more people seem to be up for helping. So I propose a workflow to give more power to other maintainers.

What I wrote if basically the default Github's workflow if all required checks on the master protected branch are enabled, plus an extra check I added to allow some time for more people to actually be able to have a look at the PR.

Of course, this doesn't intend to get merged and put in practice immediately, it's just a way of starting a discussion.