### PR TITLE
Relax Rails dependency for Rails 5.2.0

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'inherited_resources', '>= 1.7.0'
   s.add_dependency 'jquery-rails', '>= 4.2.0'
   s.add_dependency 'kaminari', '>= 1.0.1'
-  s.add_dependency 'railties', '>= 4.2', '< 5.2'
+  s.add_dependency 'railties', '>= 4.2', '< 6.0'
   s.add_dependency 'ransack', '>= 1.8.7'
   s.add_dependency 'sass', '~> 3.4'
   s.add_dependency 'sprockets', '>= 3.0', '< 4.1'


### PR DESCRIPTION
Rails 5.2.0 has been released!

- http://weblog.rubyonrails.org/2018/4/9/Rails-5-2-0-final/