### PR TITLE
allow scope to paginate collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ##### Minor
 
+* Allow AA scopes to return paginated collections [#4996][] by [@Fivell][]
 * Added `scopes_show_count` configuration to  setup show_count attribute for scopes globally [#4950][] by [@Fivell][]
 * Allow custom panel title given with `attributes_table` [#4940][] by [@ajw725][]
 
@@ -151,6 +152,7 @@ Please check [0-6-stable](https://github.com/activeadmin/activeadmin/blob/0-6-st
 [#4867]: https://github.com/activeadmin/activeadmin/pull/4867
 [#4882]: https://github.com/activeadmin/activeadmin/pull/4882
 [#4950]: https://github.com/activeadmin/activeadmin/pull/4950
+[#4996]: https://github.com/activeadmin/activeadmin/pull/4996
 
 
 [@bolshakov]: https://github.com/bolshakov

--- a/features/index/index_scopes.feature
+++ b/features/index/index_scopes.feature
@@ -243,6 +243,9 @@ Feature: Index Scoping
         scope :published do |posts|
           posts.where("published_date IS NOT NULL")
         end
+        scope :single do |posts|
+           posts.page(1).per(1)
+        end
 
         index do
           column :author_id
@@ -260,7 +263,11 @@ Feature: Index Scoping
       """
     Then I should see the scope "All" with the count 2
     And I should see the scope "Published" with the count 1
+    And I should see the scope "Single" with the count 1
     And I should see 2 posts in the table
+
+    When I follow "Single"
+    Then I should see 1 posts in the table
 
     When I follow "Published"
     Then I should see the scope "Published" selected

--- a/lib/active_admin/resource_controller/data_access.rb
+++ b/lib/active_admin/resource_controller/data_access.rb
@@ -245,6 +245,8 @@ module ActiveAdmin
       end
 
       def apply_pagination(chain)
+        # skip pagination if already was paginated by scope
+        return chain if chain.respond_to?(:total_pages)
         page_method_name = Kaminari.config.page_method_name
         page = params[Kaminari.config.param_name]
 


### PR DESCRIPTION
PaginatedCollection works only with paginated scope, so
skip apply_pagination if pagination was applied by scope logic
to make this work scope can be defined as
```
 ActiveAdmin.register Post do
    scope :all
    scope :random do |posts|
      posts.random.page(1).per(3)
    end
 end
```

[fixes #4977]