### PR TITLE
Adding :entry_name so will_paginate works with current documentation

### DIFF
--- a/lib/active_admin/orm/active_record/comments/views/active_admin_comments.rb
+++ b/lib/active_admin/orm/active_record/comments/views/active_admin_comments.rb
@@ -26,7 +26,7 @@ module ActiveAdmin
         def build_comments
           if @comments.any?
             @comments.each(&method(:build_comment))
-            div page_entries_info(@comments).html_safe, class: 'pagination_information'
+            div page_entries_info(@comments).html_safe, class: 'pagination_information', entry_name: I18n.t('active_admin.comments.resource')
           else
             build_empty_message
           end


### PR DESCRIPTION
I've been unsuccessfull on following current documentation about support of activeadmin along with will_paginate. The only way things work around here is following fully the instructions on [#1833](https://github.com/activeadmin/activeadmin/issues/1833) and adding explicit "entry_name" declaration when building comments view. Not sure if it suits all use cases, but sure does mine. Maybe better localization for entry_name would be needed.