### PR TITLE
Refactor has many, extracting HasManyBuilder

### DIFF
--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -75,7 +75,7 @@ module ActiveAdmin
       contents ||= "".html_safe
 
       new_record = builder_options[:new_record]
-      js = new_record ? js_for_has_many(assoc, form_block, template, new_record, options[:class]) : ''
+      js = new_record ? js_for_has_many(assoc, new_record, options[:class], &form_block) : ''
       contents << js
     end
 
@@ -139,7 +139,7 @@ module ActiveAdmin
     end
 
     # Capture the ADD JS
-    def js_for_has_many(assoc, form_block, template, new_record, class_string)
+    def js_for_has_many(assoc, new_record, class_string, &form_block)
       assoc_reflection = object.class.reflect_on_association assoc
       assoc_name       = assoc_reflection.klass.model_name
       placeholder      = "NEW_#{assoc_name.to_s.underscore.upcase.gsub(/\//, '_')}_RECORD"

--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -54,18 +54,7 @@ module ActiveAdmin
       end
 
       html << template.capture do
-        form_block = proc do |has_many_form|
-          render_has_many_form(has_many_form, options[:parent], builder_options, &block)
-        end
-
-        template.assigns[:has_many_block] = true
-        contents = without_wrapper { inputs(options, &form_block) } || "".html_safe
-
-        if builder_options[:new_record]
-          contents << js_for_has_many(assoc, form_block, template, builder_options[:new_record], options[:class])
-        else
-          contents
-        end
+        content_has_many(assoc, options, builder_options, &block)
       end
 
       tag = @already_in_an_inputs_block ? :li : :div
@@ -75,6 +64,20 @@ module ActiveAdmin
     end
 
     protected
+
+    def content_has_many(assoc, options, builder_options, &block)
+      form_block = proc do |has_many_form|
+        render_has_many_form(has_many_form, options[:parent], builder_options, &block)
+      end
+
+      template.assigns[:has_many_block] = true
+      contents = without_wrapper { inputs(options, &form_block) }
+      contents ||= "".html_safe
+
+      new_record = builder_options[:new_record]
+      js = new_record ? js_for_has_many(assoc, form_block, template, new_record, options[:class]) : ''
+      contents << js
+    end
 
     # Renders the Formtastic inputs then appends ActiveAdmin delete and sort actions.
     def render_has_many_form(has_many_form, parent, builder_options, &block)

--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -34,10 +34,9 @@ module ActiveAdmin
     end
 
     def has_many(assoc, options = {}, &block)
-      # remove options that should not render as attributes
-      custom_settings = :new_record, :allow_destroy, :heading, :sortable, :sortable_start
-      builder_options = {new_record: true}.merge! options.slice  *custom_settings
-      options         = {for: assoc      }.merge! options.except *custom_settings
+      builder_options, options = partition_custom_settings(options)
+      builder_options.reverse_merge!(new_record: true)
+      options.reverse_merge!(for: assoc)
       options[:class] = [options[:class], "inputs has_many_fields"].compact.join(' ')
       sortable_column = builder_options[:sortable]
       sortable_start  = builder_options.fetch(:sortable_start, 0)
@@ -64,6 +63,12 @@ module ActiveAdmin
     end
 
     protected
+
+    # remove options that should not render as attributes
+    def partition_custom_settings(options)
+      custom_settings = %i(new_record allow_destroy heading sortable sortable_start)
+      options.partition { |k, v| custom_settings.include?(k) }.map(&:to_h)
+    end
 
     def content_has_many(assoc, options, builder_options, &block)
       form_block = proc do |has_many_form|

--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -55,12 +55,7 @@ module ActiveAdmin
 
       html << template.capture do
         form_block = proc do |has_many_form|
-          index    = parent_child_index options[:parent] if options[:parent]
-          block_contents = template.capture do
-            block.call(has_many_form, index)
-          end
-          template.concat(block_contents)
-          template.concat has_many_actions(has_many_form, builder_options, "".html_safe)
+          render_has_many_form(has_many_form, options[:parent], builder_options, &block)
         end
 
         template.assigns[:has_many_block] = true
@@ -80,6 +75,13 @@ module ActiveAdmin
     end
 
     protected
+
+    # Renders the Formtastic inputs then appends ActiveAdmin delete and sort actions.
+    def render_has_many_form(has_many_form, parent, builder_options, &block)
+      index = parent && parent_child_index(parent)
+      template.concat template.capture { has_many_form.instance_exec(has_many_form, index, &block) }
+      template.concat has_many_actions(has_many_form, builder_options, "".html_safe)
+    end
 
     def has_many_actions(has_many_form, builder_options, contents)
       if has_many_form.object.new_record?

--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -28,16 +28,12 @@ module ActiveAdmin
 
     attr_accessor :already_in_an_inputs_block
 
-    def assoc_heading(assoc)
-      object.class.reflect_on_association(assoc).klass.model_name.
-        human(count: ::ActiveAdmin::Helpers::I18n::PLURAL_MANY_COUNT)
-    end
-
     def has_many(assoc, options = {}, &block)
       builder_options, options = partition_custom_settings(options)
-      builder_options.reverse_merge!(new_record: true)
+      builder_options.reverse_merge!(new_record: true, heading: assoc_heading(assoc))
       options.reverse_merge!(for: assoc)
       options[:class] = [options[:class], "inputs has_many_fields"].compact.join(' ')
+      heading = builder_options[:heading]
       sortable_column = builder_options[:sortable]
       sortable_start  = builder_options.fetch(:sortable_start, 0)
 
@@ -46,11 +42,7 @@ module ActiveAdmin
       end
 
       html = "".html_safe
-      unless builder_options.key?(:heading) && !builder_options[:heading]
-        html << template.content_tag(:h3) do
-          builder_options[:heading] || assoc_heading(assoc)
-        end
-      end
+      html << template.content_tag(:h3) { heading } if heading.present?
 
       html << template.capture do
         content_has_many(assoc, options, builder_options, &block)
@@ -68,6 +60,11 @@ module ActiveAdmin
     def partition_custom_settings(options)
       custom_settings = %i(new_record allow_destroy heading sortable sortable_start)
       options.partition { |k, v| custom_settings.include?(k) }.map(&:to_h)
+    end
+
+    def assoc_heading(assoc)
+      object.class.reflect_on_association(assoc).klass.model_name.
+        human(count: ::ActiveAdmin::Helpers::I18n::PLURAL_MANY_COUNT)
     end
 
     def content_has_many(assoc, options, builder_options, &block)

--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -57,15 +57,8 @@ module ActiveAdmin
     def render(&block)
       html = "".html_safe
       html << template.content_tag(:h3) { heading } if heading.present?
-
-      html << template.capture do
-        content_has_many(assoc, options, &block)
-      end
-
-      tag = already_in_an_inputs_block ? :li : :div
-      html = template.content_tag(tag, html, class: "has_many_container #{assoc}", 'data-sortable' => sortable_column, 'data-sortable-start' => sortable_start)
-      template.concat(html) if template.output_buffer
-      html
+      html << template.capture { content_has_many(assoc, options, &block) }
+      wrap_div_or_li(html)
     end
 
     protected
@@ -171,6 +164,14 @@ module ActiveAdmin
       template.link_to text, '#', class: "button has_many_add", data: {
         html: CGI.escapeHTML(html).html_safe, placeholder: placeholder
       }
+    end
+
+    def wrap_div_or_li(html)
+      template.content_tag(already_in_an_inputs_block ? :li : :div,
+                           html,
+                           class: "has_many_container #{assoc}",
+                           'data-sortable' => sortable_column,
+                           'data-sortable-start' => sortable_start)
     end
   end
 end


### PR DESCRIPTION
Extracts has_many related attributes and methods into a form_builder decorator that can be nested to handle nested has_many blocks.  This is just a refactoring intended to make the implementation easier to understand and extend.