### PR TITLE
Avoid method missing

### DIFF
--- a/lib/active_admin/views/components/active_admin_form.rb
+++ b/lib/active_admin/views/components/active_admin_form.rb
@@ -78,7 +78,7 @@ module ActiveAdmin
       end
 
       def add_create_another_checkbox
-        if %w(new create).include?(action_name) &&  active_admin_config && active_admin_config.create_another
+        if %w(new create).include?(helpers.action_name) &&  active_admin_config && active_admin_config.create_another
           current_arbre_element.add_child(create_another_checkbox)
         end
       end


### PR DESCRIPTION
Closes #4897.

I only enabled the `Style/ExtraSpacing` RuboCop cop, because there was a double whitespace in that same line that was bothering me :sweat_smile:.

I figured the change was small and simple enough (just whitespace) to be shipped in the same PR, but let me know if you want commits splitted into different PR's.