### PR TITLE
Revert "trigger separate js event for each batch action"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,6 @@
 * Allow AA scopes to return paginated collections [#4996][] by [@Fivell][]
 * Added `scopes_show_count` configuration to  setup show_count attribute for scopes globally [#4950][] by [@Fivell][]
 * Allow custom panel title given with `attributes_table` [#4940][] by [@ajw725][]
-* Added unique js events for each particular batch action [#5040][] by [@Fivell][]
-
 
 ## 1.0.0 [☰](https://github.com/activeadmin/activeadmin/compare/v0.6.3...master)
 

--- a/app/assets/javascripts/active_admin/lib/batch_actions.js.coffee
+++ b/app/assets/javascripts/active_admin/lib/batch_actions.js.coffee
@@ -5,8 +5,8 @@ onDOMReady = ->
   $('.batch_actions_selector li a').click (e)->
     e.stopPropagation() # prevent Rails UJS click event
     e.preventDefault()
-    if $(@).data 'confirm'
-      ActiveAdmin.modal_dialog $(@), (inputs)=>
+    if message = $(@).data 'confirm'
+      ActiveAdmin.modal_dialog message, $(@).data('inputs'), (inputs)=>
         $(@).trigger 'confirm:complete', inputs
     else
       $(@).trigger 'confirm:complete'

--- a/app/assets/javascripts/active_admin/lib/modal_dialog.js.coffee
+++ b/app/assets/javascripts/active_admin/lib/modal_dialog.js.coffee
@@ -1,7 +1,4 @@
-ActiveAdmin.modal_dialog = (batch_action, callback)->
-  message = batch_action.data 'confirm'
-  inputs  = batch_action.data 'inputs'
-  action  = batch_action.data 'action'
+ActiveAdmin.modal_dialog = (message, inputs, callback)->
   html = """<form id="dialog_confirm" title="#{message}"><ul>"""
   for name, type of inputs
     if /^(datepicker|checkbox|text|number)$/.test type
@@ -34,13 +31,11 @@ ActiveAdmin.modal_dialog = (batch_action, callback)->
 
   form = $(html).appendTo('body')
   $('body').trigger 'modal_dialog:before_open', [form]
-  $('body').trigger "modal_dialog:#{action}:before_open", [form]
 
   form.dialog
     modal: true
     open: (event, ui) ->
       $('body').trigger 'modal_dialog:after_open', [form]
-      $('body').trigger "modal_dialog:#{action}:after_open", [form]
     dialogClass: 'active_admin_dialog'
     buttons:
       OK: ->


### PR DESCRIPTION
Reverts activeadmin/activeadmin#5040

because changes number of arguments in  ActiveAdmin.modal_dialog , so not backward compatible for 1.1