### PR TITLE
fixes #2349, added option to read parent object when belongs_to

### DIFF
--- a/lib/active_admin/resource/belongs_to.rb
+++ b/lib/active_admin/resource/belongs_to.rb
@@ -13,9 +13,12 @@ module ActiveAdmin
 
       # The resource which initiated this relationship
       attr_reader :owner
+      # method_name to access parent object
+      attr_reader :method_name
 
       def initialize(owner, target_name, options = {})
         @owner, @target_name, @options = owner, target_name, options
+        @method_name = @options.delete(:method_name)
       end
 
       # Returns the target resource class or raises an exception if it doesn't exist
@@ -38,6 +41,10 @@ module ActiveAdmin
 
       def required?
         !optional?
+      end
+
+      def method_name
+        @method_name || @target_name
       end
 
       def to_param

--- a/lib/active_admin/resource/routes.rb
+++ b/lib/active_admin/resource/routes.rb
@@ -107,7 +107,7 @@ module ActiveAdmin
         # @return params to pass to instance path
         def route_instance_params(instance)
           if nested?
-            [instance.public_send(belongs_to_name).to_param, instance.to_param]
+            [instance.public_send(belongs_to_method).to_param, instance.to_param]
           else
             instance.to_param
           end
@@ -125,6 +125,10 @@ module ActiveAdmin
 
         def belongs_to_name
           resource.belongs_to_config.target.resource_name.singular if nested?
+        end
+
+        def belongs_to_method
+          resource.belongs_to_config.method_name if nested?
         end
 
         def routes

--- a/spec/unit/auto_link_spec.rb
+++ b/spec/unit/auto_link_spec.rb
@@ -90,4 +90,23 @@ RSpec.describe "auto linking resources", type: :view do
       end
     end
   end
+
+  context "when the resource is registered with belongs_to with different target" do
+
+    let(:post){ Post.create! title: "Hello World" , author: User.create!}
+    before do
+      load_resources do
+        active_admin_namespace.register User
+        active_admin_namespace.register Post do
+          belongs_to :user , method_name: :author  # ActiveRecord's Post belongs_to :author though
+        end
+      end
+    end
+    it "should return the display name of the object" do
+      expect(self).to receive(:url_options).and_return(locale: 'en')
+      expect(auto_link(post)).to \
+          match(%r{<a href="/admin/users/\d+/posts/\d+\?locale=en">Hello World</a>})
+    end
+
+  end
 end


### PR DESCRIPTION
AA auto_link method was designed to build links by object automatically,
however in many cases this was inpossible because on activerecord side belongs_to has different options.
For instance

```
class Post < ActiveRecord::Base
  belongs_to :author, class_name: 'User'
end
```

Then

```
 ActiveAdmin.register User
 ActiveAdmin.register Post { belongs_to :user }
```

breaks almost everything  because ActiveAdmin::Router calls post.user instead post.author for reading parent

accidentally activeadmin declares this case as supported for ages (take a look at features/belongs_to.feature)

To support this we can add just one more option to our belongs_to configuration

```
 ActiveAdmin.register Post { belongs_to :user, method_name: :author }
```