### PR TITLE
5369 destroy errors on nested resources

### DIFF
--- a/lib/active_admin/resource_controller/data_access.rb
+++ b/lib/active_admin/resource_controller/data_access.rb
@@ -179,7 +179,16 @@ module ActiveAdmin
       # @return [void]
       def destroy_resource(object)
         run_destroy_callbacks object do
-          object.destroy
+          if object.destroy
+            true # result used by batch delete to handle succeful and failed deletes
+          else
+            # add error message if needed.
+            # if association prevents destroy (through throw(:abort)),
+            # then the object errors array is empty
+            # to show an error flash message an error needs to be added
+            object.errors.add(:base, "Not destroyed") if object.errors.empty?
+            false
+          end
         end
       end
 


### PR DESCRIPTION
This pull-request solves a bug described in https://github.com/activeadmin/activeadmin/issues/5369
When a user tries to destroy an object, but the operation fails, for example because a throw(:abort) occurs in a before_destroy callback, without writing an error message on the object itself, then active admin will not destroy the object but it will show a positive flash message saying "Successfully deleted ....". Same happens when making a bulk delete.

In this solution the destroy outcome is checked and if it fails and the error messages are empty, then a generic error message is added, so that an error message is shown to the user instead of the wrong success message. In the case of bulk delete, successful and failed destroy operations are counted and presented to the user together, for example "Successfully destroyed 3 posts." and "Failed to destroy 2 posts.".