### PR TITLE
Correct an invalid yard tag

### DIFF
--- a/lib/active_admin/settings_node.rb
+++ b/lib/active_admin/settings_node.rb
@@ -5,7 +5,7 @@ module ActiveAdmin
       # Never instantiated.  Variables are stored in the singleton_class.
       private_class_method :new
 
-      # @returns anonymous class with same accessors as the superclass.
+      # @return anonymous class with same accessors as the superclass.
       def build(superclass = self)
         Class.new(superclass)
       end


### PR DESCRIPTION
Fixes warning

```
[warn]: Unknown tag @returns in file `lib/active_admin/settings_node.rb`
near line 9
```