### PR TITLE
Revert "Merge pull request #4618 

### DIFF
--- a/features/belongs_to.feature
+++ b/features/belongs_to.feature
@@ -110,24 +110,6 @@ Feature: Belongs To
     When I follow "Posts"
     Then the "Posts" tab should be selected
 
-  Scenario: When the belongs to is nested
-    Given a configuration of:
-    """
-      ActiveAdmin.register User
-      ActiveAdmin.register Post do
-        belongs_to :user
-      end
-      ActiveAdmin.register Tagging do
-        belongs_to :user
-        belongs_to :post
-      end
-    """
-    When I go to the last author's last post's taggings
-    Then I should see a link to "Users" in the breadcrumb
-    And I should see a link to "Jane Doe" in the breadcrumb
-    And I should see a link to "Posts" in the breadcrumb
-    And I should see a link to "Hello World" in the breadcrumb
-
   Scenario: Displaying belongs to resources in main menu
     Given a configuration of:
     """

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -50,9 +50,6 @@ module NavigationHelpers
     when /^the last post's show page$/
       admin_post_path(Post.last)
 
-    when /^the last author's last post's taggings$/
-      admin_user_post_taggings_path(User.last, Post.where(author_id: User.last.id).last)
-
     when /^the last post's edit page$/
       edit_admin_post_path(Post.last)
 

--- a/lib/active_admin/base_controller/menu.rb
+++ b/lib/active_admin/base_controller/menu.rb
@@ -22,7 +22,7 @@ module ActiveAdmin
       # Get's called through a before filter
       def set_current_tab
         @current_tab = if current_menu && active_admin_config.belongs_to? && parent?
-          parent_item = active_admin_config.belongs_to_config.first.target.menu_item
+          parent_item = active_admin_config.belongs_to_config.target.menu_item
           if current_menu.include? parent_item
             parent_item
           else

--- a/lib/active_admin/page.rb
+++ b/lib/active_admin/page.rb
@@ -85,19 +85,18 @@ module ActiveAdmin
     end
 
     def belongs_to(target, options = {})
-      this_belongs_to = Resource::BelongsTo.new(self, target, options)
-      belongs_to_config << this_belongs_to
-      self.navigation_menu_name = target unless this_belongs_to.optional?
+      @belongs_to = Resource::BelongsTo.new(self, target, options)
+      self.navigation_menu_name = target unless @belongs_to.optional?
       controller.send :belongs_to, target, options.dup
     end
 
     def belongs_to_config
-      @belongs_to ||= []
+      @belongs_to
     end
 
     # Do we belong to another resource?
     def belongs_to?
-      belongs_to_config.length > 0
+      !!belongs_to_config
     end
 
     def breadcrumb

--- a/lib/active_admin/resource.rb
+++ b/lib/active_admin/resource.rb
@@ -125,23 +125,24 @@ module ActiveAdmin
     end
 
     def belongs_to(target, options = {})
-      this_belongs_to = Resource::BelongsTo.new(self, target, options)
-      self.navigation_menu_name = target unless this_belongs_to.optional?
-      belongs_to_config << this_belongs_to
+      @belongs_to = Resource::BelongsTo.new(self, target, options)
+      self.navigation_menu_name = target unless @belongs_to.optional?
       controller.send :belongs_to, target, options.dup
     end
 
     def belongs_to_config
-      @belongs_to ||= []
+      @belongs_to
     end
 
-    def belongs_to_params
-      belongs_to_config.select{ |c| c.required? }.map{ |c| c.to_param }
+    def belongs_to_param
+      if belongs_to? && belongs_to_config.required?
+        belongs_to_config.to_param
+      end
     end
 
     # Do we belong to another resource?
     def belongs_to?
-      belongs_to_config.length > 0
+      !!belongs_to_config
     end
 
     # The csv builder for this resource

--- a/lib/active_admin/resource_dsl.rb
+++ b/lib/active_admin/resource_dsl.rb
@@ -68,11 +68,11 @@ module ActiveAdmin
     #
     def permit_params(*args, &block)
       param_key = config.param_key.to_sym
-      belongs_to_params =  config.belongs_to_params
+      belongs_to_param = config.belongs_to_param
 
       controller do
         define_method :permitted_params do
-          params.permit *(active_admin_namespace.permitted_params + belongs_to_params),
+          params.permit *(active_admin_namespace.permitted_params + Array.wrap(belongs_to_param)),
             param_key => block ? instance_exec(&block) : args
         end
       end

--- a/lib/active_admin/router.rb
+++ b/lib/active_admin/router.rb
@@ -38,22 +38,19 @@ module ActiveAdmin
         resources.each do |config|
           routes = aa_router.resource_routes(config)
 
-          # Add in the parents for each, starting from the first(out) to the last(in) exists
-          
-          if(config.belongs_to?)
-            belongs_to = config.belongs_to_config.reverse.reduce(routes) do |r,btc|
-              Proc.new do
-                # If it's optional, make the normal resource routes
-                instance_exec &r if btc.optional?
+          # Add in the parent if it exists
+          if config.belongs_to?
+            belongs_to = routes
+            routes     = Proc.new do
+              # If it's optional, make the normal resource routes
+              instance_exec &belongs_to if config.belongs_to_config.optional?
 
-                # Make the nested belongs_to routes
-                # :only is set to nothing so that we don't clobber any existing routes on the resource
-                resources btc.target.resource_name.plural, only: [] do
-                  instance_exec &r
-                end
+              # Make the nested belongs_to routes
+              # :only is set to nothing so that we don't clobber any existing routes on the resource
+              resources config.belongs_to_config.target.resource_name.plural, only: [] do
+                instance_exec &belongs_to
               end
             end
-            routes = belongs_to
           end
 
           # Add on the namespace if required

--- a/lib/active_admin/view_helpers/breadcrumb_helper.rb
+++ b/lib/active_admin/view_helpers/breadcrumb_helper.rb
@@ -13,10 +13,9 @@ module ActiveAdmin
           # 2. try using the model name translation
           # 3. default to calling `titlecase` on the URL fragment
           if part =~ /\A(\d+|[a-f0-9]{24})\z/ && parts[index-1]
-            config = active_admin_config.belongs_to_config.map(&:target).select do |parent|
-              parent.resource_name.route_key == parts[index-1]
-            end.first || active_admin_config
-            name = display_name config.find_resource part
+            parent = active_admin_config.belongs_to_config.try :target
+            config = parent && parent.resource_name.route_key == parts[index-1] ? parent : active_admin_config
+            name   = display_name config.find_resource part
           end
           name ||= I18n.t "activerecord.models.#{part.singularize}", count: ::ActiveAdmin::Helpers::I18n::PLURAL_MANY_COUNT, default: part.titlecase
 

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -33,12 +33,6 @@ create_file 'app/models/post.rb', <<-RUBY.strip_heredoc, force: true
 RUBY
 copy_file File.expand_path('../templates/post_decorator.rb', __FILE__), 'app/models/post_decorator.rb'
 
-generate :model, "post_comment message:string post_id:integer"
-inject_into_file 'app/models/post_comment.rb', %q{
-   belongs_to :post
-   attr_accessible :message, :post unless Rails::VERSION::MAJOR > 3 && !defined? ProtectedAttributes
- }, after: 'class PostComment < ActiveRecord::Base'
-
 generate :model, 'blog/post title:string body:text published_date:date author_id:integer ' +
   'position:integer custom_category_id:integer starred:boolean foo_id:integer'
 create_file 'app/models/blog/post.rb', <<-RUBY.strip_heredoc, force: true

--- a/spec/unit/belongs_to_spec.rb
+++ b/spec/unit/belongs_to_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe ActiveAdmin::Resource::BelongsTo do
   end
 
   let(:namespace) { ActiveAdmin.application.namespace(:admin) }
+  let(:user_config){ ActiveAdmin.register User }
+  let(:post_config){ ActiveAdmin.register Post do belongs_to :user end }
+  let(:belongs_to){ post_config.belongs_to_config }
 
-  let(:user_config){ namespace.resource_for('User') }
-  let(:post_config){ namespace.resource_for('Post') }
-  let(:belongs_to){ post_config.belongs_to_config.first }
 
   it "should have an owner" do
     expect(belongs_to.owner).to eq post_config

--- a/spec/unit/page_spec.rb
+++ b/spec/unit/page_spec.rb
@@ -97,7 +97,7 @@ module ActiveAdmin
       end
 
       it "builds a belongs_to relationship" do
-        belongs_to = page_config.belongs_to_config.first
+        belongs_to = page_config.belongs_to_config
 
         expect(belongs_to.target).to eq(post_config)
         expect(belongs_to.owner).to eq(page_config)

--- a/spec/unit/resource/routes_spec.rb
+++ b/spec/unit/resource/routes_spec.rb
@@ -85,39 +85,6 @@ RSpec.describe ActiveAdmin::Resource::Routes do
     end
   end
 
-  context "when the resources belongs to two other resources" do
-    let(:config) { namespace.resource_for('Tagging') }
-
-    let :tagging do
-      Tagging.new do |t|
-        t.id = 4
-        t.post = Post.new do |p|
-          p.id = 3
-          p.category = Category.new{ |c| c.id = 1 }
-        end
-      end
-    end
-
-    before do
-      load_resources do
-        ActiveAdmin.register Category
-        ActiveAdmin.register Post
-        ActiveAdmin.register Tagging do
-          belongs_to :category
-          belongs_to :post
-        end
-      end
-    end
-
-    it "should nest the collection path" do
-      expect(config.route_collection_path(category_id: 1, post_id: 3)).to eq "/admin/categories/1/posts/3/taggings"
-    end
-
-    it "should nest the instance path" do
-      expect(config.route_instance_path(tagging)).to eq "/admin/categories/1/posts/3/taggings/4"
-    end
-  end
-
   context "for batch_action handler" do
     before do
       load_resources { config.batch_actions = true }

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -80,9 +80,9 @@ module ActiveAdmin
     describe "#belongs_to" do
 
       it "should build a belongs to configuration" do
-        expect(config.belongs_to_config.length).to eq 0
+        expect(config.belongs_to_config).to eq nil
         config.belongs_to :posts
-        expect(config.belongs_to_config.length).to eq 1
+        expect(config.belongs_to_config).to_not eq nil
       end
 
       it "should set the target menu to the belongs to target" do

--- a/spec/unit/routing_spec.rb
+++ b/spec/unit/routing_spec.rb
@@ -175,31 +175,6 @@ RSpec.describe ActiveAdmin, "Routing", type: :routing do
     end
   end
 
-  describe "nested belongs to resource" do
-    before do
-      ActiveAdmin.register(Tagging) do
-        belongs_to :user, optional: true
-        belongs_to :post
-      end
-      reload_routes!
-    end
-    it "should route the nested index path" do
-      expect(admin_user_post_taggings_path(1,2)).to eq "/admin/users/1/posts/2/taggings"
-    end
-
-    it "should route the nested show path" do
-      expect(admin_user_post_tagging_path(1,2,3)).to eq "/admin/users/1/posts/2/taggings/3"
-    end
-
-    it "should route the nested skipping optional index path" do
-      expect(admin_post_taggings_path(1)).to eq "/admin/posts/1/taggings"
-    end
-
-    it "should route the nested skipping optional show path" do
-      expect(admin_post_tagging_path(1,2)).to eq "/admin/posts/1/taggings/2"
-    end
-  end
-
   describe "page" do
     context "when default namespace" do
       before(:each) do

--- a/spec/unit/view_helpers/breadcrumbs_spec.rb
+++ b/spec/unit/view_helpers/breadcrumbs_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Breadcrumbs" do
                                defined_actions: actions }
     let(:post)        { double display_name: 'Hello World' }
     let(:post_config) { double find_resource: post, resource_name: double(route_key: 'posts'),
-                               defined_actions: actions, belongs_to_config: [double(target: user_config)] }
+                               defined_actions: actions, belongs_to_config: double(target: user_config) }
 
     let :active_admin_config do
       post_config
@@ -193,7 +193,7 @@ RSpec.describe "Breadcrumbs" do
     context "when the 'show' action is disabled" do
       let(:post_config) { double find_resource: post, resource_name: double(route_key: 'posts'),
                                  defined_actions: actions - [:show], # this is the change
-                                 belongs_to_config: [double(target: user_config)] }
+                                 belongs_to_config: double(target: user_config) }
 
       let(:path) { "/admin/posts/1/edit" }
 


### PR DESCRIPTION
This reverts commit a8b3bef3a678919a69f808e7516219294a03f553, reversing
changes made to 9fb572a4f10353508e7f6876594a9989cf550367.

Hello @varyonic , @timoschilling , @deivid-rodriguez.
Hello @rdallasgray 
I want to discuss reverting of nested belongs to feature that was added before.

First of all I'm considering this to be a major feature and unfortunately  
   - we need features to cover crud operations for single belongs to 
   - we have broken default permitted_params  that doesn't support belongs_to at all
   - we have 2 different APIs for pages belongs_to that is disabled for no reason, and resource belongs_to that is already 2 level. 
   - we have some routing bugs that need to be fixed before
   - we already receiving issues related to multiple belongs to 
  
All of this became hard to reach with merging not well tested "nested belongs_to" feature that gives us new level of complexity. 

After fixing this problems we can return to nested belongs to feature
However this requires some cucumber  features to implement 
   - one of belongs_to can be optional 
   - create/edit/destroy nested resources for cases
      - one of belongs_to is optional
      - both are required
      - route in uri is different from actual activerecord's belongs_to declaration 
         


In general, let's make belongs_to work before thinking of nested belongs_to 
  
 
 