### PR TITLE
Build only protected branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ addons:
     packages:
       - google-chrome-stable
 
+branches:
+  only:
+    - master
+    - 1-4-stable
+
 language: ruby
 
 sudo: false


### PR DESCRIPTION
To save CI resources and not have to wait so much for PRs to get green.

We briefly enabled this kind of setting but decided to remove it again in https://github.com/activeadmin/activeadmin/pull/5126. The reason for reverting it was that it is what Rails does. However, this is not actually true, as can be seen by checking a random Rails PR and observing it only has a single TravisCI check (continuous-integration/travis-ci/pr). It _is_ true that they don't have this setting in the TravisCI config, but they probably have it configured in TravisCI UI.

I propose to restore the old way, because it saves quite a bit of CI time.

The only gotcha of this approach that I know of is that in some case you want a feature branch tested on TravisCI without opening a PR for it, you need to temporarily add the branch to the CI config. In my opinion, the regular time savings are worth this little inconvenience!