### PR TITLE
add belongs to to page resources 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 #### Minor
 
+* Page supports belongs_to [#4759][] by [@Fivell][] and [@zorab47][]
 * Support for custom sorting strategies [#4768][] by [@Fivell][]
 * Stream CSV downloads as they're generated [#3038][] by [@craigmcnamara][]
   * Disable streaming in development for easier debugging [#3535][] by [@seanlinsley][]
@@ -105,6 +106,8 @@ Please check [0-6-stable](https://github.com/activeadmin/activeadmin/blob/0-6-st
 [#3731]: https://github.com/activeadmin/activeadmin/issues/3731
 [#3783]: https://github.com/activeadmin/activeadmin/issues/3783
 [#4187]: https://github.com/activeadmin/activeadmin/issues/4187
+[#4759]: https://github.com/activeadmin/activeadmin/pull/4759
+[#4768]: https://github.com/activeadmin/activeadmin/pull/4768
 [@PChambino]: https://github.com/PChambino
 [@TimPetricola]: https://github.com/TimPetricola
 [@chancancode]: https://github.com/chancancode
@@ -120,3 +123,4 @@ Please check [0-6-stable](https://github.com/activeadmin/activeadmin/blob/0-6-st
 [@timoschilling]: https://github.com/timoschilling
 [@varyonic]: https://github.com/varyonic
 [@zorab47]: https://github.com/zorab47
+[@Fivell]: https://github.com/Fivell

--- a/docs/10-custom-pages.md
+++ b/docs/10-custom-pages.md
@@ -71,6 +71,19 @@ ActiveAdmin.register_page "Calendar", namespace: :today
 ActiveAdmin.register_page "Calendar", namespace: false
 ```
 
+## Belongs To
+
+To nest the page within another resource, you can use the `belongs_to` method:
+
+```ruby
+ActiveAdmin.register Project
+ActiveAdmin.register_page "Status" do
+  belongs_to :project
+end
+```
+
+See also the [Belongs To](2-resource-customization.md#belongs-to) documentation and examples.
+
 ## Add a Sidebar
 
 See the [Sidebars](7-sidebars.md) documentation.

--- a/features/registering_pages.feature
+++ b/features/registering_pages.feature
@@ -169,3 +169,20 @@ Feature: Registering Pages
     Then I should see the page title "Special users"
     And I should see the Active Admin layout
     And I should see 1 user in the table
+
+  Scenario: Displaying parent information from a belongs_to page
+    Given a configuration of:
+    """
+    ActiveAdmin.register Post
+    ActiveAdmin.register_page "Status" do
+      belongs_to :post
+
+      content do
+        "Status page for #{parent.title}"
+      end
+    end
+    """
+    And 1 post with the title "Post 1" exists
+    When I go to the first post custom status page
+    Then I should see the content "Status page for Post 1"
+

--- a/features/registering_pages.feature
+++ b/features/registering_pages.feature
@@ -178,11 +178,12 @@ Feature: Registering Pages
       belongs_to :post
 
       content do
-        "Status page for #{parent.title}"
+        "Status page for #{helpers.parent.title}"
       end
     end
     """
     And 1 post with the title "Post 1" exists
     When I go to the first post custom status page
     Then I should see the content "Status page for Post 1"
+    And  I should see a link to "Post 1" in the breadcrumb
 

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -21,6 +21,8 @@ module NavigationHelpers
       "/admin/login"
     when /the first post show page/
       "/admin/posts/1"
+    when /the first post custom status page/
+      "/admin/posts/1/status"
     when /the first post edit page/
       "/admin/posts/1/edit"
     when /the admin password reset form with token "([^"]*)"/

--- a/lib/active_admin/page.rb
+++ b/lib/active_admin/page.rb
@@ -85,18 +85,23 @@ module ActiveAdmin
     end
 
     def belongs_to(target, options = {})
-      @belongs_to = Resource::BelongsTo.new(self, target, options)
-      self.navigation_menu_name = target unless @belongs_to.optional?
+      this_belongs_to = Resource::BelongsTo.new(self, target, options)
+      belongs_to_config << this_belongs_to
+      self.navigation_menu_name = target unless this_belongs_to.optional?
       controller.send :belongs_to, target, options.dup
     end
 
     def belongs_to_config
-      @belongs_to
+      @belongs_to ||= []
     end
 
     # Do we belong to another resource?
     def belongs_to?
-      !!belongs_to_config
+      belongs_to_config.length > 0
+    end
+
+    def breadcrumb
+      instance_variable_defined?(:@breadcrumb) ? @breadcrumb : namespace.breadcrumb
     end
   end
 end

--- a/lib/active_admin/page.rb
+++ b/lib/active_admin/page.rb
@@ -73,10 +73,6 @@ module ActiveAdmin
       false
     end
 
-    def belongs_to?
-      false
-    end
-
     def add_default_action_items
     end
 
@@ -88,5 +84,19 @@ module ActiveAdmin
       @page_actions = []
     end
 
+    def belongs_to(target, options = {})
+      @belongs_to = Resource::BelongsTo.new(self, target, options)
+      self.navigation_menu_name = target unless @belongs_to.optional?
+      controller.send :belongs_to, target, options.dup
+    end
+
+    def belongs_to_config
+      @belongs_to
+    end
+
+    # Do we belong to another resource?
+    def belongs_to?
+      !!belongs_to_config
+    end
   end
 end

--- a/lib/active_admin/page_dsl.rb
+++ b/lib/active_admin/page_dsl.rb
@@ -24,5 +24,9 @@ module ActiveAdmin
         define_method(name, &block || Proc.new{})
       end
     end
+
+    def belongs_to(target, options = {})
+      config.belongs_to(target, options)
+    end
   end
 end

--- a/spec/unit/namespace/register_page_spec.rb
+++ b/spec/unit/namespace/register_page_spec.rb
@@ -68,6 +68,32 @@ describe ActiveAdmin::Namespace, "registering a page" do
       it "should not create a menu item" do
         expect(menu["Status"]).to eq nil
       end
+    end # describe "disabling the menu"
+  end # describe "adding to the menu"
+
+  describe "adding as a belongs to" do
+    context "when not optional" do
+      before do
+        namespace.register_page "Reports" do
+          belongs_to :author
+        end
+      end
+
+      it "should be excluded from the menu" do
+        expect(menu["Reports"]).to be_nil
+      end
     end
-  end
+
+    context "when optional" do
+      before do
+        namespace.register_page "Reports" do
+          belongs_to :author, :optional => true
+        end
+      end
+
+      it "should be in the menu" do
+        expect(menu["Reports"]).to_not be_nil
+      end
+    end
+  end # describe "adding as a belongs to"
 end

--- a/spec/unit/page_spec.rb
+++ b/spec/unit/page_spec.rb
@@ -11,6 +11,7 @@ module ActiveAdmin
 
     let(:application){ ActiveAdmin::Application.new }
     let(:namespace){ Namespace.new(application, :admin) }
+    let(:page_name) { "Chocolate I lØve You!" }
 
     def config(options = {})
       @config ||= namespace.register_page("Chocolate I lØve You!", options)
@@ -70,6 +71,7 @@ module ActiveAdmin
       expect(config.belongs_to?).to eq false
     end
 
+
     it "should not have any action_items" do
       expect(config.action_items?).to eq false
     end
@@ -78,5 +80,52 @@ module ActiveAdmin
       expect(config.sidebar_sections?).to eq false
     end
 
+    context "with belongs to config" do
+      let!(:post_config) { namespace.register Post }
+      let!(:page_config) {
+        namespace.register_page page_name do
+          belongs_to :post
+        end
+      }
+
+      it "configures page with belongs_to" do
+        expect(page_config.belongs_to?).to be true
+      end
+
+      it "sets navigation menu to parent" do
+        expect(page_config.navigation_menu_name).to eq :post
+      end
+
+      it "builds a belongs_to relationship" do
+        belongs_to = page_config.belongs_to_config
+
+        expect(belongs_to.target).to eq(post_config)
+        expect(belongs_to.owner).to eq(page_config)
+        expect(belongs_to.optional?).to be_falsy
+      end
+
+      it "forwards belongs_to call to controller" do
+        options = { optional: true }
+        expect(page_config.controller).to receive(:belongs_to).with(:post, options)
+        page_config.belongs_to :post, options
+      end
+    end # context "with belongs to config" do
+
+    context "with optional belongs to config" do
+      let!(:post_config) { namespace.register Post }
+      let!(:page_config) {
+        namespace.register_page page_name do
+          belongs_to :post, optional: true
+        end
+      }
+
+      it "does not override default navigation menu" do
+        expect(page_config.navigation_menu_name).to eq(:default)
+      end
+    end # context "with optional belongs to config" do
+
+    it "has no belongs_to by default" do
+      expect(config.belongs_to?).to be_falsy
+    end
   end
 end

--- a/spec/unit/page_spec.rb
+++ b/spec/unit/page_spec.rb
@@ -97,7 +97,7 @@ module ActiveAdmin
       end
 
       it "builds a belongs_to relationship" do
-        belongs_to = page_config.belongs_to_config
+        belongs_to = page_config.belongs_to_config.first
 
         expect(belongs_to.target).to eq(post_config)
         expect(belongs_to.owner).to eq(page_config)


### PR DESCRIPTION
replaces #2770

- [x] squash and rebase #2770
- [x] adopted multiple belongs_to for pages to make router happy because of #4618
- [x] changed feature with example to access parent  from arbre using helpers
- [x] display link to parent resource in breadcrumb
