### PR TITLE
Fix the default scope error when scope_to is used with a block

### DIFF
--- a/features/index/index_scope_to.feature
+++ b/features/index/index_scope_to.feature
@@ -11,7 +11,7 @@ Feature: Index Scope To
       ActiveAdmin.register Post do
         # Scope section to a specific author
         scope_to do
-          User.find_by_first_name_and_last_name "John", "Doe"
+          User.find_by_first_name_and_last_name("John", "Doe").posts
         end
 
         # Set up some scopes
@@ -36,7 +36,7 @@ Feature: Index Scope To
       """
       ActiveAdmin.register Post do
         scope_to if: proc{ false } do
-          User.find_by_first_name_and_last_name("John", "Doe")
+          User.find_by_first_name_and_last_name("John", "Doe").posts
         end
       end
       """
@@ -48,9 +48,22 @@ Feature: Index Scope To
       """
       ActiveAdmin.register Post do
         scope_to unless: proc{ true } do
-          User.find_by_first_name_and_last_name("John", "Doe")
+          User.find_by_first_name_and_last_name("John", "Doe").posts
         end
       end
       """
     When I am on the index page for posts
     Then I should see 12 posts in the table
+
+  Scenario: Viewing the default scope counts with method option
+    Given a post with the title "Hello World" written by "Agent Smith" exists
+    Given an index configuration of:
+      """
+      ActiveAdmin.register Post do
+        scope_to association_method: :posts do
+          User.find_by_first_name_and_last_name("Agent", "Smith")
+        end
+      end
+      """
+    When I am on the index page for posts
+    Then I should see 1 post in the table

--- a/lib/active_admin/resource_controller/scoping.rb
+++ b/lib/active_admin/resource_controller/scoping.rb
@@ -23,9 +23,18 @@ module ActiveAdmin
       # Returns the method for the association chain when using
       # the scope_to option
       def method_for_association_chain
-        active_admin_config.scope_to_association_method || super
+        if active_admin_config.scope_to_association_method
+          return active_admin_config.scope_to_association_method
+        end
+
+        super unless active_admin_config.scope_to_method.respond_to?(:call)
       end
 
+      def method_for_build
+        return super unless active_admin_config.scope_to_method.respond_to?(:call)
+
+        active_admin_config.scope_to_association_method ? :build : :new
+      end
     end
   end
 end

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -16,6 +16,8 @@ create_file 'app/models/post.rb', <<-RUBY.strip_heredoc, force: true
     accepts_nested_attributes_for :author
     accepts_nested_attributes_for :taggings, allow_destroy: true
 
+    scope :starred, -> { where(starred: true) }
+
     ransacker :custom_title_searcher do |parent|
       parent.table[:title]
     end

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -142,6 +142,32 @@ module ActiveAdmin
             expect(@resource.controller.new.send(:method_for_association_chain)).to eq :blog_categories
           end
         end
+        context "should be nil if using a block" do
+          before do
+            @resource = application.register Post do
+              scope_to { Post.starred }
+            end
+          end
+          it "should return nil value" do
+            expect(@resource.controller.new.send(:method_for_association_chain)).to eq nil
+          end
+          it "a build method for a new record should be :new" do
+            expect(@resource.controller.new.send(:method_for_build)).to eq :new
+          end
+        end
+        context "when passing in the method and using a block" do
+          before do
+            @resource = application.register Post do
+              scope_to(association_method: 'posts') { User.last }
+            end
+          end
+          it "should return the method from the option" do
+            expect(@resource.controller.new.send(:method_for_association_chain)).to eq 'posts'
+          end
+          it "a build method for a new record should be :build" do
+            expect(@resource.controller.new.send(:method_for_build)).to eq :build
+          end
+        end
       end
     end
 


### PR DESCRIPTION
In the docs
https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#scoping-the-queries
there is the case
```
  scope_to do
    User.most_popular_posts
  end
```
But in this case, AA will use inherited_resource association method 
https://github.com/activeadmin/activeadmin/blob/master/lib/active_admin/resource_controller/scoping.rb#L25

And it will be error, because AA is trying to execute a request like this 
`User.most_popular_posts.posts`

In my case, I try to use Pundit as authorisation(Admin can view all records, users restricts by some logic)
```
  scope_to do
    Pundit.policy_scope(current_manager, TradePoint)
  end
```
Also AA tries to use `build` method except `new` for new records if score exists