### PR TITLE
Missing internationalized string

### DIFF
--- a/lib/generators/active_admin/install/templates/admin_user.rb.erb
+++ b/lib/generators/active_admin/install/templates/admin_user.rb.erb
@@ -17,7 +17,7 @@ ActiveAdmin.register <%= @user_class %> do
   filter :created_at
 
   form do |f|
-    f.inputs "Admin Details" do
+    f.inputs do
       f.input :email
       f.input :password
       f.input :password_confirmation


### PR DESCRIPTION
I know this is really a minor thing but for completeness sake, the "admin user" generator was missing this string for interpolation. The keys weren't alphabetized so I added it near the dashboard ones.

I took the liberty of translating the addition for spanish, in case it's accepted.