### PR TITLE
Add tabs documentation

### DIFF
--- a/docs/12-arbre-components.md
+++ b/docs/12-arbre-components.md
@@ -151,3 +151,26 @@ status_tag 'active', :ok
 status_tag 'active', :ok, class: 'important', id: 'status_123', label: 'on'
 # => <span class='status_tag active ok important' id='status_123'>on</span>
 ```
+
+## Tabs
+
+The Tabs component is helpful for saving page real estate. The first tab will be
+the one open when the page initially loads and the rest hidden. You can click
+each tab to toggle back and forth between them. Arbre supports unlimited number
+of tabs.
+
+```ruby
+tabs do
+  tab :active do
+    table_for orders.active do
+      ...
+    end
+  end
+
+  tab :inactive do
+    table_for orders.inactive do
+      ...
+    end
+  end
+end
+```

--- a/docs/6-show-pages.md
+++ b/docs/6-show-pages.md
@@ -78,31 +78,3 @@ ActiveAdmin.register Book do
   end
 end
 ```
-
-# Tabs
-
-You can arrange content in tabs as shown below:
-
-```ruby
-  ActiveAdmin.register Order do 
-    show do
-      tabs do
-        tab 'Overview' do
-          attributes_table do
-            row(:status) { status_tag(order.status) }
-            row(:paid) { number_to_currency(order.amount_paid_in_dollars) }
-          end
-        end
-        
-        tab 'Payments' do
-          table_for order.payments do
-            column('Payment Type') { |p| p.payment_type.titleize }
-            column('Received On', :created_at)
-            column('Payment Details & Notes', :notes)
-            column('Amount') { |p| number_to_currency(p.amount_in_dollars) }
-          end
-        end
-      end
-    end
-  end
-```

--- a/docs/_includes/toc.html
+++ b/docs/_includes/toc.html
@@ -78,6 +78,7 @@
         <li><a href='{{ site.baseurl }}/12-arbre-components.html#columns'>Columns</a></li>
         <li><a href='{{ site.baseurl }}/12-arbre-components.html#table-for'>Table For</a></li>
         <li><a href='{{ site.baseurl }}/12-arbre-components.html#status-tag'>Status tag</a></li>
+        <li><a href='{{ site.baseurl }}/12-arbre-components.html#tabs'>Tabs</a></li>
     </ol>
     <li><a href='{{ site.baseurl }}/13-authorization-adapter.html'>Authorization Adapter</a></li>
     <ol class='level-2'>


### PR DESCRIPTION
On the [Arbre Components](https://activeadmin.info/12-arbre-components.html) page, there was no documentation for [tabs](https://github.com/activeadmin/activeadmin/blob/d01155f73a0e2cc27d712792270357e2b3759d05/lib/active_admin/views/components/tabs.rb), so I added some.

EDIT: It was [pointed out](https://github.com/activeadmin/activeadmin/pull/4919#issuecomment-295824610) that there is [existing documentation](https://github.com/activeadmin/activeadmin/blob/6fe4013d3463135183b50f73fd8d5113c4ca89c4/docs/6-show-pages.md#tabs) for Tabs. I removed it in favor of having it on the Arbre Components page. I also added a link for the Table of Contents to the new Tabs documentation.