### PR TITLE
Improving nested form styles

### DIFF
--- a/app/assets/stylesheets/active_admin/_forms.scss
+++ b/app/assets/stylesheets/active_admin/_forms.scss
@@ -96,7 +96,7 @@ form {
         &.label label { position:absolute; }
       }
 
-      &:not(.has_many_fields) ol {
+      &:not(.inputs) ol {
         float: left;
         width: 74%;
         margin: 0;
@@ -108,7 +108,7 @@ form {
         }
       }
 
-      &.has_many_fields ol {
+      &.inputs ol {
         float: left;
         width: 100%;
         margin: 0;

--- a/app/assets/stylesheets/active_admin/_forms.scss
+++ b/app/assets/stylesheets/active_admin/_forms.scss
@@ -85,17 +85,6 @@ form {
       padding: 0;
       margin-bottom: 0;
 
-      legend {
-        position:absolute;
-        width:95%;
-        padding-top:0.1em;
-        left: 0px;
-        font-size: 100%;
-        font-weight: normal;
-        span { position:absolute; }
-        &.label label { position:absolute; }
-      }
-
       &:not(.inputs) ol {
         float: left;
         width: 74%;


### PR DESCRIPTION
Example:

```bash
rails new css_test
cd css_test

echo "
gemspec path: '..'
gem 'devise'
gem 'cancan' # or cancancan
gem 'draper'
gem 'pundit'
" >> Gemfile

rails g active_admin:install
rails g migration CreateRecords value:string record:references
rake db:create db:migrate db:seed

echo "
class Record < ApplicationRecord
  belongs_to :record
  has_one :child, class_name: 'Record'
  accepts_nested_attributes_for :child
  has_many :children, class_name: 'Record'
  accepts_nested_attributes_for :children
end
" >> app/models/record.rb

echo "
ActiveAdmin.register Record do
  form do |f|
    f.semantic_errors(*f.object.errors.keys)

    f.inputs Record.model_name.human do
      f.input :value
    end

    f.has_many :children do |cf|
      cf.input :value

      cf.object.build_child
      cf.template.concat(cf.inputs('Record', for: :child) do |ccf|
        ccf.input :value

        ccf.has_many :children do |cccf|
          cccf.input :value
        end
      end)
    end

    f.actions
  end
end
" >> app/admin/records.rb
rails s
```

Before:
![2018-01-15 13 33 34](https://user-images.githubusercontent.com/5202503/34938310-f6601378-f9f8-11e7-910d-e98c0cfd94ff.png)

After `.has_many_fields` -> `.inputs`:
![2018-01-15 13 33 49](https://user-images.githubusercontent.com/5202503/34938363-27375cb8-f9f9-11e7-9a8b-f2a8bbd07dc9.png)

After removing nested legend styles:
![2018-01-15 13 33 58](https://user-images.githubusercontent.com/5202503/34938383-37114a2c-f9f9-11e7-9d95-4f9b2905db14.png)

Being unable to render nested inputs inside `has_many` simpler than using `FormBuilder#concat` is another issue, but I am unable to fix this at the moment, so this is OK for now.
