### PR TITLE
Add a missing Japanese translation "create_another"

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -8,6 +8,7 @@ ja:
     edit: "編集"
     delete: "削除"
     delete_confirmation: "本当に削除しますか？"
+    create_another: "%{model} を追加する"
     new_model: "%{model} を作成する"
     edit_model: "%{model} を編集する"
     delete_model: "%{model} を削除する"


### PR DESCRIPTION
I have added a missing translation (`create_another`) in Japanese locale file.