### PR TITLE
Travis upgrades

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,15 +46,3 @@ matrix:
       gemfile: gemfiles/rails_50.gemfile
     - rvm: jruby-9.1.10.0
       gemfile: gemfiles/rails_51.gemfile
-
-notifications:
-  irc:
-    channels:
-      - irc.freenode.org#activeadmin
-
-    on_success: change
-    on_failure: always
-    skip_join: true
-
-    template:
-      - "(%{branch}/%{commit} by %{author}): %{message} (%{build_url})"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ language: ruby
 
 sudo: false
 
+dist: trusty
+
 bundler_args: --without development
 
 branches:


### PR DESCRIPTION
These are some changes in the process of investigating why our jruby build got so slow. Note that with the upgrade to trusty, we also go from jdk 7 to jdk 8.

Let's see what Travis says.