### PR TITLE
Fix the interaction between batch actions

### DIFF
--- a/app/assets/javascripts/active_admin/lib/batch_actions.js.coffee
+++ b/app/assets/javascripts/active_admin/lib/batch_actions.js.coffee
@@ -14,7 +14,7 @@ $(document).on 'ready page:load turbolinks:load', ->
 
   $('.batch_actions_selector li a').on 'confirm:complete', (e, inputs)->
     if val = JSON.stringify inputs
-      $('#batch_action_inputs').val val
+      $('#batch_action_inputs').removeAttr('disabled').val val
     else
       $('#batch_action_inputs').attr 'disabled', 'disabled'
 


### PR DESCRIPTION
After the first usage of a batch action, reuse of another one that uses **ActiveAdmin.modal_dialog** is impossible because of **batch_action_inputs** form element is disabled and the server doesn't get its required parameters.