### PR TITLE
Restore br tags in devise shared links

### DIFF
--- a/app/views/active_admin/devise/shared/_links.erb
+++ b/app/views/active_admin/devise/shared/_links.erb
@@ -1,27 +1,33 @@
 <%- if controller_name != 'sessions' %>
   <% scope = Devise::Mapping.find_scope!(resource_name) %>
   <%= link_to t('active_admin.devise.links.sign_in'), send(:"new_#{scope}_session_path") %>
+  <br>
 <% end -%>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
   <%= link_to t('active_admin.devise.links.sign_up'), new_registration_path(resource_name) %>
+  <br>
 <% end -%>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' %>
   <%= link_to t('active_admin.devise.links.forgot_your_password'), new_password_path(resource_name) %>
+  <br>
 <% end -%>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
   <%= link_to t('active_admin.devise.links.resend_confirmation_instructions'), new_confirmation_path(resource_name) %>
+  <br>
 <% end -%>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
   <%= link_to t('active_admin.devise.links.resend_unlock_instructions'), new_unlock_path(resource_name) %>
+  <br>
 <% end -%>
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
     <%= link_to t('active_admin.devise.links.sign_in_with_omniauth_provider', provider: provider.to_s.titleize),
           omniauth_authorize_path(resource_name, provider) %>
+    <br>
   <% end -%>
 <% end -%>


### PR DESCRIPTION
In #3862 I removed the br tags here because of the extra spacing and thought I could merge this minor change in earlier but that was wrong. Since this is used in various places and you don't see all the links unless you enabled more than the Devise defaults, I didn't think there were that many other than a Forgot Password link that could show up on a login page. Quite a few can show up depending on what you've enabled.

This is the easiest fix as it involves no CSS changes and thus no conflicts with my work in #3862 where I'll be working on this further (made a todo update). I'm much better suited now to doing UI updates thanks to an updated test template (#4992) that has more features and components enabled by default. I've learned to also enable more Devise features too to replicate this so I'll improve this in #3862.

Fixes #4995 and #5057