### PR TITLE
Add filter for text_input to render text_area field

### DIFF
--- a/lib/active_admin/inputs.rb
+++ b/lib/active_admin/inputs.rb
@@ -9,6 +9,7 @@ module ActiveAdmin
 
       autoload :Base
       autoload :StringInput
+      autoload :TextInput
       autoload :DatePickerInput
       autoload :DateRangeInput
       autoload :NumericInput

--- a/lib/active_admin/inputs/filters/text_input.rb
+++ b/lib/active_admin/inputs/filters/text_input.rb
@@ -1,0 +1,26 @@
+module ActiveAdmin
+  module Inputs
+    module Filters
+      class TextInput < ::Formtastic::Inputs::TextInput
+        include Base
+        include Base::SearchMethodSelect
+
+        def input_html_options
+          {
+            :cols => builder.default_text_area_width,
+            :rows => builder.default_text_area_height
+          }.merge(super)
+        end
+
+        def to_html
+          input_wrapping do
+            label_html <<
+            builder.text_area(method, input_html_options)
+          end
+        end
+
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
As loosely referred to in #4100 this pull request provides a proper rendering of a text area for filters. The current unit tests for a `:text` type pass and I'm not sure what would be reasonable tests to include with this particular addition.