### PR TITLE
Remove remaining deleted task reference

### DIFF
--- a/tasks/local.rake
+++ b/tasks/local.rake
@@ -1,5 +1,5 @@
 desc 'Runs a command agains the local sample application'
-task local: :enforce_version do
+task :local do
   Rake::Task['setup'].invoke(false,
                              '.test-rails-apps',
                              'rails_template_with_data')


### PR DESCRIPTION
We had one usage of `enforce_version` as a task dependency but it has since been removed.