### PR TITLE
Fix Active Filter Labeling and Record Not Found 

### DIFF
--- a/lib/active_admin/filters/active_filter.rb
+++ b/lib/active_admin/filters/active_filter.rb
@@ -19,7 +19,7 @@ module ActiveAdmin
       def values
         condition_values = condition.values.map(&:value)
         if related_class
-          related_class.where(related_class.primary_key => condition_values)
+          related_class.where(related_primary_key => condition_values)
         else
           condition_values
         end
@@ -89,16 +89,34 @@ module ActiveAdmin
       def find_class
         if condition_attribute.klass != resource_class && condition_attribute.klass.primary_key == name.to_s
           condition_attribute.klass
-        else
-          assoc = condition_attribute.klass.reflect_on_all_associations.
-            reject { |r| r.options[:polymorphic] }. #skip polymorphic
-            detect { |r| r.foreign_key.to_s == name.to_s }
-          assoc.class_name.constantize if assoc
+        elsif predicate_association
+          predicate_association.class_name.constantize
         end
       end
 
       def filter
         resource.filters[name.to_sym]
+      end
+
+      def related_primary_key
+        if predicate_association
+          predicate_association.active_record_primary_key
+        elsif related_class
+          related_class.primary_key
+        end
+      end
+
+      def predicate_association
+        @predicate_association = find_predicate_association unless defined?(@predicate_association)
+        @predicate_association
+      end
+
+      private
+
+      def find_predicate_association
+        condition_attribute.klass.reflect_on_all_associations.
+          reject { |r| r.options[:polymorphic] }. #skip polymorphic
+          detect { |r| r.foreign_key.to_s == name.to_s }
       end
     end
   end

--- a/lib/active_admin/filters/active_filter.rb
+++ b/lib/active_admin/filters/active_filter.rb
@@ -19,7 +19,7 @@ module ActiveAdmin
       def values
         condition_values = condition.values.map(&:value)
         if related_class
-          related_class.find(condition_values)
+          related_class.where(id: condition_values)
         else
           condition_values
         end

--- a/spec/unit/filters/active_filter_spec.rb
+++ b/spec/unit/filters/active_filter_spec.rb
@@ -132,4 +132,16 @@ RSpec.describe ActiveAdmin::Filters::ActiveFilter do
 
   end
 
+  context 'search has no matching records' do
+    let(:search) { Post.ransack(author_id_eq: "foo") }
+
+    it 'should not produce and error' do
+      expect { subject.values }.not_to raise_error
+    end
+
+    it 'should return an enumerable' do
+      expect(subject.values).to be_a(Enumerable)
+    end
+  end
+
 end

--- a/spec/unit/filters/active_filter_spec.rb
+++ b/spec/unit/filters/active_filter_spec.rb
@@ -153,4 +153,37 @@ RSpec.describe ActiveAdmin::Filters::ActiveFilter do
     end
   end
 
+  context "the association uses a different primary_key than the related class' primary_key" do
+    let (:resource_klass) {
+      Class.new(Post) do
+        belongs_to :kategory, class_name: "Category", primary_key: :name, foreign_key: :title
+
+        def self.name
+          "SuperPost"
+        end
+      end
+    }
+
+    let(:resource) do
+      namespace.register(resource_klass)
+    end
+
+    let(:user){ User.create! first_name: "John", last_name: "Doe" }
+    let!(:category){ Category.create! name: "Category" }
+
+    let(:post){ resource_klass.create! title: "Category", author: user }
+
+    let(:search) do
+      resource_klass.ransack(title_equals: post.title)
+    end
+
+    it "should use the association's primary key to find the associated record" do
+      allow(ActiveSupport::Dependencies).to receive(:constantize).with("::SuperPost").and_return(resource_klass)
+
+      resource.add_filter(:kategory)
+
+      expect(subject.values.first).to eq category
+    end
+  end
+
 end

--- a/spec/unit/filters/active_filter_spec.rb
+++ b/spec/unit/filters/active_filter_spec.rb
@@ -140,7 +140,16 @@ RSpec.describe ActiveAdmin::Filters::ActiveFilter do
     end
 
     it 'should return an enumerable' do
-      expect(subject.values).to be_a(Enumerable)
+      expect(subject.values).to respond_to(:map)
+    end
+  end
+
+  context 'a label is set on the filter' do
+    it 'should use the filter label as the label prefix' do
+      label = "#{user.first_name}'s Post Title"
+      resource.add_filter(:title, label: label)
+
+      expect(subject.label).to eq ("#{label} equals")
     end
   end
 


### PR DESCRIPTION
:wave: 

`ActiveFilter` was added to make the current filter sidebar a bit more humanized. It adds some cool things like smart, humanized filter names and, where possible, link to related resources with human readable names! Very cool. However, there's a few issues I saw when messing around a bit.

1. If a filter with a related class (as `ActiveFilter` defines it) is given conditions that have no matching records in the related class, `ActiveFilter` produces an `ActiveRecord::RecordNotFound` when trying to generate a set of values to display in the "Current Filters" sidebar.
2. If a filter is added to the resource that has a label specified, `ActiveFilter` ignores it in favor of pulling from `i18n`. This doesn't seem too terrible but can pose problems to the developer (see below)

The first issue I believe to be a regression. Even though, truthfully, there *is* no related record matching the filter criteria (and thus no resource records either), AA would display a blank slate in all other cases where a filter(s) produces no matching records.

The second issue, is more subtle. Most cases of custom labels are covered by the current implementation of `ActiveFilter`. After all, if you want the label of `Post#title` to be something other than "Title" just put it inside of `en.yml`, and `ActiveFilter` will do as you command. Here's the rub, imagine a more complex translation situation:

```yaml
# en.yml
en:
   activerecord:
      attributes:
         user:
            external_id: "%{client_name} External ID" 
#...
```
```ruby
ActiveAdmin.register User do
#...
filter :external_id, label: config.resource_class.human_attribute_name(:external_id, client_name: ENV["CLIENT"])
end
```

In this example, we have an interpolation within our translation because the translation changes based on who's bought our super shiny app. In this situation, `ActiveFilter` would produce a `I18n::MissingInterpolationArgument` when trying to render the Current Filter sidebar with this attribute.

While this example is a bit contrived, IMHO it's better to go with whatever the developer specifies as the attribute name. If the label on the filter is set, then that's takes precedence. If not, then the translations are certainly the next best thing.

Related issues:
- #5164 
