### PR TITLE
Apply the suffix adjustment in collection_path also to batch_action_path

### DIFF
--- a/lib/active_admin/resource/routes.rb
+++ b/lib/active_admin/resource/routes.rb
@@ -90,7 +90,7 @@ module ActiveAdmin
           suffix = options[:suffix] || "path"
           route = []
 
-          route << options[:action]           # "edit" or "new"
+          route << options[:action]           # "batch_action", "edit" or "new"
           route << resource.route_prefix      # "admin"
           route += belongs_to_names
           route << resource_path_name         # "posts" or "post"

--- a/lib/active_admin/resource/routes.rb
+++ b/lib/active_admin/resource/routes.rb
@@ -51,8 +51,11 @@ module ActiveAdmin
         end
 
         def batch_action_path(params, additional_params = {})
-          path = resource.resources_configuration[:self][:route_collection_name]
-          route_name = route_name(path, action: :batch_action)
+          route_name = route_name(
+            resource.resources_configuration[:self][:route_collection_name],
+            action: :batch_action,
+            suffix: (resource.route_uncountable? ? "index_path" : "path")
+          )
 
           query = params.slice(:q, :scope)
           query = query.permit! if query.respond_to? :permit!

--- a/spec/unit/resource/routes_spec.rb
+++ b/spec/unit/resource/routes_spec.rb
@@ -103,23 +103,39 @@ module ActiveAdmin
       end
 
       context "for batch_action handler" do
-        let! :config do
-          ActiveAdmin.register Post do
-            belongs_to :category
-          end
-        end
-
         before do
-          config.batch_actions= true
+          config.batch_actions = true
           reload_routes!
         end
 
-        it "should include :scope and :q params" do
-          params = { category_id: 1, q: { name_equals: "Any" }, scope: :all }
-          additional_params = { locale: 'en' }
-          batch_action_path = "/admin/categories/1/posts/batch_action?locale=en&q%5Bname_equals%5D=Any&scope=all"
+        context "when register a singular resource" do
 
-          expect(config.route_batch_action_path(params, additional_params)).to eq batch_action_path
+          let! :config do
+            ActiveAdmin.register Post do
+              belongs_to :category
+            end
+          end
+
+          it "should include :scope and :q params" do
+            params = { category_id: 1, q: { name_equals: "Any" }, scope: :all }
+            additional_params = { locale: 'en' }
+            batch_action_path = "/admin/categories/1/posts/batch_action?locale=en&q%5Bname_equals%5D=Any&scope=all"
+
+            expect(config.route_batch_action_path(params, additional_params)).to eq batch_action_path
+          end
+        end
+
+        context "when registering a plural resource" do
+
+          class ::News; def self.has_many(*); end end
+          let!(:config) { ActiveAdmin.register News }
+
+          it "should return the plural batch action route with _index and given params" do
+            params = { q: { name_equals: "Any" }, scope: :all }
+            additional_params = { locale: 'en' }
+            batch_action_path = "/admin/news/batch_action?locale=en&q%5Bname_equals%5D=Any&scope=all"
+            expect(config.route_batch_action_path(params, additional_params)).to eq batch_action_path
+          end
         end
       end
     end


### PR DESCRIPTION
When the resource model name were an uncountable noun like "News", the URL helper method for the batch action would be suffixed with an extra `_index` suffix.

We have confirmed that this fixes the following error you get with the current implementation when ActiveAdmin renders a batch action button:

```
Showing .../vendor/bundle/ruby/2.3.0/bundler/gems/activeadmin-6463e2b717b2/app/views/active_admin/resource/index.html.arb
where line #2 raised:

undefined method `batch_action_admin_news_path' for ActiveAdmin::Helpers::Routes:Module
Did you mean?  batch_action_admin_news_index_path
               ...
```