### PR TITLE
added ability to set css class in tabs

### DIFF
--- a/lib/active_admin/views/components/tabs.rb
+++ b/lib/active_admin/views/components/tabs.rb
@@ -16,7 +16,10 @@ module ActiveAdmin
 
       def build_menu_item(title, options, &block)
         fragment = options.fetch(:id, title.parameterize)
-        li { link_to title, "##{fragment}" }
+        css_class = options.fetch(:class, '')
+        li class: css_class do 
+          link_to title, "##{fragment}"
+        end
       end
 
       def build_content_item(title, options, &block)

--- a/spec/unit/views/components/tabs_spec.rb
+++ b/spec/unit/views/components/tabs_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ActiveAdmin::Views::Tabs do
         render_arbre_component do
           tabs do
             tab :overview
-            tab I18n.t(:tab_key), { id: :something_unique }
+            tab I18n.t(:tab_key), { id: :something_unique, class: :some_css_class }
           end
         end
       end
@@ -40,6 +40,10 @@ RSpec.describe ActiveAdmin::Views::Tabs do
 
       it "should have link with fragment based on options" do
         expect(subject).to have_selector('a[href="#something_unique"]')
+      end
+
+      it "should have li with specific css class" do
+        expect(subject).to have_selector('li.some_css_class')
       end
 
     end


### PR DESCRIPTION
The reason: 
I need to set active not first tab and want to use it css class ('ui-tabs-active') for it.
It must looks like:
```ruby
tab 'Content', {class: 'ui-tabs-active'} do
  #omitted code
end
```