### PR TITLE
View factory builder methods

### DIFF
--- a/lib/active_admin/abstract_view_factory.rb
+++ b/lib/active_admin/abstract_view_factory.rb
@@ -4,6 +4,15 @@ module ActiveAdmin
     def self.register(view_hash)
       view_hash.each do |view_key, view_class|
         super view_key, view_class
+        add_writer(view_key)
+        send "#{view_key}=", view_class
+      end
+    end
+
+    def self.add_writer(name)
+      define_singleton_method("#{name}=") do |value|
+        value.builder_method name
+        instance_variable_set :"@#{name}", value
       end
     end
 

--- a/lib/active_admin/views/header.rb
+++ b/lib/active_admin/views/header.rb
@@ -15,15 +15,15 @@ module ActiveAdmin
       end
 
       def build_site_title
-        insert_tag view_factory.site_title, @namespace
+        site_title @namespace
       end
 
       def build_global_navigation
-        insert_tag view_factory.global_navigation, @menu, class: 'header-item tabs'
+        global_navigation @menu, class: 'header-item tabs'
       end
 
       def build_utility_navigation
-        insert_tag view_factory.utility_navigation, @utility_menu, id: "utility_nav", class: 'header-item tabs'
+        utility_navigation @utility_menu, id: "utility_nav", class: 'header-item tabs'
       end
 
     end

--- a/lib/active_admin/views/header.rb
+++ b/lib/active_admin/views/header.rb
@@ -9,20 +9,8 @@ module ActiveAdmin
         @menu = menu
         @utility_menu = @namespace.fetch_menu(:utility_navigation)
 
-        build_site_title
-        build_global_navigation
-        build_utility_navigation
-      end
-
-      def build_site_title
         site_title @namespace
-      end
-
-      def build_global_navigation
         global_navigation @menu, class: 'header-item tabs'
-      end
-
-      def build_utility_navigation
         utility_navigation @utility_menu, id: "utility_nav", class: 'header-item tabs'
       end
 

--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -4,8 +4,6 @@ module ActiveAdmin
       class Base < Arbre::HTML::Document
 
         def build(*args)
-          super
-          add_classes_to_body
           build_active_admin_head
           build_page
         end
@@ -23,16 +21,8 @@ module ActiveAdmin
 
         delegate :active_admin_config, :controller, :params, to: :helpers
 
-        def add_classes_to_body
-          @body.add_class(params[:action])
-          @body.add_class(params[:controller].tr('/', '_'))
-          @body.add_class("active_admin")
-          @body.add_class("logged_in")
-          @body.add_class(active_admin_namespace.name.to_s + "_namespace")
-        end
-
         def build_active_admin_head
-          within @head do
+          within head do
             html_title [title, helpers.active_admin_namespace.site_title(self)].compact.join(" | ")
 
             active_admin_application.stylesheets.each do |style, options|
@@ -56,7 +46,7 @@ module ActiveAdmin
         end
 
         def build_page
-          within @body do
+          within body(class: body_classes) do
             div id: "wrapper" do
               build_unsupported_browser
               build_header
@@ -65,6 +55,15 @@ module ActiveAdmin
               build_footer
             end
           end
+        end
+
+        def body_classes
+          Arbre::HTML::ClassList.new [
+            params[:action],
+            params[:controller].tr('/', '_'),
+            'active_admin', 'logged_in',
+            active_admin_namespace.name.to_s + '_namespace'
+          ]
         end
 
         def build_unsupported_browser

--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -10,6 +10,14 @@ module ActiveAdmin
           build_page
         end
 
+        def title
+          self.class.name
+        end
+
+        def main_content
+          I18n.t('active_admin.main_content', model: title).html_safe
+        end
+
         private
 
         delegate :active_admin_config, :controller, :params, to: :helpers
@@ -94,19 +102,6 @@ module ActiveAdmin
               main_content
             end
           end
-        end
-
-        def main_content
-          I18n.t('active_admin.main_content', model: title).html_safe
-        end
-
-        def title
-          self.class.name
-        end
-
-        # Set's the page title for the layout to render
-        def set_page_title
-          set_ivar_on_view "@page_title", title
         end
 
         # Returns the sidebar sections to render for the current action

--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -49,10 +49,10 @@ module ActiveAdmin
           within body(class: body_classes) do
             div id: "wrapper" do
               build_unsupported_browser
-              build_header
-              build_title_bar
+              header active_admin_namespace, current_menu
+              title_bar title, action_items_for_action
               build_page_content
-              build_footer
+              footer active_admin_namespace
             end
           end
         end
@@ -70,14 +70,6 @@ module ActiveAdmin
           if active_admin_namespace.unsupported_browser_matcher =~ controller.request.user_agent
             unsupported_browser
           end
-        end
-
-        def build_header
-          header active_admin_namespace, current_menu
-        end
-
-        def build_title_bar
-          title_bar title, action_items_for_action
         end
 
         def build_page_content
@@ -123,11 +115,6 @@ module ActiveAdmin
 
         def skip_sidebar?
           sidebar_sections_for_action.empty? || assigns[:skip_sidebar] == true
-        end
-
-        # Renders the content for the footer
-        def build_footer
-          footer active_admin_namespace
         end
 
       end

--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -68,16 +68,16 @@ module ActiveAdmin
 
         def build_unsupported_browser
           if active_admin_namespace.unsupported_browser_matcher =~ controller.request.user_agent
-            insert_tag view_factory.unsupported_browser
+            unsupported_browser
           end
         end
 
         def build_header
-          insert_tag view_factory.header, active_admin_namespace, current_menu
+          header active_admin_namespace, current_menu
         end
 
         def build_title_bar
-          insert_tag view_factory.title_bar, title, action_items_for_action
+          title_bar title, action_items_for_action
         end
 
         def build_page_content
@@ -127,7 +127,7 @@ module ActiveAdmin
 
         # Renders the content for the footer
         def build_footer
-          insert_tag view_factory.footer, active_admin_namespace
+          footer active_admin_namespace
         end
 
       end

--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -10,6 +10,7 @@ module ActiveAdmin
           build_page
         end
 
+        alias_method :html_title, :title # Arbre::HTML::Title
         def title
           self.class.name
         end
@@ -32,7 +33,7 @@ module ActiveAdmin
 
         def build_active_admin_head
           within @head do
-            insert_tag Arbre::HTML::Title, [title, helpers.active_admin_namespace.site_title(self)].compact.join(" | ")
+            html_title [title, helpers.active_admin_namespace.site_title(self)].compact.join(" | ")
 
             active_admin_application.stylesheets.each do |style, options|
               text_node stylesheet_link_tag(style, options).html_safe

--- a/spec/unit/abstract_view_factory_spec.rb
+++ b/spec/unit/abstract_view_factory_spec.rb
@@ -5,7 +5,7 @@ require 'active_admin/abstract_view_factory'
 RSpec.describe ActiveAdmin::AbstractViewFactory do
 
   let(:view_factory){ ActiveAdmin::AbstractViewFactory.new }
-  let(:view){ Class.new }
+  let(:view){ ActiveAdmin::Component }
 
   describe "registering a new view key" do
     before do
@@ -61,7 +61,7 @@ RSpec.describe ActiveAdmin::AbstractViewFactory do
 
   describe "subclassing the ViewFactory" do
     let(:subclass) do
-      ActiveAdmin::AbstractViewFactory.register my_subclassed_view: "From Parent"
+      ActiveAdmin::AbstractViewFactory.register my_subclassed_view: view
       Class.new(ActiveAdmin::AbstractViewFactory) do
         def my_subclassed_view
           "From Subclass"

--- a/spec/unit/views/components/unsupported_browser_spec.rb
+++ b/spec/unit/views/components/unsupported_browser_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe ActiveAdmin::Views::UnsupportedBrowser do
   let(:helpers){ mock_action_view }
   let(:namespace) { double :namespace, unsupported_browser_matcher: /MSIE [1-8]\.0/ }
   let(:component) { double :unsupported_browser_component }
-  let(:view_factory) { double :view_factory, unsupported_browser: component }
   let(:base) { ActiveAdmin::Views::Pages::Base.new }
 
   def build_panel
@@ -23,8 +22,7 @@ RSpec.describe ActiveAdmin::Views::UnsupportedBrowser do
       it "should build the unsupported browser panel" do
         expect(base).to receive(:active_admin_namespace).and_return(namespace)
         expect(base).to receive_message_chain(:controller, :request, :user_agent).and_return("Mozilla/5.0 (compatible; MSIE 7.0; Windows NT 6.2; Trident/6.0)")
-        expect(base).to receive(:view_factory).and_return(view_factory)
-        expect(base).to receive(:insert_tag).with(component)
+        expect(base).to receive(:unsupported_browser)
         base.send(:build_unsupported_browser)
       end
     end
@@ -33,7 +31,7 @@ RSpec.describe ActiveAdmin::Views::UnsupportedBrowser do
       it "should not build the unsupported browser panel" do
         expect(base).to receive(:active_admin_namespace).and_return(namespace)
         expect(base).to receive_message_chain(:controller, :request, :user_agent).and_return("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)")
-        expect(base).to receive(:insert_tag).never
+        expect(base).to receive(:unsupported_browser).never
         base.send(:build_unsupported_browser)
       end
     end

--- a/spec/unit/views/pages/base_spec.rb
+++ b/spec/unit/views/pages/base_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe ActiveAdmin::Views::Pages::Base do
+  class NewPage < ActiveAdmin::Views::Pages::Base
+  end
+
+  it "defines a default title" do
+    expect(NewPage.new.title).to eq 'NewPage'
+  end
+
+  it "defines default main content" do
+    expect(NewPage.new.main_content).to eq 'Please implement NewPage#main_content to display content.'
+  end
+end


### PR DESCRIPTION
Following on from #5206 pages/base feels quite dated compared to view components elsewhere in ActiveAdmin. I think that's because it relies on ViewFactory, which predates the inception of Arbre by several months (Feb vs Jun 2011). This PR adds a hook to ViewFactory to register builder_methods for the top level components, allowing pages/base and views/header to be simplified. ViewFactory could conceivably be deprecated and removed at a later date but I don't see that as a priority.