### PR TITLE
Deprecate old asset registration with upgrade messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Deprecations
 
+* Deprecated `config.register_stylesheet` and `config.register_javascript`. Import
+  your CSS and JS files in `active_admin.scss` or `active_admin.js`. [#5060][] by [@javierjulio][]
 * Deprecated `type` param from `status_tag` and related CSS classes [#4989][] by [@javierjulio][]
   * The method signature has changed from:
     ```ruby

--- a/features/registering_assets.feature
+++ b/features/registering_assets.feature
@@ -18,8 +18,10 @@ Feature: Registering Assets
   Scenario: Registering a CSS file
     Given a configuration of:
     """
-      ActiveAdmin.application.register_stylesheet "some-random-css.css", media: :print
-      ActiveAdmin.register Post
+      ActiveSupport::Deprecation.silence do
+        ActiveAdmin.application.register_stylesheet "some-random-css.css", media: :print
+        ActiveAdmin.register Post
+      end
     """
     When I am on the index page for posts
     Then I should see the css file "some-random-css" of media "print"
@@ -27,8 +29,10 @@ Feature: Registering Assets
   Scenario: Registering a JS file
     Given a configuration of:
     """
-      ActiveAdmin.application.register_javascript "some-random-js.js"
-      ActiveAdmin.register Post
+      ActiveSupport::Deprecation.silence do
+        ActiveAdmin.application.register_javascript "some-random-js.js"
+        ActiveAdmin.register Post
+      end
     """
     When I am on the index page for posts
     Then I should see the js file "some-random-js"

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -271,10 +271,12 @@ module ActiveAdmin
   private
 
     def register_default_assets
-      register_stylesheet 'active_admin.css',       media: 'screen'
-      register_stylesheet 'active_admin/print.css', media: 'print'
+      ActiveSupport::Deprecation.silence do
+        register_stylesheet 'active_admin.css',       media: 'screen'
+        register_stylesheet 'active_admin/print.css', media: 'print'
 
-      register_javascript 'active_admin.js'
+        register_javascript 'active_admin.js'
+      end
     end
 
     # Since app/admin is alphabetically before app/models, we have to remove it

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -271,12 +271,9 @@ module ActiveAdmin
   private
 
     def register_default_assets
-      ActiveSupport::Deprecation.silence do
-        register_stylesheet 'active_admin.css',       media: 'screen'
-        register_stylesheet 'active_admin/print.css', media: 'print'
-
-        register_javascript 'active_admin.js'
-      end
+      stylesheets['active_admin.css'] = { media: 'screen' }
+      stylesheets['active_admin/print.css'] = { media: 'print' }
+      javascripts.add 'active_admin.js'
     end
 
     # Since app/admin is alphabetically before app/models, we have to remove it

--- a/lib/active_admin/asset_registration.rb
+++ b/lib/active_admin/asset_registration.rb
@@ -2,6 +2,10 @@ module ActiveAdmin
   module AssetRegistration
 
     def register_stylesheet(path, options = {})
+      Deprecation.warn <<-MSG.strip_heredoc
+        The `register_stylesheet` config is deprecated and will be removed
+        in v2. Import your "#{path}" stylesheet in the active_admin.scss.
+      MSG
       stylesheets[path] = options
     end
 
@@ -14,6 +18,10 @@ module ActiveAdmin
     end
 
     def register_javascript(name)
+      Deprecation.warn <<-MSG.strip_heredoc
+        The `register_javascript` config is deprecated and will be removed
+        in v2. Import your "#{name}" javascript in the active_admin.js.
+      MSG
       javascripts.add name
     end
 

--- a/spec/unit/asset_registration_spec.rb
+++ b/spec/unit/asset_registration_spec.rb
@@ -8,13 +8,37 @@ RSpec.describe ActiveAdmin::AssetRegistration do
     clear_javascripts!
   end
 
+  it "is deprecated" do
+    expect(ActiveAdmin::Deprecation)
+      .to receive(:warn)
+      .with(<<-MSG.strip_heredoc
+        The `register_stylesheet` config is deprecated and will be removed
+        in v2. Import your "sample_styles.css" stylesheet in the active_admin.scss.
+      MSG
+      )
+
+    register_stylesheet "sample_styles.css"
+
+    expect(ActiveAdmin::Deprecation)
+      .to receive(:warn)
+      .with(<<-MSG.strip_heredoc
+        The `register_javascript` config is deprecated and will be removed
+        in v2. Import your "sample_scripts.js" javascript in the active_admin.js.
+      MSG
+      )
+
+    register_javascript "sample_scripts.js"
+  end
+
   it "should register a stylesheet file" do
+    expect(ActiveAdmin::Deprecation).to receive(:warn).once
     register_stylesheet "active_admin.css"
     expect(stylesheets.length).to eq 1
     expect(stylesheets.keys.first).to eq "active_admin.css"
   end
 
   it "should clear all existing stylesheets" do
+    expect(ActiveAdmin::Deprecation).to receive(:warn).once
     register_stylesheet "active_admin.css"
     expect(stylesheets.length).to eq 1
     clear_stylesheets!
@@ -22,22 +46,26 @@ RSpec.describe ActiveAdmin::AssetRegistration do
   end
 
   it "should allow media option when registering stylesheet" do
+    expect(ActiveAdmin::Deprecation).to receive(:warn).once
     register_stylesheet "active_admin.css", media: :print
     expect(stylesheets.values.first[:media]).to eq :print
   end
 
   it "shouldn't register a stylesheet twice" do
+    expect(ActiveAdmin::Deprecation).to receive(:warn).twice
     register_stylesheet "active_admin.css"
     register_stylesheet "active_admin.css"
     expect(stylesheets.length).to eq 1
   end
 
   it "should register a javascript file" do
+    expect(ActiveAdmin::Deprecation).to receive(:warn).once
     register_javascript "active_admin.js"
     expect(javascripts).to eq ["active_admin.js"].to_set
   end
 
   it "should clear all existing javascripts" do
+    expect(ActiveAdmin::Deprecation).to receive(:warn).once
     register_javascript "active_admin.js"
     expect(javascripts).to eq ["active_admin.js"].to_set
     clear_javascripts!
@@ -45,6 +73,7 @@ RSpec.describe ActiveAdmin::AssetRegistration do
   end
 
   it "shouldn't register a javascript twice" do
+    expect(ActiveAdmin::Deprecation).to receive(:warn).twice
     register_javascript "active_admin.js"
     register_javascript "active_admin.js"
     expect(javascripts.length).to eq 1


### PR DESCRIPTION
No need to keep this around since its predates the asset pipeline! 😳 Which is the preferred and best way to do this since it allows users to import what they like through the generated stylesheet and javascript files. In case anyone is using this config based approach though lets give them a heads up so they can migrate before v2 where it will be removed.