### PR TITLE
Add missing translation for Password Confirmation field

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,6 +98,8 @@ en:
         title: "Subdomain"
       password:
         title: "Password"
+      password_confirmation:
+        title: "Confirm Password"
       sign_up:
         title: "Sign up"
         submit: "Sign up"


### PR DESCRIPTION
Add missing translation for Password Confirmation field.

When using Devise's Registerable module, you'll see this on the login page right now.

```html
<span class="translation_missing" title="translation missing: en.active_admin.devise.password_confirmation.title">Title</span>
```

Adding the missing English translation here!  I am not a translator so I'll leave the additional language translation to others.