### PR TITLE
Fix bug when using a group by on a collection

### DIFF
--- a/lib/active_admin/views/components/paginated_collection.rb
+++ b/lib/active_admin/views/components/paginated_collection.rb
@@ -103,6 +103,8 @@ module ActiveAdmin
           # if there is another page or not, but the limit/offset make this
           # query fast.
           offset = collection.offset(collection.current_page * @per_page.to_i).limit(1).count
+          # if we have a collection with a group_by the count method returns a Hash
+          offset = offset.size if offset.is_a?(Hash) || offset.is_a?(ActiveSupport::OrderedHash)
           options[:total_pages] = collection.current_page + offset
           options[:right] = 0
         end
@@ -128,15 +130,17 @@ module ActiveAdmin
         end
 
         if @display_total
+          total = collection.total_count
+          # if we have a collection with a group_by the count method returns a Hash
+          total = total.size if total.is_a?(Hash) || total.is_a?(ActiveSupport::OrderedHash)
           if collection.total_pages < 2
             case collection_size
             when 0; I18n.t("active_admin.pagination.empty",    model: entries_name)
             when 1; I18n.t("active_admin.pagination.one",      model: entry_name)
-            else;   I18n.t("active_admin.pagination.one_page", model: entries_name, n: collection.total_count)
+            else;   I18n.t("active_admin.pagination.one_page", model: entries_name, n: total)
             end
           else
             offset = (collection.current_page - 1) * collection.limit_value
-            total  = collection.total_count
             I18n.t "active_admin.pagination.multiple",
                    model: entries_name,
                    total: total,


### PR DESCRIPTION
I am using a `scoped_collection` on my controller that does a `GROUP BY`. I was getting this on my pagination control:
<img width="1032" alt="screen shot 2017-10-11 at 11 11 17 am" src="https://user-images.githubusercontent.com/4342912/31449933-90793c12-ae7e-11e7-886d-86c8654e7cb9.png">
I found that the issue was on the `page_entries_info` method, since a `count` on a query that had a `group by` returns a Hash of elements with their respective count.

I also found that disabling pagination total on my index page with `pagination_total: false` wasn't working:
<img width="1014" alt="screen shot 2017-10-11 at 11 05 35 am" src="https://user-images.githubusercontent.com/4342912/31450163-1f801b7e-ae7f-11e7-9716-41b4c9cabde8.png">
because of the same issue (count returns a Hash); the `+` method tries to sum an Integer with a Hash and that was fixed for the `build_pagination` method.

The 2 changes introduced in this PR fix those 2 problems.
Thanks!

