### PR TITLE
Improve markdown linting

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,8 @@
 [Please follow the guidelines for creating a bug report](https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md#4-did-you-find-a-bug).
 
-The issue tracker is only for bugs and feature requests. If you need general help please post to [StackOverflow](http://stackoverflow.com/questions/tagged/activeadmin).
+The issue tracker is only for bugs and feature requests. If you need general
+help please post to
+[StackOverflow](http://stackoverflow.com/questions/tagged/activeadmin).
 
 ### Expected behavior
 
@@ -12,4 +14,7 @@ What actually happens?
 
 ### How to reproduce
 
-Your best chance of getting this bug looked at quickly is to provide an **executable test case** demonstrating the expected behavior that is not occurring. [Please follow the guidelines for creating a bug report](https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md#4-did-you-find-a-bug).
+Your best chance of getting this bug looked at quickly is to provide an
+**executable test case** demonstrating the expected behavior that is not
+occurring. [Please follow the guidelines for creating a bug
+report](https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md#4-did-you-find-a-bug).

--- a/.mdlrc
+++ b/.mdlrc
@@ -1,0 +1,1 @@
+style "config/mdl_style.rb"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,18 +57,23 @@ environment:
 rm -rf spec/rails && bundle update
 ```
 
-#### 4. Did you find a bug?
+### 4. Did you find a bug?
 
-* **Ensure the bug was not already reported** by [searching all issues](https://github.com/activeadmin/activeadmin/issues?q=).
+* **Ensure the bug was not already reported** by [searching all
+  issues](https://github.com/activeadmin/activeadmin/issues?q=).
 
-* If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/activeadmin/activeadmin/issues/new).
-Be sure to include a **title and clear description**, as much relevant information as possible,
-and a **code sample** or an **executable test case** demonstrating the expected behavior that is not occurring.
+* If you're unable to find an open issue addressing the problem, [open a new
+  one](https://github.com/activeadmin/activeadmin/issues/new).  Be sure to
+  include a **title and clear description**, as much relevant information as
+  possible, and a **code sample** or an **executable test case** demonstrating
+  the expected behavior that is not occurring.
 
 * If possible, use the relevant bug report templates to create the issue.
-Simply copy the content of the appropriate template into a .rb file, make the necessary changes to demonstrate the issue,
-and **paste the content into the issue description**:
-  * [**ActiveAdmin** master issues](https://github.com/activeadmin/activeadmin/blob/master/lib/bug_report_templates/active_admin_master.rb)
+  Simply copy the content of the appropriate template into a .rb file, make the
+  necessary changes to demonstrate the issue, and **paste the content into the
+  issue description**:
+  * [**ActiveAdmin** master
+    issues](https://github.com/activeadmin/activeadmin/blob/master/lib/bug_report_templates/active_admin_master.rb)
 
 ### 5. Implement your fix or feature
 
@@ -92,10 +97,8 @@ in the `.test-rails-apps` folder.
 You should now be able to open <http://localhost:3000/admin> in your browser.
 You can log in using:
 
-```
-User: admin@example.com
-Password: password
-```
+*User*: admin@example.com
+*Password*: password
 
 If you need to perform any other commands on the test application, just pass
 them to the `local` rake task. For example, to boot the rails console:

--- a/config/mdl_style.rb
+++ b/config/mdl_style.rb
@@ -1,0 +1,7 @@
+all
+
+exclude_rule "MD002"
+
+rule "MD026", punctuation: ".,;:!"
+
+exclude_rule "MD041"

--- a/docs/0-installation.md
+++ b/docs/0-installation.md
@@ -43,12 +43,10 @@ After installing the gem, you need to run the generator. Here are your options:
 
 The generator adds these core files, among others:
 
-```
-app/admin/dashboard.rb
-app/assets/javascripts/active_admin.js.coffee
-app/assets/stylesheets/active_admin.scss
-config/initializers/active_admin.rb
-```
+* `app/admin/dashboard.rb`
+* `app/assets/javascripts/active_admin.js.coffee`
+* `app/assets/stylesheets/active_admin.scss`
+* `config/initializers/active_admin.rb`
 
 Now, migrate and seed your database before starting the server:
 

--- a/docs/14-gotchas.md
+++ b/docs/14-gotchas.md
@@ -116,7 +116,7 @@ under Rails 5 as it replaces the default scaffold generator. The solution is to
 configure the default controller in `config/application.rb` as outlined in
 [activeadmin/inherited_resources#195](https://github.com/activeadmin/inherited_resources/issues/195)
 
-```
+```ruby
 module SampleApp
   class Application < Rails::Application
     ...

--- a/docs/2-resource-customization.md
+++ b/docs/2-resource-customization.md
@@ -112,7 +112,7 @@ new, edit, and destroy by providing a resource specific translation.  For
 example, to change 'New Offer' to 'Make an Offer' add the following in
 config/locales/[en].yml:
 
-```
+```yaml
 en:
   active_admin:
     resources:

--- a/docs/3-index-pages.md
+++ b/docs/3-index-pages.md
@@ -81,7 +81,7 @@ end
 
 Out of the box, Active Admin supports the following filter types:
 
-* *:string* -  A drop down for selecting "Contains", "Equals", "Starts with", 
+* *:string* -  A drop down for selecting "Contains", "Equals", "Starts with",
   "Ends with" and an input for a value.
 * *:date_range* - A start and end date field with calendar inputs
 * *:numeric* - A drop down for selecting "Equal To", "Greater Than" or "Less

--- a/tasks/lint.rake
+++ b/tasks/lint.rake
@@ -9,6 +9,13 @@ namespace :lint do
   desc "Checks markdown code style with Markdownlint"
   task :mdl do
     puts "Running mdl..."
-    abort unless system("mdl docs/*.md")
+
+    targets = [
+      *Dir.glob("docs/*.md"),
+      "CONTRIBUTING.md",
+      ".github/ISSUE_TEMPLATE.md"
+    ]
+
+    abort unless system("mdl", *targets)
   end
 end

--- a/tasks/lint.rake
+++ b/tasks/lint.rake
@@ -9,6 +9,6 @@ namespace :lint do
   desc "Checks markdown code style with Markdownlint"
   task :mdl do
     puts "Running mdl..."
-    system("mdl docs/*.md")
+    abort unless system("mdl docs/*.md")
   end
 end


### PR DESCRIPTION
This PR improves markdown linting with the following:

* Fixes CI so that it actually fails if new offenses are introduced.
* Adds some new files to the check.
* Ignores or customizes some rules that were not a good fit for our files:
  - MD002: First header _must_ be a top header (`#`). I think we don't want this because GitHub displays `#` really really big.
  - MD041: First line in the file must be a top level header. We can't enforce this because a lot of our files include jekyll redirects at the beginning.
  - MD026: We need to allow `?` in headers as trailing punctuation allowed because some of our headers are "FAQ style". 