### PR TITLE
Replace bad link on documentation site.

### DIFF
--- a/docs/_includes/toc.html
+++ b/docs/_includes/toc.html
@@ -27,7 +27,7 @@
     </ol>
     <li><a href='{{ site.baseurl }}/3-index-pages.html'>Customizing the Index Page</a></li>
     <ol class='level-2'>
-        <li><a href='{{ site.baseurl }}/3-index-pages/create-an-index.html'>Create an Index</a></li>
+        <li><a href='{{ site.baseurl }}/3-index-pages/custom-index.html'>Custom Index</a></li>
         <li><a href='{{ site.baseurl }}/3-index-pages/index-as-block.html'>Index as a Block</a></li>
         <li><a href='{{ site.baseurl }}/3-index-pages/index-as-blog.html'>Index as Blog</a></li>
         <li><a href='{{ site.baseurl }}/3-index-pages/index-as-grid.html'>Index as a Grid</a></li>


### PR DESCRIPTION
Within the documentation under the **Customizing the Index Page**, the
first item `Create an Index` links to:

`https://activeadmin.info/3-index-pages/create-an-index.html`

This causes a 404 error.