### PR TITLE
Update our JS components

### DIFF
--- a/app/assets/javascripts/active_admin/base.es6
+++ b/app/assets/javascripts/active_admin/base.es6
@@ -8,6 +8,7 @@
 //= require_self
 //= require ./ext/jquery
 //= require ./ext/jquery-ui
+//= require ./lib/active_admin
 //= require ./lib/batch_actions
 //= require ./lib/dropdown-menu
 //= require ./lib/has_many

--- a/app/assets/javascripts/active_admin/base.es6
+++ b/app/assets/javascripts/active_admin/base.es6
@@ -6,8 +6,17 @@
 //= require jquery-ui/widget
 //= require jquery_ujs
 //= require_self
-//= require_tree ./lib
-//= require_tree ./ext
-//= require_tree ./initializers
+//= require ./ext/jquery
+//= require ./ext/jquery-ui
+//= require ./lib/batch_actions
+//= require ./lib/dropdown-menu
+//= require ./lib/has_many
+//= require ./lib/modal_dialog
+//= require ./lib/per_page
+//= require ./lib/checkbox-toggler
+//= require ./lib/table-checkbox-toggler
+//= require ./initializers/datepicker
+//= require ./initializers/filters
+//= require ./initializers/tabs
 
 window.ActiveAdmin = {}

--- a/app/assets/javascripts/active_admin/initializers/datepicker.es6
+++ b/app/assets/javascripts/active_admin/initializers/datepicker.es6
@@ -1,16 +1,16 @@
-const onDOMReady = () =>
-  $(document).on('focus', 'input.datepicker:not(.hasDatepicker)', function() {
-    const input = $(this);
+(($) => {
 
-    // Only create datepickers in compatible browsers
-    if (input[0].type === 'date') { return; }
+  $(document)
+    .on('focus', 'input.datepicker:not(.hasDatepicker)', function() {
+      const input = $(this);
 
-    const defaults = { dateFormat: 'yy-mm-dd' };
-    const options  = input.data('datepicker-options');
-    input.datepicker($.extend(defaults, options));
-  })
-;
+      // Only create datepickers in compatible browsers
+      if (input[0].type === 'date') { return; }
 
-$(document).
-  ready(onDOMReady).
-  on('page:load turbolinks:load', onDOMReady);
+      const defaults = { dateFormat: 'yy-mm-dd' };
+      const options  = input.data('datepicker-options');
+
+      input.datepicker($.extend(defaults, options));
+    });
+
+})(jQuery);

--- a/app/assets/javascripts/active_admin/initializers/filters.es6
+++ b/app/assets/javascripts/active_admin/initializers/filters.es6
@@ -1,40 +1,45 @@
-const onDOMReady = function() {
-  // Clear Filters button
-  $('.clear_filters_btn').click(function(event) {
-    const params = window.location.search.slice(1).split('&');
-    const regex = /^(q\[|q%5B|q%5b|page|commit)/;
-    const cleanedParams = params.filter(param => !param.match(regex));
+(($, ActiveAdmin) => {
 
-    if (typeof Turbolinks !== 'undefined') {
+  class Filters {
+
+    static _clearForm(event) {
+      const regex = /^(q\[|q%5B|q%5b|page|utf8|commit)/;
+      const params = ActiveAdmin
+        .queryStringToParams()
+        .filter(({name}) => !name.match(regex));
+
       event.preventDefault();
-      Turbolinks.visit(window.location.href.split('?')[0] + '?' + cleanedParams.join('&'));
-    } else {
-      window.location.search = cleanedParams.join('&');
+
+      if (ActiveAdmin.turbolinks) {
+        ActiveAdmin.turbolinksVisit(params);
+      } else {
+        window.location.search = ActiveAdmin.toQueryString(params);
+      }
     }
-  });
 
-  // Filter form: don't send any inputs that are empty
-  $('.filter_form').submit(function(event) {
-    $(this)
-      .find(':input')
-      .filter(function() {
-        return this.value === '';
-      })
-      .prop('disabled', true);
+    static _disableEmptyInputFields(event) {
+      const params = $(this)
+        .find(':input')
+        .filter((i, input) => input.value === '')
+        .prop({ disabled: true })
+        .end()
+        .serializeArray();
 
-    if (typeof Turbolinks !== 'undefined') {
-      event.preventDefault();
-      Turbolinks.visit(window.location.href.split('?')[0] + '?' + $(this).serialize());
+      if (ActiveAdmin.turbolinks) {
+        event.preventDefault();
+        ActiveAdmin.turbolinksVisit(params);
+      }
     }
-  });
 
-  // Filter form: for filters that let you choose the query method from
-  // a dropdown, apply that choice to the filter input field.
-  $('.filter_form_field.select_and_search select').change(function() {
-    $(this).siblings('input').prop({name: `q[${this.value}]`});
-  });
-};
+    static _setSearchType() {
+      $(this).siblings('input').prop({name: `q[${this.value}]`});
+    }
 
-$(document).
-  ready(onDOMReady).
-  on('page:load turbolinks:load', onDOMReady);
+  }
+
+  $(document).
+    on('click', '.clear_filters_btn', Filters._clearForm).
+    on('submit', '.filter_form', Filters._disableEmptyInputFields).
+    on('change', '.filter_form_field.select_and_search select', Filters._setSearchType);
+
+})(jQuery, window.activeadmin);

--- a/app/assets/javascripts/active_admin/lib/active_admin.es6
+++ b/app/assets/javascripts/active_admin/lib/active_admin.es6
@@ -1,0 +1,41 @@
+((window, $) => {
+
+  class ActiveAdmin {
+
+    static get turbolinks() {
+      return (typeof Turbolinks !== 'undefined' && Turbolinks.supported);
+    }
+
+    static turbolinksVisit(params) {
+      const path = [window.location.pathname, '?', this.toQueryString(params)].join('')
+      Turbolinks.visit(path);
+    }
+
+    static queryString() {
+      return (window.location.search || '').replace(/^\?/, '');
+    }
+
+    static queryStringToParams() {
+      const decode = (value) => decodeURIComponent((value || '').replace(/\+/g, '%20'));
+
+      return this.queryString()
+        .split("&")
+        .map(pair => pair.split("="))
+        .map(([key, value]) => {
+          return { name: decode(key), value: decode(value) }
+        });
+    }
+
+    static toQueryString(params) {
+      const encode = (value) => encodeURIComponent(value || '');
+
+      return params
+        .map(({name, value}) => [ encode(name), encode(value) ])
+        .map(pair => pair.join('='))
+        .join('&')
+    }
+  }
+
+  window.activeadmin = ActiveAdmin
+
+})(window, jQuery);


### PR DESCRIPTION
This update is an overhaul of our JS files with various improvements. Not yet sure if this PR will completely close issue #5048 but it is related.

First, if applicable, it replaces the jQuery UI widget bridge with our own jQuery plugin interface since its easy to set up on our own. 

Second we'll be using event delegation on the document object, which now means we won't need to specify Turbolinks events like `page:load turbolinks:load` since this solves that too. 

Third we'll start to replace components like tabs and date picker with our own solution and thus removing the jQuery UI dependency entirely. 

From there we'll do general code improvements like consolidating code that deals with query strings (serializing and deserializing), on detecting Turbolinks and using a `js-` class name prefix for JS only hooks (or something similar).