### PR TITLE
Index page pagination

### DIFF
--- a/lib/active_admin/views/components/paginated_collection.rb
+++ b/lib/active_admin/views/components/paginated_collection.rb
@@ -107,7 +107,7 @@ module ActiveAdmin
           options[:right] = 0
         end
 
-        text_node paginate.html_safe collection, options
+        text_node paginate(collection, options).html_safe
       end
 
       include ::ActiveAdmin::Helpers::Collection

--- a/lib/active_admin/views/components/paginated_collection.rb
+++ b/lib/active_admin/views/components/paginated_collection.rb
@@ -107,7 +107,7 @@ module ActiveAdmin
           options[:right] = 0
         end
 
-        text_node paginate collection, options
+        text_node paginate.html_safe collection, options
       end
 
       include ::ActiveAdmin::Helpers::Collection


### PR DESCRIPTION
The pagination on index pages was broken because the pagination code was not marked as html_safe and thus the html code was just displayed instead of being rendered. This fixes it