### PR TITLE
Remove unused bourbon gem

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.2'
 
   s.add_dependency 'arbre', '>= 1.1.1'
-  s.add_dependency 'bourbon'
   s.add_dependency 'coffee-rails'
   s.add_dependency 'formtastic', '~> 3.1'
   s.add_dependency 'formtastic_i18n'

--- a/app/assets/stylesheets/active_admin/mixins/_all.scss
+++ b/app/assets/stylesheets/active_admin/mixins/_all.scss
@@ -6,4 +6,3 @@
 @import "active_admin/mixins/sections";
 @import "active_admin/mixins/utilities";
 @import "active_admin/mixins/typography";
-@import "bourbon";

--- a/lib/active_admin.rb
+++ b/lib/active_admin.rb
@@ -3,7 +3,6 @@ require 'set'
 
 require 'ransack'
 require 'ransack_ext'
-require 'bourbon'
 require 'kaminari'
 require 'formtastic'
 require 'formtastic_i18n'


### PR DESCRIPTION
I thought we were using bourbon but realized we weren’t using it to begin with so there is no need for the dependency. We have our own SASS mixins that we use but none from Bourbon. Testing locally against master, our components appear just fine, including things like gradients so this is safe removal now. No need to wait until v2.

I misread #4780 entirely since Bourbon only works with the `@include` syntax and but in our gradient mixin, we provide the explicit value of `linear-gradient` for `background-image` so we weren't even using Bourbon.

Fixes #4780 and #4791