### PR TITLE
Comment indentation error in index_as_grid.rb

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,9 @@ AllCops:
 Lint/EndAlignment:
   Enabled: true
 
+Layout/AccessModifierIndentation:
+  Enabled: true
+
 Layout/CaseIndentation:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,9 @@ Lint/EndAlignment:
 Layout/CaseIndentation:
   Enabled: true
 
+Layout/CommentIndentation:
+  Enabled: true
+
 Layout/ElseAlignment:
   Enabled: true
 

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -155,7 +155,7 @@ module ActiveAdmin
       controllers
     end
 
-  private
+    private
 
     # Since app/admin is alphabetically before app/models, we have to remove it
     # from the host app's +autoload_paths+ to prevent missing constant errors.

--- a/lib/active_admin/filters/resource_extension.rb
+++ b/lib/active_admin/filters/resource_extension.rb
@@ -83,7 +83,7 @@ module ActiveAdmin
         @filters_to_remove = nil
       end
 
-    private
+      private
 
       # Collapses the waveform, if you will, of which filters should be displayed.
       # Removes filters and adds in default filters as desired.

--- a/lib/active_admin/resource_controller/decorators.rb
+++ b/lib/active_admin/resource_controller/decorators.rb
@@ -2,7 +2,7 @@ module ActiveAdmin
   class ResourceController < BaseController
     module Decorators
 
-    protected
+      protected
 
       def apply_decorator(resource)
         decorate? ? decorator_class.new(resource) : resource
@@ -24,7 +24,7 @@ module ActiveAdmin
         end
       end
 
-    private
+      private
 
       def decorate?
         case action_name
@@ -62,7 +62,7 @@ module ActiveAdmin
           end
         end
 
-      private
+        private
 
         def self.wrap!(parent, name)
           ::Class.new parent do

--- a/lib/active_admin/views/index_as_grid.rb
+++ b/lib/active_admin/views/index_as_grid.rb
@@ -1,30 +1,30 @@
 module ActiveAdmin
   module Views
 
-     # # Index as a Grid
-     #
-     # Sometimes you want to display the index screen for a set of resources as a grid
-     # (possibly a grid of thumbnail images). To do so, use the :grid option for the
-     # index block.
-     #
-     # ```ruby
-     # index as: :grid do |product|
-     #   link_to image_tag(product.image_path), admin_product_path(product)
-     # end
-     # ```
-     #
-     # The block is rendered within a cell in the grid once for each resource in the
-     # collection. The resource is passed into the block for you to use in the view.
-     #
-     # You can customize the number of columns that are rendered using the columns
-     # option:
-     #
-     # ```ruby
-     # index as: :grid, columns: 5 do |product|
-     #   link_to image_tag(product.image_path), admin_product_path(product)
-     # end
-     # ```
-     #
+    # # Index as a Grid
+    #
+    # Sometimes you want to display the index screen for a set of resources as a grid
+    # (possibly a grid of thumbnail images). To do so, use the :grid option for the
+    # index block.
+    #
+    # ```ruby
+    # index as: :grid do |product|
+    #   link_to image_tag(product.image_path), admin_product_path(product)
+    # end
+    # ```
+    #
+    # The block is rendered within a cell in the grid once for each resource in the
+    # collection. The resource is passed into the block for you to use in the view.
+    #
+    # You can customize the number of columns that are rendered using the columns
+    # option:
+    #
+    # ```ruby
+    # index as: :grid, columns: 5 do |product|
+    #   link_to image_tag(product.image_path), admin_product_path(product)
+    # end
+    # ```
+    #
     class IndexAsGrid < ActiveAdmin::Component
 
       def build(page_presenter, collection)
@@ -42,7 +42,7 @@ module ActiveAdmin
         "grid"
       end
 
-     protected
+      protected
 
       def build_table
         resource_selection_toggle_panel if active_admin_config.batch_actions.any?

--- a/lib/active_admin/views/index_as_table.rb
+++ b/lib/active_admin/views/index_as_table.rb
@@ -362,7 +362,7 @@ module ActiveAdmin
           end
         end
 
-      private
+        private
 
         def defaults(resource, options = {})
           if controller.action_methods.include?('show') && authorized?(ActiveAdmin::Auth::READ, resource)


### PR DESCRIPTION
Looks like auto-correct Style/IndentationWidth (7480b24) corrects the code indentation but not the comments.