### PR TITLE
Scopes groups

### DIFF
--- a/app/assets/stylesheets/active_admin/components/_scopes.scss
+++ b/app/assets/stylesheets/active_admin/components/_scopes.scss
@@ -6,5 +6,8 @@
       font-size: 0.9em;
       line-height: 10px;
     }
+    &:first-child a {
+      margin-left: 10px;
+    }
   }
 }

--- a/docs/3-index-pages.md
+++ b/docs/3-index-pages.md
@@ -214,6 +214,23 @@ end
 Scopes can be labelled with a translation, e.g.
 `activerecord.scopes.invoice.expired`.
 
+### Scopes groups
+
+You can assign group names to scopes to keep related scopes together and separate them from the rest.
+
+```ruby
+# a scope in the default group
+scope :all
+
+# two scopes used to filter by status
+scope :active, group: :status
+scope :inactive, group: :status
+
+# two scopes used to filter by date
+scope :today, group: :date
+scope :tomorrow, group: :date
+```
+
 ## Index default sort order
 
 You can define the default sort order for index pages:

--- a/features/index/index_scopes.feature
+++ b/features/index/index_scopes.feature
@@ -283,3 +283,27 @@ Feature: Index Scoping
     And I should see the scope "Published" with the count 1
     And I should see 1 posts in the table
     And I should see the current scope with label "Published"
+
+  Scenario: Viewing resources with grouped scopes
+    Given 3 posts exist
+    And an index configuration of:
+      """
+      ActiveAdmin.register Post do
+        scope :all
+        scope "Published", group: :status do |posts|
+          posts.where("published_date IS NOT NULL")
+        end
+        scope "Unpublished", group: :status do |posts|
+          posts.where("published_date IS NULL")
+        end
+        scope "Today", group: :date do |posts|
+          posts.where(["created_at > ? AND created_at < ?", ::Time.zone.now.beginning_of_day, ::Time.zone.now.end_of_day])
+        end
+        scope "Tomorrow", group: :date do |posts|
+          posts.where(["created_at > ? AND created_at < ?", ::Time.zone.now.beginning_of_day + 1.day, ::Time.zone.now.end_of_day + 1.day])
+        end
+      end
+      """
+    Then I should see an empty group with the scope "All"
+    And I should see a group "status" with the scopes "Published" and "Unpublished"
+    And I should see a group "date" with the scopes "Today" and "Tomorrow"

--- a/features/step_definitions/index_scope_steps.rb
+++ b/features/step_definitions/index_scope_steps.rb
@@ -27,3 +27,16 @@ Then /^I should see the scope "([^"]*)" with no count$/ do |name|
   expect(page).to     have_css ".scopes .#{name}"
   expect(page).to_not have_css ".scopes .#{name} .count"
 end
+
+Then "I should see a group {string} with the scopes {string} and {string}" do |group, name1, name2|
+  group = group.tr(" ", "").underscore.downcase
+  name1 = name1.tr(" ", "").underscore.downcase
+  name2 = name2.tr(" ", "").underscore.downcase
+  expect(page).to     have_css ".scopes .scope-group-#{group} .#{name1}"
+  expect(page).to     have_css ".scopes .scope-group-#{group} .#{name2}"
+end
+
+Then"I should see an empty group with the scope {string}" do |name|
+  name = name.tr(" ", "").underscore.downcase
+  expect(page).to     have_css ".scopes .scope-default-group .#{name}"
+end

--- a/lib/active_admin/scope.rb
+++ b/lib/active_admin/scope.rb
@@ -1,7 +1,7 @@
 module ActiveAdmin
   class Scope
 
-    attr_reader :scope_method, :id, :scope_block, :display_if_block, :show_count, :default_block
+    attr_reader :scope_method, :id, :scope_block, :display_if_block, :show_count, :default_block, :group
 
     # Create a Scope
     #
@@ -24,6 +24,9 @@ module ActiveAdmin
     #   Scope.new ->{Date.today.strftime '%A'}, :published_today
     #   # => Scope with dynamic title using the :published_today scope method
     #
+    #   Scope.new :published, nil, group: :status
+    #   # => Scope with the group :status
+    #
     def initialize(name, method = nil, options = {}, &block)
       @name, @scope_method = name, method.try(:to_sym)
 
@@ -42,6 +45,7 @@ module ActiveAdmin
       @show_count       = options.fetch(:show_count, true)
       @display_if_block = options[:if]      || proc{ true }
       @default_block    = options[:default] || proc{ false }
+      @group            = options[:group].try(:to_sym)
     end
 
     def name

--- a/lib/active_admin/views/components/scopes.rb
+++ b/lib/active_admin/views/components/scopes.rb
@@ -13,16 +13,20 @@ module ActiveAdmin
       include ::ActiveAdmin::Helpers::Collection
 
       def default_class_name
-        "scopes table_tools_segmented_control"
+        "scopes"
       end
 
       def tag_name
-        'ul'
+        'div'
       end
 
       def build(scopes, options = {})
-        scopes.each do |scope|
-          build_scope(scope, options) if call_method_or_proc_on(self, scope.display_if_block)
+        scopes.group_by(&:group).each do |group, group_scopes|
+          ul class: "table_tools_segmented_control #{group_class(group)}" do
+            group_scopes.each do |scope|
+              build_scope(scope, options) if call_method_or_proc_on(self, scope.display_if_block)
+            end
+          end
         end
       end
 
@@ -60,6 +64,9 @@ module ActiveAdmin
         collection_size(scope_chain(scope, collection_before_scope))
       end
 
+      def group_class(group)
+        group.present? ? "scope-group-#{group}" : "scope-default-group"
+      end
     end
   end
 end

--- a/spec/support/rails_template_with_data.rb
+++ b/spec/support/rails_template_with_data.rb
@@ -143,19 +143,19 @@ inject_into_file 'app/admin/posts.rb', <<-'RUBY', after: "ActiveAdmin.register P
 
   scope :all, default: true
 
-  scope :drafts do |posts|
+  scope :drafts, group: :status do |posts|
     posts.where(["published_date IS NULL"])
   end
 
-  scope :scheduled do |posts|
+  scope :scheduled, group: :status do |posts|
     posts.where(["posts.published_date IS NOT NULL AND posts.published_date > ?", Time.now.utc])
   end
 
-  scope :published do |posts|
+  scope :published, group: :status do |posts|
     posts.where(["posts.published_date IS NOT NULL AND posts.published_date < ?", Time.now.utc])
   end
 
-  scope :my_posts do |posts|
+  scope :my_posts, group: :author do |posts|
     posts.where(author_id: current_admin_user.id)
   end
 

--- a/spec/unit/scope_spec.rb
+++ b/spec/unit/scope_spec.rb
@@ -206,4 +206,20 @@ RSpec.describe ActiveAdmin::Scope do
     end
   end
 
+  describe "group" do
+    it "should default to nil" do
+      scope = ActiveAdmin::Scope.new(:default)
+      expect(scope.group).to eq nil
+    end
+
+    it "should accept a symbol to assign a group to the scope" do
+      scope = ActiveAdmin::Scope.new(:default, nil, group: :test)
+      expect(scope.group).to eq :test
+    end
+
+    it "should accept a string to assign a group to the scope" do
+      scope = ActiveAdmin::Scope.new(:default, nil, group: "test")
+      expect(scope.group).to eq :test
+    end
+  end
 end


### PR DESCRIPTION
This is a feature proposal. The idea is to add a group attribute to scopes to allow to show them grouped in the index page.

This can be useful when working with different kind of scopes for a model. For example, a user can have a state and a role. If we add the following DSL:
```ruby
scope :active, group: :state
scope :inactive, group: :state

scope :admin, group: :role
scope :user, group: :role
scope :guest, group: :role
```
Then, users index page will show something like this in the scopes section:
```
( active | inactive ) ( admin | user | guest )
```

With this PR adding groups to scopes only provides a visual help for admin users. In the future it also could be used to allow the user to select a scope for each group, but I guess that could be more complex to implement.