### PR TITLE
Backport ransack dependency

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,8 +2,8 @@
 
 AllCops:
   DisabledByDefault: true
-  TargetRubyVersion: 2.2
-  
+  TargetRubyVersion: 2.3
+
   Exclude:
     - spec/rails/**/*
     - gemfiles/vendor/bundle/**/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ script:
 
 rvm:
   - jruby-9.1.15.0
-  - 2.2.8
-  - 2.3.5
-  - 2.4.2
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
 
 gemfile:
   - gemfiles/rails_42.gemfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.3.1 [☰](https://github.com/activeadmin/activeadmin/compare/v1.3.0...v1.3.1)
+### Bug Fixes
+
+* gemspec should have more permissive ransack dependency [#][] by [@varyonic][5447]
+
 ## 1.3.0 [☰](https://github.com/activeadmin/activeadmin/compare/v1.2.1...v1.3.0)
 
 ### Enhancements

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -22,11 +22,11 @@ Gem::Specification.new do |s|
   s.add_dependency 'coffee-rails'
   s.add_dependency 'formtastic', '~> 3.1'
   s.add_dependency 'formtastic_i18n'
-  s.add_dependency 'inherited_resources', '>= 1.7.0'
+  s.add_dependency 'inherited_resources', '>= 1.9.0'
   s.add_dependency 'jquery-rails', '>= 4.2.0'
   s.add_dependency 'kaminari', '>= 0.15'
   s.add_dependency 'railties', '>= 4.2', '< 5.3'
-  s.add_dependency 'ransack', '~> 1.3'
+  s.add_dependency 'ransack', '>= 1.8.7'
   s.add_dependency 'sass', '~> 3.1'
   s.add_dependency 'sprockets', '< 4.1'
 end

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.test_files = `git ls-files -- {spec,features}/*`.split("\n")
 
-  s.required_ruby_version = '>= 2.2'
+  s.required_ruby_version = '>= 2.3'
 
   s.add_dependency 'arbre', '>= 1.1.1'
   s.add_dependency 'coffee-rails'

--- a/gemfiles/rails_42.gemfile
+++ b/gemfiles/rails_42.gemfile
@@ -2,8 +2,8 @@ source "https://rubygems.org"
 
 eval_gemfile(File.expand_path(File.join("..", "Gemfile"), __dir__))
 
-gem "rails", "4.2.8"
-gem "devise", "~> 3.5"
+gem "rails", "4.2.10"
+gem "devise", "~> 4.4" # required for Ruby 2.5, see devise/issues/4736
 gem "draper", "~> 2.1"
 gem "activerecord-jdbcsqlite3-adapter", platforms: :jruby
 

--- a/gemfiles/rails_50.gemfile
+++ b/gemfiles/rails_50.gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 eval_gemfile(File.expand_path(File.join("..", "Gemfile"), __dir__))
 
-gem "rails", "5.0.3"
+gem "rails", "5.0.7"
 gem "devise", "~> 4.0"
 gem "draper", "~> 3.0"
 gem "activerecord-jdbcsqlite3-adapter", github: "jruby/activerecord-jdbc-adapter", platforms: :jruby

--- a/gemfiles/rails_51.gemfile
+++ b/gemfiles/rails_51.gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 eval_gemfile(File.expand_path(File.join("..", "Gemfile"), __dir__))
 
-gem "rails", "5.1.1"
+gem "rails", "5.1.6"
 gem "devise", "~> 4.3"
 gem "draper", "~> 3.0"
 gem "activerecord-jdbcsqlite3-adapter", github: "jruby/activerecord-jdbc-adapter", platforms: :jruby

--- a/gemfiles/rails_52.gemfile
+++ b/gemfiles/rails_52.gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 eval_gemfile(File.expand_path(File.join("..", "Gemfile"), __dir__))
 
-gem "rails", "~> 5.2.x"
+gem "rails", "5.2.1"
 gem "bootsnap"
 gem "devise", "~> 4.4"
 gem "draper", "~> 3.0"

--- a/lib/active_admin/version.rb
+++ b/lib/active_admin/version.rb
@@ -1,3 +1,3 @@
 module ActiveAdmin
-  VERSION = '1.3.0'
+  VERSION = '1.3.1'
 end


### PR DESCRIPTION
Fixes #5447  Tested against updated Rubies and Rails patch releases.  Drops Ruby 2.2 support.