### PR TITLE
Fix comments on decorated objects in Rails v5.2

### DIFF
--- a/lib/active_admin/orm/active_record/comments/comment.rb
+++ b/lib/active_admin/orm/active_record/comments/comment.rb
@@ -18,7 +18,7 @@ module ActiveAdmin
     def self.find_for_resource_in_namespace(resource, namespace)
       where(
         resource_type: resource_type(resource),
-        resource_id:   resource,
+        resource_id:   resource.id,
         namespace:     namespace.to_s
       ).order(ActiveAdmin.application.namespaces[namespace.to_sym].comments_order)
     end


### PR DESCRIPTION
# Why

When upgrading from Rails 5.0 to 5.2, the call to #active_admin_comments started failing for the view action of one of my models.

This model has a decorator set using `decorate_with`, using a PORO decorator as described in the second paragraph in the decorator documentation: https://activeadmin.info/11-decorators.html. 

I have not checked if this problem exists when decorating with draper.

# What

I tracked the problem to [this line](https://github.com/activeadmin/activeadmin/pull/5409/commits/91095acfa968819560cba97377861545a5eac401#diff-4a13319c8fd818410575b542ef34be56L21), where the resource itself was being passed as a parameter, leading to unexpected behaviour when an attempt to cast the decorated object in `` `ActiveRecord::ConnectionAdapters::Quoting.type_cast``` raised a ```TypeError```.

I suspect the problem could also be fixed by adding some missing methods to the PORO decorator, but it seems like a better fix to simply pass the actual ID at this line in stead of the entire resource, eliminating the risk of similar bugs in the future.

---

How does this look to you guys?