### PR TITLE
allow to create an anonymous comment without authentication

### DIFF
--- a/features/comments/commenting.feature
+++ b/features/comments/commenting.feature
@@ -27,6 +27,26 @@ Feature: Commenting
     And I should see "Hello from Comment"
     And I should see a comment by "admin@example.com"
 
+  Scenario: Create an anonymous comment without authentication
+    Given a show configuration of:
+      """
+        # disable authentication, but Comment's author is optional, it should be able to create a comment as author is anonymous
+        ActiveAdmin.application.authentication_method = false
+
+        ActiveAdmin.register Post
+      """
+    And I am logged out
+    When I go to the last post's show page
+    And I add a comment "Hello from Comment"
+    Then I should see a successful create flash
+    Given a show configuration of:
+      """
+        # reset authentication settings
+        ActiveAdmin.application.authentication_method = :authenticate_admin_user!
+        # re-register Post to make other tests pass
+        ActiveAdmin.register Post
+      """
+
   Scenario: View resource with comments turned off
     Given a show configuration of:
     """

--- a/lib/active_admin/orm/active_record/comments/comment.rb
+++ b/lib/active_admin/orm/active_record/comments/comment.rb
@@ -5,9 +5,10 @@ module ActiveAdmin
     self.table_name = "#{table_name_prefix}active_admin_comments#{table_name_suffix}"
 
     belongs_to :resource, polymorphic: true, optional: true
-    belongs_to :author, polymorphic: true
+    belongs_to :author, polymorphic: true, optional: true
 
     validates_presence_of :body, :namespace, :resource
+    validates_presence_of :author, if: -> { Rails.application.config.active_record.belongs_to_required_by_default && ActiveAdmin.application.authentication_method != false }
 
     before_create :set_resource_type
 

--- a/spec/unit/comments_spec.rb
+++ b/spec/unit/comments_spec.rb
@@ -23,6 +23,45 @@ RSpec.describe "Comments" do
       expect(comment.author).to eq(user)
     end
 
+    context "when authentication disabled" do
+      before do
+        ActiveAdmin.application.authentication_method = false
+      end
+
+      it "doesn't need an author" do
+        comment.valid?
+        expect(comment.errors[:author]).to be_empty
+      end
+    end
+
+    context "when authentication enabled" do
+      before do
+        ActiveAdmin.application.authentication_method = :authenticate_admin_user!
+      end
+
+      context "and application not using `belongs_to_required_by_default`" do
+        before do
+          allow(Rails.application.config.active_record).to receive(:belongs_to_required_by_default).and_return(false)
+        end
+
+        it "doesn't need an author" do
+          comment.valid?
+          expect(comment.errors[:author]).to be_empty
+        end
+      end
+
+      context "and application using `belongs_to_required_by_default`" do
+        before do
+          allow(Rails.application.config.active_record).to receive(:belongs_to_required_by_default).and_return(true)
+        end
+
+        it "needs an author" do
+          expect(comment).to_not be_valid
+          expect(comment.errors[:author]).to eq(["can't be blank"])
+        end
+      end
+    end
+
     it "needs a body" do
       expect(comment).to_not be_valid
       expect(comment.errors[:body]).to eq(["can't be blank"])


### PR DESCRIPTION
related to #5258 

BTW, this issue is hard to debug in test env since there is a setting in config/environments/test.rb as:

```
if Rails::VERSION::MAJOR >= 5
    config.active_record.belongs_to_required_by_default = false
end
```
