### PR TITLE
Manually add ID for polymorphic associations

### DIFF
--- a/lib/active_admin/inputs/filters/select_input.rb
+++ b/lib/active_admin/inputs/filters/select_input.rb
@@ -15,7 +15,14 @@ module ActiveAdmin
             "#{reflection.through_reflection.name}_#{reflection.foreign_key}"
           else
             name = method.to_s
-            name.concat "_#{reflection.association_primary_key}" if reflection_searchable?
+
+            if reflection_searchable?
+              name.concat "_#{reflection.association_primary_key}"
+
+            elsif reflection_polymorphic?
+              name.concat "_id"
+            end
+
             name
           end
         end
@@ -50,6 +57,10 @@ module ActiveAdmin
 
         def reflection_searchable?
           reflection && !reflection.polymorphic?
+        end
+
+        def reflection_polymorphic?
+          reflection && reflection.polymorphic?
         end
 
       end


### PR DESCRIPTION
This is a recent bug I encounter when upgrading from 1.1 to 1.2.1.

Filtering on polymorphic associations throwing an error when rendering the page. After investigation, I found that #5238 , which was a great addition, removed the `_id` field from being added to the filter search for polymorphic associations.

The whole point of #5238 was to search on associations with a primary key other than ID. However, for polymorphic associations, I think it is OK to assume the field searching on is the ID column.
