### PR TITLE
 resource attributes layer (refactoring)

### DIFF
--- a/features/index/format_as_csv.feature
+++ b/features/index/format_as_csv.feature
@@ -12,8 +12,8 @@ Feature: Format as CSV
     When I am on the index page for posts
     And I follow "CSV"
     And I should download a CSV file for "posts" containing:
-    | Id  | Title       | Body | Published date | Position | Starred | Created at | Updated at |
-    | \d+ | Hello World |      |              |          |         | (.*)       | (.*)       |
+    | Id  | Title       | Body | Published date | Position | Starred | Foo    |Created at | Updated at |
+    | \d+ | Hello World |      |                |          |         |        |(.*)       | (.*)       |
 
   Scenario: Default with alias
     Given a configuration of:
@@ -24,7 +24,7 @@ Feature: Format as CSV
     When I am on the index page for my_articles
     And I follow "CSV"
     And I should download a CSV file for "my-articles" containing:
-    | Id  | Title       | Body | Published date | Position | Starred | Created at | Updated at |
+    | Id  | Title       | Body | Published date | Position | Starred | Foo    | Created at | Updated at |
 
   Scenario: With CSV format customization
     Given a configuration of:

--- a/features/index/index_as_table.feature
+++ b/features/index/index_as_table.feature
@@ -250,14 +250,14 @@ Feature: Index as Table
       """
     When I am on the index page for posts
     Then I should see the "index_table_posts" table:
-      | [ ] | Id | Title        | Body | Published Date | Position | Starred | Created At | Updated At | |
-      | [ ] | 2 | Bye bye world | Move your...  |  |  | No | /.*/ | /.*/ | ViewEditDelete |
-      | [ ] | 1 | Hello World   | From the body |  |  | No | /.*/ | /.*/ | ViewEditDelete |
+      | [ ] | Id | Title        | Body | Published Date | Author | Position | Category | Starred | Foo | Created At | Updated At | |
+      | [ ] | 2 | Bye bye world | Move your...  |  |  |  |  | No |  | /.*/ | /.*/ | ViewEditDelete |
+      | [ ] | 1 | Hello World   | From the body |  |  |  |  | No |  | /.*/ | /.*/ | ViewEditDelete |
     When I follow "Id"
     Then I should see the "index_table_posts" table:
-      | [ ] | Id | Title        | Body | Published Date | Position | Starred | Created At | Updated At | |
-      | [ ] | 1 | Hello World   | From the body |  |  | No | /.*/ | /.*/ | ViewEditDelete |
-      | [ ] | 2 | Bye bye world | Move your...  |  |  | No | /.*/ | /.*/ | ViewEditDelete |
+      | [ ] | Id | Title        | Body | Published Date | Author | Position | Category | Starred | Foo | Created At | Updated At | |
+      | [ ] | 1 | Hello World   | From the body |  |  |  |  | No |  | /.*/ | /.*/ | ViewEditDelete |
+      | [ ] | 2 | Bye bye world | Move your...  |  |  |  |  | No |  | /.*/ | /.*/ | ViewEditDelete |
 
   Scenario: Sorting by a virtual column
     Given a post with the title "Hello World" exists

--- a/features/new_page.feature
+++ b/features/new_page.feature
@@ -25,7 +25,7 @@ Feature: New Page
     Then I should see "Post was successfully created."
     And I should see the attribute "Title" with "Hello World"
     And I should see the attribute "Body" with "This is the body"
-    #And I should see the attribute "Category" with "Music"
+    And I should see the attribute "Category" with "Music"
     And I should see the attribute "Author" with "John Doe"
 
   Scenario: Generating a custom form

--- a/features/step_definitions/attribute_steps.rb
+++ b/features/step_definitions/attribute_steps.rb
@@ -1,6 +1,6 @@
 Then /^I should see the attribute "([^"]*)" with "([^"]*)"$/ do |title, value|
   elems = all ".attributes_table th:contains('#{title}') ~ td:contains('#{value}')"
-  expect(elems.first).to_not eq(nil), 'attribute missing'
+  expect(elems.first).to_not eq(nil), "attribute missing"
 end
 
 Then /^I should see the attribute "([^"]*)" with a nicely formatted datetime$/ do |title|

--- a/lib/active_admin/csv_builder.rb
+++ b/lib/active_admin/csv_builder.rb
@@ -22,7 +22,7 @@ module ActiveAdmin
     def self.default_for_resource(resource)
       new resource: resource do
         column :id
-        resource.content_columns.each { |c| column c.name.to_sym }
+        resource.content_columns.each { |c| column c }
       end
     end
 
@@ -105,7 +105,7 @@ module ActiveAdmin
 
       def humanize_name(name, resource, humanize_name_option)
         if humanize_name_option
-          name.is_a?(Symbol) && resource.present? ? resource.human_attribute_name(name) : name.to_s.humanize
+          name.is_a?(Symbol) && resource ? resource.resource_class.human_attribute_name(name) : name.to_s.humanize
         else
           name.to_s
         end

--- a/lib/active_admin/filters/resource_extension.rb
+++ b/lib/active_admin/filters/resource_extension.rb
@@ -109,7 +109,7 @@ module ActiveAdmin
       def default_filters
         result = []
         result.concat default_association_filters if namespace.include_default_association_filters
-        result.concat default_content_filters
+        result.concat content_columns
         result.concat custom_ransack_filters
         result
       end
@@ -121,7 +121,7 @@ module ActiveAdmin
           []
         end
       end
-
+      
       # Returns a default set of filters for the associations
       def default_association_filters
         if resource_class.respond_to?(:reflect_on_all_associations)
@@ -132,15 +132,6 @@ module ActiveAdmin
 
           filters = poly.map(&:foreign_type) + not_poly.map(&:name)
           filters.map &:to_sym
-        else
-          []
-        end
-      end
-
-      # Returns a default set of filters for the content columns
-      def default_content_filters
-        if resource_class.respond_to? :content_columns
-          resource_class.content_columns.map{ |c| c.name.to_sym }
         else
           []
         end

--- a/lib/active_admin/namespace.rb
+++ b/lib/active_admin/namespace.rb
@@ -45,7 +45,7 @@ module ActiveAdmin
 
       # Register the resource
       register_resource_controller(config)
-      parse_registration_block(config, resource_class, &block) if block_given?
+      parse_registration_block(config, &block) if block_given?
       reset_menu!
 
       # Dispatch a registration event
@@ -218,8 +218,8 @@ module ActiveAdmin
       config.controller.active_admin_config = config
     end
 
-    def parse_registration_block(config, resource_class, &block)
-      config.dsl = ResourceDSL.new(config, resource_class)
+    def parse_registration_block(config, &block)
+      config.dsl = ResourceDSL.new(config)
       config.dsl.run_registration_block(&block)
     end
 

--- a/lib/active_admin/resource.rb
+++ b/lib/active_admin/resource.rb
@@ -1,4 +1,5 @@
 require 'active_admin/resource/action_items'
+require 'active_admin/resource/attributes'
 require 'active_admin/resource/controllers'
 require 'active_admin/resource/menu'
 require 'active_admin/resource/page_presenters'
@@ -87,6 +88,7 @@ module ActiveAdmin
     include Sidebars
     include Routes
     include Ordering
+    include Attributes
 
     # The class this resource wraps. If you register the Post model, Resource#resource_class
     # will point to the Post class
@@ -163,6 +165,22 @@ module ActiveAdmin
       (decorator_class && resource) ? decorator_class.new(resource) : resource
     end
 
+    def resource_columns
+      resource_attributes.values
+    end
+
+    def resource_attributes
+      @resource_attributes ||= default_attributes
+    end
+
+    def association_columns
+      @association_columns ||= resource_attributes.select{ |key, value| key != value }.values
+    end
+
+    def content_columns
+      @content_columns ||= resource_attributes.select{ |key, value| key == value }.values
+    end
+
     private
 
     def method_for_find(id)
@@ -174,7 +192,7 @@ module ActiveAdmin
     end
 
     def default_csv_builder
-      @default_csv_builder ||= CSVBuilder.default_for_resource(resource_class)
+      @default_csv_builder ||= CSVBuilder.default_for_resource(self)
     end
 
   end # class Resource

--- a/lib/active_admin/resource/attributes.rb
+++ b/lib/active_admin/resource/attributes.rb
@@ -1,0 +1,44 @@
+module ActiveAdmin
+
+  class Resource
+    module Attributes
+
+      def default_attributes
+        resource_class.columns.each_with_object({}) do |c, attrs|
+          unless reject_col?(c)
+            name = c.name.to_sym
+            attrs[name] = (method_for_column(name) || name)
+          end
+        end
+      end
+
+      def method_for_column(c)
+        resource_class.respond_to?(:reflect_on_all_associations) && foreign_methods.has_key?(c) && foreign_methods[c].name.to_sym
+      end
+
+      def foreign_methods
+        @foreign_methods ||= resource_class.reflect_on_all_associations.
+          select{ |r| r.macro == :belongs_to }.
+          reject{ |r| r.chain.length > 2 && !r.options[:polymorphic] }.
+          index_by{ |r| r.foreign_key.to_sym }
+      end
+
+      def reject_col?(c)
+        primary_col?(c) || sti_col?(c) || counter_cache_col?(c)
+      end
+
+      def primary_col?(c)
+        c.name == resource_class.primary_key
+      end
+
+      def sti_col?(c)
+        c.name == resource_class.inheritance_column
+      end
+
+      def counter_cache_col?(c)
+        c.name.end_with?('_count')
+      end
+
+    end
+  end
+end

--- a/lib/active_admin/resource_dsl.rb
+++ b/lib/active_admin/resource_dsl.rb
@@ -1,10 +1,6 @@
 module ActiveAdmin
   # This is the class where all the register blocks are evaluated.
   class ResourceDSL < DSL
-    def initialize(config, resource_class)
-      @resource = resource_class
-      super(config)
-    end
 
     private
 
@@ -105,7 +101,7 @@ module ActiveAdmin
     #   end
     #
     def csv(options={}, &block)
-      options[:resource] = @resource
+      options[:resource] = config
 
       config.csv_builder = CSVBuilder.new(options, &block)
     end

--- a/lib/active_admin/view_helpers/display_helper.rb
+++ b/lib/active_admin/view_helpers/display_helper.rb
@@ -55,8 +55,6 @@ module ActiveAdmin
       def find_value(resource, attr)
         if attr.is_a? Proc
           attr.call resource
-        elsif attr =~ /\A(.+)_id\z/ && reflection_for(resource, $1.to_sym)
-          resource.public_send $1
         elsif resource.respond_to? attr
           resource.public_send attr
         elsif resource.respond_to? :[]
@@ -79,11 +77,6 @@ module ActiveAdmin
             display_name object
           end
         end
-      end
-
-      def reflection_for(resource, method)
-        klass = resource.class
-        klass.reflect_on_association method if klass.respond_to? :reflect_on_association
       end
 
       def boolean_attr?(resource, attr)

--- a/lib/active_admin/views/index_as_table.rb
+++ b/lib/active_admin/views/index_as_table.rb
@@ -233,8 +233,8 @@ module ActiveAdmin
         proc do
           selectable_column
           id_column if resource_class.primary_key
-          resource_class.content_columns.each do |col|
-            column col.name.to_sym
+          active_admin_config.resource_columns.each do |attribute|
+            column attribute
           end
           actions
         end

--- a/lib/active_admin/views/pages/show.rb
+++ b/lib/active_admin/views/pages/show.rb
@@ -49,7 +49,7 @@ module ActiveAdmin
           end
 
           def default_attribute_table_rows
-            resource.class.columns.collect{|column| column.name.to_sym }
+            active_admin_config.resource_columns
           end
         end
 

--- a/spec/unit/csv_builder_spec.rb
+++ b/spec/unit/csv_builder_spec.rb
@@ -5,7 +5,10 @@ require 'rails_helper'
 RSpec.describe ActiveAdmin::CSVBuilder do
 
   describe '.default_for_resource using Post' do
-    let(:csv_builder) { ActiveAdmin::CSVBuilder.default_for_resource(Post).tap(&:exec_columns) }
+    let(:application){ ActiveAdmin::Application.new }
+    let(:namespace){ ActiveAdmin::Namespace.new(application, :admin) }
+    let(:resource){ ActiveAdmin::Resource.new(namespace, Post, {}) }
+    let(:csv_builder) { ActiveAdmin::CSVBuilder.default_for_resource(resource).tap(&:exec_columns) }
 
     it 'returns a default csv_builder for Post' do
       expect(csv_builder).to be_a(ActiveAdmin::CSVBuilder)
@@ -18,8 +21,8 @@ RSpec.describe ActiveAdmin::CSVBuilder do
 
     it "has Post's content_columns" do
       csv_builder.columns[1..-1].each_with_index do |column, index|
-        expect(column.name).to eq Post.content_columns[index].name.humanize
-        expect(column.data).to eq Post.content_columns[index].name.to_sym
+        expect(column.name).to eq resource.content_columns[index].to_s.humanize
+        expect(column.data).to eq resource.content_columns[index]
       end
     end
 
@@ -32,7 +35,7 @@ RSpec.describe ActiveAdmin::CSVBuilder do
       end
 
       it 'gets name from I18n' do
-        title_index = Post.content_columns.map(&:name).index('title') + 1 # First col is always id
+        title_index =  resource.content_columns.index(:title) + 1 # First col is always id
         expect(csv_builder.columns[title_index].name).to eq localized_name
       end
     end

--- a/spec/unit/filters/resource_spec.rb
+++ b/spec/unit/filters/resource_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ActiveAdmin::Filters::ResourceExtension do
 
   it "should return the defaults if no filters are set" do
     expect(resource.filters.keys).to match_array([
-      :author, :body, :category, :created_at, :custom_created_at_searcher, :custom_title_searcher, :custom_searcher_numeric, :position, :published_date, :starred, :taggings, :title, :updated_at
+      :author, :body, :category, :created_at, :custom_created_at_searcher, :custom_title_searcher, :custom_searcher_numeric, :position, :published_date, :starred, :taggings, :title, :updated_at, :foo_id
     ])
   end
 
@@ -35,7 +35,7 @@ RSpec.describe ActiveAdmin::Filters::ResourceExtension do
   it "should return the defaults without associations if default association filters are disabled on the namespace" do
     resource.namespace.include_default_association_filters = false
     expect(resource.filters.keys).to match_array([
-      :body, :created_at, :custom_created_at_searcher, :custom_title_searcher, :custom_searcher_numeric, :position, :published_date, :starred, :title, :updated_at
+      :body, :created_at, :custom_created_at_searcher, :custom_title_searcher, :custom_searcher_numeric, :position, :published_date, :starred, :title, :updated_at, :foo_id
     ])
   end
 
@@ -104,8 +104,7 @@ RSpec.describe ActiveAdmin::Filters::ResourceExtension do
       resource.add_filter :count, as: :string
 
       expect(resource.filters.keys).to match_array([
-        :author, :body, :category, :count, :created_at, :custom_created_at_searcher, :custom_title_searcher, :custom_searcher_numeric, :position, :published_date, :starred, :taggings, :title, :updated_at
-
+        :author, :body, :category, :count, :created_at, :custom_created_at_searcher, :custom_title_searcher, :custom_searcher_numeric, :position, :published_date, :starred, :taggings, :title, :updated_at, :foo_id
       ])
     end
 

--- a/spec/unit/resource/attributes_spec.rb
+++ b/spec/unit/resource/attributes_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+module ActiveAdmin
+  RSpec.describe Resource, "Attributes" do
+    let(:application) { ActiveAdmin::Application.new }
+    let(:namespace) { ActiveAdmin::Namespace.new application, :admin }
+    let(:resource_config) { ActiveAdmin::Resource.new namespace, Post }
+
+    describe "#resource_attributes" do
+      subject do
+        resource_config.resource_attributes
+      end
+
+      it 'should return attributes hash' do
+        expect(subject).to eq( author_id: :author,
+                               body: :body,
+                               created_at: :created_at,
+                               custom_category_id: :category,
+                               foo_id: :foo_id,
+                               position: :position,
+                               published_date: :published_date,
+                               starred: :starred,
+                               title: :title,
+                               updated_at: :updated_at)
+      end
+    end
+
+    describe "#association_columns" do
+      subject do
+        resource_config.association_columns
+      end
+
+      it 'should return associations' do
+        expect(subject).to eq([:author, :category])
+      end
+    end
+
+    describe "#content_columns" do
+      subject do
+        resource_config.content_columns
+      end
+
+      it 'should return columns without associations' do
+        expect(subject).to eq([:title, :body, :published_date, :position, :starred, :foo_id, :created_at, :updated_at])
+      end
+    end
+
+  end
+end
+

--- a/spec/unit/resource/includes_spec.rb
+++ b/spec/unit/resource/includes_spec.rb
@@ -7,7 +7,7 @@ module ActiveAdmin
       let(:application) { ActiveAdmin::Application.new }
       let(:namespace) { ActiveAdmin::Namespace.new application, :admin }
       let(:resource_config) { ActiveAdmin::Resource.new namespace, Post }
-      let(:dsl){ ActiveAdmin::ResourceDSL.new(resource_config, Post) }
+      let(:dsl){ ActiveAdmin::ResourceDSL.new(resource_config) }
 
       it "should register the includes in the config" do
         dsl.run_registration_block do

--- a/spec/unit/resource/ordering_spec.rb
+++ b/spec/unit/resource/ordering_spec.rb
@@ -7,7 +7,7 @@ module ActiveAdmin
       let(:application) { ActiveAdmin::Application.new }
       let(:namespace) { ActiveAdmin::Namespace.new application, :admin }
       let(:resource_config) { ActiveAdmin::Resource.new namespace, Post }
-      let(:dsl){ ActiveAdmin::ResourceDSL.new(resource_config, Post) }
+      let(:dsl){ ActiveAdmin::ResourceDSL.new(resource_config) }
 
       it "should register the ordering in the config" do
         dsl.run_registration_block do

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -197,7 +197,7 @@ module ActiveAdmin
     describe "#csv_builder" do
       context "when no csv builder set" do
         it "should return a default column builder with id and content columns" do
-          expect(config.csv_builder.exec_columns.size).to eq Category.content_columns.size + 1
+          expect(config.csv_builder.exec_columns.size).to eq @config.content_columns.size + 1
         end
       end
 
@@ -291,7 +291,7 @@ module ActiveAdmin
           end
         end.new
       }
-      let(:resource) { ActiveAdmin::ResourceDSL.new(double, double) }
+      let(:resource) { ActiveAdmin::ResourceDSL.new(double) }
 
       before do
         expect(resource).to receive(:controller).and_return(controller)

--- a/spec/unit/view_helpers/display_helper_spec.rb
+++ b/spec/unit/view_helpers/display_helper_spec.rb
@@ -151,10 +151,10 @@ RSpec.describe ActiveAdmin::ViewHelpers::DisplayHelper do
       expect(value).to eq :right
     end
 
-    it 'auto-links ActiveRecord records from foreign keys' do
+    it 'auto-links ActiveRecord records by association' do
       post = Post.create! author: User.new
 
-      value = format_attribute post, :author_id
+      value = format_attribute post, :author
 
       expect(value).to match /<a href="\/admin\/users\/\d+"> <\/a>/
     end

--- a/spec/unit/views/components/attributes_table_spec.rb
+++ b/spec/unit/views/components/attributes_table_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe ActiveAdmin::Views::AttributesTable do
       end
       it 'should call the association if one exists' do
         table = render_arbre_component assigns do
-          attributes_table_for post, :author_id
+          attributes_table_for post, :author
         end
         expect(table.find_by_tag('th').first.content).to eq 'Author'
         expect(table.find_by_tag('td').first.content).to eq 'John Doe'

--- a/spec/unit/views/pages/show_spec.rb
+++ b/spec/unit/views/pages/show_spec.rb
@@ -17,10 +17,9 @@ RSpec.describe ActiveAdmin::Views::Pages::Show do
 
     context 'when you pass a block to main content' do
       let(:block) { lambda { } }
-      let(:resource_class) { double(columns: [double('column', name: 'field')]) }
-      let(:resource) { double('resource', class: resource_class) }
+      let(:resource) { double('resource') }
 
-      before { allow(page).to receive(:active_admin_config).and_return(double(comments?: false))}
+      before { allow(page).to receive(:active_admin_config).and_return(double(comments?: false, resource_columns: [:field]))}
 
       it 'appends it to the output' do
         expect(page).to receive(:attributes_table).with(:field).and_yield


### PR DESCRIPTION
introducing correct handling foreign keys attributes on resource level.

Problems:

https://github.com/activeadmin/activeadmin/issues/4298#issuecomment-185467400 content_columns hardcoded in many places 


https://github.com/activeadmin/activeadmin/commit/f21cff30e7212706a39710e2c70ad0af8087ccea see Notes to commit message, example when renaming foreign key affects default show content


https://github.com/activeadmin/activeadmin/issues/4298#issuecomment-185849747  ActiveAdmin can't figure out if column is foreign key or not

https://github.com/activeadmin/activeadmin/commit/3efb359533df46e76bb4355a02ad31e727fb0da3#diff-b2d41db115eac24dba6f5e64bda8a690R53 introduced reflection parsing for each find_value method call because we still not know if this foreign key or not.


Idea is to initialise attributes for each resource and skip heavy magic in runtime 

@timoschilling , @varyonic ,  @deivid-rodriguez  before continue working on this, I would like to have feedback

 


