### PR TITLE
Make all JRuby builds optional in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,4 +49,3 @@ matrix:
 
   allow_failures:
     - rvm: jruby-9.1.16.0
-      gemfile: gemfiles/rails_52.gemfile


### PR DESCRIPTION
Release 0.10.0 of jruby-openssl on 17-may-2018 causes spec/bug_report_templates_spec.rb:21 to fail with “TypeError: superclass mismatch for class Cipher” during application configuration.