### PR TITLE
remove conditional checking for ProtectedAttributes

### DIFF
--- a/lib/active_admin/orm/active_record/comments/comment.rb
+++ b/lib/active_admin/orm/active_record/comments/comment.rb
@@ -6,10 +6,6 @@ module ActiveAdmin
     belongs_to :resource, polymorphic: true
     belongs_to :author,   polymorphic: true
 
-    if defined? ProtectedAttributes
-      attr_accessible :resource, :resource_id, :resource_type, :body, :namespace
-    end
-
     validates_presence_of :body, :namespace, :resource
 
     before_create :set_resource_type

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -28,9 +28,6 @@ create_file 'app/models/post.rb', <<-RUBY.strip_heredoc, force: true
       # nothing to see here
     end
 
-    if defined? ProtectedAttributes
-      attr_accessible :id, :title, :body, :starred, :author, :position, :published_date, :author_id, :custom_category_id, :category
-    end
   end
 RUBY
 copy_file File.expand_path('../templates/post_decorator.rb', __FILE__), 'app/models/post_decorator.rb'
@@ -45,9 +42,6 @@ create_file 'app/models/blog/post.rb', <<-RUBY.strip_heredoc, force: true
     accepts_nested_attributes_for :author
     accepts_nested_attributes_for :taggings, allow_destroy: true
 
-    if defined? ProtectedAttributes
-      attr_accessible :title, :body, :starred, :author, :position, :published_date, :author_id, :custom_category_id, :category
-    end
   end
 RUBY
 
@@ -64,10 +58,6 @@ create_file 'app/models/user.rb', <<-RUBY.strip_heredoc, force: true
       parent.table[:age]
     end
 
-    if defined? ProtectedAttributes
-      attr_accessible :first_name, :last_name, :username,  :age
-    end
-
     def display_name
       "\#{first_name} \#{last_name}"
     end
@@ -77,10 +67,6 @@ RUBY
 create_file 'app/models/profile.rb', <<-RUBY.strip_heredoc, force: true
   class Profile < ActiveRecord::Base
     belongs_to :user
-
-    if defined? ProtectedAttributes
-      attr_accessible :bio
-    end
   end
 RUBY
 
@@ -92,10 +78,6 @@ create_file 'app/models/category.rb', <<-RUBY.strip_heredoc, force: true
     has_many :posts, foreign_key: :custom_category_id
     has_many :authors, through: :posts
     accepts_nested_attributes_for :posts
-
-    if defined? ProtectedAttributes
-      attr_accessible :name, :description
-    end
   end
 RUBY
 
@@ -104,9 +86,6 @@ generate :model, 'store name:string'
 generate :model, 'tag name:string'
 create_file 'app/models/tag.rb', <<-RUBY.strip_heredoc, force: true
   class Tag < ActiveRecord::Base
-    if defined? ProtectedAttributes
-      attr_accessible :name
-    end
   end
 RUBY
 


### PR DESCRIPTION
protected_attributes was extracted from rails long time ago, looks like there is no reason to
support it anymore in our test environment and in internal Comment  model