### PR TITLE
Setup codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -50,6 +50,10 @@ engines:
   markdownlint:
     enabled: true
 
+  rubocop:
+    enabled: true
+    channel: rubocop-0-49
+
 exclude_paths:
   - "gemfiles/vendor/**/*"
   - ".test-rails-apps/**/*"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,58 @@
+---
+
+engines:
+  duplication:
+    enabled: true
+
+    config:
+      languages:
+        javascript:
+
+        ruby:
+          mass_threshold: 100
+
+  fixme:
+    enabled: true
+
+    config:
+      strings:
+        - FIXME
+        - BUG
+
+  grep:
+    enabled: true
+
+    config:
+      patterns:
+        no-trailing-whitespace:
+          pattern: \s*$
+          annotation: "Don't leave trailing whitespace"
+          severity: minor
+          categories: Style
+          path_patterns:
+            - "**.arb"
+            - "**.coffee"
+            - "**.css"
+            - "**.erb"
+            - "**.es6"
+            - "**.feature"
+            - "**.gemfile"
+            - "**.gemspec"
+            - "**.html"
+            - "**.js"
+            - "**.md"
+            - "**.rake"
+            - "**.rb"
+            - "**.scss"
+            - "**.yml"
+            - ".*.yml"
+
+  markdownlint:
+    enabled: true
+
+exclude_paths:
+  - "gemfiles/vendor/**/*"
+  - ".test-rails-apps/**/*"
+  - "spec/rails/**/*"
+  - "coverage/**/*"
+  - "vendor/**/*"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@
 AllCops:
   DisabledByDefault: true
   TargetRubyVersion: 2.2
-  
+
   Exclude:
     - spec/rails/**/*
     - gemfiles/vendor/bundle/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@
 * `config.show_comments_in_menu` has been removed, see `config.comments_menu` [#4187][] by [@drn][]
 * Rails 3.2 & Ruby 1.9.3 support has been dropped [#4848][] [@deivid-rodriguez][]
 * Ruby 2.0.0 support has been dropped [#4851][] [@deivid-rodriguez][]
-* Rails 4.0 & 4.1 support has been dropped [#4855][] [@deivid-rodriguez][]
+* Rails 4.0 & 4.1 support has been dropped [#4870][] [@deivid-rodriguez][]
 
 ### Enhancements
 
@@ -183,6 +183,7 @@ Please check [0-6-stable](https://github.com/activeadmin/activeadmin/blob/0-6-st
 [#4848]: https://github.com/activeadmin/activeadmin/pull/4848
 [#4851]: https://github.com/activeadmin/activeadmin/pull/4851
 [#4867]: https://github.com/activeadmin/activeadmin/pull/4867
+[#4870]: https://github.com/activeadmin/activeadmin/pull/4870
 [#4882]: https://github.com/activeadmin/activeadmin/pull/4882
 [#4940]: https://github.com/activeadmin/activeadmin/pull/4940
 [#4950]: https://github.com/activeadmin/activeadmin/pull/4950

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,7 +199,7 @@ Please check [0-6-stable](https://github.com/activeadmin/activeadmin/blob/0-6-st
 [#5060]: https://github.com/activeadmin/activeadmin/pull/5060
 [#5069]: https://github.com/activeadmin/activeadmin/pull/5069
 [#5088]: https://github.com/activeadmin/activeadmin/pull/5088
-[#5093]: https://github.com/activeadmin/activeadmin/pull/5093 
+[#5093]: https://github.com/activeadmin/activeadmin/pull/5093
 
 [@ajw725]: https://github.com/ajw725
 [@bolshakov]: https://github.com/bolshakov

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,17 +6,14 @@ like you that make Active Admin such a great tool.
 ### 1. Where do I go from here?
 
 If you've noticed a bug or have a question that doesn't belong on the
-[mailing list](http://groups.google.com/group/activeadmin) or
-[Stack Overflow](http://stackoverflow.com/questions/tagged/activeadmin),
-[search the issue tracker](https://github.com/activeadmin/activeadmin/issues?q=something)
-to see if someone else in the community has already created a ticket.
-If not, go ahead and [make one](https://github.com/activeadmin/activeadmin/issues/new)!
+[mailing list][] or [Stack Overflow][], [search the issue tracker][] to see if
+someone else in the community has already created a ticket. If not, go ahead and
+[make one][new issue]!
 
 ### 2. Fork & create a branch
 
-If this is something you think you can fix, then
-[fork Active Admin](https://help.github.com/articles/fork-a-repo)
-and create a branch with a descriptive name.
+If this is something you think you can fix, then [fork Active Admin][] and
+create a branch with a descriptive name.
 
 A good branch name would be (where issue #325 is the ticket you're working on):
 
@@ -59,21 +56,19 @@ rm -rf spec/rails && bundle update
 
 ### 4. Did you find a bug?
 
-* **Ensure the bug was not already reported** by [searching all
-  issues](https://github.com/activeadmin/activeadmin/issues?q=).
+* **Ensure the bug was not already reported** by [searching all issues][].
 
-* If you're unable to find an open issue addressing the problem, [open a new
-  one](https://github.com/activeadmin/activeadmin/issues/new).  Be sure to
-  include a **title and clear description**, as much relevant information as
-  possible, and a **code sample** or an **executable test case** demonstrating
-  the expected behavior that is not occurring.
+* If you're unable to find an open issue addressing the problem,
+  [open a new one][new issue]. Be sure to include a **title and clear
+  description**, as much relevant information as possible, and a **code sample**
+  or an **executable test case** demonstrating the expected behavior that is not
+  occurring.
 
 * If possible, use the relevant bug report templates to create the issue.
   Simply copy the content of the appropriate template into a .rb file, make the
   necessary changes to demonstrate the issue, and **paste the content into the
   issue description**:
-  * [**ActiveAdmin** master
-    issues](https://github.com/activeadmin/activeadmin/blob/master/lib/bug_report_templates/active_admin_master.rb)
+  * [**ActiveAdmin** master issues][master template]
 
 ### 5. Implement your fix or feature
 
@@ -132,9 +127,7 @@ git rebase master
 git push --set-upstream origin 325-add-japanese-translations
 ```
 
-Finally, go to GitHub and
-[make a Pull Request](https://help.github.com/articles/creating-a-pull-request)
-:D
+Finally, go to GitHub and [make a Pull Request][] :D
 
 Travis CI will run our test suite against all supported Rails versions. We care
 about quality, so your PR won't be merged until all tests pass. It's unlikely,
@@ -148,10 +141,8 @@ what's going on!
 If a maintainer asks you to "rebase" your PR, they're saying that a lot of code
 has changed, and that you need to update your branch so it's easier to merge.
 
-To learn more about rebasing in Git, there are a lot of
-[good](http://git-scm.com/book/en/Git-Branching-Rebasing)
-[resources](https://help.github.com/articles/interactive-rebase),
-but here's the suggested workflow:
+To learn more about rebasing in Git, there are a lot of [good][git rebasing]
+[resources][interactive rebase] but here's the suggested workflow:
 
 ```sh
 git checkout 325-add-japanese-translations
@@ -190,3 +181,14 @@ Maintainers need to do the following to push out a release:
   ```
 
 * `bundle exec rake release`
+
+[mailing list]: http://groups.google.com/group/activeadmin
+[Stack Overflow]: http://stackoverflow.com/questions/tagged/activeadmin
+[search the issue tracker]: https://github.com/activeadmin/activeadmin/issues?q=something
+[new issue]: https://github.com/activeadmin/activeadmin/issues/new
+[fork Active Admin]: https://help.github.com/articles/fork-a-repo
+[searching all issues]: https://github.com/activeadmin/activeadmin/issues?q=
+[master template]: https://github.com/activeadmin/activeadmin/blob/master/lib/bug_report_templates/active_admin_master.rb
+[make a pull request]: https://help.github.com/articles/creating-a-pull-request
+[git rebasing]: http://git-scm.com/book/en/Git-Branching-Rebasing
+[interactive rebase]: https://help.github.com/articles/interactive-rebase

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,14 @@ Or to migrate the database:
 bundle exec rake local db:migrate
 ```
 
-### 7. Make a Pull Request
+### 7. Get the style right
+
+Your patch should follow the same conventions & pass the same code quality
+checks as the rest of the project. [Codeclimate][codeclimate] will give you
+feedback in this regard. You can check & fix codeclimate's feedback by running
+it locally using [Codeclimate's CLI][codeclimate cli], via `codeclimate analyze`.
+
+### 8. Make a Pull Request
 
 At this point, you should switch back to your master branch and make sure it's
 up to date with Active Admin's master branch:
@@ -150,7 +157,7 @@ git pull --rebase upstream master
 git push --force-with-lease 325-add-japanese-translations
 ```
 
-### 9. Merging a PR (maintainers only)
+### 10. Merging a PR (maintainers only)
 
 A PR can only be merged into master by a maintainer if:
 
@@ -163,7 +170,7 @@ A PR can only be merged into master by a maintainer if:
 Any maintainer is allowed to merge a PR if all of these conditions are
 met.
 
-### 10. Shipping a release (maintainers only)
+### 11. Shipping a release (maintainers only)
 
 Maintainers need to do the following to push out a release:
 
@@ -189,6 +196,8 @@ Maintainers need to do the following to push out a release:
 [fork Active Admin]: https://help.github.com/articles/fork-a-repo
 [searching all issues]: https://github.com/activeadmin/activeadmin/issues?q=
 [master template]: https://github.com/activeadmin/activeadmin/blob/master/lib/bug_report_templates/active_admin_master.rb
+[codeclimate]: https://codeclimate.com
+[codeclimate cli]: https://github.com/codeclimate/codeclimate
 [make a pull request]: https://help.github.com/articles/creating-a-pull-request
 [git rebasing]: http://git-scm.com/book/en/Git-Branching-Rebasing
 [interactive rebase]: https://help.github.com/articles/interactive-rebase

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,6 @@ gem 'pry' # Easily debug from your console with `binding.pry`
 
 # Code style
 gem 'rubocop', '0.49.1'
-gem 'mdl', '0.4.0'
 
 # Translations
 gem 'i18n-tasks'

--- a/Gemfile
+++ b/Gemfile
@@ -18,9 +18,6 @@ gem 'parallel_tests'
 # Debugging
 gem 'pry' # Easily debug from your console with `binding.pry`
 
-# Code style
-gem 'rubocop', '0.49.1'
-
 # Translations
 gem 'i18n-tasks'
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@
 
 ## Getting started
 
-* Check out [the docs][docs]
-* Try the [live demo][demo]
+* Check out [the docs][docs].
+* Try the [live demo][demo].
 * The [wiki] includes links to tutorials, articles and sample projects.
 
 ## Need help?

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 [Active Admin](https://www.activeadmin.info) is a Ruby on Rails framework for creating elegant backends for website administration.
 
-[![Version         ](http://img.shields.io/gem/v/activeadmin.svg)                               ](https://rubygems.org/gems/activeadmin)
-[![Travis CI       ](http://img.shields.io/travis/activeadmin/activeadmin/master.svg)           ](https://travis-ci.org/activeadmin/activeadmin)
-[![Quality         ](http://img.shields.io/codeclimate/github/activeadmin/activeadmin.svg)      ](https://codeclimate.com/github/activeadmin/activeadmin)
-[![Coverage        ](https://codecov.io/gh/activeadmin/activeadmin/branch/master/graph/badge.svg)](https://codecov.io/gh/activeadmin/activeadmin)
-[![Inch CI         ](http://inch-ci.org/github/activeadmin/activeadmin.svg?branch=master)       ](http://inch-ci.org/github/activeadmin/activeadmin)
-[![Gratipay Team   ](https://img.shields.io/gratipay/team/Active-Admin.svg)](https://gratipay.com/Active-Admin/)
+[![Version         ][rubygems_badge]][rubygems]
+[![Travis CI       ][travis_badge]][travis]
+[![Quality         ][codeclimate_badge]][codeclimate]
+[![Coverage        ][codecov_badge]][codecov]
+[![Inch CI         ][inch_badge]][inch]
+[![Gratipay Team   ][gratipay_badge]][gratipay]
 
 ## Goals
 
@@ -17,14 +17,13 @@
 
 ## Getting started
 
-* Check out [the docs](http://activeadmin.info/0-installation.html)!
-* Try the [live demo](http://demo.activeadmin.info/admin)
-* The [wiki](https://github.com/activeadmin/activeadmin/wiki) includes links to tutorials, articles and sample projects.
+* Check out [the docs][docs]
+* Try the [live demo][demo]
+* The [wiki] includes links to tutorials, articles and sample projects.
 
 ## Need help?
 
-Please use [StackOverflow](http://stackoverflow.com/questions/tagged/activeadmin) for
-help requests and how-to questions.
+Please use [StackOverflow][stackoverflow] for help requests and how-to questions.
 
 Please open GitHub issues for bugs and enhancements only, not general help requests.
 Please search previous issues (and Google and StackOverflow) before creating a new issue.
@@ -33,14 +32,14 @@ Google Groups, IRC #activeadmin and Gitter are not actively monitored.
 
 ## Want to contribute?
 
-The [contributing guide](https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md)
+The [contributing guide][contributing]
 is a good place to start. If you have questions, feel free to ask.
 
 ## Want to support us?
 
-You can support us with a weekly tip via [Gratipay](https://gratipay.com).
+You can support us with a weekly tip via [Gratipay][gratipay.com].
 
-[![Support via Gratipay](https://cdn.rawgit.com/gratipay/gratipay-badge/2.1.3/dist/gratipay.png)](https://gratipay.com/Active-Admin)
+[![Support via Gratipay][gratipay_button]][gratipay]
 
 ## Dependencies
 
@@ -61,3 +60,24 @@ Tool                  | Description
 [Inherited Resources]: https://github.com/activeadmin/inherited_resources
 [Kaminari]: https://github.com/kaminari/kaminari
 [Ransack]: https://github.com/activerecord-hackery/ransack
+
+[rubygems_badge]: http://img.shields.io/gem/v/activeadmin.svg
+[rubygems]: https://rubygems.org/gems/activeadmin
+[travis_badge]: http://img.shields.io/travis/activeadmin/activeadmin/master.svg
+[travis]: https://travis-ci.org/activeadmin/activeadmin
+[codeclimate_badge]: http://img.shields.io/codeclimate/github/activeadmin/activeadmin.svg
+[codeclimate]: https://codeclimate.com/github/activeadmin/activeadmin
+[codecov_badge]: https://codecov.io/gh/activeadmin/activeadmin/branch/master/graph/badge.svg
+[codecov]: https://codecov.io/gh/activeadmin/activeadmin
+[inch_badge]: http://inch-ci.org/github/activeadmin/activeadmin.svg?branch=master
+[inch]: http://inch-ci.org/github/activeadmin/activeadmin
+[gratipay_badge]: https://img.shields.io/gratipay/team/Active-Admin.svg
+[gratipay]: https://gratipay.com/Active-Admin/
+
+[docs]: http://activeadmin.info/0-installation.html
+[demo]: http://demo.activeadmin.info/admin
+[wiki]: https://github.com/activeadmin/activeadmin/wiki
+[stackoverflow]: http://stackoverflow.com/questions/tagged/activeadmin
+[contributing]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
+[gratipay.com]: https://gratipay.com
+[gratipay_button]: https://cdn.rawgit.com/gratipay/gratipay-badge/2.1.3/dist/gratipay.png

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 
 ## Goals
 
-1. Enable developers to quickly create good-looking administration interfaces.
-2. Build a DSL for developers and an interface for businesses.
-3. Ensure that developers can easily customize every nook and cranny.
+* Enable developers to quickly create good-looking administration interfaces.
+* Build a DSL for developers and an interface for businesses.
+* Ensure that developers can easily customize every nook and cranny.
 
 ## Getting started
 

--- a/Rakefile
+++ b/Rakefile
@@ -35,7 +35,7 @@ end
 # Import all our rake tasks
 FileList['tasks/**/*.rake'].each { |task| import task }
 
-task default: [:test, :lint]
+task default: :test
 
 begin
   require 'jasmine'

--- a/config/mdl_style.rb
+++ b/config/mdl_style.rb
@@ -4,6 +4,8 @@ exclude_rule "first-header-h1"
 
 exclude_rule "line-length"
 
+exclude_rule "no-duplicate-header"
+
 rule "no-trailing-punctuation", punctuation: ".,;:!"
 
 exclude_rule "first-line-h1"

--- a/tasks/lint.rake
+++ b/tasks/lint.rake
@@ -1,15 +1,8 @@
 desc "Lints ActiveAdmin code base"
-task lint: ["lint:rubocop", "lint:mdl"]
+task lint: ["lint:rubocop"]
 
 namespace :lint do
   require "rubocop/rake_task"
   desc "Checks ruby code style with RuboCop"
   RuboCop::RakeTask.new
-
-  desc "Checks markdown code style with Markdownlint"
-  task :mdl do
-    puts "Running mdl..."
-
-    abort unless system("mdl", ".")
-  end
 end

--- a/tasks/lint.rake
+++ b/tasks/lint.rake
@@ -1,8 +1,0 @@
-desc "Lints ActiveAdmin code base"
-task lint: ["lint:rubocop"]
-
-namespace :lint do
-  require "rubocop/rake_task"
-  desc "Checks ruby code style with RuboCop"
-  RuboCop::RakeTask.new
-end

--- a/tasks/lint.rake
+++ b/tasks/lint.rake
@@ -10,12 +10,6 @@ namespace :lint do
   task :mdl do
     puts "Running mdl..."
 
-    targets = [
-      *Dir.glob("docs/**/*.md"),
-      "CONTRIBUTING.md",
-      ".github/ISSUE_TEMPLATE.md"
-    ]
-
-    abort unless system("mdl", *targets)
+    abort unless system("mdl", ".")
   end
 end


### PR DESCRIPTION
I configured codeclimate for active admin.

Some time ago other contributors mentioned that it'd be nice to have style checks as a separate PR check instead of having to wait for the whole CI build to complete. This setup should allow that.

Note that I haven't yet moved `rubocop` to this `codeclimate` config (which would be the main benefit of this). I'm waiting until they add support for the latest `rubocop` version. According to https://github.com/codeclimate/codeclimate-rubocop/issues/99#issuecomment-322381645, it should be in the works.