### PR TITLE
Enable mention-bot for translations

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -1,0 +1,9 @@
+{
+  "message": "@pullRequester, thanks for contributing an activeadmin
+              translation! @reviewers, are you able to review this?",
+  "findPotentialReviewers": true,
+  "actions": ["labeled"],
+  "createComment": true,
+  "withLabel": "i18n",
+  "delayed": false
+}


### PR DESCRIPTION
I just had a look at #4918.

Obviously we don't speak all the languages `activeadmin` supports. So I thought we could use [mention-bot](https://github.com/facebook/mention-bot) for this.

With this configuration, once we label a PR with the `i18n` label, the mention bot will scan previous contributors to the translation and ping them. Theoretically, since I've never actually used it.

Do you want to give it a try?