### PR TITLE
Add "Matches" predicate to EN.yml

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,7 @@ en:
         lteq_datetime: "Lesser or equal to"
         from: "From"
         to: "To"
+        matches: "Matches"
     search_status:
       headline: "Search status:"
       current_scope: "Scope:"


### PR DESCRIPTION
I noticed that the "Matches" filter predicate provided by Ransack is not included in the English Translation File for AA and thought that it would be useful to add.