### PR TITLE
Enable `Style/TrailingCommaInArguments` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -60,6 +60,9 @@ Style/PredicateName:
     - has_many
     - has_many_actions
 
+Style/TrailingCommaInArguments:
+  Enabled: true
+
 Layout/TrailingBlankLines:
   Enabled: true
 

--- a/lib/active_admin/views/components/active_admin_form.rb
+++ b/lib/active_admin/views/components/active_admin_form.rb
@@ -111,7 +111,7 @@ module ActiveAdmin
               id: 'create_another',
               class: 'create_another',
               name: 'create_another',
-              type: 'checkbox',
+              type: 'checkbox'
             )
             label(I18n.t('active_admin.create_another', model: label), for: 'create_another')
           end

--- a/spec/support/rails_template_with_data.rb
+++ b/spec/support/rails_template_with_data.rb
@@ -319,7 +319,7 @@ append_file "db/seeds.rb", "\n\n" + <<-RUBY.strip_heredoc
       namespace: :admin,
       author: AdminUser.first,
       body: "Test comment \#{i}",
-      resource: categories.sample,
+      resource: categories.sample
     )
   end
 RUBY


### PR DESCRIPTION
This is a PR to enable the `Style/TrailingCommaInArguments` cop, a convention we were already following, with a couple of exceptions.