### PR TITLE
Move all jruby builds to allow_failures 1-1-stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,8 @@ matrix:
 
   allow_failures:
     - rvm: jruby-9.1.12.0
+      gemfile: gemfiles/rails_42.gemfile
+    - rvm: jruby-9.1.12.0
       gemfile: gemfiles/rails_50.gemfile
     - rvm: jruby-9.1.12.0
       gemfile: gemfiles/rails_51.gemfile


### PR DESCRIPTION
This PR  backports #5112 to 1-1-stable.