### PR TITLE
add pagination to the comments section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 * Added `scopes_show_count` configuration to  setup show_count attribute for scopes globally [#4950][] by [@Fivell][]
 * Allow custom panel title given with `attributes_table` [#4940][] by [@ajw725][]
 * Allow passing a class to `action_item` block [#4997][] by [@Fivell][]
+* Add pagination to the comments section [#5088][] by [@alex-bogomolov][]
 
 ## 1.0.0 [☰](https://github.com/activeadmin/activeadmin/compare/v0.6.3...master)
 
@@ -195,6 +196,7 @@ Please check [0-6-stable](https://github.com/activeadmin/activeadmin/blob/0-6-st
 [#5046]: https://github.com/activeadmin/activeadmin/pull/5046
 [#5060]: https://github.com/activeadmin/activeadmin/pull/5060
 [#5069]: https://github.com/activeadmin/activeadmin/pull/5069
+[#5088]: https://github.com/activeadmin/activeadmin/pull/5088
 
 [@ajw725]: https://github.com/ajw725
 [@bolshakov]: https://github.com/bolshakov
@@ -216,3 +218,4 @@ Please check [0-6-stable](https://github.com/activeadmin/activeadmin/blob/0-6-st
 [@TimPetricola]: https://github.com/TimPetricola
 [@varyonic]: https://github.com/varyonic
 [@zorab47]: https://github.com/zorab47
+[@alex-bogomolov]: https://github.com/alex-bogomolov

--- a/app/assets/stylesheets/active_admin/components/_pagination.scss
+++ b/app/assets/stylesheets/active_admin/components/_pagination.scss
@@ -46,7 +46,7 @@
 .comments {
   .pagination {
     float: left;
-    margin-bottom: 10px;
+    margin-bottom: 30px;
   }
   .pagination_information {
     float: left;

--- a/app/assets/stylesheets/active_admin/components/_pagination.scss
+++ b/app/assets/stylesheets/active_admin/components/_pagination.scss
@@ -42,3 +42,14 @@
     padding: 1px 5px;
   }
 }
+
+.comments {
+  .pagination {
+    float: left;
+    margin-bottom: 10px;
+  }
+  .pagination_information {
+    float: left;
+    color: #000;
+  }
+}

--- a/features/comments/commenting.feature
+++ b/features/comments/commenting.feature
@@ -156,3 +156,23 @@ Feature: Commenting
     And I follow "View"
     When I add a comment "Bar"
     Then I should be in the resource section for foos
+
+  Scenario: View comments
+    Given 70 comments added by admin with an email "admin@example.com"
+    And a show configuration of:
+      """
+        ActiveAdmin.register Post
+      """
+    Then I should see "Comments (70)"
+    And I should see "Displaying comments 1 - 25 of 70 in total"
+    And I should see 25 comments
+    And I should see pagination with 3 pages
+    And I should see the pagination "Next" link
+    Then I follow "2"
+    And I should see "Displaying comments 26 - 50 of 70 in total"
+    And I should see 25 comments
+    And I should see the pagination "Next" link
+    Then I follow "Next"
+    And I should see 20 comments
+    And I should see "Displaying comments 51 - 70 of 70 in total"
+    And I should not see the pagination "Next" link

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -10,3 +10,23 @@ end
 Given /^a tag with the name "([^"]*)" exists$/ do |tag_name|
   Tag.create(name: tag_name)
 end
+
+Given /^(a|\d+) comments added by admin with an email "([^"]+)"?$/ do |number, email|
+  number = number == 'a' ? 1 : number.to_i
+  admin_user = ensure_user_created(email)
+
+  comment_text = 'Comment %i'
+
+  number.times do |i|
+    ActiveAdmin::Comment.create!(namespace:     'admin',
+                                 body:          comment_text % i,
+                                 resource_type: Post.to_s,
+                                 resource_id:   Post.first.id,
+                                 author_type:   admin_user.class.to_s,
+                                 author_id:     admin_user.id)
+  end
+end
+
+Then /^I should see (\d+) comments?$/ do |number|
+  expect(page).to have_selector('div.active_admin_comment', count: number.to_i)
+end

--- a/lib/active_admin/orm/active_record/comments/views/active_admin_comments.rb
+++ b/lib/active_admin/orm/active_record/comments/views/active_admin_comments.rb
@@ -12,7 +12,7 @@ module ActiveAdmin
 
         def build(resource)
           @resource = resource
-          @comments = ActiveAdmin::Comment.find_for_resource_in_namespace resource, active_admin_namespace.name
+          @comments = ActiveAdmin::Comment.find_for_resource_in_namespace(resource, active_admin_namespace.name).page(params[:page])
           super(title, for: resource)
           build_comments
         end
@@ -20,11 +20,13 @@ module ActiveAdmin
         protected
 
         def title
-          I18n.t 'active_admin.comments.title_content', count: @comments.count
+          I18n.t 'active_admin.comments.title_content', count: @comments.total_count
         end
 
         def build_comments
           @comments.any? ? @comments.each(&method(:build_comment)) : build_empty_message
+          div page_entries_info(@comments).html_safe, class: 'pagination_information'
+          text_node paginate @comments
           build_comment_form
         end
 


### PR DESCRIPTION
Adds pagination to the comments section.

Closes #5065 

Here's how the comments section looks like now:
![comments](https://user-images.githubusercontent.com/19406564/28334835-07aabf70-6c05-11e7-8fe6-830a79d8585f.png)
