### PR TITLE
raise error when trying to redefine controller method

### DIFF
--- a/lib/active_admin/resource_dsl.rb
+++ b/lib/active_admin/resource_dsl.rb
@@ -131,6 +131,8 @@ module ActiveAdmin
     # action.
     #
     def action(set, name, options = {}, &block)
+      raise ArgumentError, "method #{name} already defined" if controller.method_defined?(name)
+
       set << ControllerAction.new(name, options)
       title = options.delete(:title)
 

--- a/spec/unit/action_builder_spec.rb
+++ b/spec/unit/action_builder_spec.rb
@@ -1,124 +1,156 @@
 require 'rails_helper'
 
 RSpec.describe 'defining actions from registration blocks', type: :controller do
-  let(:klass){ Admin::PostsController }
+  context 'when method with given name does not exist' do
+    let(:klass){ Admin::PostsController }
 
-  before do
-    load_resources { action! }
+    before do
+      load_resources { action! }
 
-    @controller = klass.new
+      @controller = klass.new
+    end
+
+    describe 'creates a member action' do
+      after(:each) do
+        klass.clear_member_actions!
+      end
+
+      context 'with a block' do
+        let(:action!) do
+          ActiveAdmin.register Post do
+            member_action :comment do
+              # Do nothing
+            end
+          end
+        end
+
+        it 'should create a new public instance method' do
+          expect(klass.public_instance_methods.collect(&:to_s)).to include('comment')
+        end
+
+        it 'should add itself to the member actions config' do
+          expect(klass.active_admin_config.member_actions.size).to eq 1
+        end
+
+        it 'should create a new named route' do
+          expect(Rails.application.routes.url_helpers.methods.collect(&:to_s)).to include('comment_admin_post_path')
+        end
+      end
+
+      context 'without a block' do
+        let(:action!) do
+          ActiveAdmin.register Post do
+            member_action :comment
+          end
+        end
+
+        it 'should still generate a new empty action' do
+          expect(klass.public_instance_methods.collect(&:to_s)).to include('comment')
+        end
+      end
+
+      context 'with :title' do
+        let(:action!) do
+          ActiveAdmin.register Post do
+            member_action :comment, title: 'My Awesome Comment' do
+              render json: {a: 2}
+            end
+          end
+        end
+
+        it 'sets the page title' do
+          params = {id: 1}
+          params = {params: params} if ActiveAdmin::Dependency.rails5?
+          get :comment, params
+
+          expect(controller.instance_variable_get(:@page_title)).to eq 'My Awesome Comment'
+        end
+      end
+    end
+
+    describe 'creates a collection action' do
+      after(:each) do
+        klass.clear_collection_actions!
+      end
+
+      context 'with a block' do
+        let(:action!) do
+          ActiveAdmin.register Post do
+            collection_action :comments do
+              # Do nothing
+            end
+          end
+        end
+
+        it 'should create a public instance method' do
+          expect(klass.public_instance_methods.collect(&:to_s)).to include('comments')
+        end
+
+        it 'should add itself to the member actions config' do
+          expect(klass.active_admin_config.collection_actions.size).to eq 1
+        end
+
+        it 'should create a named route' do
+          expect(Rails.application.routes.url_helpers.methods.collect(&:to_s)).to include('comments_admin_posts_path')
+        end
+      end
+
+      context 'without a block' do
+        let(:action!) do
+          ActiveAdmin.register Post do
+            collection_action :comments
+          end
+        end
+
+        it 'should still generate a new empty action' do
+          expect(klass.public_instance_methods.collect(&:to_s)).to include('comments')
+        end
+      end
+
+      context 'with :title' do
+        let(:action!) do
+          ActiveAdmin.register Post do
+            collection_action :comments, title: 'My Awesome Comments' do
+              render json: {a: 2}
+            end
+          end
+        end
+
+        it 'sets the page title' do
+          get :comments
+
+          expect(controller.instance_variable_get(:@page_title)).to eq 'My Awesome Comments'
+        end
+      end
+    end
   end
 
-  describe 'creates a member action' do
-    after(:each) do
-      klass.clear_member_actions!
-    end
-
-    context 'with a block' do
-      let(:action!) do
-        ActiveAdmin.register Post do
-          member_action :comment do
-            # Do nothing
+  context 'when method with given name is already defined' do
+    describe 'defining member action' do
+      subject do
+        load_resources do
+          ActiveAdmin.register Post do
+            member_action :process
           end
         end
       end
 
-      it 'should create a new public instance method' do
-        expect(klass.public_instance_methods.collect(&:to_s)).to include('comment')
-      end
-
-      it 'should add itself to the member actions config' do
-        expect(klass.active_admin_config.member_actions.size).to eq 1
-      end
-
-      it 'should create a new named route' do
-        expect(Rails.application.routes.url_helpers.methods.collect(&:to_s)).to include('comment_admin_post_path')
+      it 'raises error' do
+        expect { subject }.to raise_error(ArgumentError)
       end
     end
 
-    context 'without a block' do
-      let(:action!) do
-        ActiveAdmin.register Post do
-          member_action :comment
-        end
-      end
-
-      it 'should still generate a new empty action' do
-        expect(klass.public_instance_methods.collect(&:to_s)).to include('comment')
-      end
-    end
-
-    context 'with :title' do
-      let(:action!) do
-        ActiveAdmin.register Post do
-          member_action :comment, title: 'My Awesome Comment' do
-            render json: {a: 2}
+    describe 'defining collection action' do
+      subject do
+        load_resources do
+          ActiveAdmin.register Post do
+            collection_action :process
           end
         end
       end
 
-      it 'sets the page title' do
-        params = {id: 1}
-        params = {params: params} if ActiveAdmin::Dependency.rails5?
-        get :comment, params
-
-        expect(controller.instance_variable_get(:@page_title)).to eq 'My Awesome Comment'
-      end
-    end
-  end
-
-  describe 'creates a collection action' do
-    after(:each) do
-      klass.clear_collection_actions!
-    end
-
-    context 'with a block' do
-      let(:action!) do
-        ActiveAdmin.register Post do
-          collection_action :comments do
-            # Do nothing
-          end
-        end
-      end
-
-      it 'should create a public instance method' do
-        expect(klass.public_instance_methods.collect(&:to_s)).to include('comments')
-      end
-
-      it 'should add itself to the member actions config' do
-        expect(klass.active_admin_config.collection_actions.size).to eq 1
-      end
-
-      it 'should create a named route' do
-        expect(Rails.application.routes.url_helpers.methods.collect(&:to_s)).to include('comments_admin_posts_path')
-      end
-    end
-
-    context 'without a block' do
-      let(:action!) do
-        ActiveAdmin.register Post do
-          collection_action :comments
-        end
-      end
-
-      it 'should still generate a new empty action' do
-        expect(klass.public_instance_methods.collect(&:to_s)).to include('comments')
-      end
-    end
-
-    context 'with :title' do
-      let(:action!) do
-        ActiveAdmin.register Post do
-          collection_action :comments, title: 'My Awesome Comments' do
-            render json: {a: 2}
-          end
-        end
-      end
-
-      it 'sets the page title' do
-        get :comments
-
-        expect(controller.instance_variable_get(:@page_title)).to eq 'My Awesome Comments'
+      it 'raises error' do
+        expect { subject }.to raise_error(ArgumentError)
       end
     end
   end


### PR DESCRIPTION
This change addresses problem in #5148.
Raising error during application loading would be better than raising uncommunicative error during request