### PR TITLE
Enhance codecov config a bit

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,13 +1,20 @@
+---
+
 codecov:
   notify:
     require_ci_to_pass: true
+
 comment: off
+
 coverage:
   precision: 2
+
   range:
-  - 70.0
-  - 100.0
+    - 70.0
+    - 100.0
+
   round: down
+
   status:
     changes: false
     patch: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,13 +7,13 @@ codecov:
 comment: off
 
 coverage:
-  precision: 2
+  precision: 1
 
   range:
     - 70.0
     - 100.0
 
-  round: down
+  round: up
 
   status:
     changes: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -12,6 +12,3 @@ coverage:
     changes: false
     patch: true
     project: true
-parsers:
-  javascript:
-    enable_partials: false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,1 @@
-require 'simplecov' if ENV["COVERAGE"] == true
+require 'simplecov' if ENV["COVERAGE"] == "true"


### PR DESCRIPTION
When PRs remove code, the global coverage percentage decreases. Codecov is too strict about this (see #5037 or #5051).

I think we can get around this by reducing a bit the precision of the bot's numbers. These checks are just to give an idea about the PR's coverage and how it affects global coverage, but nobody expects it to be very precise.