### PR TITLE
Two-column layout to better utilize screen space

### DIFF
--- a/app/assets/stylesheets/active_admin/_forms.scss
+++ b/app/assets/stylesheets/active_admin/_forms.scss
@@ -332,3 +332,22 @@ form.filter_form {
   a.clear_filters_btn { @include light-button; }
 }
 
+@media only screen and (min-width: 1170px) {
+  form {
+    fieldset.inputs {
+      display: inline-block;
+      vertical-align: top;
+
+      &:not(.has_many_fields) { // usual fieldsets -- in two columns
+        width: 49%;
+        margin-right: 1%;
+      }
+      
+      &.has_many_fields { // nested forms -- in three columns
+        width: 32%;
+        margin-right: 1%;
+      }
+    }
+    a.button.has_many_add { display: table; }
+  }
+}

--- a/app/assets/stylesheets/active_admin/_forms.scss
+++ b/app/assets/stylesheets/active_admin/_forms.scss
@@ -338,13 +338,12 @@ form.filter_form {
       display: inline-block;
       vertical-align: top;
 
-      &:not(.has_many_fields) { // usual fieldsets -- in two columns
+      &:not(.has_many_fields) { // usual fieldsets -- two columns
         width: 49%;
         margin-right: 1%;
       }
       
-      &.has_many_fields { // nested forms -- in three columns
-        width: 32%;
+      &.has_many_fields { // nested forms -- however many they can fit into
         margin-right: 1%;
       }
     }


### PR DESCRIPTION
A small change to forms layout to better utilize the limited screen space of our laptops. I'm using a MacBook Air as my main computer, I'm sure many of you do too.

Note the difference in vertical space for the same form:

![compare](https://cloud.githubusercontent.com/assets/1292290/23821966/999c2c7a-0652-11e7-8f9b-7b4ea300eb50.png)

Main fieldsets are laid out in two columns, nested forms — in however many fit on screen. (I guess, this functionality should be an optional and disabled by default but I don't know a good way to achieve that, is there one?)
