### PR TITLE
Mitigate memory bloat with CSV exports

### DIFF
--- a/lib/active_admin/csv_builder.rb
+++ b/lib/active_admin/csv_builder.rb
@@ -53,10 +53,12 @@ module ActiveAdmin
         csv << CSV.generate_line(columns.map{ |c| encode c.name, options }, csv_options)
       end
 
-      (1..paginated_collection.total_pages).each do |page|
-        paginated_collection(page).each do |resource|
-          resource = controller.send :apply_decorator, resource
-          csv << CSV.generate_line(build_row(resource, columns, options), csv_options)
+      ActiveRecord::Base.uncached do
+        (1..paginated_collection.total_pages).each do |page|
+          paginated_collection(page).each do |resource|
+            resource = controller.send :apply_decorator, resource
+            csv << CSV.generate_line(build_row(resource, columns, options), csv_options)
+          end
         end
       end
 

--- a/spec/unit/csv_builder_spec.rb
+++ b/spec/unit/csv_builder_spec.rb
@@ -234,6 +234,15 @@ RSpec.describe ActiveAdmin::CSVBuilder do
       builder.build dummy_controller, []
     end
 
+    it "should disable the ActiveRecord query cache" do
+      expect(builder).to receive(:build_row).twice do
+        expect(ActiveRecord::Base.connection.query_cache_enabled).to be_falsy
+        []
+      end
+      ActiveRecord::Base.cache do
+        builder.build dummy_controller, []
+      end
+    end
   end
 
   context "build csv using specified encoding and encoding_options" do


### PR DESCRIPTION
As reported in #4118 large CSV exports can cause memory bloat via `ActiveRecord::QueryCache`. This change disables the query cache while performing a CSV export to mitigate.