### PR TITLE
Render meta tags before javascripts so they are available when JS loads.

### DIFF
--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -29,16 +29,16 @@ module ActiveAdmin
               text_node stylesheet_link_tag(style, options).html_safe
             end
 
+            active_admin_namespace.meta_tags.each do |name, content|
+              text_node(tag(:meta, name: name, content: content))
+            end
+
             active_admin_application.javascripts.each do |path|
               text_node(javascript_include_tag(path))
             end
 
             if active_admin_namespace.favicon
               text_node(favicon_link_tag(active_admin_namespace.favicon))
-            end
-
-            active_admin_namespace.meta_tags.each do |name, content|
-              text_node(tag(:meta, name: name, content: content))
             end
 
             text_node csrf_meta_tag


### PR DESCRIPTION
The activeadmin tests passed using `export BUNDLE_GEMFILE=gemfiles/rails_51.gemfile`

I have moved the meta tags up in the header.  This way meta tags are in the head when the JS code loads. JS code currently loads before meta tags are rendered. 