### PR TITLE
Leftover order dependent failures

### DIFF
--- a/lib/active_admin/namespace.rb
+++ b/lib/active_admin/namespace.rb
@@ -194,7 +194,7 @@ module ActiveAdmin
       resources.each do |resource|
         parent = (module_name || 'Object').constantize
         name   = resource.controller_name.split('::').last
-        parent.send(:remove_const, name) if parent.const_defined? name
+        parent.send(:remove_const, name) if parent.const_defined?(name, false)
 
         # Remove circular references
         resource.controller.active_admin_config = nil

--- a/spec/unit/auto_link_spec.rb
+++ b/spec/unit/auto_link_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe "auto linking resources", type: :view do
   include ActiveAdmin::ViewHelpers::DisplayHelper
   include MethodOrProcHelper
 
-  let(:active_admin_config)   { double namespace: namespace }
   let(:active_admin_namespace){ ActiveAdmin.application.namespace(:admin) }
   let(:post){ Post.create! title: "Hello World" }
 

--- a/spec/unit/namespace/register_resource_spec.rb
+++ b/spec/unit/namespace/register_resource_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe ActiveAdmin::Namespace, "registering a resource" do
   let(:namespace){ ActiveAdmin::Namespace.new(application, :admin) }
   let(:menu){ namespace.fetch_menu(:default) }
 
+  after { namespace.unload! }
+
   context "with no configuration" do
     before do
       namespace.register Category

--- a/spec/unit/namespace_spec.rb
+++ b/spec/unit/namespace_spec.rb
@@ -24,6 +24,24 @@ RSpec.describe ActiveAdmin::Namespace do
     end
   end # context "when new"
 
+  describe "#unload!" do
+    context "when controller is only defined without a namespace" do
+      before do
+        ActiveAdmin.register Post, namespace: false
+
+        # To prevent unload! from unregistering ::PostsController
+        ActiveAdmin.application.namespaces.instance_variable_get(:@namespaces).delete(:root)
+
+        # To force Admin::PostsController to not be there
+        Admin.send(:remove_const, 'PostsController')
+      end
+
+      it "should not crash" do
+        expect { ActiveAdmin.unload! }.not_to raise_error
+      end
+    end
+  end
+
   describe "settings" do
     let(:namespace){ ActiveAdmin::Namespace.new(application, :admin) }
 

--- a/spec/unit/resource/routes_spec.rb
+++ b/spec/unit/resource/routes_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe ActiveAdmin::Resource::Routes do
     let!(:config) { ActiveAdmin.register Category, namespace: false }
 
     after(:each) do
+      application.namespace(:root).unload!
       application.namespaces.instance_variable_get(:@namespaces).delete(:root)
     end
 


### PR DESCRIPTION
Fixes the build failure in #4823. Fixing that triggered another order dependent failure that happened to be an actual bug in `ActiveAdmin`. It's a very pathological bug very unlikely to happen on any sane real application, but it doesn't hurt to fix it.