### PR TITLE
Modal dialog js library should not depend on ES6 features

### DIFF
--- a/app/assets/javascripts/active_admin/lib/modal_dialog.es6
+++ b/app/assets/javascripts/active_admin/lib/modal_dialog.es6
@@ -20,7 +20,7 @@ ActiveAdmin.modal_dialog = function(message, inputs, callback){
         (opts ? ((() => {
           const result = [];
 
-          for (let v of opts) {
+          opts.forEach(v => {
             const $elem = $(`<${elem}/>`);
             if ($.isArray(v)) {
               $elem.text(v[0]).val(v[1]);
@@ -28,7 +28,7 @@ ActiveAdmin.modal_dialog = function(message, inputs, callback){
               $elem.text(v);
             }
             result.push($elem.wrap('<div>').parent().html());
-          }
+          });
 
           return result;
         })()).join('') : '') +

--- a/features/index/batch_actions.feature
+++ b/features/index/batch_actions.feature
@@ -175,20 +175,23 @@ Feature: Batch Actions
     Then I should see the batch action :very_complex_and_time_consuming "Very Complex and Time Consuming Selected"
     And I should see the batch action :passing_a_symbol "Passing A Symbol Selected"
 
+  @javascript
   Scenario: Use a Form with text
     Given 10 posts exist
     And an index configuration of:
       """
       ActiveAdmin.register Post do
         batch_action :destroy, false
-        batch_action(:action_with_form, form: { name: :text }) {}
+        batch_action(:action_with_form, form: { name: :textarea }) {}
       end
       """
 
     When I check the 1st record
     And I follow "Batch Actions"
-    Then I should be show a input with name "name" and type "text"
+    And I click "Action With Form"
+    And I should see the field "name" of type "textarea"
 
+  @javascript
   Scenario: Use a Form with select
     Given 10 posts exist
     And an index configuration of:
@@ -201,8 +204,10 @@ Feature: Batch Actions
 
     When I check the 1st record
     And I follow "Batch Actions"
-    Then I should be show a select with name "type" with the values "a, b"
+    And I click "Action With Form"
+    And I should see the select "type" with options "a, b"
 
+  @javascript
   Scenario: Use a Form with select values from proc
     Given 10 posts exist
     And an index configuration of:
@@ -215,4 +220,5 @@ Feature: Batch Actions
 
     When I check the 1st record
     And I follow "Batch Actions"
-    Then I should be show a select with name "type" with the values "a, b"
+    And I click "Action With Form"
+    And I should see the select "type" with options "a, b"

--- a/features/step_definitions/batch_action_steps.rb
+++ b/features/step_definitions/batch_action_steps.rb
@@ -66,13 +66,3 @@ end
 Then /^I should not see checkboxes in the table$/ do
   expect(page).to_not have_css '.paginated_collection table input[type=checkbox]'
 end
-
-Then /^I should be show a input with name "([^"]*)" and type "([^"]*)"$/ do |name, type|
-  selector = ".batch_actions_selector a.batch_action:first"
-  expect(page.find(selector)["data-inputs"]).to eq "{\"#{name}\":\"#{type}\"}"
-end
-
-Then /^I should be show a select with name "([^"]*)" with the values "([^"]*)"$/ do |name, values|
-  selector = ".batch_actions_selector a.batch_action:first"
-  expect(JSON[page.find(selector)["data-inputs"]]).to eq Hash[name, values.split(', ')]
-end

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -57,6 +57,14 @@ Then /^(?:I )should( not)? see( the element)? "([^"]*)"$/ do |negate, is_css, te
   expect(page).send should, have
 end
 
+Then /^I should see the select "([^"]*)" with options "([^"]+)"?$/ do |label, with_options|
+  expect(page).to have_select(label, with_options: with_options.split(', '))
+end
+
+Then /^I should see the field "([^"]*)" of type "([^"]+)"?$/ do |label, of_type|
+  expect(page).to have_field(label, type: of_type)
+end
+
 Then /^the "([^"]*)" field(?: within (.*))? should( not)? contain "([^"]*)"$/ do |field, parent, negate, value|
   with_scope(parent) do
     field = find_field(field)


### PR DESCRIPTION
`for ... of ...` construction makes the code dependant on browser supporting some ES6 features (`Symbol`). More information here - https://github.com/activeadmin/activeadmin/pull/5081#issuecomment-347795765