### PR TITLE
Improve checkbox toggler

### DIFF
--- a/app/assets/javascripts/active_admin/lib/checkbox-toggler.js.coffee
+++ b/app/assets/javascripts/active_admin/lib/checkbox-toggler.js.coffee
@@ -23,15 +23,17 @@ class ActiveAdmin.CheckboxToggler
     @toggle_all_checkbox.change => @_didChangeToggleAllCheckbox()
 
   _didChangeCheckbox: (checkbox)->
-    switch @checkboxes.filter(':checked').length
-      when @checkboxes.length - 1 then @toggle_all_checkbox.prop checked: null
-      when @checkboxes.length     then @toggle_all_checkbox.prop checked: true
+    numChecked = @checkboxes.filter(':checked').length
+
+    allChecked = numChecked == @checkboxes.length
+    someChecked = numChecked > 0 && numChecked < @checkboxes.length
+
+    @toggle_all_checkbox.prop checked: allChecked, indeterminate: someChecked
 
   _didChangeToggleAllCheckbox: ->
-    setting = if @toggle_all_checkbox.prop 'checked' then true else null
-    @checkboxes.each (index, el)=>
-      $(el).prop checked: setting
-      @_didChangeCheckbox(el)
+    setting = @toggle_all_checkbox.prop 'checked'
+    @checkboxes.prop checked: setting
+    setting
 
   option: (key, value) ->
     if $.isPlainObject(key)

--- a/app/assets/javascripts/active_admin/lib/table-checkbox-toggler.js.coffee
+++ b/app/assets/javascripts/active_admin/lib/table-checkbox-toggler.js.coffee
@@ -11,20 +11,10 @@ class ActiveAdmin.TableCheckboxToggler extends ActiveAdmin.CheckboxToggler
   _didChangeCheckbox: (checkbox) ->
     super
 
-    $row = $(checkbox).parents 'tr'
-
-    if checkbox.checked
-      $row.addClass 'selected'
-    else
-      $row.removeClass 'selected'
+    $(checkbox).parents('tr').toggleClass 'selected', checkbox.checked
 
   _didChangeToggleAllCheckbox: ->
-    checked = super
-
-    if checked
-      @$container.find('tbody tr').addClass 'selected'
-    else
-      @$container.find('tbody tr').removeClass 'selected'
+    @$container.find('tbody tr').toggleClass 'selected', super
 
   _didClickCell: (cell) ->
     $(cell).parent('tr').find(':checkbox').click()

--- a/app/assets/javascripts/active_admin/lib/table-checkbox-toggler.js.coffee
+++ b/app/assets/javascripts/active_admin/lib/table-checkbox-toggler.js.coffee
@@ -18,6 +18,14 @@ class ActiveAdmin.TableCheckboxToggler extends ActiveAdmin.CheckboxToggler
     else
       $row.removeClass 'selected'
 
+  _didChangeToggleAllCheckbox: ->
+    checked = super
+
+    if checked
+      @$container.find('tbody tr').addClass 'selected'
+    else
+      @$container.find('tbody tr').removeClass 'selected'
+
   _didClickCell: (cell) ->
     $(cell).parent('tr').find(':checkbox').click()
 


### PR DESCRIPTION
This adds indeterminate support for checkbox toggling and simplifies some of the code. Commits have good descriptions as to why each change was made. This is pulled out from #3862.