### PR TITLE
Add better support for rendering lists

### DIFF
--- a/lib/active_admin/view_helpers/display_helper.rb
+++ b/lib/active_admin/view_helpers/display_helper.rb
@@ -69,14 +69,22 @@ module ActiveAdmin
           object.to_s
         when Date, Time
           I18n.localize object, format: active_admin_application.localize_format
+        when Array
+          format_collection(object)
         else
           if defined?(::ActiveRecord) && object.is_a?(ActiveRecord::Base) ||
              defined?(::Mongoid)      && object.class.include?(Mongoid::Document)
             auto_link object
+          elsif defined?(::ActiveRecord) && object.is_a?(ActiveRecord::Relation)
+            format_collection(object)
           else
             display_name object
           end
         end
+      end
+
+      def format_collection(collection)
+        safe_join(collection.map { |item| pretty_format(item) }, ', ')
       end
 
       def boolean_attr?(resource, attr, value)

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -13,6 +13,7 @@ create_file 'app/models/post.rb', <<-RUBY.strip_heredoc, force: true
     belongs_to :category, foreign_key: :custom_category_id
     belongs_to :author, class_name: 'User'
     has_many :taggings
+    has_many :tags, through: :taggings
     accepts_nested_attributes_for :author
     accepts_nested_attributes_for :taggings, allow_destroy: true
 
@@ -89,6 +90,8 @@ generate :model, 'store name:string'
 generate :model, 'tag name:string'
 create_file 'app/models/tag.rb', <<-RUBY.strip_heredoc, force: true
   class Tag < ActiveRecord::Base
+    has_many :taggings
+    has_many :posts, through: :taggings
   end
 RUBY
 

--- a/spec/unit/filters/resource_spec.rb
+++ b/spec/unit/filters/resource_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ActiveAdmin::Filters::ResourceExtension do
 
   it "should return the defaults if no filters are set" do
     expect(resource.filters.keys).to match_array([
-      :author, :body, :category, :created_at, :custom_created_at_searcher, :custom_title_searcher, :custom_searcher_numeric, :position, :published_date, :starred, :taggings, :title, :updated_at, :foo_id
+      :author, :body, :category, :created_at, :custom_created_at_searcher, :custom_title_searcher, :custom_searcher_numeric, :position, :published_date, :starred, :taggings, :tags, :title, :updated_at, :foo_id
     ])
   end
 
@@ -104,7 +104,7 @@ RSpec.describe ActiveAdmin::Filters::ResourceExtension do
       resource.add_filter :count, as: :string
 
       expect(resource.filters.keys).to match_array([
-        :author, :body, :category, :count, :created_at, :custom_created_at_searcher, :custom_title_searcher, :custom_searcher_numeric, :position, :published_date, :starred, :taggings, :title, :updated_at, :foo_id
+        :author, :body, :category, :count, :created_at, :custom_created_at_searcher, :custom_title_searcher, :custom_searcher_numeric, :position, :published_date, :starred, :taggings, :tags, :title, :updated_at, :foo_id
       ])
     end
 

--- a/spec/unit/view_helpers/display_helper_spec.rb
+++ b/spec/unit/view_helpers/display_helper_spec.rb
@@ -199,5 +199,26 @@ RSpec.describe ActiveAdmin::ViewHelpers::DisplayHelper do
       expect(false_value.to_s).to eq "<span class=\"status_tag no\">No</span>\n"
     end
 
+    it 'renders ActiveRecord relations as a list' do
+      tags = (1..3).map do |i|
+        Tag.create!(name: "abc#{i}")
+      end
+      post = Post.create!(tags: tags)
+
+      value = format_attribute post, :tags
+
+      expect(value.to_s).to eq "abc1, abc2, abc3"
+    end
+
+    it 'renders arrays as a list' do
+      items = (1..3).map { |i| "abc#{i}" }
+      post = Post.create!
+      allow(post).to receive(:items).and_return(items)
+
+      value = format_attribute post, :items
+
+      expect(value.to_s).to eq "abc1, abc2, abc3"
+    end
+
   end
 end


### PR DESCRIPTION
Before, lists of items (arrays and ActiveRecord relations) would render poorly. For example, if there's a `post` with tags of `[:a, :b, :c]`, then you render that with AA like so:

```rb
show do
  attributes_table do
    row :tags
  end
end
```

you'd get some thing like "Tags: Tag"

Now, it loops over those lists and joins them with a comma, so you'd get something like "Tags: a, b, c"