### PR TITLE
5090: improve download links to deal with collection

### DIFF
--- a/lib/active_admin/view_helpers/download_format_links_helper.rb
+++ b/lib/active_admin/view_helpers/download_format_links_helper.rb
@@ -14,12 +14,11 @@ module ActiveAdmin
         end
       end
 
-      def build_download_format_links(formats = self.class.formats)
-        params = request.query_parameters.except :format, :commit
+      def build_download_format_links(collection, formats = self.class.formats)
         div class: "download_links" do
           span I18n.t('active_admin.download')
           formats.each do |format|
-            a format.upcase, href: url_for(params: params, format: format)
+            a format.upcase, href: polymorphic_path([:admin, collection.name.constantize], params: collection.where_clause.to_h, format: format)
           end
         end
       end

--- a/lib/active_admin/views/components/paginated_collection.rb
+++ b/lib/active_admin/views/components/paginated_collection.rb
@@ -72,7 +72,7 @@ module ActiveAdmin
           div(page_entries_info(options).html_safe, class: "pagination_information")
 
           formats = build_download_formats @download_links
-          build_download_format_links formats if formats.any?
+          build_download_format_links(@collection, formats) if formats.any?
         end
       end
 


### PR DESCRIPTION
Hey Guys, @urkle @Fivell 

I'm opening this PR, following #5090 

It's still in progress, (and missing tests) but I did open to discuss the code, and ask about two points.

1 - `[:admin, collection.name.constantize]`, I think hardcoded `:admin` here is not a good deal, is any helper that I can get default namespace/scope routes? 
I tried `ActiveAdmin.application.router...` but I not able to found any helper that returns it,
also I saw that `ActiveAdmin.application.default_namespace` returns `:admin` but not sure if it is related to routes or folder.

2 - I'm not sure about the use of ` params: collection.where_clause.to_h`, should we just get for `foreign_keys`? should we merge it with `request.query_parameters` ?, and, fore sure we need to apply Ransack protocol here.

let me know any suggestion/question/etc.. about code

Thanks
