### PR TITLE
Don't try to find an associated class if the attribute is a column on the model

### DIFF
--- a/lib/active_admin/filters/active_filter.rb
+++ b/lib/active_admin/filters/active_filter.rb
@@ -68,6 +68,8 @@ module ActiveAdmin
       end
 
       def find_class?
+        return false if condition_attribute.klass.column_names.include?(name.to_s)
+
         ['eq', 'in'].include? condition.predicate.arel_predicate
       end
 


### PR DESCRIPTION
This PR fixes #5155. See that issue for more information.

cc @Fivell 