### PR TITLE
Make sortable items semi-transparent on drag

### DIFF
--- a/app/assets/javascripts/active_admin/lib/has_many.es6
+++ b/app/assets/javascripts/active_admin/lib/has_many.es6
@@ -66,7 +66,8 @@ var init_sortable = function() {
   elems.sortable({
     items: '> fieldset',
     handle: '> ol > .handle',
-    stop:    recompute_positions
+    start: (ev, ui) => { ui.item.css({opacity: 0.3})},
+    stop:  (ev, ui) => { ui.item.css({opacity: 1.0}); recompute_positions }
   });
   elems.each(recompute_positions);
 };


### PR DESCRIPTION
This makes the sortable feature much more useful when the items are really big (e.g. contain sub-items). The linked movies illustrate the problem (opaque vs. transparent):

opaque:
https://cool-breeze.s3.amazonaws.com/github-media/opaque.mov

semi-transparent:
https://cool-breeze.s3.amazonaws.com/github-media/transparent.mov
