### PR TITLE
search options overriding for numeric and string filters (specs and docs)

### DIFF
--- a/docs/3-index-pages.md
+++ b/docs/3-index-pages.md
@@ -100,6 +100,12 @@ the collection as a proc to be called at render time.
 filter :author, as: :check_boxes, collection: proc { Author.all }
 ```
 
+To override options for string or numeric filter pass `filters` option.
+
+```ruby
+  filter :title, filters: [:starts_with, :ends_with]
+```
+
 Also, if you don't need the select with the options 'contains', 'equals', 'starts_with' or 'ends_with'
 just add the option to the filter name with an underscore.
 

--- a/spec/unit/filters/filter_form_builder_spec.rb
+++ b/spec/unit/filters/filter_form_builder_spec.rb
@@ -96,6 +96,19 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
       expect(body).to have_selector("option[value=title_starts_with][selected=selected]", text: "Starts with")
     end
 
+    context "with filters options" do
+      let(:body) { Capybara.string(filter :title, filters: [:contains, :starts_with]) }
+
+      it "should generate provided options for filter select" do
+        expect(body).to have_selector("option[value=title_contains]", text: "Contains")
+        expect(body).to have_selector("option[value=title_starts_with]", text: "Starts with")
+      end
+
+      it "should not generate a select option for ends with" do
+        expect(body).not_to have_selector("option[value=title_ends_with]")
+      end
+    end
+
     context "with predicate" do
       %w[eq equals cont contains start starts_with end ends_with].each do |predicate|
         describe "'#{predicate}'" do
@@ -176,24 +189,39 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
   end
 
   describe "integer attribute" do
-    let(:body) { Capybara.string(filter :id) }
+    context "without options" do
+      let(:body) { Capybara.string(filter :id) }
 
-    it "should generate a select option for equal to" do
-      expect(body).to have_selector("option[value=id_equals]", text: "Equals")
+      it "should generate a select option for equal to" do
+        expect(body).to have_selector("option[value=id_equals]", text: "Equals")
+      end
+      it "should generate a select option for greater than" do
+        expect(body).to have_selector("option[value=id_greater_than]", text: "Greater than")
+      end
+      it "should generate a select option for less than" do
+        expect(body).to have_selector("option[value=id_less_than]", text: "Less than")
+      end
+      it "should generate a text field for input" do
+        expect(body).to have_selector("input[name='q[id_equals]']")
+      end
+      it "should select the option which is currently being filtered" do
+        scope = Post.search id_greater_than: 1
+        body = Capybara.string(render_filter scope, id: {})
+        expect(body).to have_selector("option[value=id_greater_than][selected=selected]", text: "Greater than")
+      end
     end
-    it "should generate a select option for greater than" do
-      expect(body).to have_selector("option", text: "Greater than")
-    end
-    it "should generate a select option for less than" do
-      expect(body).to have_selector("option", text: "Less than")
-    end
-    it "should generate a text field for input" do
-      expect(body).to have_selector("input[name='q[id_equals]']")
-    end
-    it "should select the option which is currently being filtered" do
-      scope = Post.search id_greater_than: 1
-      body = Capybara.string(render_filter scope, id: {})
-      expect(body).to have_selector("option[value=id_greater_than][selected=selected]", text: "Greater than")
+
+    context "with filters options" do
+      let(:body) { Capybara.string(filter :id, filters: [:equals, :greater_than]) }
+
+      it "should generate provided options for filter select" do
+        expect(body).to have_selector("option[value=id_equals]", text: "Equals")
+        expect(body).to have_selector("option[value=id_greater_than]", text: "Greater than")
+      end
+
+      it "should not generate a select option for less than" do
+        expect(body).not_to have_selector("option[value=id_less_than]")
+      end
     end
   end
 


### PR DESCRIPTION
closes #4800