### PR TITLE
Unlock bundler version in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,7 @@ before_install:
   - PATH=$(npm bin):$PATH # needed to install phantomjs via npm
   - if [ $(phantomjs --version) != '2.1.1' ]; then npm install phantomjs-prebuilt@2.1; fi
   - gem update --system # use the very latest Rubygems
-  - rvm @global do gem uninstall bundler -a -x
-  - rvm @global do gem install bundler -v 1.14.6 # latest version known to work
+  - gem install bundler # use the very latest Bundler
 
 script:
   - bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
   - bundle exec rake
 
 rvm:
-  - jruby-9.1.10.0
+  - jruby-9.1.12.0
   - 2.2.7
   - 2.3.4
   - 2.4.1
@@ -43,7 +43,7 @@ matrix:
   fast_finish: true
 
   allow_failures:
-    - rvm: jruby-9.1.10.0
+    - rvm: jruby-9.1.12.0
       gemfile: gemfiles/rails_50.gemfile
-    - rvm: jruby-9.1.10.0
+    - rvm: jruby-9.1.12.0
       gemfile: gemfiles/rails_51.gemfile

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,8 +27,7 @@ git checkout -b 325-add-japanese-translations
 ### 3. Get the test suite running
 
 Make sure you're using a recent ruby and have the `bundler` gem installed, at
-least version `1.14.3`. The most reliable `bundler` version to use is the same
-Travis is using.
+least version `1.14.3`.
 
 Install the development dependencies:
 


### PR DESCRIPTION
Just install the latest version, since it now appears more stable, and
our dependencies are a lot simpler now.

This is a follow up to #5009 and the comments in there.