### PR TITLE
Search Status Sidebar - Use Model Names Rather Than ID

### DIFF
--- a/lib/active_admin/filters/humanized.rb
+++ b/lib/active_admin/filters/humanized.rb
@@ -9,8 +9,26 @@ module ActiveAdmin
         @value = param[1]
       end
 
+      def related_class
+        @related_class ||=
+            begin
+              @body.split('_id').first.gsub(' ', '').classify.constantize
+            rescue
+              nil
+            end
+      end
+
+      def related_class_to_s
+        related_class ? related_class.to_s.underscore.humanize.titleize : nil
+      end
+
       def value
-        @value.is_a?(::Array) ? @value.compact.join(', ') : @value
+        @value =
+            begin
+              display_name(related_class.find(@value))
+            rescue
+              @value
+            end
       end
 
       def body
@@ -22,7 +40,7 @@ module ActiveAdmin
           predicate = active_admin_predicate_translation
         end
 
-        "#{parse_parameter_body} #{predicate}".strip
+        "#{related_class_to_s || parse_parameter_body} #{predicate}".strip
       end
 
       private

--- a/lib/active_admin/filters/resource_extension.rb
+++ b/lib/active_admin/filters/resource_extension.rb
@@ -178,6 +178,5 @@ module ActiveAdmin
         end
       end
     end
-
   end
 end

--- a/spec/unit/filters/humanized_spec.rb
+++ b/spec/unit/filters/humanized_spec.rb
@@ -2,10 +2,30 @@ require 'rails_helper'
 
 RSpec.describe ActiveAdmin::Filters::Humanized do
   describe '#value' do
-    it 'should equal query string parameter if not an Array' do
-      param = ['category_id_eq', '1']
-      subject = ActiveAdmin::Filters::Humanized.new(param)
-      expect(subject.value).to eq('1')
+    let(:category) { Category.create!(name: 'Jazz') }
+
+    context 'parameter points to a related model' do
+      it 'should equal the :name of category instance' do
+        param = ['category_id_eq', category.id]
+        humanizer = ActiveAdmin::Filters::Humanized.new(param)
+        expect(humanizer.value).to eq('Jazz')
+      end
+    end
+
+    context 'parameter looks like a related model but does not' do
+      it 'should equal query string parameter' do
+        param = ['color_id_eq', '1']
+        humanizer = ActiveAdmin::Filters::Humanized.new(param)
+        expect(humanizer.value).to eq('1')
+      end
+    end
+
+    context 'parameter is a field' do
+      it 'should equal query string parameter' do
+        param = ['requires_approval_eq', '1']
+        humanizer = ActiveAdmin::Filters::Humanized.new(param)
+        expect(humanizer.value).to eq('1')
+      end
     end
 
     it 'should equal query string parameters separated by commas if an Array' do
@@ -27,6 +47,25 @@ RSpec.describe ActiveAdmin::Filters::Humanized do
         param = ['category_id_eq', '1']
         subject = ActiveAdmin::Filters::Humanized.new(param)
         expect(subject.body).to eq('Category ID equals')
+      end
+
+      it 'returns correct model name even if multi-word model' do
+        class MultiWordKlass; end
+        param = ['multi_word_klass_id_eq', 1]
+        humanizer = ActiveAdmin::Filters::Humanized.new(param)
+        expect(humanizer.body).to start_with('Multi Word Klass')
+      end
+
+      it 'parses language from Ransack if filter is a related model' do
+        param = ['category_id_eq', category.id]
+        humanizer = ActiveAdmin::Filters::Humanized.new(param)
+        expect(humanizer.body).to eq('Category equals')
+      end
+
+      it 'parses language from Ransack if filter parameter looks like related model but does not' do
+        param = ['color_id_eq', '1']
+        humanizer = ActiveAdmin::Filters::Humanized.new(param)
+        expect(humanizer.body).to eq('Color ID equals')
       end
 
       it 'handles strings with embedded predicates' do


### PR DESCRIPTION
I just fixed merge conflicts for activeadmin/activeadmin#3902. Any other fixes will go in this branch.