### PR TITLE
trigger separate js event for each batch action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
 * Allow AA scopes to return paginated collections [#4996][] by [@Fivell][]
 * Added `scopes_show_count` configuration to  setup show_count attribute for scopes globally [#4950][] by [@Fivell][]
 * Allow custom panel title given with `attributes_table` [#4940][] by [@ajw725][]
+* Added unique js events for each particular batch action [#5040][] by [@Fivell][]
+
 
 ## 1.0.0 [☰](https://github.com/activeadmin/activeadmin/compare/v0.6.3...master)
 

--- a/app/assets/javascripts/active_admin/lib/batch_actions.js.coffee
+++ b/app/assets/javascripts/active_admin/lib/batch_actions.js.coffee
@@ -6,8 +6,8 @@ $(document).on 'ready page:load turbolinks:load', ->
   $('.batch_actions_selector li a').click (e)->
     e.stopPropagation() # prevent Rails UJS click event
     e.preventDefault()
-    if message = $(@).data 'confirm'
-      ActiveAdmin.modal_dialog message, $(@).data('inputs'), (inputs)=>
+    if $(@).data 'confirm'
+      ActiveAdmin.modal_dialog $(@), (inputs)=>
         $(@).trigger 'confirm:complete', inputs
     else
       $(@).trigger 'confirm:complete'

--- a/app/assets/javascripts/active_admin/lib/modal_dialog.js.coffee
+++ b/app/assets/javascripts/active_admin/lib/modal_dialog.js.coffee
@@ -1,4 +1,7 @@
-ActiveAdmin.modal_dialog = (message, inputs, callback)->
+ActiveAdmin.modal_dialog = (batch_action, callback)->
+  message = batch_action.data 'confirm'
+  inputs  = batch_action.data 'inputs'
+  action  = batch_action.data 'action'
   html = """<form id="dialog_confirm" title="#{message}"><ul>"""
   for name, type of inputs
     if /^(datepicker|checkbox|text|number)$/.test type
@@ -31,11 +34,13 @@ ActiveAdmin.modal_dialog = (message, inputs, callback)->
 
   form = $(html).appendTo('body')
   $('body').trigger 'modal_dialog:before_open', [form]
+  $('body').trigger "modal_dialog:#{action}:before_open", [form]
 
   form.dialog
     modal: true
     open: (event, ui) ->
       $('body').trigger 'modal_dialog:after_open', [form]
+      $('body').trigger "modal_dialog:#{action}:after_open", [form]
     dialogClass: 'active_admin_dialog'
     buttons:
       OK: ->


### PR DESCRIPTION
before for handling stuff for particular  batch action popup I need to check title 

```js
    $("body.users.index").on("modal_dialog:after_open", function (event, form) {
        if (form.parent().find('.ui-dialog-titlebar .ui-dialog-title').text() === 'Send Email') {
         //... my code 
        }
        if (form.parent().find('.ui-dialog-titlebar .ui-dialog-title').text() === 'Block Users') {
         //... my code 
        }
   }
```

Idea is give such opportunity

```js
    $("body.users.index").on("modal_dialog:send_email:after_open", function (event, form) {
         //... my code 
    }

   $("body.users.index").on("modal_dialog:block_users:after_open", function (event, form) {
         //... my code 
    }
```