### PR TITLE
I18n for Comments

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,20 @@
 en:
+  activerecord:
+    models:
+      comment: "Comment"
+      active_admin/comment:
+        one: "Comment"
+        other: "Comments"
+    attributes:
+      active_admin/comment:
+        author_type: "Author type"
+        body: "Body"
+        created_at: "Created"
+        namespace: "Namespace"
+        resource_type: "Resource type"
+        updated_at: "Updated"
   active_admin:
-    dashboard: Dashboard
+    dashboard: "Dashboard"
     dashboard_welcome:
       welcome: "Welcome to Active Admin. This is the default dashboard page."
       call_to_action: "To add dashboard sections, checkout 'app/admin/dashboard.rb'"
@@ -37,6 +51,8 @@ en:
         lteq_datetime: "Lesser or equal to"
         from: "From"
         to: "To"
+    scopes:
+      all: "All"
     search_status:
       headline: "Search status:"
       current_scope: "Scope:"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,6 +1,20 @@
 es:
+  activerecord:
+    models:
+      comment: "Comentario"
+      active_admin/comment:
+        one: "Comentario"
+        other: "Comentarios"
+    attributes:
+      active_admin/comment:
+        namespace: "Espacio de nombres"
+        body: "Cuerpo"
+        resource_type: "Tipo de recurso"
+        author_type: "Tipo de autor"
+        created_at: "Fecha de creación"
+        updated_at: "Fecha de actualización"
   active_admin:
-    dashboard: Inicio
+    dashboard: "Inicio"
     dashboard_welcome:
       welcome: "Bienvenido a Active Admin. Esta es la página de inicio predeterminada."
       call_to_action: "Para agregar secciones edite 'app/admin/dashboard.rb'"
@@ -37,6 +51,8 @@ es:
         lteq_datetime: "Menor o igual que"
         from: "Desde"
         to: "Hasta"
+    scopes:
+      all: "Todos"
     search_status:
       headline: "Estado de la búsqueda:"
       current_scope: "Alcance:"

--- a/lib/active_admin/orm/active_record/comments.rb
+++ b/lib/active_admin/orm/active_record/comments.rb
@@ -17,6 +17,17 @@ ActiveAdmin.application.view_factory.show_page.send :include, ActiveAdmin::Comme
 # Load the model as soon as it's referenced. By that point, Rails & Kaminari will be ready
 ActiveAdmin.autoload :Comment, 'active_admin/orm/active_record/comments/comment'
 
+# Hint i18n-tasks about model and attribute translations used by default install
+# i18n-tasks-use t('activerecord.models.comment')
+# i18n-tasks-use t('activerecord.models.active_admin/comment')
+# i18n-tasks-use t('activerecord.attributes.active_admin/comment.author_type')
+# i18n-tasks-use t('activerecord.attributes.active_admin/comment.body')
+# i18n-tasks-use t('activerecord.attributes.active_admin/comment.created_at')
+# i18n-tasks-use t('activerecord.attributes.active_admin/comment.namespace')
+# i18n-tasks-use t('activerecord.attributes.active_admin/comment.resource_type')
+# i18n-tasks-use t('activerecord.attributes.active_admin/comment.updated_at')
+# i18n-tasks-use t('active_admin.scopes.all')
+
 # Walk through all the loaded namespaces after they're loaded
 ActiveAdmin.after_load do |app|
   app.namespaces.each do |namespace|


### PR DESCRIPTION
I wanted to have a default installation (i.e. with comments enabled) translated by default, so I added what was missing.

This repetition:

        comment: "Comment"
        active_admin/comment: "Comment"

is needed because `comments_registration_name` is `Comment` so it looks it up without namespace for title and menu translation. The rest is used by filters and scopes generated in the index.

I added [hints](https://github.com/glebm/i18n-tasks#fine-tuning) for **i18n-tasks** about those ActiveRecord-related strings in the comments file so it can report them as missing when using `i18n-tasks missing`.