### PR TITLE
Titles are also generated with count: PLURAL_MANY_COUNT

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,7 +1,9 @@
 en:
   activerecord:
     models:
-      comment: "Comment"
+      comment:
+        one: "Comment"
+        other: "Comments"
       active_admin/comment:
         one: "Comment"
         other: "Comments"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,7 +1,9 @@
 es:
   activerecord:
     models:
-      comment: "Comentario"
+      comment:
+        one: "Comentario"
+        other: "Comentarios"
       active_admin/comment:
         one: "Comentario"
         other: "Comentarios"


### PR DESCRIPTION
This is a minor follow up for #5458 , I missed the fact that menu titles are generated with

    `count: ::ActiveAdmin::Helpers::I18n::PLURAL_MANY_COUNT`

...so this model name also needed `one`/`other` strings.

Sorry for the inconvenience!