### PR TITLE
Let jquery-ui-rails 6.0 be used in tests

### DIFF
--- a/gemfiles/rails_42.gemfile
+++ b/gemfiles/rails_42.gemfile
@@ -3,7 +3,6 @@ source "https://rubygems.org"
 eval_gemfile(File.expand_path(File.join("..", "Gemfile"), __dir__))
 
 gem "rails", "4.2.8"
-gem "jquery-ui-rails", "~> 5.0"
 gem "devise", "~> 3.5"
 gem "draper", "~> 2.1"
 gem "activerecord-jdbcsqlite3-adapter", platforms: :jruby

--- a/gemfiles/rails_50.gemfile
+++ b/gemfiles/rails_50.gemfile
@@ -3,7 +3,6 @@ source "https://rubygems.org"
 eval_gemfile(File.expand_path(File.join("..", "Gemfile"), __dir__))
 
 gem "rails", "5.0.3"
-gem "jquery-ui-rails", "~> 5.0"
 gem "devise", "~> 4.0"
 gem "draper", "~> 3.0"
 gem "activerecord-jdbcsqlite3-adapter", github: "jruby/activerecord-jdbc-adapter", branch: "rails-5", platforms: :jruby

--- a/gemfiles/rails_51.gemfile
+++ b/gemfiles/rails_51.gemfile
@@ -3,7 +3,6 @@ source "https://rubygems.org"
 eval_gemfile(File.expand_path(File.join("..", "Gemfile"), __dir__))
 
 gem "rails", "5.1.1"
-gem "jquery-ui-rails", "~> 5.0"
 gem "devise", "~> 4.3"
 gem "draper", "~> 3.0"
 gem "activerecord-jdbcsqlite3-adapter", github: "jruby/activerecord-jdbc-adapter", branch: "rails-5", platforms: :jruby


### PR DESCRIPTION
We are currently only testing against a single `jquery-ui-rails` version. It should be the latest.