### PR TITLE
Call method on helpers instead of dispatching through method_missing

### DIFF
--- a/lib/active_admin/views/components/active_admin_form.rb
+++ b/lib/active_admin/views/components/active_admin_form.rb
@@ -27,7 +27,7 @@ module ActiveAdmin
         @resource = resource
         options = options.deep_dup
         options[:builder] ||= ActiveAdmin::FormBuilder
-        form_string = semantic_form_for(resource, options) do |f|
+        form_string = helpers.semantic_form_for(resource, options) do |f|
           @form_builder = f
         end
 

--- a/lib/active_admin/views/components/attributes_table.rb
+++ b/lib/active_admin/views/components/attributes_table.rb
@@ -79,7 +79,7 @@ module ActiveAdmin
       end
 
       def content_for(record, attr)
-        value = format_attribute record, attr
+        value = helpers.format_attribute record, attr
         value.blank? && current_arbre_element.children.to_s.empty? ? empty_value : value
         # Don't add the same Arbre twice, while still allowing format_attribute to call status_tag
         current_arbre_element << value unless current_arbre_element.children.include? value

--- a/lib/active_admin/views/components/site_title.rb
+++ b/lib/active_admin/views/components/site_title.rb
@@ -41,11 +41,11 @@ module ActiveAdmin
       end
 
       def title_text
-        helpers.render_or_call_method_or_proc_on(self, @namespace.site_title)
+        helpers.render_or_call_method_or_proc_on(helpers, @namespace.site_title)
       end
 
       def title_image
-        path = helpers.render_or_call_method_or_proc_on(self, @namespace.site_title_image)
+        path = helpers.render_or_call_method_or_proc_on(helpers, @namespace.site_title_image)
         helpers.image_tag(path, id: "site_title_image", alt: title_text)
       end
 

--- a/lib/active_admin/views/components/table_for.rb
+++ b/lib/active_admin/views/components/table_for.rb
@@ -85,7 +85,7 @@ module ActiveAdmin
         @tbody = tbody do
           # Build enough rows for our collection
           @collection.each do |elem|
-            classes = [cycle('odd', 'even')]
+            classes = [helpers.cycle('odd', 'even')]
 
             if @row_class
               classes << @row_class.call(elem)
@@ -98,7 +98,7 @@ module ActiveAdmin
 
       def build_table_cell(col, resource)
         td class: col.html_class do
-          html = format_attribute(resource, col.data)
+          html = helpers.format_attribute(resource, col.data)
           # Don't add the same Arbre twice, while still allowing format_attribute to call status_tag
           current_arbre_element << html unless current_arbre_element.children.include? html
         end

--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -12,6 +12,8 @@ module ActiveAdmin
 
         private
 
+        delegate :active_admin_config, :controller, :params, to: :helpers
+
         def add_classes_to_body
           @body.add_class(params[:action])
           @body.add_class(params[:controller].tr('/', '_'))

--- a/lib/active_admin/views/pages/form.rb
+++ b/lib/active_admin/views/pages/form.rb
@@ -6,7 +6,7 @@ module ActiveAdmin
 
         def title
           if form_presenter[:title]
-            render_or_call_method_or_proc_on(resource, form_presenter[:title])
+            helpers.render_or_call_method_or_proc_on(resource, form_presenter[:title])
           else
             assigns[:page_title] || ActiveAdmin::Localizers.resource(active_admin_config).t("#{normalized_action}_model")
           end


### PR DESCRIPTION
Call method on helpers instead of dispatching through Arbre::Element#method_missing.