### PR TITLE
Use default_url_options in auto_link

### DIFF
--- a/features/index/batch_actions.feature
+++ b/features/index/batch_actions.feature
@@ -21,6 +21,28 @@ Feature: Batch Actions
     Then I should see a flash with "Successfully destroyed 2 posts"
     And I should see 8 posts in the table
 
+  Scenario: Use default (destroy) batch action when default_url_options present
+    Given 3 posts exist
+    And an index configuration of:
+    """
+      ActiveAdmin.register Post do
+        controller do
+          protected
+
+          def default_url_options
+            { locale: I18n.locale }
+          end
+        end
+      end
+    """
+    When I check the 1st record
+    And I follow "Batch Actions"
+    Then I should see the batch action :destroy "Delete Selected"
+
+    Given I submit the batch action form with "destroy"
+    Then I should see a flash with "Successfully destroyed 1 post"
+    And I should see 2 posts in the table
+
   Scenario: Use default (destroy) batch action on a decorated resource
     Given 5 posts exist
     And an index configuration of:

--- a/lib/active_admin/batch_actions/resource_extension.rb
+++ b/lib/active_admin/batch_actions/resource_extension.rb
@@ -51,18 +51,6 @@ module ActiveAdmin
         @batch_actions = {}
       end
 
-      # Path to the batch action itself
-      def batch_action_path(params = {}, url_options = {})
-        uri = URI(route_collection_path(params, url_options))
-        uri.path += "/batch_action"
-
-        query = params.slice(:q, :scope)
-        query = query.permit! if query.respond_to? :permit!
-        query = query.to_h if Rails::VERSION::MAJOR >= 5
-        uri.query = [uri.query, query.to_param].compact.join('&') if query.present?
-        uri.to_s
-      end
-
       private
 
       # @return [ActiveAdmin::BatchAction] The default "delete" action

--- a/lib/active_admin/batch_actions/resource_extension.rb
+++ b/lib/active_admin/batch_actions/resource_extension.rb
@@ -52,12 +52,15 @@ module ActiveAdmin
       end
 
       # Path to the batch action itself
-      def batch_action_path(params = {})
-        path = [route_collection_path(params), "batch_action"].join("/")
+      def batch_action_path(params = {}, url_options = {})
+        uri = URI(route_collection_path(params, url_options))
+        uri.path += "/batch_action"
+
         query = params.slice(:q, :scope)
         query = query.permit! if query.respond_to? :permit!
         query = query.to_h if Rails::VERSION::MAJOR >= 5
-        [path, query.to_param].reject(&:blank?).join("?")
+        uri.query = [uri.query, query.to_param].compact.join('&') if query.present?
+        uri.to_s
       end
 
       private

--- a/lib/active_admin/batch_actions/views/batch_action_form.rb
+++ b/lib/active_admin/batch_actions/views/batch_action_form.rb
@@ -15,7 +15,7 @@ module ActiveAdmin
         # Open a form with two hidden input fields:
         # batch_action        => name of the specific action called
         # batch_action_inputs => a JSON string of any requested confirmation values
-        text_node form_tag active_admin_config.batch_action_path(params, url_options), id: options[:id]
+        text_node form_tag active_admin_config.route_batch_action_path(params, url_options), id: options[:id]
         input name: :batch_action,        id: :batch_action,        type: :hidden
         input name: :batch_action_inputs, id: :batch_action_inputs, type: :hidden
 

--- a/lib/active_admin/batch_actions/views/batch_action_form.rb
+++ b/lib/active_admin/batch_actions/views/batch_action_form.rb
@@ -15,7 +15,7 @@ module ActiveAdmin
         # Open a form with two hidden input fields:
         # batch_action        => name of the specific action called
         # batch_action_inputs => a JSON string of any requested confirmation values
-        text_node form_tag active_admin_config.batch_action_path(params), id: options[:id]
+        text_node form_tag active_admin_config.batch_action_path(params, url_options), id: options[:id]
         input name: :batch_action,        id: :batch_action,        type: :hidden
         input name: :batch_action_inputs, id: :batch_action_inputs, type: :hidden
 

--- a/lib/active_admin/resource/menu.rb
+++ b/lib/active_admin/resource/menu.rb
@@ -26,7 +26,7 @@ module ActiveAdmin
         {
           id: resource_name.plural,
           label: proc{ resource.plural_resource_label },
-          url:   proc{ resource.route_collection_path(params) },
+          url:   proc{ resource.route_collection_path(params, url_options) },
           if:    proc{ authorized?(Auth::READ, menu_resource_class) }
         }
       end

--- a/lib/active_admin/resource/routes.rb
+++ b/lib/active_admin/resource/routes.rb
@@ -4,19 +4,19 @@ module ActiveAdmin
       # @param params [Hash] of params: { study_id: 3 }
       # @return [String] the path to this resource collection page
       # @example "/admin/posts"
-      def route_collection_path(params = {})
-        RouteBuilder.new(self).collection_path(params)
+      def route_collection_path(params = {}, additional_params = {})
+        RouteBuilder.new(self).collection_path(params, additional_params)
       end
 
       # @param resource [ActiveRecord::Base] the instance we want the path of
       # @return [String] the path to this resource collection page
       # @example "/admin/posts/1"
-      def route_instance_path(resource)
-        RouteBuilder.new(self).instance_path(resource)
+      def route_instance_path(resource, additional_params = {})
+        RouteBuilder.new(self).instance_path(resource, additional_params)
       end
 
-      def route_edit_instance_path(resource)
-        RouteBuilder.new(self).edit_instance_path(resource)
+      def route_edit_instance_path(resource, additional_params = {})
+        RouteBuilder.new(self).edit_instance_path(resource, additional_params)
       end
 
       # Returns the routes prefix for this config
@@ -37,32 +37,32 @@ module ActiveAdmin
           @resource = resource
         end
 
-        def collection_path(params)
+        def collection_path(params, additional_params = {})
           route_name = route_name(
             resource.resources_configuration[:self][:route_collection_name],
             suffix: (resource.route_uncountable? ? "index_path" : "path")
           )
 
-          routes.public_send route_name, *route_collection_params(params)
+          routes.public_send route_name, *route_collection_params(params), additional_params
         end
 
         # @return [String] the path to this resource collection page
         # @param instance [ActiveRecord::Base] the instance we want the path of
         # @example "/admin/posts/1"
-        def instance_path(instance)
+        def instance_path(instance, additional_params = {})
           route_name = route_name(resource.resources_configuration[:self][:route_instance_name])
 
-          routes.public_send route_name, *route_instance_params(instance)
+          routes.public_send route_name, *route_instance_params(instance), additional_params
         end
 
         # @return [String] the path to the edit page of this resource
         # @param instance [ActiveRecord::Base] the instance we want the path of
         # @example "/admin/posts/1/edit"
-        def edit_instance_path(instance)
+        def edit_instance_path(instance, additional_params = {})
           path = resource.resources_configuration[:self][:route_instance_name]
           route_name = route_name(path, action: :edit)
 
-          routes.public_send route_name, *route_instance_params(instance)
+          routes.public_send route_name, *route_instance_params(instance), additional_params
         end
 
         private

--- a/lib/active_admin/resource/routes.rb
+++ b/lib/active_admin/resource/routes.rb
@@ -8,6 +8,10 @@ module ActiveAdmin
         RouteBuilder.new(self).collection_path(params, additional_params)
       end
 
+      def route_batch_action_path(params = {}, additional_params = {})
+        RouteBuilder.new(self).batch_action_path(params, additional_params)
+      end
+
       # @param resource [ActiveRecord::Base] the instance we want the path of
       # @return [String] the path to this resource collection page
       # @example "/admin/posts/1"
@@ -44,6 +48,16 @@ module ActiveAdmin
           )
 
           routes.public_send route_name, *route_collection_params(params), additional_params
+        end
+
+        def batch_action_path(params, additional_params = {})
+          path = resource.resources_configuration[:self][:route_collection_name]
+          route_name = route_name(path, action: :batch_action)
+
+          query = params.slice(:q, :scope)
+          query = query.permit! if query.respond_to? :permit!
+          query = query.to_h if Rails::VERSION::MAJOR >= 5
+          routes.public_send route_name, *route_collection_params(params), additional_params.merge(query)
         end
 
         # @return [String] the path to this resource collection page

--- a/lib/active_admin/view_helpers/auto_link_helper.rb
+++ b/lib/active_admin/view_helpers/auto_link_helper.rb
@@ -26,10 +26,10 @@ module ActiveAdmin
 
         if config.controller.action_methods.include?("show") &&
           authorized?(ActiveAdmin::Auth::READ, resource)
-          url_for config.route_instance_path resource
+          url_for config.route_instance_path resource, url_options
         elsif config.controller.action_methods.include?("edit") &&
           authorized?(ActiveAdmin::Auth::UPDATE, resource)
-          url_for config.route_edit_instance_path resource
+          url_for config.route_edit_instance_path resource, url_options
         end
       end
 

--- a/spec/unit/auto_link_spec.rb
+++ b/spec/unit/auto_link_spec.rb
@@ -10,10 +10,6 @@ describe "auto linking resources" do
   let(:active_admin_namespace){ ActiveAdmin::Namespace.new(ActiveAdmin::Application.new, :admin) }
   let(:post){ Post.create! title: "Hello World" }
 
-  def admin_post_path(post)
-    "/admin/posts/#{post.id}"
-  end
-
   def authorized?(*)
     true
   end
@@ -29,8 +25,10 @@ describe "auto linking resources" do
       active_admin_namespace.register Post
     end
     it "should return a link with the display name of the object" do
+      url_path = "/admin/posts/#{post.id}?locale=en"
+      expect(self).to receive(:url_options).and_return(locale: 'en')
       expect(self).to receive(:url_for) { |url| url }
-      expect(self).to receive(:link_to).with "Hello World", admin_post_path(post)
+      expect(self).to receive(:link_to).with "Hello World", url_path
       auto_link(post)
     end
 
@@ -47,7 +45,8 @@ describe "auto linking resources" do
       end
 
       it "should fallback to edit" do
-        url_path = "/admin/posts/#{post.id}/edit"
+        url_path = "/admin/posts/#{post.id}/edit?locale=en"
+        expect(self).to receive(:url_options).and_return(locale: 'en')
         expect(self).to receive(:url_for) { |url| url }
         expect(self).to receive(:link_to).with "Hello World", url_path
         auto_link(post)

--- a/spec/unit/batch_actions/resource_spec.rb
+++ b/spec/unit/batch_actions/resource_spec.rb
@@ -52,19 +52,6 @@ describe ActiveAdmin::BatchActions::ResourceExtension do
 
   end
 
-  describe "#batch_action_path" do
-
-    it "returns the path as a symbol" do
-      expect(resource.batch_action_path).to eq "/admin/posts/batch_action"
-    end
-
-    it "includes :scope and :q params" do
-      params = { q: { name_equals: "Any" }, scope: :all }
-      batch_action_path = "/admin/posts/batch_action?q%5Bname_equals%5D=Any&scope=all"
-      expect(resource.batch_action_path(params)).to eq(batch_action_path)
-    end
-  end
-
   describe "#display_if_block" do
 
     it "should return true by default" do

--- a/spec/unit/resource/routes_spec.rb
+++ b/spec/unit/resource/routes_spec.rb
@@ -101,6 +101,27 @@ module ActiveAdmin
           expect(config.route_instance_path(tagging)).to eq "/admin/categories/1/posts/3/taggings/4"
         end
       end
+
+      context "for batch_action handler" do
+        let! :config do
+          ActiveAdmin.register Post do
+            belongs_to :category
+          end
+        end
+
+        before do
+          config.batch_actions= true
+          reload_routes!
+        end
+
+        it "should include :scope and :q params" do
+          params = { category_id: 1, q: { name_equals: "Any" }, scope: :all }
+          additional_params = { locale: 'en' }
+          batch_action_path = "/admin/categories/1/posts/batch_action?locale=en&q%5Bname_equals%5D=Any&scope=all"
+
+          expect(config.route_batch_action_path(params, additional_params)).to eq batch_action_path
+        end
+      end
     end
   end
 end

--- a/spec/unit/view_helpers/display_helper_spec.rb
+++ b/spec/unit/view_helpers/display_helper_spec.rb
@@ -16,6 +16,10 @@ describe ActiveAdmin::ViewHelpers::DisplayHelper do
     true
   end
 
+  def url_options
+    { locale: nil }
+  end
+
   describe '#display_name' do
     ActiveAdmin::Application.new.display_name_methods.map(&:to_s).each do |m|
       it "should return #{m} when defined" do


### PR DESCRIPTION
`auto_link` ignores `default_url_options` now.

Before patch:
<img width="415" alt="screen shot 2017-01-27 at 10 06 02 am" src="https://cloud.githubusercontent.com/assets/434466/22363076/ba159b7c-e478-11e6-9aff-0099eecd27a7.png">

After patch:
<img width="409" alt="screen shot 2017-01-27 at 10 07 59 am" src="https://cloud.githubusercontent.com/assets/434466/22363084/ce52e3b0-e478-11e6-9f0d-8ef361efe18a.png">

Also I'm not happy with how `batch_action_path` was implemented and how it's implemented now. Why can't we just define route?
