### PR TITLE
Pluralize resource generator files (again)

### DIFF
--- a/docs/2-resource-customization.md
+++ b/docs/2-resource-customization.md
@@ -10,7 +10,7 @@ resource you must first create a Rails model for it.
 ## Create a Resource
 
 The basic command for creating a resource is `rails g active_admin:resource Post`.
-The generator will produce an empty `app/admin/post.rb` file like so:
+The generator will produce an empty `app/admin/posts.rb` file like so:
 
 ```ruby
 ActiveAdmin.register Post do

--- a/lib/generators/active_admin/resource/resource_generator.rb
+++ b/lib/generators/active_admin/resource/resource_generator.rb
@@ -12,7 +12,7 @@ module ActiveAdmin
 
       def generate_config_file
         @boilerplate = ActiveAdmin::Generators::Boilerplate.new(class_name)
-        template "admin.rb.erb", "app/admin/#{file_path.tr('/', '_')}.rb"
+        template "admin.rb", "app/admin/#{file_path.gsub('/', '_').pluralize}.rb"
       end
 
     end


### PR DESCRIPTION
Reverts #2249.  Closes #2334.  See also #5076.

Having the same filename for models and resource DSL causes issues with the Rails autoloader.
Pluralizing is consistent with the Rails naming convention for controllers, which is much of what the DSL is generating.