### PR TITLE
Officially support MRI 2.1 by testing against it in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ script:
 
 rvm:
   - jruby-9.1.8.0
+  - 2.1.10
   - 2.2.7
   - 2.3.4
   - 2.4.1
@@ -35,6 +36,12 @@ env:
 
 matrix:
   fast_finish: true
+
+  exclude:
+    - rvm: 2.1.10
+      gemfile: gemfiles/rails_50.gemfile
+    - rvm: 2.1.10
+      gemfile: gemfiles/rails_51.gemfile
 
   allow_failures:
     - rvm: jruby-9.1.8.0


### PR DESCRIPTION
Before 1.0.0, we should decide what to do with MRI 2.1 support. There's 2 options:

* Drop it. I vote for this since [it's been EOL'd](https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/) and dropping it gets us in sync with Rails support range.

* Support it. In that case, we should start testing it in CI to ensure AA actually works against this version.
