### PR TITLE
Add missing filter predicate translations to nb

### DIFF
--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -31,6 +31,10 @@ nb:
         ends_with: "Slutter med"
         greater_than: "Større enn"
         less_than: "Mindre enn"
+        gteq_datetime: "Større enn eller lik"
+        lteq_datetime: "Mindre enn eller lik"
+        from: "Fra"
+        to: "Til"
     search_status:
       headline: "Søkestatus:"
       current_scope: "Søkeområde:"


### PR DESCRIPTION
I noticed these four predicates were not added to the Norwegian translation file, so here they are!