### PR TITLE
Views::ActiveAdminForm#create_another_checkbox styles are fixed

### DIFF
--- a/app/assets/stylesheets/active_admin/_forms.scss
+++ b/app/assets/stylesheets/active_admin/_forms.scss
@@ -241,7 +241,7 @@ form {
     input[type=submit], input[type=button], button { margin-right: 10px; }
   }
 
-  .buttons .actions .create_another {
+  .actions .create_another {
     float: none;
     margin-bottom: 10px;
 

--- a/lib/active_admin/views/components/active_admin_form.rb
+++ b/lib/active_admin/views/components/active_admin_form.rb
@@ -105,11 +105,10 @@ module ActiveAdmin
         create_another = params[:create_another]
         label = @resource.class.model_name.human
         Arbre::Context.new do
-          li do
+          li class: 'create_another' do
             input(
               checked: create_another,
               id: 'create_another',
-              class: 'create_another',
               name: 'create_another',
               type: 'checkbox'
             )


### PR DESCRIPTION
Before:
![2018-01-22 11 57 15](https://user-images.githubusercontent.com/5202503/35212502-6e21af4e-ff6b-11e7-9071-571247ac7fa4.png)

After:
![2018-01-22 11 53 25](https://user-images.githubusercontent.com/5202503/35212507-7219012e-ff6b-11e7-9996-22d28540657d.png)

Is there any way to spec this?