### PR TITLE
Drop MRI 2.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ script:
 
 rvm:
   - jruby-9.1.10.0
-  - 2.1.10
   - 2.2.7
   - 2.3.4
   - 2.4.1
@@ -41,12 +40,6 @@ env:
 
 matrix:
   fast_finish: true
-
-  exclude:
-    - rvm: 2.1.10
-      gemfile: gemfiles/rails_50.gemfile
-    - rvm: 2.1.10
-      gemfile: gemfiles/rails_51.gemfile
 
   allow_failures:
     - rvm: jruby-9.1.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Master (unreleased)
 
+### Removals
+
+* Ruby 2.1 support has been dropped [#5002][] by [@deivid-rodriguez][]
+
 ### Deprecations
 
 * Deprecated `type` param from `status_tag` and related CSS classes [#4989][] by [@javierjulio][]

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.test_files = `git ls-files -- {spec,features}/*`.split("\n")
 
-  s.required_ruby_version = '>= 2.1'
+  s.required_ruby_version = '>= 2.2'
 
   s.add_dependency 'arbre', '>= 1.1.1'
   s.add_dependency 'bourbon'


### PR DESCRIPTION
This PR drops support for Ruby 2.1, which was EOL'd the 1st of April: https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/.