### PR TITLE
Update Policy template

### DIFF
--- a/spec/support/templates/policies/active_admin/comment_policy.rb
+++ b/spec/support/templates/policies/active_admin/comment_policy.rb
@@ -1,6 +1,6 @@
 module ActiveAdmin
   class CommentPolicy < ApplicationPolicy
-    class Scope < Struct.new(:user, :scope)
+    class Scope < Scope
       def resolve
         scope
       end

--- a/spec/support/templates/policies/active_admin/page_policy.rb
+++ b/spec/support/templates/policies/active_admin/page_policy.rb
@@ -1,6 +1,6 @@
 module ActiveAdmin
   class PagePolicy < ApplicationPolicy
-    class Scope < Struct.new(:user, :scope)
+    class Scope < Scope
       def resolve
         scope
       end

--- a/spec/support/templates/policies/admin_user_policy.rb
+++ b/spec/support/templates/policies/admin_user_policy.rb
@@ -1,5 +1,5 @@
 class AdminUserPolicy < ApplicationPolicy
-  class Scope < Struct.new(:user, :scope)
+  class Scope < Scope
     def resolve
       scope
     end

--- a/spec/support/templates/policies/application_policy.rb
+++ b/spec/support/templates/policies/application_policy.rb
@@ -41,4 +41,17 @@ class ApplicationPolicy
   def scope
     Pundit.policy_scope!(user, record.class)
   end
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope
+    end
+  end
 end

--- a/spec/support/templates/policies/category_policy.rb
+++ b/spec/support/templates/policies/category_policy.rb
@@ -1,5 +1,5 @@
 class CategoryPolicy < ApplicationPolicy
-  class Scope < Struct.new(:user, :scope)
+  class Scope < Scope
     def resolve
       scope
     end

--- a/spec/support/templates/policies/post_policy.rb
+++ b/spec/support/templates/policies/post_policy.rb
@@ -1,5 +1,5 @@
 class PostPolicy < ApplicationPolicy
-  class Scope < Struct.new(:user, :scope)
+  class Scope < Scope
     def resolve
       scope
     end

--- a/spec/support/templates/policies/store_policy.rb
+++ b/spec/support/templates/policies/store_policy.rb
@@ -1,5 +1,5 @@
 class StorePolicy < ApplicationPolicy
-  class Scope < Struct.new(:user, :scope)
+  class Scope < Scope
     def resolve
       scope
     end

--- a/spec/support/templates/policies/user_policy.rb
+++ b/spec/support/templates/policies/user_policy.rb
@@ -1,5 +1,5 @@
 class UserPolicy < ApplicationPolicy
-  class Scope < Struct.new(:user, :scope)
+  class Scope < Scope
     def resolve
       scope
     end


### PR DESCRIPTION
Pundit gem's policy template has replace ` Scope < Struct.new(:user, :scope)`  with `Scope class`, so I update ActiveAdmin's policy template.

ref:
- https://github.com/varvet/pundit#scopes
- [pundit's application policy template](https://github.com/varvet/pundit/blob/master/lib/generators/pundit/install/templates/application_policy.rb#L37-L48)