### PR TITLE
Remove unnecessary css class

### DIFF
--- a/app/assets/stylesheets/active_admin/components/_panels.scss
+++ b/app/assets/stylesheets/active_admin/components/_panels.scss
@@ -1,5 +1,5 @@
 // ----------------------------------- Helper class to apply to elements to make them sections
-.section, .panel{ @include section; }
+.panel{ @include section; }
 
 // ----------------------------------- Sidebar Sections
 


### PR DESCRIPTION
Should fix #2930?

In a quick look didn't see any usage of this class. If there's any, we should just use the "panel" class instead... I guess.

Post 1.0.0, of course.