### PR TITLE
Fix undefined variable error in app generation

### DIFF
--- a/spec/support/rails_template_with_data.rb
+++ b/spec/support/rails_template_with_data.rb
@@ -318,7 +318,7 @@ append_file "db/seeds.rb", "\n\n" + <<-RUBY.strip_heredoc
     ActiveAdmin::Comment.create!(
       namespace: :admin,
       author: AdminUser.first,
-      body: "Test comment #{i}",
+      body: "Test comment \#{i}",
       resource: categories.sample,
     )
   end


### PR DESCRIPTION
This PR fixes a crash when generating our sample application because of a variable being evaluated in the wrong context.