### PR TITLE
do not register the comments controller if config.comments == false

### DIFF
--- a/lib/active_admin/orm/active_record/comments.rb
+++ b/lib/active_admin/orm/active_record/comments.rb
@@ -20,70 +20,72 @@ ActiveAdmin.autoload :Comment, 'active_admin/orm/active_record/comments/comment'
 # Walk through all the loaded namespaces after they're loaded
 ActiveAdmin.after_load do |app|
   app.namespaces.each do |namespace|
-    namespace.register ActiveAdmin::Comment, as: namespace.comments_registration_name do
-      actions :index, :show, :create, :destroy
+    if namespace.settings.comments
+      namespace.register ActiveAdmin::Comment, as: namespace.comments_registration_name do
+        actions :index, :show, :create, :destroy
 
-      menu namespace.comments ? namespace.comments_menu : false
+        menu namespace.comments ? namespace.comments_menu : false
 
-      config.comments      = false # Don't allow comments on comments
-      config.batch_actions = false # The default destroy batch action isn't showing up anyway...
+        config.comments      = false # Don't allow comments on comments
+        config.batch_actions = false # The default destroy batch action isn't showing up anyway...
 
-      scope :all, show_count: false
-      # Register a scope for every namespace that exists.
-      # The current namespace will be the default scope.
-      app.namespaces.map(&:name).each do |name|
-        scope name, default: namespace.name == name do |scope|
-          scope.where namespace: name.to_s
-        end
-      end
-
-      # Store the author and namespace
-      before_save do |comment|
-        comment.namespace = active_admin_config.namespace.name
-        comment.author    = current_active_admin_user
-      end
-
-      controller do
-        # Prevent N+1 queries
-        def scoped_collection
-          super.includes(:author, :resource)
+        scope :all, show_count: false
+        # Register a scope for every namespace that exists.
+        # The current namespace will be the default scope.
+        app.namespaces.map(&:name).each do |name|
+          scope name, default: namespace.name == name do |scope|
+            scope.where namespace: name.to_s
+          end
         end
 
-        # Redirect to the resource show page after comment creation
-        def create
-          create! do |success, failure|
-            success.html do
-              ActiveAdmin::Dependency.rails.redirect_back self, active_admin_root
-            end
-            failure.html do
-              flash[:error] = I18n.t 'active_admin.comments.errors.empty_text'
-              ActiveAdmin::Dependency.rails.redirect_back self, active_admin_root
-            end
+        # Store the author and namespace
+        before_save do |comment|
+          comment.namespace = active_admin_config.namespace.name
+          comment.author    = current_active_admin_user
+        end
+
+        controller do
+          # Prevent N+1 queries
+          def scoped_collection
+            super.includes(:author, :resource)
           end
 
-          def destroy
-            destroy! do |success, failure|
+          # Redirect to the resource show page after comment creation
+          def create
+            create! do |success, failure|
               success.html do
                 ActiveAdmin::Dependency.rails.redirect_back self, active_admin_root
               end
               failure.html do
+                flash[:error] = I18n.t 'active_admin.comments.errors.empty_text'
                 ActiveAdmin::Dependency.rails.redirect_back self, active_admin_root
+              end
+            end
+
+            def destroy
+              destroy! do |success, failure|
+                success.html do
+                  ActiveAdmin::Dependency.rails.redirect_back self, active_admin_root
+                end
+                failure.html do
+                  ActiveAdmin::Dependency.rails.redirect_back self, active_admin_root
+                end
               end
             end
           end
         end
-      end
 
-      permit_params :body, :namespace, :resource_id, :resource_type
+        permit_params :body, :namespace, :resource_id, :resource_type
 
-      index do
-        column I18n.t('active_admin.comments.resource_type'), :resource_type
-        column I18n.t('active_admin.comments.author_type'),   :author_type
-        column I18n.t('active_admin.comments.resource'),      :resource
-        column I18n.t('active_admin.comments.author'),        :author
-        column I18n.t('active_admin.comments.body'),          :body
-        column I18n.t('active_admin.comments.created_at'),    :created_at
-        actions
+        index do
+          column I18n.t('active_admin.comments.resource_type'), :resource_type
+          column I18n.t('active_admin.comments.author_type'),   :author_type
+          column I18n.t('active_admin.comments.resource'),      :resource
+          column I18n.t('active_admin.comments.author'),        :author
+          column I18n.t('active_admin.comments.body'),          :body
+          column I18n.t('active_admin.comments.created_at'),    :created_at
+          actions
+        end
       end
     end
   end


### PR DESCRIPTION
Setting `config.comments = false` is supposed to **completely** disable comments functionality, but it doesn't exclude comments from the routes after calling ActiveAdmin.routes(self) and there is no way to remove a registered resource.  This PR addresses this issue by preventing the Comments controller from being registered at all if config.comments is set to false.