### PR TITLE
[fix] do not display pagination info when there are no comments

### DIFF
--- a/lib/active_admin/orm/active_record/comments/views/active_admin_comments.rb
+++ b/lib/active_admin/orm/active_record/comments/views/active_admin_comments.rb
@@ -24,8 +24,13 @@ module ActiveAdmin
         end
 
         def build_comments
-          @comments.any? ? @comments.each(&method(:build_comment)) : build_empty_message
-          div page_entries_info(@comments).html_safe, class: 'pagination_information'
+          if @comments.any?
+            @comments.each(&method(:build_comment))
+            div page_entries_info(@comments).html_safe, class: 'pagination_information'
+          else
+            build_empty_message
+          end
+
           text_node paginate @comments
           build_comment_form
         end


### PR DESCRIPTION
This commit fixes the bug when redundant information was displayed if there were no comments in the resource:

![bug_picture](https://user-images.githubusercontent.com/19406564/28935529-8080151e-788d-11e7-92b3-d689600ac312.png)
