### PR TITLE
Remove unnecessary br tags

### DIFF
--- a/app/views/active_admin/devise/shared/_links.erb
+++ b/app/views/active_admin/devise/shared/_links.erb
@@ -1,27 +1,27 @@
 <%- if controller_name != 'sessions' %>
   <% scope = Devise::Mapping.find_scope!(resource_name) %>
-  <%= link_to t('active_admin.devise.links.sign_in'), send(:"new_#{scope}_session_path") %><br />
+  <%= link_to t('active_admin.devise.links.sign_in'), send(:"new_#{scope}_session_path") %>
 <% end -%>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to t('active_admin.devise.links.sign_up'), new_registration_path(resource_name) %><br />
+  <%= link_to t('active_admin.devise.links.sign_up'), new_registration_path(resource_name) %>
 <% end -%>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' %>
-  <%= link_to t('active_admin.devise.links.forgot_your_password'), new_password_path(resource_name) %><br />
+  <%= link_to t('active_admin.devise.links.forgot_your_password'), new_password_path(resource_name) %>
 <% end -%>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to t('active_admin.devise.links.resend_confirmation_instructions'), new_confirmation_path(resource_name) %><br />
+  <%= link_to t('active_admin.devise.links.resend_confirmation_instructions'), new_confirmation_path(resource_name) %>
 <% end -%>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to t('active_admin.devise.links.resend_unlock_instructions'), new_unlock_path(resource_name) %><br />
+  <%= link_to t('active_admin.devise.links.resend_unlock_instructions'), new_unlock_path(resource_name) %>
 <% end -%>
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
     <%= link_to t('active_admin.devise.links.sign_in_with_omniauth_provider', provider: provider.to_s.titleize),
-          omniauth_authorize_path(resource_name, provider) %><br />
+          omniauth_authorize_path(resource_name, provider) %>
   <% end -%>
 <% end -%>


### PR DESCRIPTION
These `<br>` tags cause excessive bottom padding in the login panel (logged_out view). We want to be able to control spacing through CSS. This is pulled out from #3862.