### PR TITLE
Add link to Formtastic wiki

### DIFF
--- a/docs/5-forms.md
+++ b/docs/5-forms.md
@@ -28,7 +28,7 @@ ActiveAdmin.register Post do
 end
 ```
 
-For more details, please see Formtastic's documentation.
+For more details, please see [Formtastic's documentation](https://github.com/justinfrench/formtastic/wiki).
 
 ## Default
 


### PR DESCRIPTION
The current documentation on forms recommends that the reader "see the Formtastic documentation for more details". It would be useful to have a link to the mentioned documentation.

This pull request will add a link to the Formtastic wiki to the documentation

#### Issue Link
https://github.com/activeadmin/activeadmin/issues/5082


closes #5082