### PR TITLE
Revert asset registration removal

### DIFF
--- a/app/views/layouts/active_admin_logged_out.html.erb
+++ b/app/views/layouts/active_admin_logged_out.html.erb
@@ -5,9 +5,12 @@
 
   <title><%= [@page_title, ActiveAdmin.application.site_title(self)].compact.join(" | ") %></title>
 
-  <%= stylesheet_link_tag 'active_admin.css', media: 'screen' %>
-  <%= stylesheet_link_tag 'active_admin/print.css', media: 'print' %>
-  <%= javascript_include_tag 'active_admin.js' %>
+  <% ActiveAdmin.application.stylesheets.each do |style, options| %>
+    <%= stylesheet_link_tag style, options %>
+  <% end %>
+  <% ActiveAdmin.application.javascripts.each do |path| %>
+    <%= javascript_include_tag path %>
+  <% end %>
 
   <%= favicon_link_tag ActiveAdmin.application.favicon if ActiveAdmin.application.favicon %>
 

--- a/features/registering_assets.feature
+++ b/features/registering_assets.feature
@@ -9,7 +9,30 @@ Feature: Registering Assets
     """
     And I am logged in
 
+
   Scenario: Viewing default asset files
     When I am on the index page for posts
     Then I should see the css file "active_admin"
     Then I should see the js file "active_admin"
+
+  Scenario: Registering a CSS file
+    Given a configuration of:
+    """
+      ActiveSupport::Deprecation.silence do
+        ActiveAdmin.application.register_stylesheet "some-random-css.css", media: :print
+        ActiveAdmin.register Post
+      end
+    """
+    When I am on the index page for posts
+    Then I should see the css file "some-random-css" of media "print"
+
+  Scenario: Registering a JS file
+    Given a configuration of:
+    """
+      ActiveSupport::Deprecation.silence do
+        ActiveAdmin.application.register_javascript "some-random-js.js"
+        ActiveAdmin.register Post
+      end
+    """
+    When I am on the index page for posts
+    Then I should see the js file "some-random-js"

--- a/features/step_definitions/asset_steps.rb
+++ b/features/step_definitions/asset_steps.rb
@@ -1,5 +1,9 @@
 Then /^I should see the css file "([^"]*)"$/ do |path|
-  expect(page).to have_xpath("//link[contains(@href, '#{path}') and contains(@media, 'screen')]", visible: false)
+  step %{I should see the css file "#{path}" of media "screen"}
+end
+
+Then /^I should see the css file "([^"]*)" of media "([^"]*)"$/ do |path, media|
+  expect(page).to have_xpath("//link[contains(@href, '#{path}') and contains(@media, '#{media}')]", visible: false)
 end
 
 Then /^I should see the js file "([^"]*)"$/ do |path|

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -43,12 +43,15 @@ module ActiveAdmin
       @namespaces = Namespace::Store.new
     end
 
+    include AssetRegistration
+
     # Event that gets triggered on load of Active Admin
     BeforeLoadEvent = 'active_admin.application.before_load'.freeze
     AfterLoadEvent  = 'active_admin.application.after_load'.freeze
 
     # Runs before the app's AA initializer
     def setup!
+      register_default_assets
     end
 
     # Runs after the app's AA initializer
@@ -160,6 +163,12 @@ module ActiveAdmin
     end
 
     private
+
+    def register_default_assets
+      stylesheets['active_admin.css'] = { media: 'screen' }
+      stylesheets['active_admin/print.css'] = { media: 'print' }
+      javascripts.add 'active_admin.js'
+    end
 
     # Since app/admin is alphabetically before app/models, we have to remove it
     # from the host app's +autoload_paths+ to prevent missing constant errors.

--- a/lib/active_admin/asset_registration.rb
+++ b/lib/active_admin/asset_registration.rb
@@ -1,0 +1,37 @@
+module ActiveAdmin
+  module AssetRegistration
+
+    def register_stylesheet(path, options = {})
+      Deprecation.warn <<-MSG.strip_heredoc
+        The `register_stylesheet` config is deprecated and will be removed
+        in v2. Import your "#{path}" stylesheet in the active_admin.scss.
+      MSG
+      stylesheets[path] = options
+    end
+
+    def stylesheets
+      @stylesheets ||= {}
+    end
+
+    def clear_stylesheets!
+      stylesheets.clear
+    end
+
+    def register_javascript(name)
+      Deprecation.warn <<-MSG.strip_heredoc
+        The `register_javascript` config is deprecated and will be removed
+        in v2. Import your "#{name}" javascript in the active_admin.js.
+      MSG
+      javascripts.add name
+    end
+
+    def javascripts
+      @javascripts ||= Set.new
+    end
+
+    def clear_javascripts!
+      javascripts.clear
+    end
+
+  end
+end

--- a/lib/active_admin/engine.rb
+++ b/lib/active_admin/engine.rb
@@ -6,11 +6,12 @@ module ActiveAdmin
     end
 
     initializer "active_admin.precompile", group: :all do |app|
-      app.config.assets.precompile += [
-        'active_admin.css',
-        'active_admin/print.css',
-        'active_admin.js'
-      ]
+      ActiveAdmin.application.stylesheets.each do |path, _|
+        app.config.assets.precompile << path
+      end
+      ActiveAdmin.application.javascripts.each do |path|
+        app.config.assets.precompile << path
+      end
     end
 
     initializer 'active_admin.routes' do

--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -26,14 +26,17 @@ module ActiveAdmin
           within @head do
             insert_tag Arbre::HTML::Title, [title, helpers.active_admin_namespace.site_title(self)].compact.join(" | ")
 
-            text_node stylesheet_link_tag('active_admin.css', media: 'screen').html_safe
-            text_node stylesheet_link_tag('active_admin/print.css', media: 'print').html_safe
+            active_admin_application.stylesheets.each do |style, options|
+              text_node stylesheet_link_tag(style, options).html_safe
+            end
 
             active_admin_namespace.meta_tags.each do |name, content|
               text_node(tag(:meta, name: name, content: content))
             end
 
-            text_node(javascript_include_tag('active_admin.js'))
+            active_admin_application.javascripts.each do |path|
+              text_node(javascript_include_tag(path))
+            end
 
             if active_admin_namespace.favicon
               text_node(favicon_link_tag(active_admin_namespace.favicon))

--- a/lib/generators/active_admin/install/templates/active_admin.rb.erb
+++ b/lib/generators/active_admin/install/templates/active_admin.rb.erb
@@ -186,6 +186,21 @@ ActiveAdmin.setup do |config|
   #
   # config.create_another = true
 
+  # == Register Stylesheets & Javascripts
+  #
+  # We recommend using the built in Active Admin layout and loading
+  # up your own stylesheets / javascripts to customize the look
+  # and feel.
+  #
+  # To load a stylesheet:
+  #   config.register_stylesheet 'my_stylesheet.css'
+  #
+  # You can provide an options hash for more control, which is passed along to stylesheet_link_tag():
+  #   config.register_stylesheet 'my_print_stylesheet.css', media: :print
+  #
+  # To load a javascript file:
+  #   config.register_javascript 'my_javascript.js'
+
   # == CSV options
   #
   # Set the CSV builder separator

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -2,6 +2,8 @@
 
 copy_file File.expand_path('../templates/manifest.js', __FILE__), 'app/assets/config/manifest.js', force: true
 
+create_file 'app/assets/stylesheets/some-random-css.css'
+create_file 'app/assets/javascripts/some-random-js.js'
 create_file 'app/assets/images/a/favicon.ico'
 
 generate :model, 'post title:string body:text published_date:date author_id:integer ' +
@@ -101,7 +103,7 @@ gsub_file 'config/environments/test.rb', /  config.cache_classes = true/, <<-RUB
 
   config.cache_classes = !ENV['CLASS_RELOADING']
   config.action_mailer.default_url_options = {host: 'example.com'}
-  config.assets.precompile += %w( a/favicon.ico )
+  config.assets.precompile += %w( some-random-css.css some-random-js.js a/favicon.ico )
 
   config.active_record.maintain_test_schema = false
 

--- a/spec/unit/asset_registration_spec.rb
+++ b/spec/unit/asset_registration_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe ActiveAdmin::AssetRegistration do
+  include ActiveAdmin::AssetRegistration
+
+  before do
+    clear_stylesheets!
+    clear_javascripts!
+  end
+
+  it "is deprecated" do
+    expect(ActiveAdmin::Deprecation).to receive(:warn).with(<<-MSG.strip_heredoc
+        The `register_stylesheet` config is deprecated and will be removed
+        in v2. Import your "sample_styles.css" stylesheet in the active_admin.scss.
+      MSG
+      )
+
+    register_stylesheet "sample_styles.css"
+
+    expect(ActiveAdmin::Deprecation).to receive(:warn).with(<<-MSG.strip_heredoc
+        The `register_javascript` config is deprecated and will be removed
+        in v2. Import your "sample_scripts.js" javascript in the active_admin.js.
+      MSG
+      )
+
+    register_javascript "sample_scripts.js"
+  end
+
+  it "should register a stylesheet file" do
+    expect(ActiveAdmin::Deprecation).to receive(:warn).once
+    register_stylesheet "active_admin.css"
+    expect(stylesheets.length).to eq 1
+    expect(stylesheets.keys.first).to eq "active_admin.css"
+  end
+
+  it "should clear all existing stylesheets" do
+    expect(ActiveAdmin::Deprecation).to receive(:warn).once
+    register_stylesheet "active_admin.css"
+    expect(stylesheets.length).to eq 1
+    clear_stylesheets!
+    expect(stylesheets).to be_empty
+  end
+
+  it "should allow media option when registering stylesheet" do
+    expect(ActiveAdmin::Deprecation).to receive(:warn).once
+    register_stylesheet "active_admin.css", media: :print
+    expect(stylesheets.values.first[:media]).to eq :print
+  end
+
+  it "shouldn't register a stylesheet twice" do
+    expect(ActiveAdmin::Deprecation).to receive(:warn).twice
+    register_stylesheet "active_admin.css"
+    register_stylesheet "active_admin.css"
+    expect(stylesheets.length).to eq 1
+  end
+
+  it "should register a javascript file" do
+    expect(ActiveAdmin::Deprecation).to receive(:warn).once
+    register_javascript "active_admin.js"
+    expect(javascripts).to eq ["active_admin.js"].to_set
+  end
+
+  it "should clear all existing javascripts" do
+    expect(ActiveAdmin::Deprecation).to receive(:warn).once
+    register_javascript "active_admin.js"
+    expect(javascripts).to eq ["active_admin.js"].to_set
+    clear_javascripts!
+    expect(javascripts).to be_empty
+  end
+
+  it "shouldn't register a javascript twice" do
+    expect(ActiveAdmin::Deprecation).to receive(:warn).twice
+    register_javascript "active_admin.js"
+    register_javascript "active_admin.js"
+    expect(javascripts.length).to eq 1
+  end
+end


### PR DESCRIPTION
Resolves #5216. See also #5060, #5099, #5170, #5201.

Better to have working cruft than an unimplemented replacement.

Hopefully something better will be implemented soon, but until then this leaves the previous functionality in place.