### PR TITLE
Correct one greek translation

### DIFF
--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -33,7 +33,7 @@ el:
         less_than: "Μικρότερο από"
     status_tag:
       "yes": "Ναι"
-      "no": "Δεν"
+      "no": "Όχι"
     main_content: "Παρακαλώ υλοποιήστε την %{model}#main_content για να εμφανίσετε περιεχόμενο."
     logout: "Αποσύνδεση"
     powered_by: "Powered by %{active_admin} %{version}"


### PR DESCRIPTION
This PR fixes a word that was not interpreted correctly by Google Translate, given the context of the translation.