### PR TITLE
Update 5-forms.md

### DIFF
--- a/docs/5-forms.md
+++ b/docs/5-forms.md
@@ -107,7 +107,7 @@ ActiveAdmin.register Post do
     f.inputs do
       f.has_many :comment,
                  new_record: 'Leave Comment',
-                 allow_destroy: -> { |c| c.author?(current_admin_user) } do |b|
+                 allow_destroy: -> (c) { c.author?(current_admin_user) } do |b|
         b.input :body
       end
     end


### PR DESCRIPTION
Using the `allow_destroy` option with a Proc object as documented leads into a syntax error.