### PR TITLE
Add Gratipay to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Quality         ](http://img.shields.io/codeclimate/github/activeadmin/activeadmin.svg)      ](https://codeclimate.com/github/activeadmin/activeadmin)
 [![Coverage        ](https://codecov.io/gh/activeadmin/activeadmin/branch/master/graph/badge.svg)](https://codecov.io/gh/activeadmin/activeadmin)
 [![Inch CI         ](http://inch-ci.org/github/activeadmin/activeadmin.svg?branch=master)       ](http://inch-ci.org/github/activeadmin/activeadmin)
+[![Gratipay Team   ](https://img.shields.io/gratipay/team/Active-Admin.svg)](https://gratipay.com/Active-Admin/)
 
 ## State of the project
 
@@ -47,6 +48,12 @@ Google Groups, IRC #activeadmin and Gitter are not actively monitored.
 
 The [contributing guide](https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md)
 is a good place to start. If you have questions, feel free to ask.
+
+## Want to support us?
+
+You can support us with a weekly tip via [Gratipay](https://gratipay.com).
+
+[![Support via Gratipay](https://cdn.rawgit.com/gratipay/gratipay-badge/2.1.3/dist/gratipay.png)](https://gratipay.com/Active-Admin)
 
 ## Dependencies
 


### PR DESCRIPTION
I set up a Gratipay account a while ago but we never added it to the README. That's probably why we are at $0 :joy:.