### PR TITLE
Add priority option to action item 

### DIFF
--- a/docs/8-custom-actions.md
+++ b/docs/8-custom-actions.md
@@ -146,6 +146,17 @@ action_item :super_action,
 end
 ```
 
+By default action items are positioned in the same order as they defined (after default actions), 
+but it’s also possible to specify their position manually:
+
+```ruby
+action_item :help, priority: 0 do
+  "Display this action to the first position"
+end
+```
+
+Default action item priority is 10.
+
 # Modifying the Controller
 
 The generated controller is available to you within the registration block by

--- a/lib/active_admin/resource/action_items.rb
+++ b/lib/active_admin/resource/action_items.rb
@@ -24,10 +24,8 @@ module ActiveAdmin
       #                         this action item on.
       #                 :except: A single or array of controller actions not to
       #                          display this action item on.
-      #                 :first: Place action item to the beginning of action_items array.
       def add_action_item(name, options = {}, &block)
-        method_name = options.delete(:first) ? :unshift : :<<
-        action_items.public_send method_name, ActiveAdmin::ActionItem.new(name, options, &block)
+        self.action_items << ActiveAdmin::ActionItem.new(name, options, &block)
       end
 
       def remove_action_item(name)
@@ -40,7 +38,7 @@ module ActiveAdmin
       #
       # @return [Array] Array of ActionItems for the controller actions
       def action_items_for(action, render_context = nil)
-        action_items.select{ |item| item.display_on? action, render_context }
+        action_items.select { |item| item.display_on? action, render_context }.sort_by(&:priority)
       end
 
       # Clears all the existing action items for this resource
@@ -111,6 +109,10 @@ module ActiveAdmin
 
     def html_class
       "action_item #{@options[:class]}".rstrip
+    end
+
+    def priority
+      @options[:priority] || 10
     end
   end
 

--- a/lib/active_admin/resource/action_items.rb
+++ b/lib/active_admin/resource/action_items.rb
@@ -24,8 +24,10 @@ module ActiveAdmin
       #                         this action item on.
       #                 :except: A single or array of controller actions not to
       #                          display this action item on.
+      #                 :first: Place action item to the beginning of action_items array.
       def add_action_item(name, options = {}, &block)
-        self.action_items << ActiveAdmin::ActionItem.new(name, options, &block)
+        method_name = options.delete(:first) ? :unshift : :<<
+        action_items.public_send method_name, ActiveAdmin::ActionItem.new(name, options, &block)
       end
 
       def remove_action_item(name)

--- a/lib/active_admin/resource/action_items.rb
+++ b/lib/active_admin/resource/action_items.rb
@@ -24,6 +24,7 @@ module ActiveAdmin
       #                         this action item on.
       #                 :except: A single or array of controller actions not to
       #                          display this action item on.
+      #                 :priority: A single integer value. To control the display order. Default is 10.
       def add_action_item(name, options = {}, &block)
         self.action_items << ActiveAdmin::ActionItem.new(name, options, &block)
       end

--- a/spec/unit/resource/action_items_spec.rb
+++ b/spec/unit/resource/action_items_spec.rb
@@ -36,10 +36,14 @@ RSpec.describe ActiveAdmin::Resource::ActionItems do
       resource.add_action_item :first, priority: 0 do
         # Empty ...
       end
+      resource.add_action_item :some_other do
+        # Empty ...
+      end
       resource.add_action_item :second, priority: 1 do
         # Empty ...
       end
-      expect(resource.action_items_for(:index).collect(&:name)).to eq [:first, :second, :empty]
+
+      expect(resource.action_items_for(:index).collect(&:name)).to eq [:first, :second, :empty, :some_other]
     end
 
   end

--- a/spec/unit/resource/action_items_spec.rb
+++ b/spec/unit/resource/action_items_spec.rb
@@ -32,6 +32,13 @@ RSpec.describe ActiveAdmin::Resource::ActionItems do
       expect(resource.action_items.first.html_class).to eq("action_item test")
     end
 
+    it 'should be first when specified' do
+      resource.add_action_item :first_item, first: true do
+        # Empty ...
+      end
+      expect(resource.action_items.first.name).to eq :first_item
+    end
+
   end
 
   describe "setting an action item to only display on specific controller actions" do

--- a/spec/unit/resource/action_items_spec.rb
+++ b/spec/unit/resource/action_items_spec.rb
@@ -32,11 +32,14 @@ RSpec.describe ActiveAdmin::Resource::ActionItems do
       expect(resource.action_items.first.html_class).to eq("action_item test")
     end
 
-    it 'should be first when specified' do
-      resource.add_action_item :first_item, first: true do
+    it 'should be ordered by priority' do
+      resource.add_action_item :first, priority: 0 do
         # Empty ...
       end
-      expect(resource.action_items.first.name).to eq :first_item
+      resource.add_action_item :second, priority: 1 do
+        # Empty ...
+      end
+      expect(resource.action_items_for(:index).collect(&:name)).to eq [:first, :second, :empty]
     end
 
   end


### PR DESCRIPTION
Able to add action item to the beginning of action items via adding `priority: 0`.

```ruby
action_item :view, only: :show, priority: 0 do
  link_to 'View on site', post_path(post) if post.published?
end
```
![image](https://image.prntscr.com/image/NhjxSc_OQNCf5TTIHIrlAA.png)