### PR TITLE
Fix #5306 HTML-safe strings getting sanitized again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Bug fixes
 
+* Fixed [#5306][] HTML-safe strings getting sanitized again [#5307][] by [@tiagotex][]
+
 ## 1.2.0 [☰](https://github.com/activeadmin/activeadmin/compare/v1.1.0...v1.2.0)
 
 ### Enhancements
@@ -216,6 +218,7 @@ Please check [0-6-stable][] for previous changes.
 [#4254]: https://github.com/activeadmin/activeadmin/issues/4254
 [#5043]: https://github.com/activeadmin/activeadmin/issues/5043
 [#5198]: https://github.com/activeadmin/activeadmin/issues/5198
+[#5306]: https://github.com/activeadmin/activeadmin/issues/5306
 
 [#4477]: https://github.com/activeadmin/activeadmin/pull/4477
 [#4759]: https://github.com/activeadmin/activeadmin/pull/4759
@@ -256,6 +259,7 @@ Please check [0-6-stable][] for previous changes.
 [#5253]: https://github.com/activeadmin/activeadmin/pull/5253
 [#5272]: https://github.com/activeadmin/activeadmin/pull/5272
 [#5284]: https://github.com/activeadmin/activeadmin/pull/5284
+[#5307]: https://github.com/activeadmin/activeadmin/pull/5307
 
 [@5t111111]: https://github.com/5t111111
 [@aarek]: https://github.com/aarek
@@ -286,6 +290,7 @@ Please check [0-6-stable][] for previous changes.
 [@RobinvanderVliet]: https://github.com/RobinvanderVliet
 [@seanlinsley]: https://github.com/seanlinsley
 [@shekibobo]: https://github.com/shekibobo
+[@tiagotex]: https://github.com/tiagotex
 [@timoschilling]: https://github.com/timoschilling
 [@TimPetricola]: https://github.com/TimPetricola
 [@varyonic]: https://github.com/varyonic

--- a/lib/active_admin/view_helpers/display_helper.rb
+++ b/lib/active_admin/view_helpers/display_helper.rb
@@ -65,6 +65,8 @@ module ActiveAdmin
       # Attempts to create a human-readable string for any object
       def pretty_format(object)
         case object
+        when ActiveSupport::SafeBuffer
+          object.to_s
         when String, Numeric, Symbol, Arbre::Element
           sanitize(object.to_s)
         when Date, Time

--- a/spec/unit/pretty_format_spec.rb
+++ b/spec/unit/pretty_format_spec.rb
@@ -22,6 +22,16 @@ RSpec.describe "#pretty_format" do
     expect(pretty_format(Arbre::Element.new.script('alert("foo");'))).to eq("alert(&amp;quot;foo&amp;quot;);\n")
   end
 
+  it "sanitizes String" do
+    expect(pretty_format('<a rel="nofollow" data-method="delete" href="/admin/posts/1">Delete</a>'))
+      .to eq('<a href="/admin/posts/1">Delete</a>')
+  end
+
+  it "doesn't sanitize SafeBuffer" do
+    expect(pretty_format('<a rel="nofollow" data-method="delete" href="/admin/posts/1">Delete</a>'.html_safe))
+      .to eq('<a rel="nofollow" data-method="delete" href="/admin/posts/1">Delete</a>')
+  end
+
   shared_examples_for 'a time-ish object' do |t|
     it "formats it with the default long format" do
       expect(pretty_format(t)).to eq "February 28, 1985 20:15"


### PR DESCRIPTION
When we started [preventing XSS](https://github.com/activeadmin/activeadmin/commit/3c708349774490a13ba2c4e747240d6794a22cbf) we started calling  [`sanitize` in all Strings](https://github.com/activeadmin/activeadmin/commit/3c708349774490a13ba2c4e747240d6794a22cbf#diff-b2d41db115eac24dba6f5e64bda8a690R69):

```ruby
def pretty_format(object)
  case object
  when String, Numeric, Symbol, Arbre::Element
    - object.to_s
    + sanitize(object.to_s)
  (...)
```

I think this had the unintended side effect of cleaning strings that are marked as HTML-safe, like the ones generated by `link_to`, so I think we should skip sanitization for `ActiveSupport::SafeBuffer`.

Fixes #5306
  