### PR TITLE
Generate comments data with random categories for variation

### DIFF
--- a/spec/support/rails_template_with_data.rb
+++ b/spec/support/rails_template_with_data.rb
@@ -319,7 +319,7 @@ append_file "db/seeds.rb", "\n\n" + <<-RUBY.strip_heredoc
       namespace: :admin,
       author: AdminUser.first,
       body: "Test comment #{i}",
-      resource: categories[rand(categories.size - 1)],
+      resource: categories.sample,
     )
   end
 RUBY

--- a/spec/support/rails_template_with_data.rb
+++ b/spec/support/rails_template_with_data.rb
@@ -313,6 +313,15 @@ append_file "db/seeds.rb", "\n\n" + <<-RUBY.strip_heredoc
                 author: user,
                 starred: true
   end
+
+  800.times do |i|
+    ActiveAdmin::Comment.create!(
+      namespace: :admin,
+      author: AdminUser.first,
+      body: "Test comment #{i}",
+      resource: categories[rand(categories.size - 1)],
+    )
+  end
 RUBY
 
 rake 'db:seed'


### PR DESCRIPTION
Since we support comments we should have data to begin with when loading up a test app to try out the admin. I used categories since we only have a couple, this way we get many comments for one of them and can active pagination. We've had some issues submitted on that lately and would be good to have this in place for testing, also for updates to come in v2 (#3862).