### PR TITLE
Don't trigger double CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ sudo: false
 
 bundler_args: --without development
 
+branches:
+  only:
+    - master
+
 cache: bundler
 
 before_install:


### PR DESCRIPTION
I added this change in another PR, but was told "don't do this". Opening a separate PR for discussion.

As you can see in the status checks of other PR's of mine, there's two separate Travis checks: `continuous-integration/travis-ci/pr` and `continuous-integration/travis-ci/push`. One is triggered every time you push to a branch in the `activeadmin` repository, the other one is triggered every time you update a PR. I see no point on doing this. It slows down Travis builds and it's confusing to have duplicate Travis checks in our PR's. Note that if you work on your personal fork you don't experience this, since you are not pushing to a branch in `activeadmin`'s repository, so you get a single build for the PR.

@timoschilling Could you explain why we shouldn't do this?