### PR TITLE
simplify ActiveAdmin::Filters::Active

### DIFF
--- a/lib/active_admin/filters/active.rb
+++ b/lib/active_admin/filters/active.rb
@@ -8,23 +8,15 @@ module ActiveAdmin
 
       def initialize(resource_class, params)
         @resource_class = resource_class
-        @params = normalize_params(params)
+        @params = params.to_unsafe_h
         @scope = humanize_scope
         @filters = build_filters
       end
 
       private
 
-      def normalize_params(params)
-        if params.is_a?(HashWithIndifferentAccess)
-          params
-        else
-          params.to_unsafe_h
-        end
-      end
-
       def build_filters
-        filters = @params[:q] || []
+        filters = @params['q'] || []
         filters.map{ |param| Humanized.new(param) }
       end
 


### PR DESCRIPTION
since we removed support for old rails versions we can simplify this since to_unsafe_h returns
Hash for rails <= 4.2 and HashWithIndifferentAccess for rails > 4.2