### PR TITLE
Lock gem version for jasmine pending Ruby 2.2 EOL.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ group :test do
   gem 'cucumber'
   gem 'database_cleaner'
   gem 'jasmine'
+  gem 'jasmine-core', '2.9.1' # last release with Ruby 2.2 support.
   gem 'launchy'
   gem 'rails-i18n' # Provides default i18n for many languages
   gem 'rspec-rails'


### PR DESCRIPTION
Fixes build.  @sgravrock decided to drop Ruby 2.2 support [a few weeks early](https://github.com/jasmine/jasmine-gem/commit/bf16a478100a461a9a924c65020368db8f85c383), included in 2.99 a day or two ago.