### PR TITLE
Move all jruby travis builds to `allow_failures` section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,8 @@ matrix:
 
   allow_failures:
     - rvm: jruby-9.1.12.0
+      gemfile: gemfiles/rails_42.gemfile
+    - rvm: jruby-9.1.12.0
       gemfile: gemfiles/rails_50.gemfile
     - rvm: jruby-9.1.12.0
       gemfile: gemfiles/rails_51.gemfile


### PR DESCRIPTION
As we discussed that we'd move this to the `allow_failures` section. I just had another travis failure because the jruby rails42 build is failing in #5081. 😩 Sorry @deivid-rodriguez. 😞