### PR TITLE
Fix documentation on CanCan::Ability for Dashboard

### DIFF
--- a/docs/13-authorization-adapter.md
+++ b/docs/13-authorization-adapter.md
@@ -233,7 +233,7 @@ class Ability
     can :manage, Post
     can :read, User
     can :manage, User, id: user.id
-    can :read, ActiveAdmin::Page, name: "Dashboard", namespace_name: :admin
+    can :read, ActiveAdmin::Page, name: "Dashboard", namespace_name: "admin"
   end
 
 end


### PR DESCRIPTION
The ActiveAdmin::Page namespace_name is a [string](https://github.com/activeadmin/activeadmin/blob/master/lib/active_admin/page.rb#L60), not a symbol. Otherwise the authorization will fail and result in an infinite loop, if the dashboard is your admin root.