### PR TITLE
Add a missing jp translations

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -32,6 +32,10 @@ ja:
         ends_with: "で終わる"
         greater_than: "より大きい"
         less_than: "より小さい"
+        gteq_datetime: "以上"
+        lteq_datetime: "以下"
+        from: "開始"
+        to: "終了"
     search_status:
       headline: "検索条件:"
       current_scope: "範囲:"


### PR DESCRIPTION
I added a missing translations(``gteq_datetime``, ``lteq_datetime``, ``from``, ``to``) in Japanese locale file.