### PR TITLE
Wrap resource_selection_toggle_cell in a label tag for greater hit area

### DIFF
--- a/app/assets/stylesheets/active_admin/components/_batch_actions.scss
+++ b/app/assets/stylesheets/active_admin/components/_batch_actions.scss
@@ -3,9 +3,4 @@
   >.resource_selection_toggle_cell {
     float:left;
   }
-  #collection_selection_toggle_explaination {
-    float:left;
-    margin-left:5px;
-    font-style:italic;
-  }
 }

--- a/lib/active_admin/batch_actions/views/selection_cells.rb
+++ b/lib/active_admin/batch_actions/views/selection_cells.rb
@@ -7,7 +7,7 @@ module ActiveAdmin
     class ResourceSelectionToggleCell < ActiveAdmin::Component
       builder_method :resource_selection_toggle_cell
 
-      def build(label_text='')
+      def build(label_text = '')
         label do
           input type: "checkbox", id: "collection_selection_toggle_all", name: "collection_selection_toggle_all", class: "toggle_all"
           text_node label_text if label_text.present?

--- a/lib/active_admin/batch_actions/views/selection_cells.rb
+++ b/lib/active_admin/batch_actions/views/selection_cells.rb
@@ -7,8 +7,11 @@ module ActiveAdmin
     class ResourceSelectionToggleCell < ActiveAdmin::Component
       builder_method :resource_selection_toggle_cell
 
-      def build
-        input type: "checkbox", id: "collection_selection_toggle_all", name: "collection_selection_toggle_all", class: "toggle_all"
+      def build(label_text='')
+        label do
+          input type: "checkbox", id: "collection_selection_toggle_all", name: "collection_selection_toggle_all", class: "toggle_all"
+          text_node label_text if label_text.present?
+        end
       end
     end
 
@@ -27,10 +30,8 @@ module ActiveAdmin
 
       def build
         super(id: "collection_selection_toggle_panel")
-        resource_selection_toggle_cell
-        div(id: "collection_selection_toggle_explaination") { I18n.t('active_admin.batch_actions.selection_toggle_explanation', default: "(Toggle Selection)") }
+        resource_selection_toggle_cell(I18n.t('active_admin.batch_actions.selection_toggle_explanation', default: "(Toggle Selection)"))
       end
-
     end
 
   end


### PR DESCRIPTION
This way the text itself is also clickable and toggles the checkbox. No need for additional div wrappers either. This is being pulled out of #3862.