### PR TITLE
Remove DataAccess#clean_search_params

### DIFF
--- a/lib/active_admin/resource_controller/data_access.rb
+++ b/lib/active_admin/resource_controller/data_access.rb
@@ -222,14 +222,8 @@ module ActiveAdmin
       # Applies any Ransack search methods to the currently scoped collection.
       # Both `search` and `ransack` are provided, but we use `ransack` to prevent conflicts.
       def apply_filtering(chain)
-        @search = chain.ransack clean_search_params
+        @search = chain.ransack(params[:q] || {})
         @search.result
-      end
-
-      def clean_search_params
-        q = params[:q] || {}
-        q = q.to_unsafe_h if q.respond_to? :to_unsafe_h
-        q.delete_if{ |key, value| value.blank? }
       end
 
       def apply_scoping(chain)

--- a/spec/unit/resource_controller/data_access_spec.rb
+++ b/spec/unit/resource_controller/data_access_spec.rb
@@ -20,6 +20,22 @@ describe ActiveAdmin::ResourceController::DataAccess do
       expect(chain).to receive(:ransack).with(params[:q]).once.and_return(Post.ransack)
       controller.send :apply_filtering, chain
     end
+
+    context "params includes empty values" do
+      let(:params) do
+        { q: {id_eq: 1, position_eq: ""} }
+      end
+      it "should return relation without empty filters" do
+        expect(Post).to receive(:ransack).with(params[:q]).once.and_wrap_original do |original, *args|
+          chain  = original.call(*args)
+          expect(chain.conditions.size).to eq(1)
+          chain
+        end
+        controller.send :apply_filtering, Post
+      end
+    end
+
+
   end
 
   describe "sorting" do


### PR DESCRIPTION
ransack cleaning params by itslef, so no need to do it twice