### PR TITLE
Add version check for jquery-rails

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'formtastic', '~> 3.1'
   s.add_dependency 'formtastic_i18n'
   s.add_dependency 'inherited_resources', '~> 1.7'
-  s.add_dependency 'jquery-rails'
+  s.add_dependency 'jquery-rails', '>= 4.2.0'
   s.add_dependency 'kaminari', '>= 1.0.1'
   s.add_dependency 'railties', '>= 4.2', '< 5.2'
   s.add_dependency 'ransack', '~> 1.3'


### PR DESCRIPTION
I was also facing the following issue:
https://github.com/activeadmin/activeadmin/issues/5129

Upon investigating a bit, it turned out that I had an outdated version (4.1.0) of `jquery-rails` gem installed. `jquery3` is required in the base javascript file, and the support for it was not available before the `4.2.0` version in `jquery-rails` gem. Therefore, I have made that version the bare minimum.

Closes #5129 