### PR TITLE
Remove chromedriver-helper dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ bundler_args: --without development
 cache: bundler
 
 before_script:
+  - bin/install_chromedriver.sh
   - unset _JAVA_OPTIONS
 
 before_install:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,9 @@ git checkout -b 325-add-japanese-translations
 Make sure you're using a recent ruby and have the `bundler` gem installed, at
 least version `1.14.3`.
 
+You'll also need chrome and [chromedriver] installed in order to run cucumber
+scenarios.
+
 Select the Gemfile for your preferred Rails version, preferably the latest:
 
 ```sh
@@ -189,6 +192,7 @@ Maintainers need to do the following to push out a release:
 
 * `bundle exec rake release`
 
+[chromedriver]: https://sites.google.com/a/chromium.org/chromedriver/getting-started
 [mailing list]: http://groups.google.com/group/activeadmin
 [Stack Overflow]: http://stackoverflow.com/questions/tagged/activeadmin
 [search the issue tracker]: https://github.com/activeadmin/activeadmin/issues?q=something

--- a/Gemfile
+++ b/Gemfile
@@ -50,5 +50,4 @@ group :test do
   gem 'shoulda-matchers', '<= 2.8.0'
   gem 'sqlite3', platforms: :mri
   gem 'selenium-webdriver'
-  gem 'chromedriver-helper', '1.1.0' # 1.2 causing build failure with JRuby.
 end

--- a/bin/install_chromedriver.sh
+++ b/bin/install_chromedriver.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -euo pipefail
+
+curl --silent \
+     --show-error \
+     --location \
+     --fail \
+     --retry 3 \
+     --output /tmp/chromedriver_linux64.zip \
+     https://chromedriver.storage.googleapis.com/2.38/chromedriver_linux64.zip
+
+unzip /tmp/chromedriver_linux64.zip chromedriver -d ~/.local/bin
+
+rm /tmp/chromedriver_linux64.zip
+
+chromedriver --version


### PR DESCRIPTION
This gem currently has a hard to debug [issue](https://github.com/flavorjones/chromedriver-helper/issues/57), which makes installing it break _other_ projects's specs which use `chromedriver` but don't use the `chromedriver-helper` gem.

Also, we're pinning it already because of other issues.

And finally, we sometimes get some weird spec failures when `chromedriver` fails to start, so who knows if this will also fix that.

This gem does very little (download a binary and put it in your path), I don't think it's worth using it.