### PR TITLE
FIX: now use resource as references at comment (start at #4734)

### DIFF
--- a/features/comments/commenting.feature
+++ b/features/comments/commenting.feature
@@ -145,19 +145,6 @@ Feature: Commenting
     And I should be in the resource section for publishers
     And I should see "Hello World"
 
-  Scenario: Commenting on a class with string id
-    Given a tag with the name "coolness" exists
-    Given a configuration of:
-    """
-    ActiveAdmin.register Tag
-    """
-    Given I am logged in
-    When I am on the index page for tags
-    And I follow "View"
-    When I add a comment "Tag Comment"
-    Then I should see a flash with "Comment was successfully created"
-    And I should be in the resource section for tags
-
   Scenario: Commenting on an aliased resource with an existing non-aliased config
     Given a configuration of:
     """

--- a/lib/active_admin/orm/active_record/comments/comment.rb
+++ b/lib/active_admin/orm/active_record/comments/comment.rb
@@ -19,21 +19,12 @@ module ActiveAdmin
       ResourceController::Decorators.undecorate(resource).class.base_class.name.to_s
     end
 
-    # Postgres adapters won't compare strings to numbers (issue 34)
-    def self.resource_id_cast(record)
-      resource_id_type == :string ? record.id.to_s : record.id
-    end
-
     def self.find_for_resource_in_namespace(resource, namespace)
       where(
         resource_type: resource_type(resource),
-        resource_id:   resource_id_cast(resource),
+        resource_id:   resource,
         namespace:     namespace.to_s
       ).order(ActiveAdmin.application.namespaces[namespace.to_sym].comments_order)
-    end
-
-    def self.resource_id_type
-      columns.detect{ |i| i.name == "resource_id" }.type
     end
 
     def set_resource_type
@@ -42,4 +33,3 @@ module ActiveAdmin
 
   end
 end
-

--- a/lib/generators/active_admin/install/templates/migrations/create_active_admin_comments.rb.erb
+++ b/lib/generators/active_admin/install/templates/migrations/create_active_admin_comments.rb.erb
@@ -8,8 +8,7 @@ class CreateActiveAdminComments < <%= parent_class.to_s %>
     create_table :active_admin_comments do |t|
       t.string :namespace
       t.text   :body
-      t.string :resource_id,   null: false
-      t.string :resource_type, null: false
+      t.references :resource, polymorphic: true
       t.references :author, polymorphic: true
       <%- if Rails::VERSION::MAJOR >= 5 -%>
       t.timestamps
@@ -21,9 +20,9 @@ class CreateActiveAdminComments < <%= parent_class.to_s %>
     <%- unless Rails::VERSION::MAJOR >= 5 -%>
 
     add_index :active_admin_comments, [:author_type, :author_id]
+    add_index :active_admin_comments, [:resource_type, :resource_id]
     <%- end -%>
 
-    add_index :active_admin_comments, [:resource_type, :resource_id]
   end
 
   def self.down

--- a/spec/unit/comments_spec.rb
+++ b/spec/unit/comments_spec.rb
@@ -85,18 +85,6 @@ RSpec.describe "Comments" do
       end
     end
 
-    describe ".resource_id_cast" do
-      let(:post) { Post.create!(title: "Testing.") }
-      let(:namespace_name) { "admin" }
-
-      it "should cast resource_id as string" do
-        comment = ActiveAdmin::Comment.create! resource: post,
-                                                body: "Another Comment",
-                                                namespace: namespace_name
-        expect(ActiveAdmin::Comment.resource_id_cast(comment).class).to eql String
-      end
-    end
-
     describe ".resource_type" do
       let(:post) { Post.create!(title: "Testing.") }
       let(:post_decorator) { double 'PostDecorator' }
@@ -120,12 +108,6 @@ RSpec.describe "Comments" do
         it "returns object class string" do
           expect(ActiveAdmin::Comment.resource_type resource).to eql 'Post'
         end
-      end
-    end
-
-    describe ".resource_id_type" do
-      it "should be :string" do
-        expect(ActiveAdmin::Comment.resource_id_type).to eql :string
       end
     end
 


### PR DESCRIPTION
In base case migration used a separated resource_id and resource_type. And resource_id was a STRING type column. It's terrible.
Now we will use normal references for resource such as author.