### PR TITLE
Backport phantomjs removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,6 @@ spec/rails
 *.sqlite3-journal
 Gemfile.lock
 gemfiles/rails_[3-5][0-9].gemfile.lock
-capybara*
-viewcumber
 .test-rails-apps
 public
 .rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 ---
 
+addons:
+  chrome: stable
+
 language: ruby
 
 sudo: false
@@ -14,8 +17,6 @@ before_script:
   - unset _JAVA_OPTIONS
 
 before_install:
-  - PATH=$(npm bin):$PATH # needed to install phantomjs via npm
-  - if [ $(phantomjs --version) != '2.1.1' ]; then npm install phantomjs-prebuilt@2.1; fi
   - gem update --system # use the very latest Rubygems
   - gem install bundler # use the very latest Bundler
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ bundler_args: --without development
 cache: bundler
 
 before_script:
+  - bin/install_chromedriver.sh
   - unset _JAVA_OPTIONS
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 ---
 
 addons:
-  chrome: stable
+  apt:
+    packages:
+      - google-chrome-stable
 
 language: ruby
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,9 @@ git checkout -b 325-add-japanese-translations
 Make sure you're using a recent ruby and have the `bundler` gem installed, at
 least version `1.14.3`.
 
+You'll also need chrome and [chromedriver] installed in order to run cucumber
+scenarios.
+
 Select the Gemfile for your preferred Rails version, preferably the latest:
 
 ```sh
@@ -170,6 +173,7 @@ A PR can only be merged into master by a maintainer if:
 Any maintainer is allowed to merge a PR if all of these conditions are
 met.
 
+[chromedriver]: https://sites.google.com/a/chromium.org/chromedriver/getting-started
 [mailing list]: http://groups.google.com/group/activeadmin
 [Stack Overflow]: http://stackoverflow.com/questions/tagged/activeadmin
 [search the issue tracker]: https://github.com/activeadmin/activeadmin/issues?q=something

--- a/Gemfile
+++ b/Gemfile
@@ -48,5 +48,6 @@ group :test do
   gem 'i18n-spec'
   gem 'shoulda-matchers', '<= 2.8.0'
   gem 'sqlite3', platforms: :mri
-  gem 'poltergeist'
+  gem 'selenium-webdriver'
+  gem 'chromedriver-helper'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -49,5 +49,4 @@ group :test do
   gem 'shoulda-matchers', '<= 2.8.0'
   gem 'sqlite3', platforms: :mri
   gem 'selenium-webdriver'
-  gem 'chromedriver-helper'
 end

--- a/bin/install_chromedriver.sh
+++ b/bin/install_chromedriver.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -euo pipefail
+
+curl --silent \
+     --show-error \
+     --location \
+     --fail \
+     --retry 3 \
+     --output /tmp/chromedriver_linux64.zip \
+     https://chromedriver.storage.googleapis.com/2.38/chromedriver_linux64.zip
+
+unzip /tmp/chromedriver_linux64.zip chromedriver -d ~/.local/bin
+
+rm /tmp/chromedriver_linux64.zip
+
+chromedriver --version

--- a/features/step_definitions/batch_action_steps.rb
+++ b/features/step_definitions/batch_action_steps.rb
@@ -58,9 +58,6 @@ Given /^I submit the batch action form with "([^"]*)"$/ do |action|
 end
 
 When /^I click "(.*?)" and accept confirmation$/ do |link|
-  # Use this implementation instead if poltergeist ever implements it
-  # page.driver.accept_modal(:confirm) { click_link(link) }
-
   click_link(link)
   expect(page).to have_content("Are you sure you want to delete these posts?")
   click_button("OK")

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -52,7 +52,15 @@ require 'capybara/cucumber'
 require 'capybara/session'
 require 'selenium-webdriver'
 
-Capybara.javascript_driver = :selenium_chrome_headless
+# copied from https://about.gitlab.com/2017/12/19/moving-to-headless-chrome/
+Capybara.register_driver :chrome do |app|
+  options = Selenium::WebDriver::Chrome::Options.new(
+    args: %w[headless disable-gpu no-sandbox]
+  )
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+end
+
+Capybara.javascript_driver = :chrome
 
 # Capybara defaults to XPath selectors rather than Webrat's default of CSS3. In
 # order to ease the transition to Capybara we set the default here. If you'd

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -50,10 +50,9 @@ end
 require 'capybara/rails'
 require 'capybara/cucumber'
 require 'capybara/session'
-require 'capybara/poltergeist'
-require 'phantomjs/poltergeist'
+require 'selenium-webdriver'
 
-Capybara.javascript_driver = :poltergeist
+Capybara.javascript_driver = :selenium_chrome_headless
 
 # Capybara defaults to XPath selectors rather than Webrat's default of CSS3. In
 # order to ease the transition to Capybara we set the default here. If you'd


### PR DESCRIPTION
I want to backport the removal of `phantomjs` to 1-4-stable in order to avoid potential discrepancies between tests on master and tests here.