### PR TITLE
Allow proc label in datepicker input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Master (unreleased)
 
+### Enhancements
+
+#### Minor
+
+* Allow proc label in datepicker input [#5408][] by [@tiagotex][]
+
 ### Bug fixes
 
 * Fixed the string representation of the resolved `sort_key` when no explicit
@@ -292,6 +298,7 @@ Please check [0-6-stable][] for previous changes.
 [#5401]: https://github.com/activeadmin/activeadmin/pull/5401
 [#5464]: https://github.com/activeadmin/activeadmin/pull/5464
 [#5501]: https://github.com/activeadmin/activeadmin/pull/5501
+[#5408]: https://github.com/activeadmin/activeadmin/pull/5408
 
 [@5t111111]: https://github.com/5t111111
 [@aarek]: https://github.com/aarek
@@ -324,6 +331,7 @@ Please check [0-6-stable][] for previous changes.
 [@RobinvanderVliet]: https://github.com/RobinvanderVliet
 [@seanlinsley]: https://github.com/seanlinsley
 [@shekibobo]: https://github.com/shekibobo
+[@tiagotex]: https://github.com/tiagotex
 [@timoschilling]: https://github.com/timoschilling
 [@TimPetricola]: https://github.com/TimPetricola
 [@varyonic]: https://github.com/varyonic

--- a/docs/5-forms.md
+++ b/docs/5-forms.md
@@ -168,6 +168,9 @@ form do |f|
 end
 ```
 
+Datepicker also accepts the `:label` option as a string or proc to display.
+If it's a proc, it will be called each time the datepicker is rendered.
+
 ## Displaying Errors
 
 To display a list of all validation errors:

--- a/lib/active_admin/inputs/datepicker_input.rb
+++ b/lib/active_admin/inputs/datepicker_input.rb
@@ -9,6 +9,13 @@ module ActiveAdmin
         end
       end
 
+      # Can pass proc to filter label option
+      def label_from_options
+        res = super
+        res = res.call if res.is_a? Proc
+        res
+      end
+
       private
       def datepicker_options
         options = self.options.fetch(:datepicker_options, {})

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -994,5 +994,19 @@ RSpec.describe ActiveAdmin::FormBuilder do
         expect(body.find(selector)["data-datepicker-options"]).to eq({ minDate: '2013-10-18', maxDate: '2013-12-31' }.to_json)
       end
     end
+
+    describe "with label as proc" do
+      let :body do
+        build_form do |f|
+          f.inputs do
+            f.input :created_at, as: :datepicker, label: proc { 'Title from proc' }
+          end
+        end
+      end
+
+      it "should render proper label" do
+        expect(body).to have_selector("label", text: "Title from proc")
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently datepicker input doesn't allow to pass label as a proc, this is needed when supporting multiple languages.