### PR TITLE
[WIP] improve optional belongs_to routes 

### DIFF
--- a/lib/active_admin/resource/menu.rb
+++ b/lib/active_admin/resource/menu.rb
@@ -26,7 +26,8 @@ module ActiveAdmin
         {
           id: resource_name.plural,
           label: proc{ resource.plural_resource_label },
-          url:   proc{ resource.route_collection_path(params, url_options) },
+          # menu url should be params independent
+          url:   proc{ resource.route_collection_path({}, url_options) },
           if:    proc{ authorized?(Auth::READ, menu_resource_class) }
         }
       end

--- a/spec/unit/resource/routes_spec.rb
+++ b/spec/unit/resource/routes_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe ActiveAdmin::Resource::Routes do
 
       shared_examples :valid_batch_action_path do
         it "should include :scope and :q params" do
-          params = { category_id: 1, q: { name_equals: "Any" }, scope: :all }
+          params = ::ActionController::Parameters.new({ category_id: 1, q: { name_equals: "Any" }, scope: :all })
           additional_params = { locale: 'en' }
           batch_action_path = "/admin/categories/1/posts/batch_action?locale=en&q%5Bname_equals%5D=Any&scope=all"
 
@@ -158,7 +158,7 @@ RSpec.describe ActiveAdmin::Resource::Routes do
       let(:config) { ActiveAdmin.register News }
 
       it "should return the plural batch action route with _index and given params" do
-        params = { q: { name_equals: "Any" }, scope: :all }
+        params = ::ActionController::Parameters.new({ q: { name_equals: "Any" }, scope: :all })
         additional_params = { locale: 'en' }
         batch_action_path = "/admin/news/batch_action?locale=en&q%5Bname_equals%5D=Any&scope=all"
         expect(config.route_batch_action_path(params, additional_params)).to eq batch_action_path


### PR DESCRIPTION
- [x] added failing specs for optional belongs_to routes
- [x] fix  optional belongs_to routes 
- [ ] form/member/collection actions and should keep optional belongs_to

 closes #3801


upd:
this changes are about supporting optional belong_to for collection_path and batch_action_path. 
now route_name is ignoring parent param if it is optional and always submit filters and batch actions forms to resource without parent. 
