### PR TITLE
Cache-able select filters

### DIFF
--- a/lib/active_admin/inputs/filters/base.rb
+++ b/lib/active_admin/inputs/filters/base.rb
@@ -38,6 +38,15 @@ module ActiveAdmin
           end
         end
 
+        def cache_filter(cache_key, &block)
+          full_key = "filter/#{cache_key}"
+          if Rails.configuration.action_controller.perform_caching
+            Rails.cache.fetch(full_key, &block)
+          else
+            yield
+          end
+        end
+
       end
     end
   end

--- a/lib/active_admin/inputs/filters/select_input.rb
+++ b/lib/active_admin/inputs/filters/select_input.rb
@@ -37,15 +37,27 @@ module ActiveAdmin
 
         # Provides an efficient default lookup query if the attribute is a DB column.
         def collection
-          if !options[:collection] && column
-            pluck_column
-          else
-            super
+          cache_on_demand do
+            if !options[:collection] && column
+              pluck_column
+            else
+              super
+            end
           end
         end
 
         def pluck_column
           klass.reorder("#{method} asc").distinct.pluck method
+        end
+
+        def cache_on_demand(&block)
+          if options[:cache]
+            cache_name = "#{klass.name}/#{method}"
+            cache_name = "#{cache_name}/#{options[:cache_key].call}" if options[:cache_key]
+            cache_filter(cache_name, &block)
+          else
+            yield
+          end
         end
 
       end


### PR DESCRIPTION
I use ActiveAdmin often, and in some instances I'll have a select filter for an association that has an expensive collection to fetch for every request. Or I'll have many association filters such that grabbing all their collections in aggregate adds too much time to the request.

I created this caching feature for select filters for those situations in my own work. Since I love this framework, I thought it be good to offer it back and maybe get some improvements out of it! The premise is simple, if the select options tells us we should cache the filter, we'll store it in the `Rails.cache` (if caching is enabled). Like thus:

```ruby
  filter :author, cache: true, cache_key: -> { Author.cache_key }
# ...
```

I'm completely open to changes, particular around the options that should be used to enable caching for the filter. For example, should we only look for `:cache_key`? That way caching is only enabled when a `cache_key` is given (thereby encouraging not to have stale caches). Any thoughts or opinions would be most welcome.  Cheers :beers: