### PR TITLE
Added option to tweak csv_builder batch sizes

### DIFF
--- a/lib/active_admin/csv_builder.rb
+++ b/lib/active_admin/csv_builder.rb
@@ -39,13 +39,22 @@ module ActiveAdmin
       @columns << Column.new(name, @resource, column_transitive_options.merge(options), block)
     end
 
+    def page_count
+      max_page_count = @options[:max_batch_page_count] || 0
+      batch_page_count = paginated_collection.total_pages
+      batch_page_count = max_page_count if max_page_count > 0 && batch_page_count > max_page_count
+      return batch_page_count
+    end
+
     def build(controller, csv)
       @collection  = controller.send :find_collection, except: :pagination
       columns      = exec_columns controller.view_context
       options      = ActiveAdmin.application.csv_options.merge self.options
       bom          = options.delete :byte_order_mark
       column_names = options.delete(:column_names) { true }
-      csv_options  = options.except :encoding_options, :humanize_name
+      csv_options  = options.except(
+        :encoding_options, :humanize_name, :batch_size, :max_batch_page_count
+      )
 
       csv << bom if bom
 
@@ -54,7 +63,7 @@ module ActiveAdmin
       end
 
       ActiveRecord::Base.uncached do
-        (1..paginated_collection.total_pages).each do |page|
+        (1..page_count).each do |page|
           paginated_collection(page).each do |resource|
             resource = controller.send :apply_decorator, resource
             csv << CSV.generate_line(build_row(resource, columns, options), csv_options)
@@ -125,7 +134,9 @@ module ActiveAdmin
     end
 
     def batch_size
-      1000
+      batch_size = @options[:batch_size] || 1000
+      batch_size = 1 if batch_size < 1
+      return batch_size
     end
   end
 end


### PR DESCRIPTION
My first pull request ever. If I missed something please tell me! I haven't created an issue for this but since I already made a hack for it in a project I thought I should pull request it.

This is an update to the csv_builder. By default the csv_builder have a static batch_size of 1000 and always writes all data to file. I think this is a good default and have not changed the default behavior. In some cases though it might be a good idea to ensure that the feature does not impact performance of the server for the regular users while the admin user wants a csv file made. To enforce this changing the batch_size and adding a max_batch_page_count option so that a concise number of records cannot be exceeded and therefore only impacts the server in a predictive manner for a predictive amount of time.

Specifications:
max_batch_page_count:
  if negative, 0 or nil the default behavior of writing all batches
  otherwise the amount of batches made cannot exceed the number given
batch_size:
  if negative, 0 or nil the default of 1000 records
  otherwise the number given is the assigned as the size of the batches 

Edit: Updated specification