### PR TITLE
Debug codecov

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -9,5 +9,8 @@ end
 
 if ENV['CI'] == 'true'
   require 'codecov'
-  SimpleCov.formatter = SimpleCov::Formatter::Codecov
+  SimpleCov.formatters = [
+    SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::Codecov
+  ]
 end

--- a/cucumber.yml
+++ b/cucumber.yml
@@ -1,3 +1,2 @@
 default: --format 'progress' --require features/support/regular_env.rb features --tags 'not @requires-reloading' --tags 'not @wip'
-wip: --format 'progress' --require features/support/env.rb features --tags @wip:3 --wip features
 class-reloading: CLASS_RELOADING=true --format 'progress' --require features/support/reload_env.rb features --tags @requires-reloading

--- a/features/authorization.feature
+++ b/features/authorization.feature
@@ -1,3 +1,4 @@
+@authorization
 Feature: Authorizing Access
 
   Ensure that access denied exceptions are managed

--- a/features/authorization_cancan.feature
+++ b/features/authorization_cancan.feature
@@ -1,3 +1,4 @@
+@authorization
 Feature: Authorizing Access using CanCan
 
   Background:

--- a/features/authorization_pundit.feature
+++ b/features/authorization_pundit.feature
@@ -1,3 +1,4 @@
+@authorization
 Feature: Authorizing Access using Pundit
 
   Background:

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -16,7 +16,6 @@ Given /^I am logged in$/ do
   login_as ensure_user_created 'admin@example.com'
 end
 
-# only for @requires-reloading scenario
 Given /^I am logged in with capybara$/ do
   ensure_user_created 'admin@example.com'
   step 'log out'

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -35,11 +35,11 @@ require 'cucumber/rails'
 require 'rspec/mocks'
 World(RSpec::Mocks::ExampleMethods)
 
-Before do
+Around do |scenario, block|
   RSpec::Mocks.setup
-end
 
-After do
+  block.call
+
   begin
     RSpec::Mocks.verify
   ensure

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -81,10 +81,6 @@ include Warden::Test::Helpers
 
 After do
   Warden.test_reset!
-
-  # Reset back to the default auth adapter
-  ActiveAdmin.application.namespace(:admin).
-    authorization_adapter = ActiveAdmin::AuthorizationAdapter
 end
 
 Before do
@@ -99,6 +95,12 @@ end
 
 # Force deprecations to raise an exception.
 ActiveSupport::Deprecation.behavior = :raise
+
+After '@authorization' do |scenario, block|
+  # Reset back to the default auth adapter
+  ActiveAdmin.application.namespace(:admin).
+    authorization_adapter = ActiveAdmin::AuthorizationAdapter
+end
 
 Around '@silent_unpermitted_params_failure' do |scenario, block|
   original = ActionController::Parameters.action_on_unpermitted_parameters

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -105,10 +105,6 @@ end
 # Force deprecations to raise an exception.
 ActiveSupport::Deprecation.behavior = :raise
 
-# improve the performance of the specs suite by not logging anything
-# see http://blog.plataformatec.com.br/2011/12/three-tips-to-improve-the-performance-of-your-test-suite/
-Rails.logger.level = 4
-
 Around '@silent_unpermitted_params_failure' do |scenario, block|
   original = ActionController::Parameters.action_on_unpermitted_parameters
   ActionController::Parameters.action_on_unpermitted_parameters = false

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -88,18 +88,13 @@ After do
 end
 
 Before do
-  begin
-    # We are caching classes, but need to manually clear references to
-    # the controllers. If they aren't clear, the router stores references
-    ActiveSupport::Dependencies.clear
+  # We are caching classes, but need to manually clear references to
+  # the controllers. If they aren't clear, the router stores references
+  ActiveSupport::Dependencies.clear
 
-    # Reload Active Admin
-    ActiveAdmin.unload!
-    ActiveAdmin.load!
-  rescue
-    p $!
-    raise $!
-  end
+  # Reload Active Admin
+  ActiveAdmin.unload!
+  ActiveAdmin.load!
 end
 
 # Force deprecations to raise an exception.

--- a/spec/unit/page_spec.rb
+++ b/spec/unit/page_spec.rb
@@ -33,11 +33,8 @@ module ActiveAdmin
       end
 
       it "returns the singular, lowercase name" do
-        if RUBY_VERSION >= '2.4.0'
-          expect(config.resource_name.singular).to eq "chocolate i løve you!"
-        else
-          expect(config.resource_name.singular).to eq "chocolate i lØve you!"
-        end
+        expect(config.resource_name.singular)
+          .to eq "chocolate i l#{RUBY_VERSION >= '2.4.0' ? 'ø' : 'Ø'}ve you!"
       end
     end
 

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -16,11 +16,6 @@ namespace :cucumber do
     t.bundler = false
   end
 
-  Cucumber::Rake::Task.new(:wip, "Run the cucumber scenarios with the @wip tag") do |t|
-    t.profile = 'wip'
-    t.bundler = false
-  end
-
   Cucumber::Rake::Task.new(:reloading, "Run the cucumber scenarios that test reloading") do |t|
     t.profile = 'class-reloading'
     t.bundler = false


### PR DESCRIPTION
We are having random coverage increases and decreases that cause some PR's to fail the codecov check (see https://codecov.io/gh/activeadmin/activeadmin/compare/6a0f2481761ee1387b30b9c89353faa4b4ffb359...870a474df28a6b331cc4205d9a484ee69c0f2f30/changes for an example).

The obvious fix for this is to add coverage for the "flaky" line, but out of curiosity I'd like to know why this happens.

These are some changes I made while investigating it. The useful one for this is to log the coverage percentage sent to codecov, that way I'll be able to see if the decrease happens consistenly for the same matrix entry or it's just fully random.

The other changes are just tweaks to the test run unrelated to this, maybe I should extract them to a separate PR? 
