### PR TITLE
Bump version to 2.0.0.alpha

### DIFF
--- a/lib/active_admin/version.rb
+++ b/lib/active_admin/version.rb
@@ -1,3 +1,3 @@
 module ActiveAdmin
-  VERSION = '1.1.0'
+  VERSION = '2.0.0.alpha'
 end


### PR DESCRIPTION
As master is now tracking the 2.0 release, I thought it'd make it clearer by reflecting it with a version change. This will also make it clear that you are using 2.x when installing via Github.

Currently I see this even though I'm using the latest commit from master:

![image](https://user-images.githubusercontent.com/293672/29209555-7ed46a5a-7e8f-11e7-9c3c-4c7b1b982ef4.png)
