### PR TITLE
Make ResourceController contain actual action methods only

### DIFF
--- a/lib/active_admin/base_controller.rb
+++ b/lib/active_admin/base_controller.rb
@@ -22,17 +22,17 @@ module ActiveAdmin
       attr_accessor :active_admin_config
     end
 
+    include Authorization
+    include Menu
+
+    private
+
     # By default Rails will render un-implemented actions when the view exists. Because Active
     # Admin allows you to not render any of the actions by using the #actions method, we need
     # to check if they are implemented.
     def only_render_implemented_actions
       raise AbstractController::ActionNotFound unless action_methods.include?(params[:action])
     end
-
-    include Authorization
-    include Menu
-
-    private
 
     # Calls the authentication method as defined in ActiveAdmin.authentication_method
     def authenticate_active_admin_user

--- a/lib/active_admin/helpers/scope_chain.rb
+++ b/lib/active_admin/helpers/scope_chain.rb
@@ -1,5 +1,6 @@
 module ActiveAdmin
   module ScopeChain
+    private
     # Scope an ActiveRecord::Relation chain
     #
     # Example:

--- a/lib/active_admin/resource_controller/action_builder.rb
+++ b/lib/active_admin/resource_controller/action_builder.rb
@@ -7,11 +7,21 @@ module ActiveAdmin
       module ClassMethods
 
         def clear_member_actions!
+          remove_action_methods(:member)
           active_admin_config.clear_member_actions!
         end
 
         def clear_collection_actions!
+          remove_action_methods(:collection)
           active_admin_config.clear_collection_actions!
+        end
+
+        private
+
+        def remove_action_methods(actions_type)
+          active_admin_config.public_send("#{actions_type}_actions").each do |action|
+            remove_method action.name
+          end
         end
       end
 

--- a/lib/active_admin/resource_controller/resource_class_methods.rb
+++ b/lib/active_admin/resource_controller/resource_class_methods.rb
@@ -13,6 +13,8 @@ module ActiveAdmin
             @active_admin_config ? @active_admin_config.resource_class : nil
           end
 
+          private
+
           def resource_class
             self.class.resource_class
           end

--- a/lib/active_admin/resource_dsl.rb
+++ b/lib/active_admin/resource_dsl.rb
@@ -74,6 +74,8 @@ module ActiveAdmin
 
           params.permit(*permitted_params, param_key => block ? instance_exec(&block) : args)
         end
+
+        private :permitted_params
       end
     end
 

--- a/lib/active_admin/view_helpers/download_format_links_helper.rb
+++ b/lib/active_admin/view_helpers/download_format_links_helper.rb
@@ -1,6 +1,7 @@
 module ActiveAdmin
   module ViewHelpers
     module DownloadFormatLinksHelper
+      private
 
       def build_download_formats(download_links)
         download_links = instance_exec(&download_links) if download_links.is_a?(Proc)

--- a/spec/unit/resource_controller_spec.rb
+++ b/spec/unit/resource_controller_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe ActiveAdmin::ResourceController do
         after_destroy :call_after_destroy
 
         controller do
+          private
+
           def call_after_build(obj); end
           def call_before_save(obj); end
           def call_after_save(obj); end
@@ -101,6 +103,17 @@ RSpec.describe ActiveAdmin::ResourceController do
         expect(controller).to receive(:call_after_destroy).with(resource)
         controller.send :destroy_resource, resource
       end
+    end
+  end
+
+  describe "action methods" do
+    before do
+      load_resources { ActiveAdmin.register Post }
+    end
+
+    it "should have actual action methods" do
+      controller.class.clear_action_methods! # make controller recalculate :action_methods on the next call
+      expect(controller.action_methods.sort).to eq ["batch_action", "create", "destroy", "edit", "index", "new", "show", "update"]
     end
   end
 end


### PR DESCRIPTION
In any Rails controller public methods are considered as action methods and may be available through routes. So, we should avoid unnecessary public methods in controllers, which are not supposed to be action methods.

Now `ActiveAdmin::ResourceController.action_methods`  returns 

`#<Set: {"batch_action", "build_download_formats", "build_download_format_links", "index", "scope_chain", "only_render_implemented_actions", "render_or_call_method_or_proc_on", "render_in_context", "call_method_or_exec_proc", "call_method_or_proc_on", "new", "update", "create", "destroy", "edit", "show"}>`

But it should be

`#<Set: {"batch_action", "index",  "new", "update", "create", "destroy", "edit", "show"}>`

This PR fixes this problem.