### PR TITLE
Use jQuery 3 as default minimum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   are now within the vendor directory. This will be replaced by alternatives and
   dropped entirely in a major release. Please remove any direct inclusions
   of `//= require jquery-ui`. [#5052][] by [@javierjulio][]
+* AA won't work properly with jQuery 1 & 2. Use jQuery 3 instead (`#= require jquery3`
+ in `active_admin.js.coffee`)
 
 ### Deprecations
 


### PR DESCRIPTION
Upgrading AA from 1.0.0 to 1.1.0 won't work as usual if jQuery 3 is not used in `active_admin.js.coffee`. jQuery UI functionalities does not work properly with jQuery 1 & 2 any more. Lots of type errors are thrown (`Uncaught TypeError: $(...).tableCheckboxToggler is not a function`) on any resource index page. Batch-Action button does not activate at all.