### PR TITLE
Add option to ignore warning when redefining method

### DIFF
--- a/lib/active_admin/resource_dsl.rb
+++ b/lib/active_admin/resource_dsl.rb
@@ -133,7 +133,11 @@ module ActiveAdmin
     # action.
     #
     def action(set, name, options = {}, &block)
-      warn "Warning: method `#{name}` already defined" if controller.method_defined?(name)
+      display_warning = !options.delete(:ignore_warning)
+
+      if controller.method_defined?(name) && display_warning
+        warn "Warning: method `#{name}` already defined"
+      end
 
       set << ControllerAction.new(name, options)
       title = options.delete(:title)

--- a/spec/unit/action_builder_spec.rb
+++ b/spec/unit/action_builder_spec.rb
@@ -143,6 +143,18 @@ RSpec.describe 'defining actions from registration blocks', type: :controller do
       end
     end
 
+    describe 'ignoring the warning about redefining a member action' do
+      let :action! do
+        ActiveAdmin.register Post do
+          member_action :process, ignore_warning: true
+        end
+      end
+
+      it 'writes warning to $stderr' do
+        expect($stderr.string).not_to include('Warning: method `process` already defined')
+      end
+    end
+
     describe 'defining collection action' do
       let :action! do
         ActiveAdmin.register Post do
@@ -152,6 +164,18 @@ RSpec.describe 'defining actions from registration blocks', type: :controller do
 
       it 'writes warning to $stderr' do
         expect($stderr.string).to include('Warning: method `process` already defined')
+      end
+    end
+
+    describe 'ignoring the warning about redefining a collection action' do
+      let :action! do
+        ActiveAdmin.register Post do
+          collection_action :process, ignore_warning: true
+        end
+      end
+
+      it 'writes warning to $stderr' do
+        expect($stderr.string).not_to include('Warning: method `process` already defined')
       end
     end
   end


### PR DESCRIPTION
Fixes #5316.

[This commit](https://github.com/activeadmin/activeadmin/commit/c9e7f9ac9aee5b4ad4a58ba5216488cb5e7f4972#diff-c854d1a85b2cb3e8e48e1a559229039a) was added to warn about redefining a controller method. In my instance, we added the method to override the default controller's method. This merge adds an option when defining an action to ignore the warning message. It can be done similar to:

```ruby
member_action :method_name, ignore_warning: true
```

Otherwise, it will still continue to warn about the overwritten method.