### PR TITLE
Issue #4423: Allow array as collection

### DIFF
--- a/features/registering_pages.feature
+++ b/features/registering_pages.feature
@@ -146,3 +146,26 @@ Feature: Registering Pages
     And I follow "Check"
     Then I should see the content "Chocolate lØves You Too!"
     And I should see the Active Admin layout
+
+  Scenario: Registering a page with paginated index table for a collection Array
+    Given a user named "John Doe" exists
+    Given a configuration of:
+    """
+    ActiveAdmin.register_page "Special users" do
+      content do
+        collection = Kaminari.paginate_array(User.all).page(params.fetch(:page, 1))
+
+        table_for(collection, class: "index_table") do
+          column :first_name
+          column :last_name
+        end
+
+        paginated_collection(collection, entry_name: "Special users")
+      end
+    end
+    """
+    When I go to the dashboard
+    And I follow "Special users"
+    Then I should see the page title "Special users"
+    And I should see the Active Admin layout
+    And I should see 1 user in the table

--- a/lib/active_admin/helpers/collection.rb
+++ b/lib/active_admin/helpers/collection.rb
@@ -4,6 +4,8 @@ module ActiveAdmin
       # 1. removes `select` and `order` to prevent invalid SQL
       # 2. correctly handles the Hash returned when `group by` is used
       def collection_size(c = collection)
+        return c.count if c.is_a?(Array)
+
         c = c.except :select, :order
 
         c.group_values.present? ? c.count.count : c.count

--- a/spec/unit/helpers/collection_spec.rb
+++ b/spec/unit/helpers/collection_spec.rb
@@ -32,6 +32,10 @@ describe ActiveAdmin::Helpers::Collection do
       expect(collection_size(Post.select("title, count(*) as nb_posts").group(:title).order("nb_posts"))).to eq 2
     end
 
+    it "should return the collection size for an Array" do
+      expect(collection_size(Post.where(title: "A post").to_a)).to eq 2
+    end
+
     it "should take the defined collection by default" do
       def collection; Post.where(nil); end
 
@@ -40,6 +44,10 @@ describe ActiveAdmin::Helpers::Collection do
       def collection; Post.where(title: "An other post"); end
 
       expect(collection_size).to eq 1
+
+      def collection; Post.where(title: "A post").to_a end
+
+      expect(collection_size).to eq 2
     end
   end
 


### PR DESCRIPTION
This allows you to use not only an ActiveRecord::Relation but also an Array as collection for code that calls ActiveAdmin::Helpers::Collection.collection_size.

Passing an Array might be needed in case of creating a table on a custom page with a paginated array as collection.

See https://github.com/activeadmin/activeadmin/issues/4423