### PR TITLE
Fix incorrect link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Active Admin
 
-[Active Admin](https://www.activeadmin.info) is a Ruby on Rails framework for
+[Active Admin](https://activeadmin.info) is a Ruby on Rails framework for
 creating elegant backends for website administration.
 
 [![Version         ][rubygems_badge]][rubygems]


### PR DESCRIPTION
I receive a certificate error when I click the top ActiveAdmin link in the README.  It goes to https://www.activeadmin.info but I believe it should go to https://activeadmin.info .