### PR TITLE
Drop ruby 2.0 support

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -5,8 +5,6 @@ appraise 'rails_40' do
   gem 'jquery-ui-rails', '~> 5.0'
   gem 'devise', '~> 3.5'
 
-  gem 'inherited_resources'
-
   gem 'draper', '~> 2.1'
 
   gem 'activerecord-jdbcsqlite3-adapter', platforms: :jruby
@@ -18,8 +16,6 @@ appraise 'rails_41' do
   gem 'rails', '4.1.16'
   gem 'jquery-ui-rails', '~> 5.0'
   gem 'devise', '~> 3.5'
-
-  gem 'inherited_resources'
 
   gem 'draper', '~> 2.1'
 
@@ -33,8 +29,6 @@ appraise 'rails_42' do
   gem 'jquery-ui-rails', '~> 5.0'
   gem 'devise', '~> 3.5'
 
-  gem 'inherited_resources'
-
   gem 'draper', '~> 2.1'
 
   gem 'activerecord-jdbcsqlite3-adapter', platforms: :jruby
@@ -46,9 +40,6 @@ appraise 'rails_50' do
   gem 'rails', '5.0.2'
   gem 'jquery-ui-rails', '~> 5.0'
   gem 'devise', '> 4.x'
-
-  # Note: when updating this list, be sure to also update the README
-  gem 'inherited_resources', git: 'https://github.com/activeadmin/inherited_resources'
 
   gem 'draper', '> 3.x'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Iconic has been removed [#3553][] by [@timoschilling][]
 * `config.show_comments_in_menu` has been removed, see `config.comments_menu` [#4187][] by [@drn][]
 * Rails 3.2 & Ruby 1.9.3 support has been dropped [#4848][] [@deivid-rodriguez][]
+* Ruby 2.0.0 support has been dropped [#4851][] [@deivid-rodriguez][]
 
 ### Enhancements
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,6 @@ Tool                  | Description
 [Arbre]: https://github.com/activeadmin/arbre
 [Devise]: https://github.com/plataformatec/devise
 [Formtastic]: https://github.com/justinfrench/formtastic
-[Inherited Resources]: https://github.com/josevalim/inherited_resources
+[Inherited Resources]: https://github.com/activeadmin/inherited_resources
 [Kaminari]: https://github.com/kaminari/kaminari
 [Ransack]: https://github.com/activerecord-hackery/ransack

--- a/README.md
+++ b/README.md
@@ -27,14 +27,6 @@ gem 'activeadmin', '~> 1.0.0.pre5'
 
 *Keep in mind that during the time where we use `pre`-release label, things can break in each release!*
 
-### Rails 5
-
-Active Admin master has preliminary support for Rails 5. To give it a try, these Gemfile changes may be needed:
-
-```ruby
-gem 'inherited_resources', git: 'https://github.com/activeadmin/inherited_resources'
-```
-
 ### 0.6.x
 
 The plan is to follow [semantic versioning](http://semver.org/) as of 1.0.0. The 0.6.x line will

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'coffee-rails'
   s.add_dependency 'formtastic',          '~> 3.1'
   s.add_dependency 'formtastic_i18n'
-  s.add_dependency 'inherited_resources', '~> 1.6'
+  s.add_dependency 'inherited_resources', '~> 1.7'
   s.add_dependency 'jquery-rails'
   s.add_dependency 'jquery-ui-rails'
   s.add_dependency 'kaminari',            '>= 0.15', '< 2.0'

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.test_files    = `git ls-files -- {spec,features}/*`.split("\n")
 
-  s.required_ruby_version = '>= 2.0'
+  s.required_ruby_version = '>= 2.1'
 
   s.add_dependency 'arbre',               '~> 1.0', '>= 1.0.2'
   s.add_dependency 'bourbon'

--- a/docs/14-gotchas.md
+++ b/docs/14-gotchas.md
@@ -101,7 +101,7 @@ YourModel.solr_search
 
 ### Rails 5 scaffold generators
 
-Active Admin requires the `inherited_resources` gem which may break scaffolding under Rails 5 as it replaces the default scaffold generator. The solution is to configure the default controller in `config/application.rb` as outlined in [josevalim/inherited_resources#195](https://github.com/josevalim/inherited_resources/issues/195)
+Active Admin requires the `inherited_resources` gem which may break scaffolding under Rails 5 as it replaces the default scaffold generator. The solution is to configure the default controller in `config/application.rb` as outlined in [activeadmin/inherited_resources#195](https://github.com/activeadmin/inherited_resources/issues/195)
 
 ```
 module SampleApp

--- a/docs/2-resource-customization.md
+++ b/docs/2-resource-customization.md
@@ -313,8 +313,8 @@ end
 
 ## Customizing resource retrieval
 
-Our controllers are built on [Inherited Resources](https://github.com/josevalim/inherited_resources),
-so you can use [all of its features](https://github.com/josevalim/inherited_resources#overwriting-defaults).
+Our controllers are built on [Inherited Resources](https://github.com/activeadmin/inherited_resources),
+so you can use [all of its features](https://github.com/activeadmin/inherited_resources#overwriting-defaults).
 
 If you need to customize the collection properties, you can overwrite the `scoped_collection` method.
 

--- a/gemfiles/rails_40.gemfile
+++ b/gemfiles/rails_40.gemfile
@@ -10,7 +10,6 @@ gem "pry"
 gem "rails", "4.0.13"
 gem "jquery-ui-rails", "~> 5.0"
 gem "devise", "~> 3.5"
-gem "inherited_resources"
 gem "draper", "~> 2.1"
 gem "activerecord-jdbcsqlite3-adapter", :platforms => :jruby
 

--- a/gemfiles/rails_41.gemfile
+++ b/gemfiles/rails_41.gemfile
@@ -10,7 +10,6 @@ gem "pry"
 gem "rails", "4.1.16"
 gem "jquery-ui-rails", "~> 5.0"
 gem "devise", "~> 3.5"
-gem "inherited_resources"
 gem "draper", "~> 2.1"
 gem "activerecord-jdbcsqlite3-adapter", :platforms => :jruby
 

--- a/gemfiles/rails_42.gemfile
+++ b/gemfiles/rails_42.gemfile
@@ -10,7 +10,6 @@ gem "pry"
 gem "rails", "4.2.8"
 gem "jquery-ui-rails", "~> 5.0"
 gem "devise", "~> 3.5"
-gem "inherited_resources"
 gem "draper", "~> 2.1"
 gem "activerecord-jdbcsqlite3-adapter", :platforms => :jruby
 

--- a/gemfiles/rails_50.gemfile
+++ b/gemfiles/rails_50.gemfile
@@ -10,7 +10,6 @@ gem "pry"
 gem "rails", "5.0.2"
 gem "jquery-ui-rails", "~> 5.0"
 gem "devise", "> 4.x"
-gem "inherited_resources", :git => "https://github.com/activeadmin/inherited_resources"
 gem "draper", "> 3.x"
 gem "activerecord-jdbcsqlite3-adapter", :git => "https://github.com/jruby/activerecord-jdbc-adapter", :branch => "rails-5", :platforms => :jruby
 

--- a/lib/bug_report_templates/rails_5_master.rb
+++ b/lib/bug_report_templates/rails_5_master.rb
@@ -21,8 +21,6 @@ gemfile(true) do
   else
     gem 'activeadmin', git: 'https://github.com/activeadmin/activeadmin', require: false
   end
-
-  gem 'inherited_resources', '~> 1.7', require: false
 end
 
 # prepare active_record database

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -143,7 +143,6 @@ RUBY
 
 # Add our local Active Admin to the application
 gem 'activeadmin', path: '../..'
-gem 'inherited_resources', git: 'https://github.com/activeadmin/inherited_resources'
 gem 'devise'
 
 run 'bundle install'


### PR DESCRIPTION
* Gets in sync `inherited_resources` & `activeadmin`'s ruby version support (ruby 2.1 at least).
* Bumps minimum inherited_resources version to the latest `1.7` (first one supporting `Rails 5`).
* Remove all places where `inherited_resources` from master is installed. The default `1.7` should now just work everywhere.