### PR TITLE
HTML encode display_name output.

### DIFF
--- a/lib/active_admin/view_helpers/display_helper.rb
+++ b/lib/active_admin/view_helpers/display_helper.rb
@@ -15,7 +15,7 @@ module ActiveAdmin
       # Attempts to call any known display name methods on the resource.
       # See the setting in `application.rb` for the list of methods and their priority.
       def display_name(resource)
-        render_in_context resource, display_name_method_for(resource) unless resource.nil?
+        sanitize(render_in_context(resource, display_name_method_for(resource)).to_s) unless resource.nil?
       end
 
       # Looks up and caches the first available display name method.

--- a/spec/unit/view_helpers/breadcrumbs_spec.rb
+++ b/spec/unit/view_helpers/breadcrumbs_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe "Breadcrumbs" do
 
   include ActiveAdmin::ViewHelpers
+  include ActionView::Helpers::SanitizeHelper
 
   describe "generating a trail from paths" do
 

--- a/spec/unit/view_helpers/display_helper_spec.rb
+++ b/spec/unit/view_helpers/display_helper_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe ActiveAdmin::ViewHelpers::DisplayHelper do
   include MethodOrProcHelper
   include ActionView::Helpers::UrlHelper
   include ActionView::Helpers::TranslationHelper
+  include ActionView::Helpers::SanitizeHelper
 
   def active_admin_namespace
     active_admin_application.namespaces[:admin]
@@ -38,6 +39,13 @@ RSpec.describe ActiveAdmin::ViewHelpers::DisplayHelper do
           define_method(m) { m }
         end
         expect(display_name klass.new).to eq m
+      end
+
+      it "should sanitize the result of #{m} when defined" do
+        klass = Class.new do
+          define_method(m) { '<script>alert(1)</script>' }
+        end
+        expect(display_name klass.new).to eq 'alert(1)'
       end
     end
 
@@ -72,7 +80,7 @@ RSpec.describe ActiveAdmin::ViewHelpers::DisplayHelper do
 
     it "should default to `to_s`" do
       subject = Class.new.new
-      expect(display_name subject).to eq subject.to_s
+      expect(display_name subject).to eq sanitize(subject.to_s)
     end
 
     context "when no display name method is defined" do
@@ -148,7 +156,7 @@ RSpec.describe ActiveAdmin::ViewHelpers::DisplayHelper do
 
       value = format_attribute double(object: object), :object
 
-      expect(value).to eq :right
+      expect(value).to eq 'right'
     end
 
     it 'auto-links ActiveRecord records by association' do


### PR DESCRIPTION
The display_name helper can end up invoking methods on ActiveRecord models or other arbitrary ruby objects that can contain unsafe user supplied data resulting in XSS holes.

Refs #5198
Refs #5265
Refs #5275