### PR TITLE
StringSymbolOrProcSetting < DynamicSetting

### DIFF
--- a/app/views/active_admin/devise/confirmations/new.html.erb
+++ b/app/views/active_admin/devise/confirmations/new.html.erb
@@ -1,5 +1,5 @@
 <div id="login">
-  <h2><%= render_or_call_method_or_proc_on(self, active_admin_application.site_title) %> <%= title t('active_admin.devise.resend_confirmation_instructions.title') %></h2>
+  <h2><%= active_admin_application.site_title(self) %> <%= title t('active_admin.devise.resend_confirmation_instructions.title') %></h2>
 
   <%= devise_error_messages! %>
   <%= active_admin_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|

--- a/app/views/active_admin/devise/passwords/edit.html.erb
+++ b/app/views/active_admin/devise/passwords/edit.html.erb
@@ -1,5 +1,5 @@
 <div id="login">
-  <h2><%= render_or_call_method_or_proc_on(self, active_admin_application.site_title) %> <%= title t('active_admin.devise.change_password.title') %></h2>
+  <h2><%= active_admin_application.site_title(self) %> <%= title t('active_admin.devise.change_password.title') %></h2>
 
   <%= devise_error_messages! %>
   <%= active_admin_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|

--- a/app/views/active_admin/devise/passwords/new.html.erb
+++ b/app/views/active_admin/devise/passwords/new.html.erb
@@ -1,5 +1,5 @@
 <div id="login">
-  <h2><%= render_or_call_method_or_proc_on(self, active_admin_application.site_title) %> <%= title t('active_admin.devise.reset_password.title') %></h2>
+  <h2><%= active_admin_application.site_title(self) %> <%= title t('active_admin.devise.reset_password.title') %></h2>
 
   <%= devise_error_messages! %>
   <%= active_admin_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|

--- a/app/views/active_admin/devise/registrations/new.html.erb
+++ b/app/views/active_admin/devise/registrations/new.html.erb
@@ -1,5 +1,5 @@
 <div id="login">
-  <h2><%= render_or_call_method_or_proc_on(self, active_admin_application.site_title) %> <%= title t('active_admin.devise.sign_up.title') %></h2>
+  <h2><%= active_admin_application.site_title(self) %> <%= title t('active_admin.devise.sign_up.title') %></h2>
 
   <% scope = Devise::Mapping.find_scope!(resource_name) %>
   <%= devise_error_messages! %>

--- a/app/views/active_admin/devise/sessions/new.html.erb
+++ b/app/views/active_admin/devise/sessions/new.html.erb
@@ -1,5 +1,5 @@
 <div id="login">
-  <h2><%= render_or_call_method_or_proc_on(self, active_admin_application.site_title) %> <%= title t('active_admin.devise.login.title') %></h2>
+  <h2><%= active_admin_application.site_title(self) %> <%= title t('active_admin.devise.login.title') %></h2>
 
   <% scope = Devise::Mapping.find_scope!(resource_name) %>
   <%= active_admin_form_for(resource, as: resource_name, url: send(:"#{scope}_session_path"), html: { id: "session_new" }) do |f|

--- a/app/views/active_admin/devise/unlocks/new.html.erb
+++ b/app/views/active_admin/devise/unlocks/new.html.erb
@@ -1,5 +1,5 @@
 <div id="login">
-  <h2><%= render_or_call_method_or_proc_on(self, active_admin_application.site_title) %> <%= title t('active_admin.devise.unlock.title') %></h2>
+  <h2><%= active_admin_application.site_title(self) %> <%= title t('active_admin.devise.unlock.title') %></h2>
 
   <%= devise_error_messages! %>
   <%= active_admin_form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f|

--- a/app/views/layouts/active_admin_logged_out.html.erb
+++ b/app/views/layouts/active_admin_logged_out.html.erb
@@ -3,7 +3,7 @@
 <head>
   <meta http-equiv="Content-type" content="text/html; charset=utf-8">
 
-  <title><%= [@page_title, render_or_call_method_or_proc_on(self, ActiveAdmin.application.site_title)].compact.join(" | ") %></title>
+  <title><%= [@page_title, ActiveAdmin.application.site_title(self)].compact.join(" | ") %></title>
 
   <%= stylesheet_link_tag 'active_admin.css', media: 'screen' %>
   <%= stylesheet_link_tag 'active_admin/print.css', media: 'print' %>

--- a/lib/active_admin/dynamic_setting.rb
+++ b/lib/active_admin/dynamic_setting.rb
@@ -1,8 +1,14 @@
 module ActiveAdmin
 
   class DynamicSetting
-    def self.build(setting)
-      new(setting)
+    def self.build(setting, type)
+      (type ? klass(type) : self).new(setting)
+    end
+
+    def self.klass(type)
+      klass = "#{type.to_s.camelcase}Setting"
+      raise ArgumentError, "Unknown type: #{type}" unless ActiveAdmin.const_defined?(klass)
+      ActiveAdmin.const_get(klass)
     end
 
     def initialize(setting)
@@ -11,6 +17,21 @@ module ActiveAdmin
 
     def value(*_args)
       @setting
+    end
+  end
+
+  # Many configuration options (Ex: site_title, title_image) could either be
+  # static (String), methods (Symbol) or procs (Proc). This wrapper takes care of
+  # returning the content when String or using instance_eval when Symbol or Proc.
+  #
+  class StringSymbolOrProcSetting < DynamicSetting
+    def value(context = self)
+      case @setting
+      when Symbol, Proc
+        context.instance_eval(&@setting)
+      else
+        @setting
+      end
     end
   end
 

--- a/lib/active_admin/dynamic_setting.rb
+++ b/lib/active_admin/dynamic_setting.rb
@@ -1,0 +1,17 @@
+module ActiveAdmin
+
+  class DynamicSetting
+    def self.build(setting)
+      new(setting)
+    end
+
+    def initialize(setting)
+      @setting = setting
+    end
+
+    def value(*_args)
+      @setting
+    end
+  end
+
+end

--- a/lib/active_admin/dynamic_settings_node.rb
+++ b/lib/active_admin/dynamic_settings_node.rb
@@ -1,0 +1,28 @@
+require 'active_admin/dynamic_setting'
+require 'active_admin/settings_node'
+
+module ActiveAdmin
+
+  class DynamicSettingsNode < SettingsNode
+    class << self
+      def register(name, value)
+        class_attribute "#{name}_setting"
+        add_reader(name)
+        add_writer(name)
+        send "#{name}=", value
+      end
+
+      def add_reader(name)
+        define_singleton_method(name) do
+          send("#{name}_setting").value
+        end
+      end
+
+      def add_writer(name)
+        define_singleton_method("#{name}=") do |value|
+          send("#{name}_setting=", DynamicSetting.build(value))
+        end
+      end
+    end
+  end
+end

--- a/lib/active_admin/dynamic_settings_node.rb
+++ b/lib/active_admin/dynamic_settings_node.rb
@@ -5,22 +5,22 @@ module ActiveAdmin
 
   class DynamicSettingsNode < SettingsNode
     class << self
-      def register(name, value)
+      def register(name, value, type = nil)
         class_attribute "#{name}_setting"
         add_reader(name)
-        add_writer(name)
+        add_writer(name, type)
         send "#{name}=", value
       end
 
       def add_reader(name)
-        define_singleton_method(name) do
-          send("#{name}_setting").value
+        define_singleton_method(name) do |*args|
+          send("#{name}_setting").value(*args)
         end
       end
 
-      def add_writer(name)
+      def add_writer(name, type)
         define_singleton_method("#{name}=") do |value|
-          send("#{name}_setting=", DynamicSetting.build(value))
+          send("#{name}_setting=", DynamicSetting.build(value, type))
         end
       end
     end

--- a/lib/active_admin/namespace_settings.rb
+++ b/lib/active_admin/namespace_settings.rb
@@ -15,7 +15,7 @@ module ActiveAdmin
     register :site_title_link, ""
 
     # Set the site title image displayed in the main layout (has precendence over :site_title)
-    register :site_title_image, ""
+    register :site_title_image, "", :string_symbol_or_proc
 
     # Set the site footer text (defaults to Powered by ActiveAdmin text with version)
     register :footer, ""

--- a/lib/active_admin/namespace_settings.rb
+++ b/lib/active_admin/namespace_settings.rb
@@ -1,7 +1,7 @@
-require 'active_admin/settings_node'
+require 'active_admin/dynamic_settings_node'
 
 module ActiveAdmin
-  class NamespaceSettings < SettingsNode
+  class NamespaceSettings < DynamicSettingsNode
     # The default number of resources to display on index pages
     register :default_per_page, 30
 

--- a/lib/active_admin/namespace_settings.rb
+++ b/lib/active_admin/namespace_settings.rb
@@ -9,7 +9,7 @@ module ActiveAdmin
     register :max_per_page, 10_000
 
     # The title which gets displayed in the main layout
-    register :site_title, ""
+    register :site_title, "", :string_symbol_or_proc
 
     # Set the site title link href (defaults to AA dashboard)
     register :site_title_link, ""

--- a/lib/active_admin/namespace_settings.rb
+++ b/lib/active_admin/namespace_settings.rb
@@ -18,7 +18,7 @@ module ActiveAdmin
     register :site_title_image, "", :string_symbol_or_proc
 
     # Set the site footer text (defaults to Powered by ActiveAdmin text with version)
-    register :footer, ""
+    register :footer, "", :string_symbol_or_proc
 
     # Set a favicon
     register :favicon, false

--- a/lib/active_admin/settings_node.rb
+++ b/lib/active_admin/settings_node.rb
@@ -6,7 +6,7 @@ module ActiveAdmin
       private_class_method :new
 
       # @returns anonymous class with same accessors as the superclass.
-      def build(superclass = SettingsNode)
+      def build(superclass = self)
         Class.new(superclass)
       end
 

--- a/lib/active_admin/views/components/site_title.rb
+++ b/lib/active_admin/views/components/site_title.rb
@@ -22,8 +22,8 @@ module ActiveAdmin
         @namespace.site_title_link.present?
       end
 
-      def site_title_image?
-        @namespace.site_title_image.present?
+      def site_title_image
+        @site_title_image ||= @namespace.site_title_image(helpers)
       end
 
       private
@@ -33,7 +33,7 @@ module ActiveAdmin
       end
 
       def site_title_content
-        if site_title_image?
+        if site_title_image.present?
           title_image
         else
           title_text
@@ -45,8 +45,7 @@ module ActiveAdmin
       end
 
       def title_image
-        path = helpers.render_or_call_method_or_proc_on(helpers, @namespace.site_title_image)
-        helpers.image_tag(path, id: "site_title_image", alt: title_text)
+        helpers.image_tag(site_title_image, id: "site_title_image", alt: title_text)
       end
 
     end

--- a/lib/active_admin/views/components/site_title.rb
+++ b/lib/active_admin/views/components/site_title.rb
@@ -41,7 +41,7 @@ module ActiveAdmin
       end
 
       def title_text
-        helpers.render_or_call_method_or_proc_on(helpers, @namespace.site_title)
+        @title_text ||= @namespace.site_title(helpers)
       end
 
       def title_image

--- a/lib/active_admin/views/footer.rb
+++ b/lib/active_admin/views/footer.rb
@@ -6,21 +6,17 @@ module ActiveAdmin
         super id: "footer"
         @namespace = namespace
 
-        if footer?
+        if footer_text.present?
           para footer_text
         else
           para powered_by_message
         end
       end
 
-      def footer?
-        @namespace.footer.present?
-      end
-
       private
 
       def footer_text
-        helpers.render_or_call_method_or_proc_on(self, @namespace.footer)
+        @footer_text ||= @namespace.footer(self)
       end
 
       def powered_by_message

--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -24,7 +24,7 @@ module ActiveAdmin
 
         def build_active_admin_head
           within @head do
-            insert_tag Arbre::HTML::Title, [title, render_or_call_method_or_proc_on(self, active_admin_namespace.site_title)].compact.join(" | ")
+            insert_tag Arbre::HTML::Title, [title, helpers.active_admin_namespace.site_title(self)].compact.join(" | ")
 
             text_node stylesheet_link_tag('active_admin.css', media: 'screen').html_safe
             text_node stylesheet_link_tag('active_admin/print.css', media: 'print').html_safe

--- a/spec/unit/dynamic_settings_spec.rb
+++ b/spec/unit/dynamic_settings_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe ActiveAdmin::DynamicSettingsNode do
+  subject { ActiveAdmin::DynamicSettingsNode.build }
+
+  context "StringSymbolOrProcSetting" do
+    before { subject.register :foo, 'bar', :string_symbol_or_proc }
+
+    it "should pass through a string" do
+      subject.foo = "string"
+      expect(subject.foo(self)).to eq "string"
+    end
+
+    it "should instance_exec if context given" do
+      ctx = Hash[i: 42]
+      subject.foo = proc { self[:i] += 1 }
+      expect(subject.foo(ctx)).to eq 43
+      expect(subject.foo(ctx)).to eq 44
+    end
+
+    it "should send message if symbol given" do
+      ctx = double
+      expect(ctx).to receive(:quux).and_return 'qqq'
+      subject.foo = :quux
+      expect(subject.foo(ctx)).to eq 'qqq'
+    end
+  end
+end

--- a/spec/unit/views/components/site_title_spec.rb
+++ b/spec/unit/views/components/site_title_spec.rb
@@ -3,11 +3,17 @@ require 'rails_helper'
 RSpec.describe ActiveAdmin::Views::SiteTitle do
 
   let(:helpers){ mock_action_view }
+  let(:settings) { ActiveAdmin::SettingsNode.build(ActiveAdmin::NamespaceSettings) }
 
   def build_title(namespace)
     render_arbre_component({namespace: namespace}, helpers) do
       insert_tag ActiveAdmin::Views::SiteTitle, assigns[:namespace]
     end
+  end
+
+  def double(params)
+    params.each { |key, value| settings.send "#{key}=", value }
+    settings
   end
 
   context "when a value" do


### PR DESCRIPTION
This refactoring encapsulates dynamic behavior of settings, easing maintenance.
Declarative approach makes clear in NamespaceSettings which settings have dynamic behavior.
Reduces usage of view helper: replaces more than half of invocations of call_method_or_proc_on
originally introduced by #1033