### PR TITLE
Nested namespaces support

### DIFF
--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -18,7 +18,7 @@ Given /^(a|\d+) comments added by admin with an email "([^"]+)"?$/ do |number, e
   comment_text = 'Comment %i'
 
   number.times do |i|
-    ActiveAdmin::Comment.create!(namespace:     'admin',
+    ActiveAdmin::Comment.create!(namespace:     [:admin],
                                  body:          comment_text % i,
                                  resource_type: Post.to_s,
                                  resource_id:   Post.first.id,

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -27,7 +27,11 @@ module NavigationHelpers
     # the index page for posts in the user_admin namespace
     when /^the index page for (.*) in the (.*) namespace$/
       if $2 != 'root'
-        send "#{$2}_#{$1}_path"
+        if $2 != 'admin'
+          send "admin_#{$2}_#{$1}_path"
+        else
+          send "admin_#{$1}_path"
+        end
       else
         send "#{$1}_path"
       end

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -27,11 +27,7 @@ module NavigationHelpers
     # the index page for posts in the user_admin namespace
     when /^the index page for (.*) in the (.*) namespace$/
       if $2 != 'root'
-        if $2 != 'admin'
-          send "admin_#{$2}_#{$1}_path"
-        else
-          send "admin_#{$1}_path"
-        end
+        send "#{$2}_#{$1}_path"
       else
         send "#{$1}_path"
       end

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -163,9 +163,7 @@ module ActiveAdmin
     end
 
     def build_name_path(name)
-      names = Array(name).map { |n| [true, false, nil].include?(n) ? n : n.to_s.underscore.to_sym }
-      return names if [:root, false, nil].include?(default_namespace) || [:root, default_namespace].include?(names.first)
-      [default_namespace] + names
+      Array(name).map(&:to_s).map(&:underscore).map(&:to_sym)
     end
 
     private

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -74,7 +74,7 @@ module ActiveAdmin
     def namespace(name)
       name ||= :root
 
-      namespace = namespaces[name] ||= begin
+      namespace = namespaces[build_name_path(name)] ||= begin
         namespace = Namespace.new(self, name)
         ActiveSupport::Notifications.publish ActiveAdmin::Namespace::RegisterEvent, namespace
         namespace
@@ -160,6 +160,12 @@ module ActiveAdmin
       controllers = [BaseController]
       controllers.push *Devise.controllers_for_filters if Dependency.devise?
       controllers
+    end
+
+    def build_name_path(name)
+      names = Array(name).map { |n| [true, false, nil].include?(n) ? n : n.to_s.underscore.to_sym }
+      return names if [:root, false, nil].include?(default_namespace) || [:root, default_namespace].include?(names.first)
+      [default_namespace] + names
     end
 
     private

--- a/lib/active_admin/base_controller.rb
+++ b/lib/active_admin/base_controller.rb
@@ -36,11 +36,27 @@ module ActiveAdmin
 
     # Calls the authentication method as defined in ActiveAdmin.authentication_method
     def authenticate_active_admin_user
-      send(active_admin_namespace.authentication_method) if active_admin_namespace.authentication_method
+      if active_admin_namespace.authentication_method
+        auth_method = active_admin_namespace.authentication_method
+        if auth_method.is_a?(Proc)
+          namespace = active_admin_namespace.name_path
+          send(auth_method.call(namespace))
+        else
+          send(auth_method)
+        end
+      end
     end
 
     def current_active_admin_user
-      send(active_admin_namespace.current_user_method) if active_admin_namespace.current_user_method
+      if active_admin_namespace.current_user_method
+        user_method = active_admin_namespace.current_user_method
+        if user_method.is_a?(Proc)
+          namespace = active_admin_namespace.name_path
+          send(user_method.call(namespace))
+        else
+          send(user_method)
+        end
+      end
     end
     helper_method :current_active_admin_user
 

--- a/lib/active_admin/namespace.rb
+++ b/lib/active_admin/namespace.rb
@@ -37,7 +37,7 @@ module ActiveAdmin
 
     def initialize(application, name)
       @application = application
-      @name = Array(name).first.to_s.underscore.to_sym
+      # @name_splits = name.split('/').map(&:to_sym)
       @name_path = application.build_name_path(name)
       @resources = ResourceCollection.new
       register_module unless root?
@@ -46,7 +46,7 @@ module ActiveAdmin
 
     def name
       Deprecation.warn "name replaced by name_path now that namespaces can be nested."
-      @name
+      name_path.first
     end
 
     def settings
@@ -91,7 +91,7 @@ module ActiveAdmin
     end
 
     def root?
-      @name == :root
+      name_path.first == :root
     end
 
     # Returns the name of the module if required. Will be nil if none

--- a/lib/active_admin/namespace.rb
+++ b/lib/active_admin/namespace.rb
@@ -253,7 +253,7 @@ module ActiveAdmin
 
     class Store
       include Enumerable
-      delegate :[], :[]=, :empty?, to: :@namespaces
+      delegate :[]=, :empty?, to: :@namespaces
 
       def initialize
         @namespaces = {}
@@ -263,9 +263,19 @@ module ActiveAdmin
         @namespaces.values.each(&block)
       end
 
+      def [](key)
+        @namespaces[Array(key)]
+      end
+
       def names
+        Deprecation.warn "names replaced by name_paths now that namespaces can be nested."
+        @namespaces.keys.first
+      end
+
+      def name_paths
         @namespaces.keys
       end
+
     end
   end
 end

--- a/lib/active_admin/orm/active_record/comments.rb
+++ b/lib/active_admin/orm/active_record/comments.rb
@@ -31,15 +31,16 @@ ActiveAdmin.after_load do |app|
       scope :all, show_count: false
       # Register a scope for every namespace that exists.
       # The current namespace will be the default scope.
-      app.namespaces.map(&:name).each do |name|
-        scope name, default: namespace.name == name do |scope|
-          scope.where namespace: name.to_s
+      app.namespaces.map(&:name_path).each do |name_path|
+        scope_name = name_path.is_a?(Array) ? "/#{name_path.join('/')}" : name_path
+        scope scope_name, default: namespace.name_path == name_path do |scope|
+          scope.where namespace: name_path.to_s
         end
       end
 
       # Store the author and namespace
       before_save do |comment|
-        comment.namespace = active_admin_config.namespace.name
+        comment.namespace = active_admin_config.namespace.name_path
         comment.author    = current_active_admin_user
       end
 

--- a/lib/active_admin/orm/active_record/comments/comment.rb
+++ b/lib/active_admin/orm/active_record/comments/comment.rb
@@ -15,12 +15,12 @@ module ActiveAdmin
       ResourceController::Decorators.undecorate(resource).class.base_class.name.to_s
     end
 
-    def self.find_for_resource_in_namespace(resource, namespace)
+    def self.find_for_resource_in_namespace(resource, name)
       where(
         resource_type: resource_type(resource),
         resource_id:   resource,
-        namespace:     namespace.to_s
-      ).order(ActiveAdmin.application.namespaces[namespace.to_sym].comments_order)
+        namespace:     name.to_s
+      ).order(ActiveAdmin.application.namespaces[ActiveAdmin.application.build_name_path(name)].comments_order)
     end
 
     def set_resource_type

--- a/lib/active_admin/orm/active_record/comments/views/active_admin_comments.rb
+++ b/lib/active_admin/orm/active_record/comments/views/active_admin_comments.rb
@@ -12,7 +12,7 @@ module ActiveAdmin
 
         def build(resource)
           @resource = resource
-          @comments = ActiveAdmin::Comment.find_for_resource_in_namespace(resource, active_admin_namespace.name).includes(:author).page(params[:page])
+          @comments = ActiveAdmin::Comment.find_for_resource_in_namespace(resource, active_admin_namespace.name_path).includes(:author).page(params[:page])
           super(title, for: resource)
           build_comments
         end
@@ -58,7 +58,7 @@ module ActiveAdmin
 
         def comments_url(*args)
           parts = []
-          parts << active_admin_namespace.name unless active_admin_namespace.root?
+          parts << active_admin_namespace.name_path unless active_admin_namespace.root?
           parts << active_admin_namespace.comments_registration_name.underscore
           parts << 'path'
           send parts.join('_'), *args
@@ -66,7 +66,7 @@ module ActiveAdmin
 
         def comment_form_url
           parts = []
-          parts << active_admin_namespace.name unless active_admin_namespace.root?
+          parts << active_admin_namespace.name_path unless active_admin_namespace.root?
           parts << active_admin_namespace.comments_registration_name.underscore.pluralize
           parts << 'path'
           send parts.join '_'

--- a/lib/active_admin/page.rb
+++ b/lib/active_admin/page.rb
@@ -57,7 +57,12 @@ module ActiveAdmin
     end
 
     def namespace_name
+      Deprecation.warn "namespace_name replaced by namespace_name now that namespaces can be nested."
       namespace.name.to_s
+    end
+
+    def namespace_name_path
+      namespace.name_path
     end
 
     def default_menu_options

--- a/lib/active_admin/resource/belongs_to.rb
+++ b/lib/active_admin/resource/belongs_to.rb
@@ -6,7 +6,7 @@ module ActiveAdmin
 
       class TargetNotFound < StandardError
         def initialize(key, namespace)
-          super "Could not find #{key} in #{namespace.name} " +
+          super "Could not find #{key} in #{namespace.name_path} " +
                 "with #{namespace.resources.map(&:resource_name)}"
         end
       end

--- a/lib/active_admin/router.rb
+++ b/lib/active_admin/router.rb
@@ -19,7 +19,7 @@ module ActiveAdmin
         if namespace.root?
           router.root namespace.root_to_options.merge(to: namespace.root_to)
         else
-          router.namespace namespace.name, namespace.route_options.dup do
+          define_nested_namespace(namespace.name_path, namespace) do
             router.root namespace.root_to_options.merge(to: namespace.root_to, as: :root)
           end
         end
@@ -105,8 +105,18 @@ module ActiveAdmin
     end
 
     def define_namespace(config)
-      router.namespace config.namespace.name, config.namespace.route_options.dup do
+      define_nested_namespace(config.namespace.name_path, config.namespace) do
         define_routes(config)
+      end
+    end
+
+    def define_nested_namespace(names, namespace)
+      router.namespace names.first, namespace.route_options.dup do
+        if names.size > 1
+          define_nested_namespace(names.drop(1), namespace, &Proc.new)
+        else
+          yield
+        end
       end
     end
   end

--- a/lib/active_admin/scope.rb
+++ b/lib/active_admin/scope.rb
@@ -31,7 +31,7 @@ module ActiveAdmin
         raise "A string/symbol is required as the second argument if your label is a proc." unless method
         @id = ActiveAdmin::Dependency.rails.parameterize method.to_s
       else
-        @scope_method ||= name.to_sym
+        @scope_method ||= (name.is_a?(Array) ? name.join('_').underscore : name).to_sym
         @id = ActiveAdmin::Dependency.rails.parameterize name.to_s
       end
 

--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -62,7 +62,7 @@ module ActiveAdmin
             params[:action],
             params[:controller].tr('/', '_'),
             'active_admin', 'logged_in',
-            active_admin_namespace.name.to_s + '_namespace'
+            active_admin_namespace.name_path.map(&:to_s).join('_') + '_namespace'
           ]
         end
 

--- a/spec/requests/default_namespace_spec.rb
+++ b/spec/requests/default_namespace_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe ActiveAdmin::Application, type: :request do
 
     it "should generate resource paths" do
       expect(resource1.route_collection_path).to eq "/test/categories"
-      expect(resource2.route_collection_path).to eq "/test/foo/bar/categories"
+      expect(resource2.route_collection_path).to eq "/foo/bar/categories"
     end
 
     it "should generate a log out path" do
@@ -72,7 +72,7 @@ RSpec.describe ActiveAdmin::Application, type: :request do
 
     it "should generate resource paths" do
       expect(resource1.route_collection_path).to eq "/abc_123/categories"
-      expect(resource2.route_collection_path).to eq "/abc_123/foo/bar/categories"
+      expect(resource2.route_collection_path).to eq "/foo/bar/categories"
     end
 
     it "should generate a log out path" do

--- a/spec/requests/default_namespace_spec.rb
+++ b/spec/requests/default_namespace_spec.rb
@@ -4,7 +4,19 @@ RSpec.describe ActiveAdmin::Application, type: :request do
 
   include Rails.application.routes.url_helpers
 
-  let(:resource) { ActiveAdmin.register Category }
+  before do
+    load_defaults!
+    ActiveAdmin.register(Category, namespace: [:foo, :bar])
+    reload_routes!
+  end
+
+  after :all do
+    load_defaults!
+    reload_routes!
+  end
+
+  let(:resource1) { ActiveAdmin.register Category }
+  let(:resource2) { ActiveAdmin.register Category, namespace: [:foo, :bar] }
 
   [false, nil].each do |value|
 
@@ -15,7 +27,8 @@ RSpec.describe ActiveAdmin::Application, type: :request do
       end
 
       it "should generate resource paths" do
-        expect(resource.route_collection_path).to eq "/categories"
+        expect(resource1.route_collection_path).to eq "/categories"
+        expect(resource2.route_collection_path).to eq "/foo/bar/categories"
       end
 
       it "should generate a log out path" do
@@ -37,7 +50,8 @@ RSpec.describe ActiveAdmin::Application, type: :request do
     end
 
     it "should generate resource paths" do
-      expect(resource.route_collection_path).to eq "/test/categories"
+      expect(resource1.route_collection_path).to eq "/test/categories"
+      expect(resource2.route_collection_path).to eq "/test/foo/bar/categories"
     end
 
     it "should generate a log out path" do
@@ -57,7 +71,8 @@ RSpec.describe ActiveAdmin::Application, type: :request do
     end
 
     it "should generate resource paths" do
-      expect(resource.route_collection_path).to eq "/abc_123/categories"
+      expect(resource1.route_collection_path).to eq "/abc_123/categories"
+      expect(resource2.route_collection_path).to eq "/abc_123/foo/bar/categories"
     end
 
     it "should generate a log out path" do

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe ActiveAdmin::Application do
         ActiveSupport::Deprecation.silence do
           expect(ns.name).to eq :new_namespace
         end
-        expect(ns.name_path).to eq [:admin, :new_namespace]
+        expect(ns.name_path).to eq [:new_namespace]
       end
     end
 
@@ -155,7 +155,7 @@ RSpec.describe ActiveAdmin::Application do
     end
 
     it "should return an instantiated nested-namespace" do
-      ns = application.namespace [:foo, :bar]
+      ns = application.namespace [:admin, :foo, :bar]
       expect(ns).to eq application.namespaces[[:admin, :foo, :bar]]
       application.namespaces.instance_variable_get(:@namespaces).delete([:admin, :foo, :bar])
     end
@@ -172,7 +172,7 @@ RSpec.describe ActiveAdmin::Application do
     it "should not pollute the global app" do
       expect(application.namespaces).to be_empty
       application.namespace(:brand_new_ns)
-      expect(application.namespaces.names).to eq [[:admin, :brand_new_ns]]
+      expect(application.namespaces.names).to eq [[:brand_new_ns]]
       expect(ActiveAdmin.application.namespaces.names).to eq [[:admin]]
     end
   end

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -172,8 +172,12 @@ RSpec.describe ActiveAdmin::Application do
     it "should not pollute the global app" do
       expect(application.namespaces).to be_empty
       application.namespace(:brand_new_ns)
-      expect(application.namespaces.names).to eq [[:brand_new_ns]]
-      expect(ActiveAdmin.application.namespaces.names).to eq [[:admin]]
+      ActiveSupport::Deprecation.silence do
+        expect(application.namespaces.names).to eq [:brand_new_ns]
+        expect(ActiveAdmin.application.namespaces.names).to eq [:admin]
+      end
+      expect(application.namespaces.name_paths).to eq [[:brand_new_ns]]
+      expect(ActiveAdmin.application.namespaces.name_paths).to eq [[:admin]]
     end
   end
 

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -142,13 +142,22 @@ RSpec.describe ActiveAdmin::Application do
 
     it "should yield a new namespace" do
       application.namespace :new_namespace do |ns|
-        expect(ns.name).to eq :new_namespace
+        ActiveSupport::Deprecation.silence do
+          expect(ns.name).to eq :new_namespace
+        end
+        expect(ns.name_path).to eq [:admin, :new_namespace]
       end
     end
 
     it "should return an instantiated namespace" do
       admin = application.namespace :admin
       expect(admin).to eq application.namespaces[:admin]
+    end
+
+    it "should return an instantiated nested-namespace" do
+      ns = application.namespace [:foo, :bar]
+      expect(ns).to eq application.namespaces[[:admin, :foo, :bar]]
+      application.namespaces.instance_variable_get(:@namespaces).delete([:admin, :foo, :bar])
     end
 
     it "should yield an existing namespace" do
@@ -163,8 +172,8 @@ RSpec.describe ActiveAdmin::Application do
     it "should not pollute the global app" do
       expect(application.namespaces).to be_empty
       application.namespace(:brand_new_ns)
-      expect(application.namespaces.names).to eq [:brand_new_ns]
-      expect(ActiveAdmin.application.namespaces.names).to eq [:admin]
+      expect(application.namespaces.names).to eq [[:admin, :brand_new_ns]]
+      expect(ActiveAdmin.application.namespaces.names).to eq [[:admin]]
     end
   end
 

--- a/spec/unit/comments_spec.rb
+++ b/spec/unit/comments_spec.rb
@@ -30,9 +30,9 @@ RSpec.describe "Comments" do
         end
 
         it "should not return a comment for the same resource in a different namespace" do
-          ActiveAdmin.application.namespaces[[:admin, :public]] = ActiveAdmin.application.namespaces[[:admin]]
-          expect(ActiveAdmin::Comment.find_for_resource_in_namespace(post, 'public')).to eq []
-          ActiveAdmin.application.namespaces.instance_variable_get(:@namespaces).delete([:admin, :public])
+          ActiveAdmin.application.namespaces[[:public]] = ActiveAdmin.application.namespaces[[:admin]]
+          expect(ActiveAdmin::Comment.find_for_resource_in_namespace(post, application.build_name_path('public'))).to eq []
+          ActiveAdmin.application.namespaces.instance_variable_get(:@namespaces).delete([:public])
         end
 
         it "should not return a comment for a different resource" do
@@ -92,14 +92,14 @@ RSpec.describe "Comments" do
       end
 
       context "with nested namespaces" do
-        let(:namespace_name) { [:foo, :bar] }
-        before { ActiveAdmin.application.namespace [:foo, :bar] }
+        let(:namespace_name) { [:admin, :foo, :bar] }
+        before { ActiveAdmin.application.namespace [:admin, :foo, :bar] }
         it_behaves_like :find_for_resource_in_namespace_expectation
         after { ActiveAdmin.application.namespaces.instance_variable_get(:@namespaces).delete([:admin, :foo, :bar]) }
 
         context "name should not include default namespace" do
           let(:namespace_name) { [:admin, :foo, :bar] }
-          before { ActiveAdmin.application.namespace [:foo, :bar] }
+          before { ActiveAdmin.application.namespace [:admin, :foo, :bar] }
           it_behaves_like :find_for_resource_in_namespace_expectation
           after { ActiveAdmin.application.namespaces.instance_variable_get(:@namespaces).delete([:admin, :foo, :bar]) }
         end

--- a/spec/unit/namespace/register_resource_spec.rb
+++ b/spec/unit/namespace/register_resource_spec.rb
@@ -148,14 +148,14 @@ RSpec.describe ActiveAdmin::Namespace, "registering a resource" do
       it "should be namespaced" do
         namespace = ActiveAdmin::Namespace.new(application, :one)
         namespace.register Category
-        expect(defined?(Admin::One::CategoriesController)).to eq 'constant'
+        expect(defined?(One::CategoriesController)).to eq 'constant'
       end
     end
     context "when not namespaced" do
       it "should not be namespaced" do
         namespace = ActiveAdmin::Namespace.new(application, :two)
         namespace.register Category
-        expect(defined?(Admin::Two::CategoriesController)).to eq 'constant'
+        expect(defined?(Two::CategoriesController)).to eq 'constant'
       end
     end
   end # describe "dashboard controller name"

--- a/spec/unit/namespace/register_resource_spec.rb
+++ b/spec/unit/namespace/register_resource_spec.rb
@@ -148,14 +148,14 @@ RSpec.describe ActiveAdmin::Namespace, "registering a resource" do
       it "should be namespaced" do
         namespace = ActiveAdmin::Namespace.new(application, :one)
         namespace.register Category
-        expect(defined?(One::CategoriesController)).to eq 'constant'
+        expect(defined?(Admin::One::CategoriesController)).to eq 'constant'
       end
     end
     context "when not namespaced" do
       it "should not be namespaced" do
         namespace = ActiveAdmin::Namespace.new(application, :two)
         namespace.register Category
-        expect(defined?(Two::CategoriesController)).to eq 'constant'
+        expect(defined?(Admin::Two::CategoriesController)).to eq 'constant'
       end
     end
   end # describe "dashboard controller name"

--- a/spec/unit/page_spec.rb
+++ b/spec/unit/page_spec.rb
@@ -68,6 +68,26 @@ module ActiveAdmin
           expect(config.namespace_name).to eq "admin"
         end
       end
+      context "when nest namespaced controller" do
+        let(:namespace){ ActiveAdmin::Namespace.new(application, [:foo, :bar]) }
+        it "returns the name of the namespace" do
+          ActiveSupport::Deprecation.silence do
+            expect(config.namespace_name).to eq "foo"
+          end
+        end
+      end
+    end
+
+    describe "#namespace_name_path" do
+      it "returns the name of the namespace" do
+        expect(config.namespace_name_path).to eq [:admin]
+      end
+      context "when nest namespaced controller" do
+        let(:namespace){ ActiveAdmin::Namespace.new(application, [:foo, :bar]) }
+        it "returns the name of the namespace" do
+          expect(config.namespace_name_path).to eq [:foo, :bar]
+        end
+      end
     end
 
     it "should not belong_to anything" do

--- a/spec/unit/page_spec.rb
+++ b/spec/unit/page_spec.rb
@@ -25,6 +25,12 @@ module ActiveAdmin
           expect(config.controller_name).to eq "ChocolateILoveYouController"
         end
       end
+      context "when nest namespaced controller" do
+        let(:namespace){ ActiveAdmin::Namespace.new(application, [:foo, :bar]) }
+        it "should return a nest namespaced controller name" do
+          expect(config.controller_name).to eq "Foo::Bar::ChocolateILoveYouController"
+        end
+      end
     end
 
     describe "#resource_name" do

--- a/spec/unit/page_spec.rb
+++ b/spec/unit/page_spec.rb
@@ -64,7 +64,9 @@ module ActiveAdmin
 
     describe "#namespace_name" do
       it "returns the name of the namespace" do
-        expect(config.namespace_name).to eq "admin"
+        ActiveSupport::Deprecation.silence do
+          expect(config.namespace_name).to eq "admin"
+        end
       end
     end
 

--- a/spec/unit/resource/routes_spec.rb
+++ b/spec/unit/resource/routes_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe ActiveAdmin::Resource::Routes do
 
     after(:each) do
       application.namespace(:root).unload!
-      application.namespaces.instance_variable_get(:@namespaces).delete(:root)
+      application.namespaces.instance_variable_get(:@namespaces).delete([:root])
     end
 
     it "should have a nil route_prefix" do

--- a/spec/unit/resource_controller_spec.rb
+++ b/spec/unit/resource_controller_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe "A specific resource controller", type: :controller do
       controller.send(:authenticate_active_admin_user)
     end
 
-    it "should call the authentication_method when set" do
+    it "should call the authentication_method when set as Symbol" do
       namespace = controller.class.active_admin_config.namespace
 
       expect(namespace).to receive(:authentication_method).twice.
@@ -142,6 +142,17 @@ RSpec.describe "A specific resource controller", type: :controller do
       expect(controller).to receive(:authenticate_admin_user!).and_return(true)
 
       controller.send(:authenticate_active_admin_user)
+    end
+
+    context "should call the authentication_method when set as Proc" do
+      let(:proc) { Proc.new { :proc_authenticate_admin_user! } }
+      let(:ns) { controller.class.active_admin_config.namespace }
+      it {
+        expect(ns).to receive(:authentication_method).twice.and_return(proc)
+
+        expect(controller).to receive(:proc_authenticate_admin_user!).once
+        controller.send(:authenticate_active_admin_user)
+      }
     end
 
   end
@@ -154,7 +165,7 @@ RSpec.describe "A specific resource controller", type: :controller do
       expect(controller.send(:current_active_admin_user)).to eq nil
     end
 
-    it "should call the current_user_method when set" do
+    it "should call the current_user_method when set as Symbol" do
       user = double
       namespace = controller.class.active_admin_config.namespace
 
@@ -164,6 +175,20 @@ RSpec.describe "A specific resource controller", type: :controller do
       expect(controller).to receive(:current_admin_user).and_return(user)
 
       expect(controller.send(:current_active_admin_user)).to eq user
+    end
+
+    context "should call the current_user_method when set as Proc" do
+      let(:user) { double }
+      let(:proc) { Proc.new { :proc_current_admin_user } }
+      let(:namespace) { controller.class.active_admin_config.namespace }
+      it {
+        expect(namespace).to receive(:current_user_method).twice.
+            and_return(proc)
+
+        expect(controller).to receive(:proc_current_admin_user).and_return(user)
+
+        expect(controller.send(:current_active_admin_user)).to eq user
+      }
     end
   end
 

--- a/spec/unit/resource_registration_spec.rb
+++ b/spec/unit/resource_registration_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Registering an object to administer" do
     let(:namespace) { ActiveAdmin::Namespace.new(application, :admin) }
 
     before do
-      application.namespaces[namespace.name] = namespace
+      application.namespaces[namespace.name_path] = namespace
     end
 
     it "should call register on the namespace" do
@@ -26,7 +26,7 @@ RSpec.describe "Registering an object to administer" do
   context "with a different namespace" do
     it "should call register on the namespace" do
       namespace = ActiveAdmin::Namespace.new(application, :hello_world)
-      application.namespaces[namespace.name] = namespace
+      application.namespaces[namespace.name_path] = namespace
       expect(namespace).to receive(:register)
 
       application.register Category, namespace: :hello_world
@@ -42,7 +42,7 @@ RSpec.describe "Registering an object to administer" do
   context "with no namespace" do
     it "should call register on the root namespace" do
       namespace = ActiveAdmin::Namespace.new(application, :root)
-      application.namespaces[namespace.name] = namespace
+      application.namespaces[namespace.name_path] = namespace
       expect(namespace).to receive(:register)
 
       application.register Category, namespace: false

--- a/spec/unit/routing_spec.rb
+++ b/spec/unit/routing_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ActiveAdmin, "Routing", type: :routing do
   let(:namespaces) { ActiveAdmin.application.namespaces }
 
   it "should only have the namespaces necessary for route testing" do
-    expect(namespaces.names).to eq [:admin]
+    expect(namespaces.names).to eq [[:admin]]
   end
 
   it "should route to the admin dashboard" do
@@ -33,12 +33,12 @@ RSpec.describe ActiveAdmin, "Routing", type: :routing do
   describe "route_options" do
     context "with a custom path set in route_options" do
       before do
-        namespaces[:admin].route_options = { path: '/custom-path' }
+        namespaces[[:admin]].route_options = { path: '/custom-path' }
         reload_routes!
       end
 
       after do
-        namespaces[:admin].route_options = {}
+        namespaces[[:admin]].route_options = {}
         reload_routes!
       end
 
@@ -67,13 +67,39 @@ RSpec.describe ActiveAdmin, "Routing", type: :routing do
       end
     end
 
+    context "when in nested admin namespace" do
+      before(:each) do
+        load_resources { ActiveAdmin.register(Post, namespace: [:foo, :bar]) }
+      end
+
+      after(:each) do
+        namespaces.instance_variable_get(:@namespaces).delete([:admin, :foo, :bar])
+      end
+
+      it "should route the index path" do
+        expect(admin_foo_bar_posts_path).to eq "/admin/foo/bar/posts"
+      end
+
+      it "should route the show path" do
+        expect(admin_foo_bar_post_path(1)).to eq "/admin/foo/bar/posts/1"
+      end
+
+      it "should route the new path" do
+        expect(new_admin_foo_bar_post_path).to eq "/admin/foo/bar/posts/new"
+      end
+
+      it "should route the edit path" do
+        expect(edit_admin_foo_bar_post_path(1)).to eq "/admin/foo/bar/posts/1/edit"
+      end
+    end
+
     context "when in root namespace" do
       before(:each) do
         load_resources { ActiveAdmin.register(Post, namespace: false) }
       end
 
       after(:each) do
-        namespaces.instance_variable_get(:@namespaces).delete(:root)
+        namespaces.instance_variable_get(:@namespaces).delete([:root])
       end
 
       it "should route the index path" do
@@ -138,37 +164,87 @@ RSpec.describe ActiveAdmin, "Routing", type: :routing do
   end
 
   describe "belongs to resource" do
-    it "should route the nested index path" do
-      expect(admin_user_posts_path(1)).to eq "/admin/users/1/posts"
-    end
-
-    it "should route the nested show path" do
-      expect(admin_user_post_path(1, 2)).to eq "/admin/users/1/posts/2"
-    end
-
-    it "should route the nested new path" do
-      expect(new_admin_user_post_path(1)).to eq "/admin/users/1/posts/new"
-    end
-
-    it "should route the nested edit path" do
-      expect(edit_admin_user_post_path(1, 2)).to eq "/admin/users/1/posts/2/edit"
-    end
-
-    context "with collection action" do
-      before do
-        load_resources do
-          ActiveAdmin.register(Post) do
-            belongs_to :user, optional: true
-          end
-          ActiveAdmin.register(User) do
-            collection_action "do_something"
-          end
-        end
+    context "when default namespace" do
+      it "should route the nested index path" do
+        expect(admin_user_posts_path(1)).to eq "/admin/users/1/posts"
       end
 
-      it "should properly route the collection action" do
-        expect({ get: "/admin/users/do_something" }).to \
+      it "should route the nested show path" do
+        expect(admin_user_post_path(1, 2)).to eq "/admin/users/1/posts/2"
+      end
+
+      it "should route the nested new path" do
+        expect(new_admin_user_post_path(1)).to eq "/admin/users/1/posts/new"
+      end
+
+      it "should route the nested edit path" do
+        expect(edit_admin_user_post_path(1, 2)).to eq "/admin/users/1/posts/2/edit"
+      end
+
+      context "with collection action" do
+        before do
+          load_resources do
+            ActiveAdmin.register(Post) do
+              belongs_to :user, optional: true
+            end
+            ActiveAdmin.register(User) do
+              collection_action "do_something"
+            end
+          end
+        end
+
+        it "should properly route the collection action" do
+          expect({ get: "/admin/users/do_something" }).to \
           route_to({ controller: 'admin/users', action: 'do_something'})
+        end
+      end
+    end
+
+    context "when in default nested namespace" do
+
+      before(:each) do
+        load_resources {
+          ActiveAdmin.register(User, namespace: [:foo, :bar])
+          ActiveAdmin.register(Post, namespace: [:foo, :bar]){ belongs_to :user, optional: true }
+        }
+      end
+
+      after(:each) do
+        namespaces.instance_variable_get(:@namespaces).delete([:admin, :foo, :bar])
+      end
+
+      it "should route the nested index path" do
+        expect(admin_foo_bar_user_posts_path(1)).to eq "/admin/foo/bar/users/1/posts"
+      end
+
+      it "should route the nested show path" do
+        expect(admin_foo_bar_user_post_path(1, 2)).to eq "/admin/foo/bar/users/1/posts/2"
+      end
+
+      it "should route the nested new path" do
+        expect(new_admin_foo_bar_user_post_path(1)).to eq "/admin/foo/bar/users/1/posts/new"
+      end
+
+      it "should route the nested edit path" do
+        expect(edit_admin_foo_bar_user_post_path(1, 2)).to eq "/admin/foo/bar/users/1/posts/2/edit"
+      end
+
+      context "with collection action" do
+        before do
+          load_resources do
+            ActiveAdmin.register(User, namespace: [:foo, :bar]){ collection_action "do_something" }
+            ActiveAdmin.register(Post, namespace: [:foo, :bar]){ belongs_to :user, optional: true }
+          end
+        end
+
+        after do
+          namespaces.instance_variable_get(:@namespaces).delete([:admin, :foo, :bar])
+        end
+
+        it "should properly route the collection action" do
+          expect({ get: "/admin/foo/bar/users/do_something" }).to \
+          route_to({ controller: 'admin/foo/bar/users', action: 'do_something'})
+        end
       end
     end
   end
@@ -184,13 +260,27 @@ RSpec.describe ActiveAdmin, "Routing", type: :routing do
       end
     end
 
+    context "when in default nested namespace" do
+      before(:each) do
+        load_resources { ActiveAdmin.register_page("Chocolate I lØve You!", namespace: [:foo, :bar]) }
+      end
+
+      after(:each) do
+        namespaces.instance_variable_get(:@namespaces).delete([:admin, :foo, :bar])
+      end
+
+      it "should route to the page under /admin" do
+        expect(admin_foo_bar_chocolate_i_love_you_path).to eq "/admin/foo/bar/chocolate_i_love_you"
+      end
+    end
+
     context "when in the root namespace" do
       before(:each) do
         load_resources { ActiveAdmin.register_page("Chocolate I lØve You!", namespace: false) }
       end
 
       after(:each) do
-        namespaces.instance_variable_get(:@namespaces).delete(:root)
+        namespaces.instance_variable_get(:@namespaces).delete([:root])
       end
 
       it "should route to page under /" do

--- a/spec/unit/routing_spec.rb
+++ b/spec/unit/routing_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ActiveAdmin, "Routing", type: :routing do
   let(:namespaces) { ActiveAdmin.application.namespaces }
 
   it "should only have the namespaces necessary for route testing" do
-    expect(namespaces.names).to eq [[:admin]]
+    expect(namespaces.name_paths).to eq [[:admin]]
   end
 
   it "should route to the admin dashboard" do

--- a/spec/unit/routing_spec.rb
+++ b/spec/unit/routing_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe ActiveAdmin, "Routing", type: :routing do
 
     context "when in nested admin namespace" do
       before(:each) do
-        load_resources { ActiveAdmin.register(Post, namespace: [:foo, :bar]) }
+        load_resources { ActiveAdmin.register(Post, namespace: [:admin, :foo, :bar]) }
       end
 
       after(:each) do
@@ -204,8 +204,8 @@ RSpec.describe ActiveAdmin, "Routing", type: :routing do
 
       before(:each) do
         load_resources {
-          ActiveAdmin.register(User, namespace: [:foo, :bar])
-          ActiveAdmin.register(Post, namespace: [:foo, :bar]){ belongs_to :user, optional: true }
+          ActiveAdmin.register(User, namespace: [:admin, :foo, :bar])
+          ActiveAdmin.register(Post, namespace: [:admin, :foo, :bar]){ belongs_to :user, optional: true }
         }
       end
 
@@ -232,8 +232,8 @@ RSpec.describe ActiveAdmin, "Routing", type: :routing do
       context "with collection action" do
         before do
           load_resources do
-            ActiveAdmin.register(User, namespace: [:foo, :bar]){ collection_action "do_something" }
-            ActiveAdmin.register(Post, namespace: [:foo, :bar]){ belongs_to :user, optional: true }
+            ActiveAdmin.register(User, namespace: [:admin, :foo, :bar]){ collection_action "do_something" }
+            ActiveAdmin.register(Post, namespace: [:admin, :foo, :bar]){ belongs_to :user, optional: true }
           end
         end
 
@@ -262,7 +262,7 @@ RSpec.describe ActiveAdmin, "Routing", type: :routing do
 
     context "when in default nested namespace" do
       before(:each) do
-        load_resources { ActiveAdmin.register_page("Chocolate I lØve You!", namespace: [:foo, :bar]) }
+        load_resources { ActiveAdmin.register_page("Chocolate I lØve You!", namespace: [:admin, :foo, :bar]) }
       end
 
       after(:each) do

--- a/spec/unit/view_helpers/display_helper_spec.rb
+++ b/spec/unit/view_helpers/display_helper_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ActiveAdmin::ViewHelpers::DisplayHelper do
   include ActionView::Helpers::SanitizeHelper
 
   def active_admin_namespace
-    active_admin_application.namespaces[:admin]
+    active_admin_application.namespaces[[:admin]]
   end
 
   def authorized?(*)

--- a/spec/unit/views/pages/layout_spec.rb
+++ b/spec/unit/views/pages/layout_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe ActiveAdmin::Views::Pages::Layout do
     end
 
     it "should have namespace class" do
-      expect(layout.build.class_list).to include "#{active_admin_namespace.name}_namespace"
+      expect(layout.build.class_list).to include "#{active_admin_namespace.name_path.map(&:to_s).join('_')}_namespace"
     end
 
   end


### PR DESCRIPTION
This PR allows you to register resources/pages with nested namespaces. For example:

/app/admin/site1/foo/bar/posts.rb
```ruby
ActiveAdmin.register Post, namespace: [:site1, :foo, :bar] do
  ...
end
```

/app/admin/site2/demo/posts.rb
```ruby
ActiveAdmin.register Post, namespace: [:site2, :demo] do
  ...
end
```

It will generate routes like:

```
              admin_site1_foo_bar_root GET        /admin/site1/foo/bar(.:format)                    admin/site1/foo/bar/dashboard#index
                 admin_site2_demo_root GET        /admin/site2/demo(.:format)                       
batch_action_admin_site1_foo_bar_posts POST       /admin/site1/foo/bar/posts/batch_action(.:format) admin/site1/foo/bar/posts#batch_action
             admin_site1_foo_bar_posts GET        /admin/site1/foo/bar/posts(.:format)              admin/site1/foo/bar/posts#index
                                       POST       /admin/site1/foo/bar/posts(.:format)              admin/site1/foo/bar/posts#create
          new_admin_site1_foo_bar_post GET        /admin/site1/foo/bar/posts/new(.:format)          admin/site1/foo/bar/posts#new
         edit_admin_site1_foo_bar_post GET        /admin/site1/foo/bar/posts/:id/edit(.:format)     admin/site1/foo/bar/posts#edit
              admin_site1_foo_bar_post GET        /admin/site1/foo/bar/posts/:id(.:format)          admin/site1/foo/bar/posts#show
                                       PATCH      /admin/site1/foo/bar/posts/:id(.:format)          admin/site1/foo/bar/posts#update
                                       PUT        /admin/site1/foo/bar/posts/:id(.:format)          admin/site1/foo/bar/posts#update
                                       DELETE     /admin/site1/foo/bar/posts/:id(.:format)          admin/site1/foo/bar/posts#destroy
          admin_site1_foo_bar_comments GET        /admin/site1/foo/bar/comments(.:format)           admin/site1/foo/bar/comments#index
                                       POST       /admin/site1/foo/bar/comments(.:format)           admin/site1/foo/bar/comments#create
           admin_site1_foo_bar_comment GET        /admin/site1/foo/bar/comments/:id(.:format)       admin/site1/foo/bar/comments#show
                                       DELETE     /admin/site1/foo/bar/comments/:id(.:format)       admin/site1/foo/bar/comments#destroy
   batch_action_admin_site2_demo_posts POST       /admin/site2/demo/posts/batch_action(.:format)    admin/site2/demo/posts#batch_action
                admin_site2_demo_posts GET        /admin/site2/demo/posts(.:format)                 admin/site2/demo/posts#index
            edit_admin_site2_demo_post GET        /admin/site2/demo/posts/:id/edit(.:format)        admin/site2/demo/posts#edit
                 admin_site2_demo_post GET        /admin/site2/demo/posts/:id(.:format)             admin/site2/demo/posts#show
                                       PATCH      /admin/site2/demo/posts/:id(.:format)             admin/site2/demo/posts#update
                                       PUT        /admin/site2/demo/posts/:id(.:format)             admin/site2/demo/posts#update
             admin_site2_demo_comments GET        /admin/site2/demo/comments(.:format)              admin/site2/demo/comments#index
                                       POST       /admin/site2/demo/comments(.:format)              admin/site2/demo/comments#create
              admin_site2_demo_comment GET        /admin/site2/demo/comments/:id(.:format)          admin/site2/demo/comments#show
                                       DELETE     /admin/site2/demo/comments/:id(.:format)          admin/site2/demo/comments#destroy

```
---

In your initializers/active_admin.rb, you can define your own handler to the following methods.

* authentication_method
* current_user_method
* logout_link_path

For example:

``` ruby
  # config.authentication_method = :authenticate_admin_user!
  config.authentication_method = Proc.new do |namespace|
    if namespace && namespace.is_a?(Array)
      "authenticate_#{namespace.map(&:to_s).join('_').underscore}_admin_user!".to_sym
    else
      :authenticate_admin_user!
    end
  end
```
And In your routes.rb:

```ruby
  namespace :site1 do
    namespace :foo do
      namespace :bar do
        devise_for :admin_users, ActiveAdmin::Devise.config
      end
    end
  end
  namespace :site2 do
    namespace :demo do
      devise_for :admin_users, ActiveAdmin::Devise.config
    end
  end
```
---

You can checkout the demo here: [https://github.com/siutin/activeadmin-nested-namespaces-example](https://github.com/siutin/activeadmin-nested-namespaces-example)