### PR TITLE
Remove debugging traces from tests

### DIFF
--- a/features/show/tabs.feature
+++ b/features/show/tabs.feature
@@ -24,7 +24,6 @@ Feature: Show - Tabs
       end
     """
 
-    Then show me the page
     Then I should see two tabs "Overview" and "テスト"
     And I should see the element "#overview span"
     And I should not see the element "#test_non_ascii span"

--- a/features/step_definitions/additional_web_steps.rb
+++ b/features/step_definitions/additional_web_steps.rb
@@ -46,13 +46,6 @@ Then /^I should be in the resource section for (.+)$/ do |resource_name|
   expect(current_url).to include resource_name.tr(' ', '').underscore.pluralize
 end
 
-Then /^I should wait and see "([^"]*)"(?: within "([^"]*)")?$/ do |text, selector|
-  sleep 1
-  step 'show me the page'
-  selector ||= "*"
-  locate(:xpath, "//#{selector}[text()='#{text}']")
-end
-
 Then /^I should see the page title "([^"]*)"$/ do |title|
   within('h2#page_title') do
     expect(page).to have_content title

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -80,7 +80,3 @@ end
 Then /^(?:|I )should be on (.+)$/ do |page_name|
   expect(URI.parse(current_url).path).to eq path_to page_name
 end
-
-Then /^show me the page$/ do
-  save_and_open_page
-end


### PR DESCRIPTION
Running tests currently open a browser window. This PR removes that, and other debugging traces.