### PR TITLE
Fix resource filtering by association when the resource has custom primary key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   [@chumakoff][]
 * Fixed `if:` scope option when a lambda is passed [#5501][] by [@deivid-rodriguez][]
 * Comment validation adding redundant errors when resource is missing [#5516][] by [@deivid-rodriguez][]
+* Fixed resource filtering by association when the resource has custom primary key [#5446][] by [@wasifhossain][]
 
 ## 1.3.0 [☰](https://github.com/activeadmin/activeadmin/compare/v1.2.1...v1.3.0)
 
@@ -297,6 +298,7 @@ Please check [0-6-stable][] for previous changes.
 [#5343]: https://github.com/activeadmin/activeadmin/pull/5343
 [#5399]: https://github.com/activeadmin/activeadmin/pull/5399
 [#5401]: https://github.com/activeadmin/activeadmin/pull/5401
+[#5446]: https://github.com/activeadmin/activeadmin/pull/5446
 [#5464]: https://github.com/activeadmin/activeadmin/pull/5464
 [#5501]: https://github.com/activeadmin/activeadmin/pull/5501
 [#5408]: https://github.com/activeadmin/activeadmin/pull/5408
@@ -337,5 +339,6 @@ Please check [0-6-stable][] for previous changes.
 [@timoschilling]: https://github.com/timoschilling
 [@TimPetricola]: https://github.com/TimPetricola
 [@varyonic]: https://github.com/varyonic
+[@wasifhossain]: https://github.com/wasifhossain
 [@wspurgin]: https://github.com/wspurgin
 [@zorab47]: https://github.com/zorab47

--- a/lib/active_admin/filters/active_filter.rb
+++ b/lib/active_admin/filters/active_filter.rb
@@ -102,7 +102,7 @@ module ActiveAdmin
 
       def related_primary_key
         if predicate_association
-          predicate_association.active_record_primary_key
+          predicate_association.association_primary_key
         elsif related_class
           related_class.primary_key
         end

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -92,7 +92,7 @@ create_file 'app/models/category.rb', <<-RUBY.strip_heredoc, force: true
   end
 RUBY
 
-generate :model, 'store name:string'
+generate :model, 'store name:string user_id:integer'
 
 generate :model, 'tag name:string'
 create_file 'app/models/tag.rb', <<-RUBY.strip_heredoc, force: true

--- a/spec/unit/filters/active_filter_spec.rb
+++ b/spec/unit/filters/active_filter_spec.rb
@@ -193,4 +193,33 @@ RSpec.describe ActiveAdmin::Filters::ActiveFilter do
     end
   end
 
+  context 'when the resource has a custom primary key' do
+    let(:resource_klass) do
+      Class.new(Store) do
+        self.primary_key = 'name'
+        belongs_to :user
+
+        def self.name
+          'SubStore'
+        end
+      end
+    end
+
+    let(:resource) do
+      namespace.register(resource_klass)
+    end
+
+    let(:user) { User.create! first_name: 'John', last_name: 'Doe' }
+    let(:store) { resource_klass.create! name: 'Store 1', user_id: user.id }
+
+    let(:search) do
+      resource_klass.ransack(user_id_eq: user.id)
+    end
+
+    it "should use the association's primary key to find the associated record" do
+      allow(ActiveSupport::Dependencies).to receive(:constantize).with("::#{resource_klass.name}").and_return(resource_klass)
+
+      expect(subject.values.first).to eq user
+    end
+  end
 end


### PR DESCRIPTION
## Scenario

Given a resource (`Product`) has a custom primary key (`:sku`) and it has a `belongs_to` association (`Brand`) which is available in the filter, if we filter products by a brand, https://github.com/activeadmin/activeadmin/pull/5223 (introduced in `1.2.0`) throws an error:

```
ActionView::Template::Error: PG::UndefinedColumn: ERROR: column brands.sku does not exist 
LINE 1: SELECT "brands".* FROM "brands" WHERE "brands"."sku" = '36'
```

This PR uses `predicate_association.association_primary_key` instead of `predicate_association.active_record_primary_key`, which returns the primary key of the association (Brand) instead of the resource (Product), that will generate the desired query:

```
SELECT "brands".* FROM "brands" WHERE "brands"."id" = '36'
```
