### PR TITLE
Tweak appraisal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,20 +46,20 @@ matrix:
       gemfile: gemfiles/rails_50.gemfile
 
     - rvm: 2.4.0
-      env: RAILS=3.2.22
+      gemfile: gemfiles/rails_32.gemfile
 
     - rvm: 2.4.0
-      env: RAILS=4.0.13
+      gemfile: gemfiles/rails_40.gemfile
 
     - rvm: 2.4.0
-      env: RAILS=4.1.16
+      gemfile: gemfiles/rails_41.gemfile
 
   allow_failures:
     - rvm: jruby-9.1.7.0
       gemfile: gemfiles/rails_50.gemfile
 
     - rvm: 2.4.0
-      env: RAILS=4.2.7.1
+      gemfile: gemfiles/rails_42.gemfile
 
 notifications:
   irc:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,13 @@ If your tests are passing locally but they're failing on Travis, reset your test
 rm -rf spec/rails && script/appraisal update
 ```
 
+If you find running everything through appraisal too verbose, you can also do
+`export BUNDLE_GEMFILE=gemfiles/rails_50.gemfile` and then run all commands
+directly (`bundle exec rake test`, `bundle exec rake setup`) without Appraisal.
+
+If you find issues apparently related to `bundler`, check the `.travis.yml` file
+and make sure you're using exactly the same version Travis is using.
+
 ### 4. Implement your fix or feature
 
 At this point, you're ready to make your changes! Feel free to ask for help;

--- a/Gemfile
+++ b/Gemfile
@@ -23,11 +23,6 @@ group :development do
 
   # Performance
   gem 'rack-mini-profiler'                  # Inline app profiler. See ?pp=help for options.
-  gem 'flamegraph', platforms: :mri         # Flamegraph visualiztion: ?pp=flamegraph
-
-  # Flamegraph dependency
-  gem 'stackprof', platforms: [:mri_21, :mri_22, :mri_23], require: false
-  gem 'fast_stack', platforms: [:mri_19, :mri_20], require: false
 
   # Documentation
   gem 'yard'                                # Documentation generator

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'pry'                                   # Easily debug from your console wit
 group :development do
   # Debugging
   gem 'better_errors',                      # Web UI to debug exceptions. Go to /__better_errors to access the latest one
-      platforms: [:ruby_20, :ruby_21, :ruby_22, :ruby_23]
+      platforms: [:ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24]
 
   gem 'binding_of_caller', platforms: :mri  # Retrieve the binding of a method's caller in MRI Ruby >= 1.9.2
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'appraisal'
-
 # Optional dependencies
 gem 'cancan'
 gem 'pundit'
@@ -35,6 +33,7 @@ group :development do
   gem 'yard'                                # Documentation generator
   gem 'redcarpet', platforms: :mri          # Markdown implementation (for yard)
   gem 'kramdown', platforms: :jruby         # Markdown implementation (for yard)
+  gem 'appraisal', require: false
 end
 
 group :test do

--- a/gemfiles/rails_32.gemfile
+++ b/gemfiles/rails_32.gemfile
@@ -19,9 +19,6 @@ group :development do
   gem "better_errors", :platforms => [:ruby_20, :ruby_21, :ruby_22, :ruby_23]
   gem "binding_of_caller", :platforms => :mri
   gem "rack-mini-profiler"
-  gem "flamegraph", :platforms => :mri
-  gem "stackprof", :platforms => [:mri_21, :mri_22, :mri_23], :require => false
-  gem "fast_stack", :platforms => [:mri_19, :mri_20], :require => false
   gem "yard"
   gem "redcarpet", :platforms => :mri
   gem "kramdown", :platforms => :jruby

--- a/gemfiles/rails_32.gemfile
+++ b/gemfiles/rails_32.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
 gem "cancan"
 gem "pundit"
 gem "thor", "<= 0.19.1"
@@ -26,6 +25,7 @@ group :development do
   gem "yard"
   gem "redcarpet", :platforms => :mri
   gem "kramdown", :platforms => :jruby
+  gem "appraisal", :require => false
 end
 
 group :test do

--- a/gemfiles/rails_32.gemfile
+++ b/gemfiles/rails_32.gemfile
@@ -16,7 +16,7 @@ gem "test-unit", "~> 3.0"
 gem "draper", "~> 2.1"
 
 group :development do
-  gem "better_errors", :platforms => [:ruby_20, :ruby_21, :ruby_22, :ruby_23]
+  gem "better_errors", :platforms => [:ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24]
   gem "binding_of_caller", :platforms => :mri
   gem "rack-mini-profiler"
   gem "yard"

--- a/gemfiles/rails_40.gemfile
+++ b/gemfiles/rails_40.gemfile
@@ -15,7 +15,7 @@ gem "inherited_resources"
 gem "draper", "~> 2.1"
 
 group :development do
-  gem "better_errors", :platforms => [:ruby_20, :ruby_21, :ruby_22, :ruby_23]
+  gem "better_errors", :platforms => [:ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24]
   gem "binding_of_caller", :platforms => :mri
   gem "rack-mini-profiler"
   gem "yard"

--- a/gemfiles/rails_40.gemfile
+++ b/gemfiles/rails_40.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
 gem "cancan"
 gem "pundit"
 gem "thor", "<= 0.19.1"
@@ -25,6 +24,7 @@ group :development do
   gem "yard"
   gem "redcarpet", :platforms => :mri
   gem "kramdown", :platforms => :jruby
+  gem "appraisal", :require => false
 end
 
 group :test do

--- a/gemfiles/rails_40.gemfile
+++ b/gemfiles/rails_40.gemfile
@@ -18,9 +18,6 @@ group :development do
   gem "better_errors", :platforms => [:ruby_20, :ruby_21, :ruby_22, :ruby_23]
   gem "binding_of_caller", :platforms => :mri
   gem "rack-mini-profiler"
-  gem "flamegraph", :platforms => :mri
-  gem "stackprof", :platforms => [:mri_21, :mri_22, :mri_23], :require => false
-  gem "fast_stack", :platforms => [:mri_19, :mri_20], :require => false
   gem "yard"
   gem "redcarpet", :platforms => :mri
   gem "kramdown", :platforms => :jruby

--- a/gemfiles/rails_41.gemfile
+++ b/gemfiles/rails_41.gemfile
@@ -15,7 +15,7 @@ gem "inherited_resources"
 gem "draper", "~> 2.1"
 
 group :development do
-  gem "better_errors", :platforms => [:ruby_20, :ruby_21, :ruby_22, :ruby_23]
+  gem "better_errors", :platforms => [:ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24]
   gem "binding_of_caller", :platforms => :mri
   gem "rack-mini-profiler"
   gem "yard"

--- a/gemfiles/rails_41.gemfile
+++ b/gemfiles/rails_41.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
 gem "cancan"
 gem "pundit"
 gem "thor", "<= 0.19.1"
@@ -25,6 +24,7 @@ group :development do
   gem "yard"
   gem "redcarpet", :platforms => :mri
   gem "kramdown", :platforms => :jruby
+  gem "appraisal", :require => false
 end
 
 group :test do

--- a/gemfiles/rails_41.gemfile
+++ b/gemfiles/rails_41.gemfile
@@ -18,9 +18,6 @@ group :development do
   gem "better_errors", :platforms => [:ruby_20, :ruby_21, :ruby_22, :ruby_23]
   gem "binding_of_caller", :platforms => :mri
   gem "rack-mini-profiler"
-  gem "flamegraph", :platforms => :mri
-  gem "stackprof", :platforms => [:mri_21, :mri_22, :mri_23], :require => false
-  gem "fast_stack", :platforms => [:mri_19, :mri_20], :require => false
   gem "yard"
   gem "redcarpet", :platforms => :mri
   gem "kramdown", :platforms => :jruby

--- a/gemfiles/rails_42.gemfile
+++ b/gemfiles/rails_42.gemfile
@@ -15,7 +15,7 @@ gem "inherited_resources"
 gem "draper", "~> 2.1"
 
 group :development do
-  gem "better_errors", :platforms => [:ruby_20, :ruby_21, :ruby_22, :ruby_23]
+  gem "better_errors", :platforms => [:ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24]
   gem "binding_of_caller", :platforms => :mri
   gem "rack-mini-profiler"
   gem "yard"

--- a/gemfiles/rails_42.gemfile
+++ b/gemfiles/rails_42.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
 gem "cancan"
 gem "pundit"
 gem "thor", "<= 0.19.1"
@@ -25,6 +24,7 @@ group :development do
   gem "yard"
   gem "redcarpet", :platforms => :mri
   gem "kramdown", :platforms => :jruby
+  gem "appraisal", :require => false
 end
 
 group :test do

--- a/gemfiles/rails_42.gemfile
+++ b/gemfiles/rails_42.gemfile
@@ -18,9 +18,6 @@ group :development do
   gem "better_errors", :platforms => [:ruby_20, :ruby_21, :ruby_22, :ruby_23]
   gem "binding_of_caller", :platforms => :mri
   gem "rack-mini-profiler"
-  gem "flamegraph", :platforms => :mri
-  gem "stackprof", :platforms => [:mri_21, :mri_22, :mri_23], :require => false
-  gem "fast_stack", :platforms => [:mri_19, :mri_20], :require => false
   gem "yard"
   gem "redcarpet", :platforms => :mri
   gem "kramdown", :platforms => :jruby

--- a/gemfiles/rails_50.gemfile
+++ b/gemfiles/rails_50.gemfile
@@ -15,7 +15,7 @@ gem "inherited_resources", :git => "https://github.com/activeadmin/inherited_res
 gem "draper", "> 3.x"
 
 group :development do
-  gem "better_errors", :platforms => [:ruby_20, :ruby_21, :ruby_22, :ruby_23]
+  gem "better_errors", :platforms => [:ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24]
   gem "binding_of_caller", :platforms => :mri
   gem "rack-mini-profiler"
   gem "yard"

--- a/gemfiles/rails_50.gemfile
+++ b/gemfiles/rails_50.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
 gem "cancan"
 gem "pundit"
 gem "thor", "<= 0.19.1"
@@ -25,6 +24,7 @@ group :development do
   gem "yard"
   gem "redcarpet", :platforms => :mri
   gem "kramdown", :platforms => :jruby
+  gem "appraisal", :require => false
 end
 
 group :test do

--- a/gemfiles/rails_50.gemfile
+++ b/gemfiles/rails_50.gemfile
@@ -18,9 +18,6 @@ group :development do
   gem "better_errors", :platforms => [:ruby_20, :ruby_21, :ruby_22, :ruby_23]
   gem "binding_of_caller", :platforms => :mri
   gem "rack-mini-profiler"
-  gem "flamegraph", :platforms => :mri
-  gem "stackprof", :platforms => [:mri_21, :mri_22, :mri_23], :require => false
-  gem "fast_stack", :platforms => [:mri_19, :mri_20], :require => false
   gem "yard"
   gem "redcarpet", :platforms => :mri
   gem "kramdown", :platforms => :jruby

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,33 +37,12 @@ module ActiveAdminIntegrationSpecHelper
     reload_routes!
   end
 
-  # Sets up a describe block where you can render controller
-  # actions. Uses the Admin::PostsController as the subject
-  # for the describe block
-  def describe_with_render(*args, &block)
-    describe *args do
-      include RSpec::Rails::ControllerExampleGroup
-      render_views
-      # metadata[:behaviour][:describes] = ActiveAdmin.namespaces[:admin].resources['Post'].controller
-      module_eval &block
-    end
-  end
-
   def arbre(assigns = {}, helpers = mock_action_view, &block)
     Arbre::Context.new(assigns, helpers, &block)
   end
 
   def render_arbre_component(assigns = {}, helpers = mock_action_view, &block)
     arbre(assigns, helpers, &block).children.first
-  end
-
-  # Setup a describe block which uses capybara and rails integration
-  # test methods.
-  def describe_with_capybara(*args, &block)
-    describe *args do
-      include RSpec::Rails::IntegrationExampleGroup
-      module_eval &block
-    end
   end
 
   # Returns a fake action view instance to use with our renderers


### PR DESCRIPTION
We've seen some segfaults in Travis with ruby 2.4.0 after introducing Appraisal.

They only happen when running things like Travis does it: setting the `BUNDLE_GEMFILE` environment variable and then running commands as usual. I had only tried the other way: running things directly through appraisal (`script/appraisal rails_50 rake test`, for example).

I could reproduce the segfaults locally and these changes seem to prevent them. I have no idea why tests passed in the previous PR, I guess they just happen randomly.

Let's see if Travis passes...