### PR TITLE
[WIP] add opportunity to add a form to sidebar on resource's index page

### DIFF
--- a/app/assets/stylesheets/active_admin/_base.scss
+++ b/app/assets/stylesheets/active_admin/_base.scss
@@ -27,6 +27,7 @@
 @import "active_admin/components/index_list";
 @import "active_admin/components/unsupported_browser";
 @import "active_admin/components/tabs";
+@import "active_admin/components/sidebar_form";
 @import "active_admin/pages/logged_out";
 @import "active_admin/structure/footer";
 @import "active_admin/structure/main_structure";

--- a/app/assets/stylesheets/active_admin/components/_sidebar_form.scss
+++ b/app/assets/stylesheets/active_admin/components/_sidebar_form.scss
@@ -1,0 +1,30 @@
+.sidebar_section.panel {
+  .cancel {
+    display: none;
+  }
+
+  fieldset {
+    box-shadow: none;
+
+    .input {
+      padding: 0;
+    }
+
+    legend {
+      span {
+        background-color: inherit;
+        background-image: none;
+        border: none;
+        box-shadow: none;
+        padding-left: 0;
+      }
+    }
+
+    margin-bottom: 0;
+  }
+
+  fieldset.actions {
+    padding-bottom: 0;
+    margin-top: 0;
+  }
+}

--- a/lib/active_admin.rb
+++ b/lib/active_admin.rb
@@ -122,6 +122,7 @@ require 'active_admin/error'
 # Require internal plugins
 require 'active_admin/batch_actions'
 require 'active_admin/filters'
+require 'active_admin/sidebar_form'
 
 # Require ORM-specific plugins
 require 'active_admin/orm/active_record' if defined? ActiveRecord

--- a/lib/active_admin/resource_controller/data_access.rb
+++ b/lib/active_admin/resource_controller/data_access.rb
@@ -301,6 +301,8 @@ module ActiveAdmin
       def smart_resource_url
         if create_another?
           new_resource_url(create_another: params[:create_another])
+        elsif params[:redirect_to_index]
+          smart_collection_url
         else
           super
         end

--- a/lib/active_admin/sidebar_form.rb
+++ b/lib/active_admin/sidebar_form.rb
@@ -1,0 +1,7 @@
+require 'active_admin/sidebar_form/resource_extension'
+require 'active_admin/sidebar_form/dsl'
+require 'active_admin/sidebar_form/form'
+
+ActiveAdmin::Resource.send :include, ActiveAdmin::SidebarForm::ResourceExtension
+ActiveAdmin::ResourceDSL.send :include, ActiveAdmin::SidebarForm::DSL
+ActiveAdmin::Views::SidebarSection.send :include, ActiveAdmin::SidebarForm::Form

--- a/lib/active_admin/sidebar_form/dsl.rb
+++ b/lib/active_admin/sidebar_form/dsl.rb
@@ -1,0 +1,9 @@
+module ActiveAdmin
+  module SidebarForm
+    module DSL
+      def show_form_in_sidebar
+        config.add_sidebar_form
+      end
+    end
+  end
+end

--- a/lib/active_admin/sidebar_form/form.rb
+++ b/lib/active_admin/sidebar_form/form.rb
@@ -1,0 +1,28 @@
+module ActiveAdmin
+  module SidebarForm
+    module Form
+
+      private
+
+      def options_for_form
+        {
+          url:               @arbre_context.helpers.collection_path,
+          as:                active_admin_config.param_key,
+          redirect_to_index: true
+        }
+      end
+
+      def form_presenter
+        active_admin_config.get_page_presenter(:form) || default_form_presenter
+      end
+
+      def default_form_presenter
+        ActiveAdmin::PagePresenter.new do |f|
+          f.semantic_errors
+          f.inputs
+          f.actions
+        end
+      end
+    end
+  end
+end

--- a/lib/active_admin/sidebar_form/resource_extension.rb
+++ b/lib/active_admin/sidebar_form/resource_extension.rb
@@ -1,0 +1,33 @@
+module ActiveAdmin
+  module SidebarForm
+    module ResourceExtension
+      def initialize(*)
+        super
+        add_sidebar_form_section
+      end
+
+      def add_sidebar_form
+        @show_form_in_sidebar = true
+      end
+
+      def show_sidebar_form?
+        @show_form_in_sidebar.present?
+      end
+
+      private
+
+      def add_sidebar_form_section
+        self.sidebar_sections << sidebar_form_section
+      end
+
+      def sidebar_form_section
+        title = "new_#{resource_name.singular}".to_sym
+        ActiveAdmin::SidebarSection.new title, only: :index, if: ->{ active_admin_config.show_sidebar_form? } do
+          resource = @arbre_context.helpers.resource_class.new
+
+          active_admin_form_for resource, options_for_form, &form_presenter.block
+        end
+      end
+    end
+  end
+end

--- a/lib/active_admin/views/components/active_admin_form.rb
+++ b/lib/active_admin/views/components/active_admin_form.rb
@@ -31,6 +31,10 @@ module ActiveAdmin
           @form_builder = f
         end
 
+        if options[:redirect_to_index].present? || params[:redirect_to_index].present?
+          add_child hidden_field_tag :redirect_to_index, true
+        end
+
         @opening_tag, @closing_tag = split_string_on(form_string, "</form>")
         instance_eval(&block) if block_given?
 


### PR DESCRIPTION
This PR solves #5108. 

The newly added DSL:
```ruby
  sidebar_form do |f|
    f.input :keyword
  end
```

The form created by the new DSL:
![active_admin_sidebar_form](https://user-images.githubusercontent.com/19406564/28670481-8516ce94-72e1-11e7-8a3c-78a48b922542.png)


This feature isn't finished yet and is in progress. I haven't modify the controller related code to redirect to index page when the entry was created with sidebar form yet. Also some stuff has to be done on the front-end part. All opinions about improving the code are welcome :)
@javierjulio @Fivell What do you think about this feature?