### PR TITLE
Do not cache queries that are used to construct CSV exports

### DIFF
--- a/lib/active_admin/csv_builder.rb
+++ b/lib/active_admin/csv_builder.rb
@@ -71,8 +71,16 @@ module ActiveAdmin
     end
 
     def build_row(resource, columns, options)
-      columns.map do |column|
-        encode call_method_or_proc_on(resource, column.data), options
+      p = Proc.new do
+        columns.map do |column|
+          encode call_method_or_proc_on(resource, column.data), options
+        end
+      end
+
+      if defined?(::ActiveRecord)
+        ActiveRecord::Base.uncached { p.call }
+      else
+        p.call
       end
     end
 


### PR DESCRIPTION
Do not cache queries that are used to construct CSV exports, as it causes runaway memory consumption due to the ActiveRecord Query cache.

The majority of these one-off queries are issued in the `build_row` method.

This bug is documented here: https://github.com/activeadmin/activeadmin/issues/4118, where `ActiveRecord::Base.uncached` is used as a workaround.