### PR TITLE
Allow Rails 5.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ least version `1.14.3`.
 Select the Gemfile for your preferred Rails version, preferably the latest:
 
 ```sh
-export BUNDLE_GEMFILE=gemfiles/rails_51.gemfile
+export BUNDLE_GEMFILE=gemfiles/rails_52.gemfile
 ```
 
 Now install the development dependencies:

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ group :test do
   gem 'capybara', '< 3.0'
   gem 'simplecov', require: false # Test coverage generator. Go to /coverage/ after running tests
   gem 'codecov', require: false # Test coverage website. Go to https://codecov.io
-  gem 'cucumber-rails', require: false
+  gem 'cucumber-rails', '~> 1.5', require: false
   gem 'cucumber'
   gem 'database_cleaner'
   gem 'jasmine'

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'inherited_resources', '>= 1.7.0'
   s.add_dependency 'jquery-rails', '>= 4.2.0'
   s.add_dependency 'kaminari', '>= 1.0.1'
-  s.add_dependency 'railties', '>= 4.2', '< 5.2'
+  s.add_dependency 'railties', '>= 4.2', '< 5.3'
   s.add_dependency 'ransack', '>= 1.8.7'
   s.add_dependency 'sass', '~> 3.4'
   s.add_dependency 'sprockets', '>= 3.0', '< 4.1'

--- a/gemfiles/rails_52.gemfile
+++ b/gemfiles/rails_52.gemfile
@@ -4,7 +4,7 @@ eval_gemfile(File.expand_path(File.join("..", "Gemfile"), __dir__))
 
 gem "rails", "~> 5.2.x"
 gem "bootsnap"
-gem "devise", git: "https://github.com/plataformatec/devise" # https://github.com/plataformatec/devise/pull/4712
+gem "devise", "~> 4.4"
 gem "draper", "~> 3.0"
 gem "activerecord-jdbcsqlite3-adapter", "~> 51.0", platforms: :jruby
 


### PR DESCRIPTION
Allows Rails 5.2 by adjusting the restriction on railties to be `<= 5.3`.

Why 5.3? Incase there are releases between 5.2 and 6.0 that require changes to support. See discussion in #5391 and #4916.