### PR TITLE
Disable destroy buttons in has_many_form if false is passed as an option

### DIFF
--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -107,7 +107,7 @@ module ActiveAdmin
     end
 
     def has_many_actions(form_builder, contents)
-      if form_builder.object.new_record?
+      if form_builder.object.new_record? && builder_options[:allow_destroy] != false
         contents << template.content_tag(:li) do
           remove_text = remove_record.is_a?(String) ? remove_record : I18n.t("active_admin.has_many_remove")
           template.link_to remove_text, "#", class: "button has_many_remove"


### PR DESCRIPTION
Don't create "remove buttons" on has_many forms when build_options gets passed `allow_destroy: false`, even on `.new_record?`s.
Rationale: You might have new records with children already populated and don't want the user to change their count.