### PR TITLE
Add translation for "Per page" (en and ja only)

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,7 @@ en:
       one_page: "Displaying <b>all %{n}</b> %{model}"
       multiple: "Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> of <b>%{total}</b> in total"
       multiple_without_total: "Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      per_page: "Per page: "
       entry:
         one: "entry"
         other: "entries"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -51,6 +51,7 @@ ja:
       one_page: "<b>全 %{n}</b> 件の %{model} を表示しています"
       multiple: "全 <b>%{total}</b> 件中 <b>%{from}&nbsp;-&nbsp;%{to}</b> 件の %{model} を表示しています"
       multiple_without_total: "<b>%{from}&nbsp;-&nbsp;%{to}</b> 件の %{model} を表示しています"
+      per_page: "表示件数: "
       entry:
         one: "レコード"
         other: "レコード"

--- a/lib/active_admin/views/components/paginated_collection.rb
+++ b/lib/active_admin/views/components/paginated_collection.rb
@@ -83,7 +83,7 @@ module ActiveAdmin
 
       def build_per_page_select
         div class: "pagination_per_page" do
-          text_node "Per page:"
+          text_node I18n.t("active_admin.pagination.per_page")
           select do
             @per_page.each do |per_page|
               option(


### PR DESCRIPTION
Some of our local clients seemed unfamiliar with the English phrase, so I think it needs translation.

Just for the record, our tentative solution was to use some JavaScript: `$(".pagination_per_page").contents().first().replaceWith("..translation..")`