### PR TITLE
Allow checkbox filtering on a namespaced association

### DIFF
--- a/lib/active_admin/filters/active_filter.rb
+++ b/lib/active_admin/filters/active_filter.rb
@@ -90,7 +90,7 @@ module ActiveAdmin
         if condition_attribute.klass != resource_class && condition_attribute.klass.primary_key == name.to_s
           condition_attribute.klass
         elsif predicate_association
-          predicate_association.class_name.constantize
+          predicate_association.klass
         end
       end
 


### PR DESCRIPTION
If you have two models in the same namespace, they can have associations without specifying the namespace.

`predicate_association.class_name` does not include the namespace so you can't `constantize` it.

I ran into this switching from `filter :my_association` to `filter :my_association, as: :check_boxes`