### PR TITLE
resolve related class in active filters if possible

### DIFF
--- a/lib/active_admin/filters/active_filter.rb
+++ b/lib/active_admin/filters/active_filter.rb
@@ -13,7 +13,7 @@ module ActiveAdmin
       def initialize(resource, condition)
         @resource = resource
         @condition = condition
-        @related_class = find_class
+        @related_class = find_class if find_class?
       end
 
       def values
@@ -65,6 +65,10 @@ module ActiveAdmin
 
       def ransack_predicate_name
         Ransack::Translate.predicate(condition.predicate.name)
+      end
+
+      def find_class?
+        ['eq', 'in'].include? condition.predicate.arel_predicate
       end
 
       # detect related class for Ransack::Nodes::Attribute


### PR DESCRIPTION
there are only few cases when it makes sense to detect related class in active filter by predicate
 - dropdown with single value (`eq` arel predicate)
 - dropdown/checkboxes with multiple values (`in` arel predicate)

so let's skip detecting unless in and eq arel predicates are used

[refs #5091]