### PR TITLE
Stop passing Proc as sort_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Bug fixes
 
+* Fixed the string representation of the resolved `sort_key` when no explicit `sortable` attribute is passed [#5464][] by [@chumakoff][]
+* Fixed docs on the column `sortable` attribute (which actually doesn't have to be explicitly specified when a block is passed to column) [#5464][] by [@chumakoff][]
+
 ## 1.3.0 [☰](https://github.com/activeadmin/activeadmin/compare/v1.2.1...v1.3.0)
 
 ### Enhancements

--- a/docs/3-index-pages/index-as-table.md
+++ b/docs/3-index-pages/index-as-table.md
@@ -131,9 +131,7 @@ When a column is generated from an Active Record attribute, the table is
 sortable by default. If you are creating a custom column, you may need to give
 Active Admin a hint for how to sort the table.
 
-If a column is defined using a block, you must pass the key to turn on sorting. The key
-is the attribute which gets used to sort objects using Active Record.
-
+You can pass the key specifying the attribute which gets used to sort objects using Active Record.
 By default, this is the column on the resource's table that the attribute corresponds to.
 Otherwise, any attribute that the resource collection responds to can be used.
 

--- a/lib/active_admin/views/components/table_for.rb
+++ b/lib/active_admin/views/components/table_for.rb
@@ -176,18 +176,9 @@ module ActiveAdmin
         # to the sortable option:
         #   column :username, sortable: 'other_column_to_sort_on'
         #
-        # If you pass a block to be rendered for this column, the column
-        # will not be sortable unless you pass a string to sortable to
-        # sort the column on:
-        #
-        #   column('Username', sortable: 'login'){ @user.pretty_name }
-        #   # => Sort key will be 'login'
-        #
         def sort_key
           # If boolean or nil, use the default sort key.
-          if @options[:sortable] == true || @options[:sortable] == false
-            @data.to_s
-          elsif @options[:sortable].nil?
+          if @options[:sortable].nil? || @options[:sortable] == true || @options[:sortable] == false
             sort_column_name
           else
             @options[:sortable].to_s

--- a/lib/active_admin/views/index_as_table.rb
+++ b/lib/active_admin/views/index_as_table.rb
@@ -130,9 +130,7 @@ module ActiveAdmin
     # sortable by default. If you are creating a custom column, you may need to give
     # Active Admin a hint for how to sort the table.
     #
-    # If a column is defined using a block, you must pass the key to turn on sorting. The key
-    # is the attribute which gets used to sort objects using Active Record.
-    #
+    # You can pass the key specifying the attribute which gets used to sort objects using Active Record.
     # By default, this is the column on the resource's table that the attribute corresponds to.
     # Otherwise, any attribute that the resource collection responds to can be used.
     #

--- a/spec/unit/views/components/table_for_spec.rb
+++ b/spec/unit/views/components/table_for_spec.rb
@@ -376,6 +376,11 @@ RSpec.describe ActiveAdmin::Views::TableFor do
     context "when a block given with no sort key" do
       let(:table_column){ build_column("Username"){ } }
       it { is_expected.to be_sortable }
+
+      describe '#sort_key' do
+        subject { super().sort_key }
+        it { is_expected.to eq("Username") }
+      end
     end
 
     context "when a block given with a sort key" do


### PR DESCRIPTION
**First**

https://github.com/activeadmin/activeadmin/blob/ac5481c9bc2db03bb5bfb6516c1b2fb1fe1b710c/lib/active_admin/views/components/table_for.rb#L179
```
        # If you pass a block to be rendered for this column, the column
        # will not be sortable unless you pass a string to sortable to
        # sort the column on:
        #
        #   column('Username', sortable: 'login'){ @user.pretty_name }
        #   # => Sort key will be 'login'
        #
        def sort_key
```

This hasn't been true since https://github.com/activeadmin/activeadmin/commit/b9a84532b04880319670e8bd97f65b57806cda17

Confirmed by this test: https://github.com/activeadmin/activeadmin/blob/ac5481c9bc2db03bb5bfb6516c1b2fb1fe1b710c/spec/unit/views/components/table_for_spec.rb#L376

I removed the comment, as `:sort_key` resolution now doesn't depend on whether the block is passed to the `:column` method or not.

**Second**

There is a related problem. If a proc is passed to the `:column` method and `:sortable` option is boolean, then `:sort_key` is set to the string representation of the proc (something like `"Proc:0x00007fb3c40c8080@/home/user_name/app_folder/app/admin/model_name.rb:99_method_name"`). 

So, the same value is present in the url as the `order` parameter value:

`http://host/admin/model_name?order=Proc:0x00007fb3c40c8080@/home/user_name/app_folder/app/admin/model_name.rb:99_method_name`