### PR TITLE
Fix Paginated Collection Pagination Info

### DIFF
--- a/lib/active_admin/views/components/paginated_collection.rb
+++ b/lib/active_admin/views/components/paginated_collection.rb
@@ -141,7 +141,7 @@ module ActiveAdmin
                    model: entries_name,
                    total: total,
                    from: offset + 1,
-                   to: offset + collection_size
+                   to: offset + collection.per_page
           end
         else
           # Do not display total count, in order to prevent a `SELECT count(*)`.
@@ -150,7 +150,7 @@ module ActiveAdmin
           I18n.t "active_admin.pagination.multiple_without_total",
                  model: entries_name,
                  from: offset + 1,
-                 to: offset + collection_size
+                 to: offset + collection.per_page
         end
       end
 


### PR DESCRIPTION
I found there was an error on the Pagination Info when creating paginated_collections:

`I18n.t "active_admin.pagination.multiple",
                   model: entries_name,
                   total: total,
                   from: offset + 1,
                   to: offset + collection_size`

If you have a collection of 88 elements and you are in page 4 with a per_page(10) you are getting **Displaying 41 to 121 of 88**

I changed it to 

`I18n.t "active_admin.pagination.multiple",
                   model: entries_name,
                   total: total,
                   from: offset + 1,
                   to: offset + collection.per_page`

So you get now  **Displaying 41 to 50 of 88**