### PR TITLE
Attributes table title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # Changelog
+
+## Master (unreleased)
+
+### Enhancements
+
+##### Minor
+
+* Allow custom panel title given with `attributes_table` [#4940][] by [@ajw725][]
+
 ## 1.0.0 [☰](https://github.com/activeadmin/activeadmin/compare/v0.6.3...master)
 
 ### Breaking Changes

--- a/features/show/attributes_table_title.feature
+++ b/features/show/attributes_table_title.feature
@@ -1,0 +1,54 @@
+Feature: Show - Attributes Table Title
+  
+  Modifying the title of the panel wrapping the attributes table
+  
+  Background:
+    Given a post with the title "Hello World" written by "Jane Doe" exists
+  
+  Scenario: Set a string as the title
+    Given a show configuration of:
+    """
+      ActiveAdmin.register Post do
+        show do
+          attributes_table title: "Title From String"
+        end
+      end
+    """
+    Then I should see the panel title "Title From String"
+    And I should see the attributes table
+  
+  Scenario: Set a method to be called on the resource as the title
+    Given a show configuration of:
+    """
+      ActiveAdmin.register Post do
+        show do
+          attributes_table title: :title
+        end
+      end
+    """
+    Then I should see the panel title "Hello World"
+    And I should see the attributes table
+  
+  Scenario: Set a proc as the title
+    Given a show configuration of:
+    """
+      ActiveAdmin.register Post do
+        show do
+          attributes_table title: proc{ |post| "Title: #{post.title}" }
+        end
+      end
+    """
+    Then I should see the panel title "Title: Hello World"
+    And I should see the attributes table
+  
+  Scenario: Should not accept other keys
+    Given a show configuration of:
+    """
+      ActiveAdmin.register Post do
+        show do
+          attributes_table foo: "Title From String"
+        end
+      end
+    """
+    Then I should not see the panel title "Title From String"
+    And I should see the attributes table

--- a/features/step_definitions/attributes_table_title_steps.rb
+++ b/features/step_definitions/attributes_table_title_steps.rb
@@ -1,0 +1,11 @@
+Then /^I should see the panel title "([^"]*)"$/ do |title|
+  expect(page).to have_css '.panel > h3', text: title
+end
+
+Then /^I should not see the panel title "([^"]*)"$/ do |title|
+  expect(page).to_not have_css '.panel > h3', text: title
+end
+
+Then /^I should see the attributes table$/ do
+  expect(page).to have_css '.panel .attributes_table'
+end

--- a/lib/active_admin/views/pages/show.rb
+++ b/lib/active_admin/views/pages/show.rb
@@ -25,7 +25,12 @@ module ActiveAdmin
         end
 
         def attributes_table(*args, &block)
-          table_title = ActiveAdmin::Localizers.resource(active_admin_config).t(:details)
+          opts = args.extract_options!
+          table_title = if opts.has_key?(:title)
+            render_or_call_method_or_proc_on(resource, opts[:title])
+          else
+            ActiveAdmin::Localizers.resource(active_admin_config).t(:details)
+          end
           panel(table_title) do
             attributes_table_for resource, *args, &block
           end


### PR DESCRIPTION
Allow a custom title given with `attributes_table` for the panel wrapping the actual attributes table (replaces the default "Object Details" title). Accepts options hash with either `:title` or `:header` key, and takes string, method name, or proc.