### PR TITLE
improve predicates translations for active filters

### DIFF
--- a/lib/active_admin/filters/active_filter.rb
+++ b/lib/active_admin/filters/active_filter.rb
@@ -26,11 +26,18 @@ module ActiveAdmin
       end
 
       def label
+        # TODO: to remind us to go back to the simpler str.downcase once we support ruby >= 2.4 only.
+        translated_predicate = predicate_name.mb_chars.downcase.to_s
         if related_class
-          "#{related_class.model_name.human} #{predicate_name}".strip
+          "#{related_class.model_name.human} #{translated_predicate}".strip
         else
-          "#{attribute_name} #{predicate_name}".strip
+          "#{attribute_name} #{translated_predicate}".strip
         end
+      end
+
+      def predicate_name
+        I18n.t("active_admin.filters.predicates.#{condition.predicate.name}",
+               default: ransack_predicate_name)
       end
 
       def html_options
@@ -56,8 +63,7 @@ module ActiveAdmin
         condition_attribute.attr_name
       end
 
-      # translated predicated (equals, contains, etc)
-      def predicate_name
+      def ransack_predicate_name
         Ransack::Translate.predicate(condition.predicate.name)
       end
 

--- a/spec/unit/filters/active_filter_spec.rb
+++ b/spec/unit/filters/active_filter_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe ActiveAdmin::Filters::ActiveFilter do
     expect(subject.label).to eq("Title equals")
   end
 
+  it 'should pick predicate name translation' do
+    expect(subject.predicate_name).to eq(I18n.t("active_admin.filters.predicates.equals"))
+  end
+
   context 'search by belongs_to association' do
     let(:search) do
       Post.ransack(custom_category_id_eq: category.id)
@@ -45,6 +49,10 @@ RSpec.describe ActiveAdmin::Filters::ActiveFilter do
 
     it 'should have valid label' do
       expect(subject.label).to eq("Category equals")
+    end
+
+    it 'should pick predicate name translation' do
+      expect(subject.predicate_name).to eq(Ransack::Translate.predicate('eq'))
     end
 
   end


### PR DESCRIPTION
since we have aliases for ransack predicates
and localization strings for them
we should find translation in 'active_admin.filters.predicates' scope
and in case when not found use ransack localization

source: https://github.com/activeadmin/activeadmin/pull/4951#issuecomment-304500117