### PR TITLE
Fix sometimes broken ActiveAdmin.application.load_paths

### DIFF
--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -24,7 +24,7 @@ module ActiveAdmin
     # Load paths for admin configurations. Add folders to this load path
     # to load up other resources for administration. External gems can
     # include their paths in this load path to provide active_admin UIs
-    setting :load_paths, [File.expand_path('app/admin', Rails.root)]
+    setting :load_paths, proc { [File.expand_path('app/admin', Rails.root)] }
 
     # The default number of resources to display on index pages
     inheritable_setting :default_per_page, 30

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -24,7 +24,7 @@ module ActiveAdmin
     # Load paths for admin configurations. Add folders to this load path
     # to load up other resources for administration. External gems can
     # include their paths in this load path to provide active_admin UIs
-    setting :load_paths, proc { [File.expand_path('app/admin', Rails.root)] }
+    setting :load_paths, wrap_value { [File.expand_path('app/admin', Rails.root)] }
 
     # The default number of resources to display on index pages
     inheritable_setting :default_per_page, 30

--- a/lib/active_admin/helpers/settings.rb
+++ b/lib/active_admin/helpers/settings.rb
@@ -22,6 +22,10 @@ module ActiveAdmin
     end
 
     def read_default_setting(name)
+      if (value = default_settings[name]).respond_to?(:call)
+        default_settings[name] = value.call
+      end
+
       default_settings[name]
     end
 

--- a/lib/active_admin/helpers/settings.rb
+++ b/lib/active_admin/helpers/settings.rb
@@ -22,11 +22,7 @@ module ActiveAdmin
     end
 
     def read_default_setting(name)
-      if (value = default_settings[name]).respond_to?(:call)
-        default_settings[name] = value.call
-      end
-
-      default_settings[name]
+      self.class.unwrap_value(default_settings[name])
     end
 
     private
@@ -36,6 +32,19 @@ module ActiveAdmin
     end
 
     module ClassMethods
+      WrappedValue = Struct.new(:block) do
+        def unwrap
+          block.call
+        end
+      end
+
+      def wrap_value(&block)
+        WrappedValue.new(block)
+      end
+
+      def unwrap_value(value)
+        value.is_a?(WrappedValue) ? value.unwrap : value
+      end
 
       def setting(name, default)
         default_settings[name] = default

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -5,16 +5,6 @@ RSpec.describe ActiveAdmin::Application do
 
   let(:application) { ActiveAdmin::Application.new }
 
-  around do |example|
-    old_load_paths = application.load_paths
-    # TODO: Figure out why load paths need to be overriden
-    application.load_paths = [File.expand_path('app/admin', Rails.root)]
-
-    example.call
-
-    application.load_paths = old_load_paths
-  end
-
   it "should have a default load path of ['app/admin']" do
     expect(application.load_paths).to eq [File.expand_path('app/admin', Rails.root)]
   end


### PR DESCRIPTION
Rails.root is always `nil` when active_admin/application.rb is loaded.

Initialize this setting at it's first-time use, so `Rails.root` will
be already there.

My application don't start when `CWD` is `$HOME`, `load_paths` don't clean-up and my application crashes because of circular dependency that is caused by same file names in `app/admin` and `app/models` directories.

After these changes tests are green without setting `load_paths` in `application_spec.rb`