### PR TITLE
Cleanup Settings changes

### DIFF
--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -20,7 +20,6 @@ module ActiveAdmin
 
       def inheritable_setting(name, default)
         namespace_default_settings.settings[name] = default
-        Namespace.default_settings.settings[name] = default
       end
     end
 

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -7,11 +7,11 @@ module ActiveAdmin
 
     class << self
       def default_settings
-        @settings ||= SettingsNode.new
+        @settings ||= SettingsNode.build
       end
 
       def namespace_default_settings
-        @namespace_settings ||= SettingsNode.new
+        @namespace_settings ||= SettingsNode.build
       end
 
       def setting(name, default)
@@ -23,16 +23,12 @@ module ActiveAdmin
       end
     end
 
-    def default_settings
-      self.class.default_settings
-    end
-
     def settings
-      @settings ||= SettingsNode.new(self.class.default_settings)
+      @settings ||= SettingsNode.build(self.class.default_settings)
     end
 
     def namespace_settings
-      @namespace_settings ||= SettingsNode.new(self.class.namespace_default_settings)
+      @namespace_settings ||= SettingsNode.build(self.class.namespace_default_settings)
     end
 
     def respond_to_missing?(method, include_private = false)

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -15,11 +15,11 @@ module ActiveAdmin
       end
 
       def setting(name, default)
-        default_settings.settings[name] = default
+        default_settings.register name, default
       end
 
       def inheritable_setting(name, default)
-        namespace_default_settings.settings[name] = default
+        namespace_default_settings.register name, default
       end
     end
 

--- a/lib/active_admin/engine.rb
+++ b/lib/active_admin/engine.rb
@@ -1,10 +1,8 @@
 module ActiveAdmin
   class Engine < ::Rails::Engine
     initializer "active_admin.load_app_path" do |app|
-      ActiveAdmin.application.instance_exec(app) do |app|
-        default_settings[:app_path] = app.root
-        default_settings[:load_paths] = [File.expand_path('app/admin', app.root)]
-      end
+      ActiveAdmin::Application.setting :app_path, app.root
+      ActiveAdmin::Application.setting :load_paths, [File.expand_path('app/admin', app.root)]
     end
 
     initializer "active_admin.precompile", group: :all do |app|

--- a/lib/active_admin/namespace.rb
+++ b/lib/active_admin/namespace.rb
@@ -48,7 +48,7 @@ module ActiveAdmin
     end
 
     def settings
-      @settings ||= SettingsNode.new(application.namespace_settings)
+      @settings ||= SettingsNode.build(application.namespace_settings)
     end
 
     def respond_to_missing?(method, include_private = false)

--- a/lib/active_admin/namespace.rb
+++ b/lib/active_admin/namespace.rb
@@ -26,12 +26,8 @@ module ActiveAdmin
   #
   class Namespace
     class << self
-      def default_settings
-        @settings ||= SettingsNode.new
-      end
-
       def setting(name, default)
-        default_settings.settings[name] = default
+        Deprecation.warn "This method does not do anything and will be removed."
       end
     end
 

--- a/lib/active_admin/settings_node.rb
+++ b/lib/active_admin/settings_node.rb
@@ -5,6 +5,10 @@ module ActiveAdmin
       @parent = parent
     end
 
+    def register(name, value)
+      settings[name] = value
+    end
+
     def settings
       @settings ||= {}
     end

--- a/lib/active_admin/settings_node.rb
+++ b/lib/active_admin/settings_node.rb
@@ -1,50 +1,18 @@
 module ActiveAdmin
 
   class SettingsNode
-    def initialize(parent = nil)
-      @parent = parent
-    end
+    class << self
+      # Never instantiated.  Variables are stored in the singleton_class.
+      private_class_method :new
 
-    def register(name, value)
-      settings[name] = value
-    end
-
-    def settings
-      @settings ||= {}
-    end
-
-    protected
-
-    def parent
-      @parent ||= self.class.new
-    end
-
-    def has_key?(name)
-      settings.has_key?(name.to_sym) || @parent && @parent.has_key?(name.to_sym)
-    end
-
-    def fetch(name)
-      if settings.has_key?(name.to_sym)
-        settings.fetch(name.to_sym)
-      elsif @parent
-        parent.fetch(name)
+      # @returns anonymous class with same accessors as the superclass.
+      def build(superclass = SettingsNode)
+        Class.new(superclass)
       end
-    end
 
-    def respond_to_missing?(method, include_private = false)
-      has_key?(method.to_s.chomp '=') || super
-    end
-
-    def method_missing(method, *args)
-      name = method.to_s
-      if has_key?(name.chomp '=')
-        if name.chomp! '='
-          settings[name.to_sym] = args.first
-        else
-          fetch(name)
-        end
-      else
-        super
+      def register(name, value)
+        class_attribute name
+        send "#{name}=", value
       end
     end
   end

--- a/lib/active_admin/settings_node.rb
+++ b/lib/active_admin/settings_node.rb
@@ -9,8 +9,6 @@ module ActiveAdmin
       @settings ||= {}
     end
 
-    delegate :[]=, to: :settings
-
     protected
 
     def parent

--- a/spec/unit/namespace_spec.rb
+++ b/spec/unit/namespace_spec.rb
@@ -50,7 +50,9 @@ RSpec.describe ActiveAdmin::Namespace do
     let(:namespace){ ActiveAdmin::Namespace.new(application, :admin) }
 
     it "should inherit the site title from the application" do
-      ActiveAdmin::Namespace.setting :site_title, "Not the Same"
+      ActiveSupport::Deprecation.silence do
+        ActiveAdmin::Namespace.setting :site_title, "Not the Same"
+      end
       expect(namespace.site_title).to eq application.site_title
     end
 

--- a/spec/unit/settings_node_spec.rb
+++ b/spec/unit/settings_node_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ActiveAdmin::SettingsNode do
   let(:child) { ActiveAdmin::SettingsNode.new(subject) }
 
   context 'parent setting includes foo' do
-    before { subject.settings[:foo] = true }
+    before { subject.register :foo, true }
 
     it 'returns parent settings' do
       expect(child.foo).to eq true

--- a/spec/unit/settings_node_spec.rb
+++ b/spec/unit/settings_node_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe ActiveAdmin::SettingsNode do
-  subject { ActiveAdmin::SettingsNode.new }
-  let(:child) { ActiveAdmin::SettingsNode.new(subject) }
+  subject { ActiveAdmin::SettingsNode.build }
+  let!(:child) { ActiveAdmin::SettingsNode.build(subject) }
 
   context 'parent setting includes foo' do
     before { subject.register :foo, true }


### PR DESCRIPTION
Simplifies #5105 and #5106.  Deprecates a dead method, and uses a different approach for SettingsNode.  Each commit is related but stands on its own.