### PR TITLE
Remove status_tag type parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Master (unreleased)
 
+### Deprecations
+
+* Deprecated `type` param from `status_tag` and related CSS classes [#4989][] by [@javierjulio][]
+  * The method signature has changed from:
+    ```ruby
+    status_tag(status, :ok, class: 'completed', label: 'on')
+    # now changes to:
+    status_tag(status, class: 'completed ok', label: 'on')
+    ```
+  * The following CSS classes have been deprecated and will be removed in the future:
+    ```css
+    .status_tag {
+      &.ok, &.published, &.complete, &.completed, &.green { background: #8daa92; }
+      &.warn, &.warning, &.orange { background: #e29b20; }
+      &.error, &.errored, &.red { background: #d45f53; }
+    }
+    ```
+
+
 ### Enhancements
 
 ##### Minor
@@ -69,7 +88,7 @@ index download_links: ->{ can?(:view_all_download_links) || [:pdf] }
 
 ### Security Fixes
 
-* Prevents access to formats that the user not permitted to see [#4867][] by [@Fivell][] and [@timoschilling][] 
+* Prevents access to formats that the user not permitted to see [#4867][] by [@Fivell][] and [@timoschilling][]
 * Prevents potential DOS attack via Ruby symbols [#1926][] by [@seanlinsley][]
   * [this isn't an issue for those using Ruby >= 2.2](http://rubykaigi.org/2014/presentation/S-NarihiroNakamura)
 

--- a/app/assets/stylesheets/active_admin/components/_status_tags.scss
+++ b/app/assets/stylesheets/active_admin/components/_status_tags.scss
@@ -6,6 +6,7 @@
   padding: 3px 5px 2px 5px;
   font-size: 0.8em;
 
+  // TODO: deprecated, remove in a v2 release
   &.ok, &.published, &.complete, &.completed, &.green { background: #8daa92; }
   &.warn, &.warning, &.orange { background: #e29b20; }
   &.error, &.errored, &.red { background: #d45f53; }

--- a/docs/12-arbre-components.md
+++ b/docs/12-arbre-components.md
@@ -138,18 +138,15 @@ takes a block.
 Status tags provide convenient syntactic sugar for styling items that have
 status. A common example of where the status tag could be useful is for orders
 that are complete or in progress. `status_tag` takes a status, like
-"In Progress", a type, which defaults to nil, and a hash of options. The
-status_tag will generate html markup that Active Admin css uses in styling.
+"In Progress", and a hash of options. The status_tag will generate HTML markup
+that Active Admin CSS uses in styling.
 
 ```ruby
 status_tag 'In Progress'
 # => <span class='status_tag in_progress'>In Progress</span>
 
-status_tag 'active', :ok
-# => <span class='status_tag active ok'>Active</span>
-
-status_tag 'active', :ok, class: 'important', id: 'status_123', label: 'on'
-# => <span class='status_tag active ok important' id='status_123'>on</span>
+status_tag 'active', class: 'important', id: 'status_123', label: 'on'
+# => <span class='status_tag active important' id='status_123'>on</span>
 ```
 
 ## Tabs

--- a/lib/active_admin/views/components/status_tag.rb
+++ b/lib/active_admin/views/components/status_tag.rb
@@ -12,9 +12,8 @@ module ActiveAdmin
         'status_tag'
       end
 
-      # @overload status_tag(status, type = nil, options = {})
+      # @overload status_tag(status, options = {})
       #   @param [String] status the status to display. One of the span classes will be an underscored version of the status.
-      #   @param [Symbol] type type of status. Will become a class of the span. ActiveAdmin provide style for :ok, :warning and :error.
       #   @param [Hash] options
       #   @option options [String] :class to override the default class
       #   @option options [String] :id to override the default id
@@ -26,17 +25,14 @@ module ActiveAdmin
       #   # => <span class='status_tag in_progress'>In Progress</span>
       #
       # @example
-      #   status_tag('active', :ok)
-      #   # => <span class='status_tag active ok'>Active</span>
-      #
-      # @example
-      #   status_tag('active', :ok, class: 'important', id: 'status_123', label: 'on')
-      #   # => <span class='status_tag active ok important' id='status_123'>on</span>
+      #   status_tag('active', class: 'important', id: 'status_123', label: 'on')
+      #   # => <span class='status_tag active important' id='status_123'>on</span>
       #
       def build(*args)
         options = args.extract_options!
         status = args[0]
         type = args[1]
+
         label = options.delete(:label)
         classes = options.delete(:class)
         status = convert_to_boolean_status(status)
@@ -50,7 +46,19 @@ module ActiveAdmin
         super(content, options)
 
         add_class(status_to_class(status)) if status
-        add_class(type.to_s) if type
+
+        if type
+          Deprecation.warn <<-MSG.strip_heredoc
+            The `type` parameter has been deprecated. Provide the "#{type}" type as
+            a class instead. For example, `status_tag(status, :#{type}, class: "abc")`
+            would change to `status_tag(status, class: "#{type} abc")`. Also note that
+            the "#{type}" CSS rule will be removed too, so you'll have to provide
+            the styles yourself. See https://github.com/activeadmin/activeadmin/blob/master/CHANGELOG.md#110-
+            for more information.
+          MSG
+          add_class(type.to_s)
+        end
+
         add_class(classes) if classes
       end
 

--- a/spec/unit/views/components/status_tag_spec.rb
+++ b/spec/unit/views/components/status_tag_spec.rb
@@ -134,17 +134,38 @@ RSpec.describe ActiveAdmin::Views::StatusTag do
     context "when status is 'Active' and type is :ok" do
       subject { status_tag('Active', :ok) }
 
+      describe 'is deprecated' do
+        subject { super().class_list }
+        it do
+          expect(ActiveAdmin::Deprecation)
+            .to receive(:warn)
+            .with(<<-MSG.strip_heredoc
+              The `type` parameter has been deprecated. Provide the "ok" type as
+              a class instead. For example, `status_tag(status, :ok, class: "abc")`
+              would change to `status_tag(status, class: "ok abc")`. Also note that
+              the "ok" CSS rule will be removed too, so you'll have to provide
+              the styles yourself. See https://github.com/activeadmin/activeadmin/blob/master/CHANGELOG.md#110-
+              for more information.
+            MSG
+            )
+          is_expected.to include('ok')
+        end
+      end
+
       describe '#class_list' do
+        before  { expect(ActiveAdmin::Deprecation).to receive(:warn).once }
         subject { super().class_list }
         it      { is_expected.to include('status_tag') }
       end
 
       describe '#class_list' do
+        before  { expect(ActiveAdmin::Deprecation).to receive(:warn).once }
         subject { super().class_list }
         it      { is_expected.to include('active') }
       end
 
       describe '#class_list' do
+        before  { expect(ActiveAdmin::Deprecation).to receive(:warn).once }
         subject { super().class_list }
         it      { is_expected.to include('ok') }
       end
@@ -193,8 +214,8 @@ RSpec.describe ActiveAdmin::Views::StatusTag do
       end
     end
 
-    context "when status is 'So useless', type is :ok, class is 'woot awesome' and id is 'useless'" do
-      subject { status_tag('So useless', :ok, class: 'woot awesome', id: 'useless') }
+    context "when status is 'So useless', class is 'woot awesome' and id is 'useless'" do
+      subject { status_tag('So useless', class: 'woot awesome', id: 'useless') }
 
       describe '#content' do
         subject { super().content }
@@ -204,11 +225,6 @@ RSpec.describe ActiveAdmin::Views::StatusTag do
       describe '#class_list' do
         subject { super().class_list }
         it      { is_expected.to include('status_tag') }
-      end
-
-      describe '#class_list' do
-        subject { super().class_list }
-        it      { is_expected.to include('ok') }
       end
 
       describe '#class_list' do


### PR DESCRIPTION
This is a change that was requested by @timoschilling in https://github.com/activeadmin/activeadmin/pull/3677#issuecomment-65922117 (look at item 2) and was pulled from #3862 there since we want to incorporate it earlier and minimize the amount of changes needed for review. Also we did want to remove the additional classes as users should be able to add those on their own rather than defining ones and styles they might not want.

Before providing any options, a second argument called `type` was required. So you would write something like the following:

```ruby
status_tag('active', :ok, class: 'abc', label: 'on')
status_tag('active', nil, class: 'abc', label: 'on')
```

This didn't make much sense as type was just appending to class but its just easier for users to provide their own classes for styling while ActiveAdmin just focuses on providing the defaults it handles which are true/false. 

**Now with `type` removed, the usage becomes**:

```ruby
status_tag('active', class: 'abc', label: 'on')
```