### PR TITLE
New form_helper_method setting

### DIFF
--- a/lib/active_admin/namespace_settings.rb
+++ b/lib/active_admin/namespace_settings.rb
@@ -40,6 +40,9 @@ module ActiveAdmin
     # is a currently authenticated admin user
     register :authentication_method, false
 
+    # The method to call to create forms
+    register :form_helper_method, :semantic_form_for
+
     # The path to log user's out with. If set to a symbol, we assume
     # that it's a method to call which returns the path
     register :logout_link_path, :destroy_admin_user_session_path

--- a/lib/active_admin/views/components/active_admin_form.rb
+++ b/lib/active_admin/views/components/active_admin_form.rb
@@ -27,7 +27,7 @@ module ActiveAdmin
         @resource = resource
         options = options.deep_dup
         options[:builder] ||= ActiveAdmin::FormBuilder
-        form_string = helpers.semantic_form_for(resource, options) do |f|
+        form_string = helpers.send( ActiveAdmin.application.form_helper_method, resource, options ) do |f|
           @form_builder = f
         end
 

--- a/lib/active_admin/views/components/active_admin_form.rb
+++ b/lib/active_admin/views/components/active_admin_form.rb
@@ -27,7 +27,7 @@ module ActiveAdmin
         @resource = resource
         options = options.deep_dup
         options[:builder] ||= ActiveAdmin::FormBuilder
-        form_string = helpers.send( ActiveAdmin.application.form_helper_method, resource, options ) do |f|
+        form_string = helpers.send(ActiveAdmin.application.form_helper_method, resource, options) do |f|
           @form_builder = f
         end
 

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -110,6 +110,10 @@ RSpec.describe ActiveAdmin::Application do
       expect(application.authentication_method).to eq false
     end
 
+    it "should have a default form helper method" do
+      expect(application.form_helper_method).to eq :semantic_form_for
+    end
+
     it "should have a logout link path (Devise's default)" do
       expect(application.logout_link_path).to eq :destroy_admin_user_session_path
     end


### PR DESCRIPTION
To use SimpleForm / Formtastic / any other form system.

Usage example (with `config.form_helper_method = :simple_form_for` in the initializer):

```rb
  form builder: ::SimpleForm::FormBuilder do |f|
    f.input :published
    f.input :name
    f.input :category
    f.submit
  end
```

In my opinion another setting could be added to specify a default form builder (ActiveAdmin::FormBuilder or something else).