### PR TITLE
Fix app path setting during engine initialization

### DIFF
--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -21,6 +21,8 @@ module ActiveAdmin
       @namespaces = Namespace::Store.new
     end
 
+    setting :app_path, Rails.root
+
     # Load paths for admin configurations. Add folders to this load path
     # to load up other resources for administration. External gems can
     # include their paths in this load path to provide active_admin UIs

--- a/lib/active_admin/engine.rb
+++ b/lib/active_admin/engine.rb
@@ -1,5 +1,12 @@
 module ActiveAdmin
   class Engine < ::Rails::Engine
+    initializer "active_admin.load_app_path" do |app|
+      ActiveAdmin.application.instance_exec(app) do |app|
+        default_settings[:app_path] = app.root
+        default_settings[:load_paths] = [File.expand_path('app/admin', app.root)]
+      end
+    end
+
     initializer "active_admin.precompile", group: :all do |app|
       ActiveAdmin.application.stylesheets.each do |path, _|
         app.config.assets.precompile << path

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -5,18 +5,8 @@ RSpec.describe ActiveAdmin::Application do
 
   let(:application) { ActiveAdmin::Application.new }
 
-  around do |example|
-    old_load_paths = application.load_paths
-    # TODO: Figure out why load paths need to be overriden
-    application.load_paths = [File.expand_path('app/admin', Rails.root)]
-
-    example.call
-
-    application.load_paths = old_load_paths
-  end
-
   it "should have a default load path of ['app/admin']" do
-    expect(application.load_paths).to eq [File.expand_path('app/admin', Rails.root)]
+    expect(application.load_paths).to eq [File.expand_path('app/admin', application.app_path)]
   end
 
   it "should remove app/admin from the autoload paths (Active Admin deals with loading)" do
@@ -125,12 +115,12 @@ RSpec.describe ActiveAdmin::Application do
 
   describe "files in load path" do
     it "should load files in the first level directory" do
-      expect(application.files).to include(File.expand_path("app/admin/dashboard.rb", Rails.root))
+      expect(application.files).to include(File.expand_path("app/admin/dashboard.rb", application.app_path))
     end
 
     it "should load files from subdirectories" do
-      test_dir = File.expand_path("app/admin/public", Rails.root)
-      test_file = File.expand_path("app/admin/public/posts.rb", Rails.root)
+      test_dir = File.expand_path("app/admin/public", application.app_path)
+      test_file = File.expand_path("app/admin/public/posts.rb", application.app_path)
 
       begin
         FileUtils.mkdir_p(test_dir)


### PR DESCRIPTION
I offer this alternative to #5076 that does not rely on further changes to the Settings mixin, in particular read_default_setting().