### PR TITLE
 Allow setting defaults for new records on form.has_many

### DIFF
--- a/docs/5-forms.md
+++ b/docs/5-forms.md
@@ -99,13 +99,18 @@ ActiveAdmin.register Post do
       end
     end
     f.inputs do
-      f.has_many :taggings, sortable: :position, sortable_start: 1 do |t|
+      f.has_many :taggings, sortable: :position,
+                            sortable_start: 1,
+                            new_record: 'Add Tag' do |t|
         t.input :tag
       end
     end
     f.inputs do
       f.has_many :comment,
-                 new_record: 'Leave Comment',
+                 new_record: {
+                   text: 'Leave Comment',
+                   value: Comment.new(body: 'Active Admin rules!')
+                 },
                  allow_destroy: -> { |c| c.author?(current_admin_user) } do |b|
         b.input :body
       end
@@ -127,8 +132,11 @@ The `:heading` option adds a custom heading. You can hide it entirely by passing
 `false`.
 
 The `:new_record` option controls the visibility of the new record button (shown
-by default).  If you pass a string, it will be used as the text for the new
-record button.
+by default). You can pass `false` to hide the new record button. When you pass a
+string, it will be used as the text for the new record button. Your can control
+the defaults for the new record by passing a hash with a :value field containing
+a default record. When you pass a hash, the :text field is used as the text for
+the new record button.
 
 The `:sortable` option adds a hidden field and will enable drag & drop sorting
 of the children. It expects the name of the column that will store the index of

--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -158,13 +158,17 @@ module ActiveAdmin
     def js_for_has_many(class_string, &form_block)
       assoc_name       = assoc_klass.model_name
       placeholder      = "NEW_#{assoc_name.to_s.underscore.upcase.gsub(/\//, '_')}_RECORD"
+      record           = (new_record.is_a?(Hash) && new_record[:value]) || assoc_klass.new
       opts = {
-        for: [assoc, assoc_klass.new],
+        for: [assoc, record],
         class: class_string,
         for_options: { child_index: placeholder }
       }
       html = template.capture{ __getobj__.send(:inputs_for_nested_attributes, opts, &form_block) }
-      text = new_record.is_a?(String) ? new_record : I18n.t('active_admin.has_many_new', model: assoc_name.human)
+      text =
+        (new_record.is_a?(Hash) && new_record[:text]) ||
+        (new_record.is_a?(String) && new_record) ||
+        (I18n.t('active_admin.has_many_new', model: assoc_name.human))
 
       template.link_to text, '#', class: "button has_many_add", data: {
         html: CGI.escapeHTML(html).html_safe, placeholder: placeholder

--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -84,6 +84,14 @@ module ActiveAdmin
       @assoc_klass ||= __getobj__.object.class.reflect_on_association(assoc).klass
     end
 
+    def assoc_name
+      @assoc_name ||= assoc_klass.model_name
+    end
+
+    def assoc_placeholder
+      @assoc_placeholder ||= "NEW_#{assoc_name.to_s.underscore.upcase.gsub(/\//, '_')}_RECORD"
+    end
+
     def content_has_many(&block)
       form_block = proc do |form_builder|
         render_has_many_form(form_builder, options[:parent], &block)
@@ -156,23 +164,27 @@ module ActiveAdmin
 
     # Capture the ADD JS
     def js_for_has_many(class_string, &form_block)
-      assoc_name       = assoc_klass.model_name
-      placeholder      = "NEW_#{assoc_name.to_s.underscore.upcase.gsub(/\//, '_')}_RECORD"
-      record           = (new_record.is_a?(Hash) && new_record[:value]) || assoc_klass.new
-      opts = {
-        for: [assoc, record],
-        class: class_string,
-        for_options: { child_index: placeholder }
-      }
-      html = template.capture{ __getobj__.send(:inputs_for_nested_attributes, opts, &form_block) }
-      text =
-        (new_record.is_a?(Hash) && new_record[:text]) ||
-        (new_record.is_a?(String) && new_record) ||
-        (I18n.t('active_admin.has_many_new', model: assoc_name.human))
+      template.link_to js_text_for_has_many, '#',
+        class: "button has_many_add",
+        data: {
+          html: CGI.escapeHTML(js_html_for_has_many(class_string, &form_block)).html_safe,
+          placeholder: assoc_placeholder
+        }
+    end
 
-      template.link_to text, '#', class: "button has_many_add", data: {
-        html: CGI.escapeHTML(html).html_safe, placeholder: placeholder
+    def js_html_for_has_many(class_string, &form_block)
+      opts = {
+        for: [assoc, (new_record.is_a?(Hash) && new_record[:value]) || assoc_klass.new],
+        class: class_string,
+        for_options: { child_index: assoc_placeholder }
       }
+      template.capture{ __getobj__.send(:inputs_for_nested_attributes, opts, &form_block) }
+    end
+
+    def js_text_for_has_many
+      (new_record.is_a?(Hash) && new_record[:text]) ||
+      (new_record.is_a?(String) && new_record) ||
+      (I18n.t('active_admin.has_many_new', model: assoc_name.human))
     end
 
     def wrap_div_or_li(html)

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -610,7 +610,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
       end
     end
 
-    describe "with custom new record link" do
+    describe "with custom new record text" do
       let :body do
         build_form({url: '/categories'}, Category.new) do |f|
           f.object.posts.build
@@ -622,6 +622,38 @@ RSpec.describe ActiveAdmin::FormBuilder do
 
       it "should add a custom new record link" do
         expect(body).to have_selector("a", text: "My Custom New Post")
+      end
+    end
+
+    describe "with custom new record hash with a :text field" do
+      let :body do
+        build_form({url: '/categories'}, Category.new) do |f|
+          f.object.posts.build
+          f.has_many :posts, new_record: { text: 'My Custom New Post' } do |p|
+            p.input :title
+          end
+        end
+      end
+
+      it "should add a custom new record link" do
+        expect(body).to have_selector("a", text: "My Custom New Post")
+      end
+    end
+
+    describe "with custom new record hash with a :value field" do
+      let :body do
+        build_form({url: '/categories'}, Category.new) do |f|
+          f.object.posts.build
+          f.has_many :posts, new_record: { value: Post.new(title: "Great news") } do |p|
+            p.input :title
+          end
+        end
+      end
+
+      it "should add a new record link with default values specified in the data-html attribute" do
+        link = body.find('.has_many_container > a.button.has_many_add')
+        fieldset = Capybara.string(link[:"data-html"])
+        expect(fieldset).to have_selector("input[name='category[posts_attributes][NEW_POST_RECORD][title]'][value='Great news']")
       end
     end
 


### PR DESCRIPTION
Use example:

```
  form do |f|
    f.inputs do
      f.has_many :comments, new_record: { text: 'Leave comment, value: Comment.new(body: 'Active Admin rules!') } do |b|
        b.input :body
    end
  end
```