### PR TITLE
(regression) Filter label can be a proc

### DIFF
--- a/lib/active_admin/filters/active_filter.rb
+++ b/lib/active_admin/filters/active_filter.rb
@@ -28,7 +28,9 @@ module ActiveAdmin
       def label
         # TODO: to remind us to go back to the simpler str.downcase once we support ruby >= 2.4 only.
         translated_predicate = predicate_name.mb_chars.downcase.to_s
-        if filter_label
+        if filter_label && filter_label.is_a?(Proc)
+          "#{filter_label.call} #{translated_predicate}"
+        elsif filter_label
           "#{filter_label} #{translated_predicate}"
         elsif related_class
           "#{related_class_name} #{translated_predicate}"

--- a/spec/unit/filters/active_filter_spec.rb
+++ b/spec/unit/filters/active_filter_spec.rb
@@ -151,6 +151,13 @@ RSpec.describe ActiveAdmin::Filters::ActiveFilter do
 
       expect(subject.label).to eq ("#{label} equals")
     end
+
+    it 'should use the filter label as the label prefix' do
+      label = proc { "#{user.first_name}'s Post Title" }
+      resource.add_filter(:title, label: label)
+
+      expect(subject.label).to eq("#{label.call} equals")
+    end
   end
 
   context "the association uses a different primary_key than the related class' primary_key" do


### PR DESCRIPTION
Label should be also consider `Procs`.

This a feature broken +v1.1.0