### PR TITLE
Remove unbind on element that has no event handlers

### DIFF
--- a/app/assets/javascripts/active_admin/lib/dropdown-menu.js.coffee
+++ b/app/assets/javascripts/active_admin/lib/dropdown-menu.js.coffee
@@ -32,7 +32,6 @@ class ActiveAdmin.DropdownMenu
     @
 
   destroy: ->
-    @$element.unbind()
     @$element = null
     @
 


### PR DESCRIPTION
While looking into #5047 and going through what's been deprecated and removed in jQuery v3, I noticed we were using unbind which has been deprecated in v3. We can safely just remove this though since the element itself has no event handlers bound to it in other words it does nothing. We should avoid using any deprecated methods.