### PR TITLE
Remove mention_bot

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -1,9 +1,0 @@
-{
-  "message": "@pullRequester, thanks for contributing an activeadmin
-              translation! @reviewers, are you able to review this?",
-  "findPotentialReviewers": true,
-  "actions": ["labeled"],
-  "createComment": true,
-  "withLabel": "i18n",
-  "delayed": false
-}


### PR DESCRIPTION
This reverts commit fee94b9ad170717ac5917534154f2202675cc151, reversing
changes made to c5b7746e15071d7a2e0a0d4cfbf19e8c1e699583.

The configuration added is not working, so I'll just remove it since the benefit would be minor anyways (and might annoy some people?). The right thing to do would be to get an official translation maintainer for each language, I guess.