### PR TITLE
Resource::Routes#route_member_action_path should be exposed

### DIFF
--- a/lib/active_admin/resource/routes.rb
+++ b/lib/active_admin/resource/routes.rb
@@ -20,7 +20,11 @@ module ActiveAdmin
       end
 
       def route_edit_instance_path(resource, additional_params = {})
-        route_builder.edit_instance_path(resource, additional_params)
+        route_builder.member_action_path(:edit, resource, additional_params)
+      end
+
+      def route_member_action_path(action, resource, additional_params = {})
+        route_builder.member_action_path(action, resource, additional_params)
       end
 
       # Returns the routes prefix for this config
@@ -75,12 +79,13 @@ module ActiveAdmin
           routes.public_send route_name, *route_instance_params(instance), additional_params
         end
 
-        # @return [String] the path to the edit page of this resource
+        # @return [String] the path to the member action of this resource
+        # @param action [Symbol]
         # @param instance [ActiveRecord::Base] the instance we want the path of
         # @example "/admin/posts/1/edit"
-        def edit_instance_path(instance, additional_params = {})
+        def member_action_path(action, instance, additional_params = {})
           path = resource.resources_configuration[:self][:route_instance_name]
-          route_name = route_name(path, action: :edit)
+          route_name = route_name(path, action: action)
 
           routes.public_send route_name, *route_instance_params(instance), additional_params
         end

--- a/spec/unit/resource/routes_spec.rb
+++ b/spec/unit/resource/routes_spec.rb
@@ -73,7 +73,11 @@ RSpec.describe ActiveAdmin::Resource::Routes do
     before do
       load_resources do
         ActiveAdmin.register Category
-        ActiveAdmin.register(Post) { belongs_to :category }
+        ActiveAdmin.register(Post) do
+          belongs_to :category
+
+          member_action :foo
+        end
       end
     end
 
@@ -83,6 +87,10 @@ RSpec.describe ActiveAdmin::Resource::Routes do
 
     it "should nest the instance path" do
       expect(config.route_instance_path(post)).to eq "/admin/categories/1/posts/3"
+    end
+
+    it "should nest the member action path" do
+      expect(config.route_member_action_path(:foo, post)).to eq "/admin/categories/1/posts/3/foo"
     end
   end
 


### PR DESCRIPTION
This method would ease things for modules shared across registered resources.