### PR TITLE
Add default templates for Kaminari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (unreleased)
 
+* Fixed [#4173](../../issues/4173) by including the default Kaminari templates [#5069](../../pull/5069) by [@javierjulio][]
+
 ### Removals
 
 * Ruby 2.1 support has been dropped [#5002][] by [@deivid-rodriguez][]

--- a/app/views/kaminari/active_admin/_first_page.html.erb
+++ b/app/views/kaminari/active_admin/_first_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="first">
+  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote %>
+</span>

--- a/app/views/kaminari/active_admin/_gap.html.erb
+++ b/app/views/kaminari/active_admin/_gap.html.erb
@@ -1,0 +1,8 @@
+<%# Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page gap"><%= t('views.pagination.truncate').html_safe %></span>

--- a/app/views/kaminari/active_admin/_last_page.html.erb
+++ b/app/views/kaminari/active_admin/_last_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Last" page
+  - available local variables
+    url:           url to the last page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="last">
+  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote %>
+</span>

--- a/app/views/kaminari/active_admin/_next_page.html.erb
+++ b/app/views/kaminari/active_admin/_next_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="next">
+  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote %>
+</span>

--- a/app/views/kaminari/active_admin/_page.html.erb
+++ b/app/views/kaminari/active_admin/_page.html.erb
@@ -1,0 +1,12 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page<%= ' current' if page.current? %>">
+  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel} %>
+</span>

--- a/app/views/kaminari/active_admin/_paginator.html.erb
+++ b/app/views/kaminari/active_admin/_paginator.html.erb
@@ -1,0 +1,25 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<%= paginator.render do -%>
+  <nav class="pagination">
+    <%= first_page_tag unless current_page.first? %>
+    <%= prev_page_tag unless current_page.first? %>
+    <% each_page do |page| -%>
+      <% if page.display_tag? -%>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? -%>
+        <%= gap_tag %>
+      <% end -%>
+    <% end -%>
+    <% unless current_page.out_of_range? %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    <% end %>
+  </nav>
+<% end -%>

--- a/app/views/kaminari/active_admin/_prev_page.html.erb
+++ b/app/views/kaminari/active_admin/_prev_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="prev">
+  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote %>
+</span>

--- a/lib/active_admin/views/components/paginated_collection.rb
+++ b/lib/active_admin/views/components/paginated_collection.rb
@@ -92,7 +92,7 @@ module ActiveAdmin
       end
 
       def build_pagination
-        options = {}
+        options = { theme: 'active_admin' }
         options[:params]     = @params     if @params
         options[:param_name] = @param_name if @param_name
 


### PR DESCRIPTION
We should have Kaminari's default templates at a minimum just like we do for Devise regardless if we change them or not (although we will be changing them in #3862). We should include the defaults now to fix this longstanding issue where a host app defines its own Kaminari templates but because ActiveAdmin doesn't, it inherits those and breaks the pagination display. 

By including these defaults we don't break the host app that has custom templates since AA will always use what we have set. Plus, if the host app **does not** have any templates set, it will use the Kaminari default as expected and not what AA has set. All around we fix any possible issue of one overriding the other so we are safer by including our own templates for Kaminari than not.

Fixes #4173