### PR TITLE
Remove unnecessary requires

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,6 @@ spec/rails
 *.sqlite3-journal
 .test-rails-apps
 public
-.rspec
 .rspec_failures
 .rails-version
 .rbenv-version

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require rails_helper

--- a/.simplecov
+++ b/.simplecov
@@ -1,6 +1,3 @@
-# TODO: Always run simplecov again once
-# https://github.com/colszowka/simplecov/issues/404,
-# https://github.com/glebm/i18n-tasks/issues/221 are fixed
 SimpleCov.start do
   add_filter 'spec/rails/'
 end

--- a/spec/bug_report_templates_spec.rb
+++ b/spec/bug_report_templates_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe 'bug_report_templates' do
   subject do
     Bundler.with_original_env do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -19,16 +19,9 @@ ActiveAdmin.application.authentication_method = false
 ActiveAdmin.application.current_user_method = false
 
 RSpec.configure do |config|
-  config.disable_monkey_patching!
   config.use_transactional_fixtures = true
   config.use_instantiated_fixtures = false
   config.render_views = false
-  config.filter_run focus: true
-  config.filter_run_excluding skip: true
-  config.run_all_when_everything_filtered = true
-  config.color = true
-  config.order = :random
-  config.example_status_persistence_file_path = ".rspec_failures"
 
   devise = ActiveAdmin::Dependency.devise >= '4.2' ? Devise::Test::ControllerHelpers : Devise::TestHelpers
   config.include devise, type: :controller

--- a/spec/requests/default_namespace_spec.rb
+++ b/spec/requests/default_namespace_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Application, type: :request do
 
   include Rails.application.routes.url_helpers

--- a/spec/requests/memory_spec.rb
+++ b/spec/requests/memory_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe "Memory Leak", type: :request, if: RUBY_ENGINE == 'ruby' do
   before do
     load_defaults!

--- a/spec/requests/stylesheets_spec.rb
+++ b/spec/requests/stylesheets_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe "Stylesheets", type: :request do
 
   require "sprockets"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,11 @@
 require 'simplecov' if ENV["COVERAGE"] == "true"
+
+RSpec.configure do |config|
+  config.disable_monkey_patching!
+  config.filter_run focus: true
+  config.filter_run_excluding skip: true
+  config.run_all_when_everything_filtered = true
+  config.color = true
+  config.order = :random
+  config.example_status_persistence_file_path = ".rspec_failures"
+end

--- a/spec/unit/abstract_view_factory_spec.rb
+++ b/spec/unit/abstract_view_factory_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 require 'active_admin/abstract_view_factory'
 
 RSpec.describe ActiveAdmin::AbstractViewFactory do

--- a/spec/unit/action_builder_spec.rb
+++ b/spec/unit/action_builder_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe 'defining actions from registration blocks', type: :controller do
   let(:klass){ Admin::PostsController }
 

--- a/spec/unit/active_admin_spec.rb
+++ b/spec/unit/active_admin_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin do
   %w(register register_page unload! load! routes).each do |method|
     it "delegates ##{method} to application" do

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -1,4 +1,3 @@
-require 'rails_helper'
 require 'fileutils'
 
 RSpec.describe ActiveAdmin::Application do

--- a/spec/unit/asset_registration_spec.rb
+++ b/spec/unit/asset_registration_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::AssetRegistration do
   include ActiveAdmin::AssetRegistration
 

--- a/spec/unit/authorization/authorization_adapter_spec.rb
+++ b/spec/unit/authorization/authorization_adapter_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::AuthorizationAdapter do
 
   let(:adapter) { ActiveAdmin::AuthorizationAdapter.new(double, double) }

--- a/spec/unit/authorization/controller_authorization_spec.rb
+++ b/spec/unit/authorization/controller_authorization_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe "Controller Authorization", type: :controller do
 
   let(:authorization){ controller.send(:active_admin_authorization) }

--- a/spec/unit/authorization/index_overriding_spec.rb
+++ b/spec/unit/authorization/index_overriding_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe 'Index overriding', type: :controller do
   before do
     load_resources { ActiveAdmin.register Post }

--- a/spec/unit/auto_link_spec.rb
+++ b/spec/unit/auto_link_spec.rb
@@ -1,4 +1,3 @@
-require 'rails_helper'
 require 'active_admin/view_helpers/active_admin_application_helper'
 require 'active_admin/view_helpers/auto_link_helper'
 require 'active_admin/view_helpers/display_helper'

--- a/spec/unit/batch_actions/resource_spec.rb
+++ b/spec/unit/batch_actions/resource_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::BatchActions::ResourceExtension do
 
   let(:resource) do

--- a/spec/unit/batch_actions/settings_spec.rb
+++ b/spec/unit/batch_actions/settings_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe "Batch Actions Settings" do
   let(:app) { ActiveAdmin::Application.new }
   let(:ns) { ActiveAdmin::Namespace.new(app, "Admin") }

--- a/spec/unit/belongs_to_spec.rb
+++ b/spec/unit/belongs_to_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Resource::BelongsTo do
   before do
     load_resources do

--- a/spec/unit/cancan_adapter_spec.rb
+++ b/spec/unit/cancan_adapter_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::CanCanAdapter do
 
   describe "full integration" do

--- a/spec/unit/comments_spec.rb
+++ b/spec/unit/comments_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe "Comments" do
   let(:application) { ActiveAdmin::Application.new }
 

--- a/spec/unit/component_spec.rb
+++ b/spec/unit/component_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 class MockComponentClass < ActiveAdmin::Component; end
 
 RSpec.describe ActiveAdmin::Component do

--- a/spec/unit/controller_filters_spec.rb
+++ b/spec/unit/controller_filters_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Application do
   let(:application){ ActiveAdmin::Application.new }
   let(:controllers){ application.controllers_for_filters }

--- a/spec/unit/csv_builder_spec.rb
+++ b/spec/unit/csv_builder_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::CSVBuilder do
 
   describe '.default_for_resource using Post' do

--- a/spec/unit/dependency_spec.rb
+++ b/spec/unit/dependency_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Dependency do
 
   k = ActiveAdmin::Dependency

--- a/spec/unit/devise_spec.rb
+++ b/spec/unit/devise_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Devise::Controller do
 
   let(:controller_class) do

--- a/spec/unit/dsl_spec.rb
+++ b/spec/unit/dsl_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 module MockModuleToInclude
   def self.included(dsl)
   end

--- a/spec/unit/dynamic_settings_spec.rb
+++ b/spec/unit/dynamic_settings_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::DynamicSettingsNode do
   subject { ActiveAdmin::DynamicSettingsNode.build }
 

--- a/spec/unit/filters/active_filter_spec.rb
+++ b/spec/unit/filters/active_filter_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Filters::ActiveFilter do
 
   let(:namespace) do

--- a/spec/unit/filters/active_spec.rb
+++ b/spec/unit/filters/active_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Filters::Active do
 
   let(:resource) do

--- a/spec/unit/filters/filter_form_builder_spec.rb
+++ b/spec/unit/filters/filter_form_builder_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Filters::ViewHelper do
 
   # Setup an ActionView::Base object which can be used for

--- a/spec/unit/filters/resource_spec.rb
+++ b/spec/unit/filters/resource_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Filters::ResourceExtension do
 
   let(:resource) do

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -1,4 +1,3 @@
-require 'rails_helper'
 require "rspec/mocks/standalone"
 
 RSpec.describe ActiveAdmin::FormBuilder do

--- a/spec/unit/generators/install_spec.rb
+++ b/spec/unit/generators/install_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe "AA installation" do
   context "should create" do
 

--- a/spec/unit/helpers/collection_spec.rb
+++ b/spec/unit/helpers/collection_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Helpers::Collection do
 
   include ActiveAdmin::Helpers::Collection

--- a/spec/unit/helpers/output_safety_helper_spec.rb
+++ b/spec/unit/helpers/output_safety_helper_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 # Adapted from Rails 5 to support Rails 4.
 # https://github.com/rails/rails/blob/9c35bf2a6a27431c6aa283db781c19f61c5155be/actionview/test/template/output_safety_helper_test.rb
 RSpec.describe ActiveAdmin::OutputSafetyHelper, type: :view do

--- a/spec/unit/helpers/scope_chain_spec.rb
+++ b/spec/unit/helpers/scope_chain_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::ScopeChain do
 
   include ActiveAdmin::ScopeChain

--- a/spec/unit/i18n_spec.rb
+++ b/spec/unit/i18n_spec.rb
@@ -1,4 +1,3 @@
-require 'rails_helper'
 require 'i18n/tasks'
 
 Dir.glob('config/locales/*.yml') do |locale_file|

--- a/spec/unit/localizers/resource_localizer_spec.rb
+++ b/spec/unit/localizers/resource_localizer_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.shared_examples_for "ActiveAdmin::Localizers::ResourceLocalizer" do
   it "should use proper translation" do
     string = ActiveAdmin::Localizers::ResourceLocalizer.t(action, model: model, model_name: model_name)

--- a/spec/unit/menu_collection_spec.rb
+++ b/spec/unit/menu_collection_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::MenuCollection do
 
   let(:menus) { ActiveAdmin::MenuCollection.new }

--- a/spec/unit/menu_item_spec.rb
+++ b/spec/unit/menu_item_spec.rb
@@ -1,4 +1,3 @@
-require 'rails_helper'
 require 'active_admin/menu'
 require 'active_admin/menu_item'
 

--- a/spec/unit/menu_spec.rb
+++ b/spec/unit/menu_spec.rb
@@ -1,4 +1,3 @@
-require 'rails_helper'
 require 'active_admin/menu'
 require 'active_admin/menu_item'
 

--- a/spec/unit/namespace/authorization_spec.rb
+++ b/spec/unit/namespace/authorization_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Resource, "authorization" do
 
   let(:app){ ActiveAdmin::Application.new }

--- a/spec/unit/namespace/register_page_spec.rb
+++ b/spec/unit/namespace/register_page_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Namespace, "registering a page" do
   let(:application){ ActiveAdmin::Application.new }
   let(:namespace){ ActiveAdmin::Namespace.new(application, :admin) }

--- a/spec/unit/namespace/register_resource_spec.rb
+++ b/spec/unit/namespace/register_resource_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 # TODO: refactor this file so it doesn't depend on the Admin namespace in such a broken way.
 #       Specifically, the dashboard is already defined.
 

--- a/spec/unit/namespace_spec.rb
+++ b/spec/unit/namespace_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Namespace do
 
   let(:application){ ActiveAdmin::Application.new }

--- a/spec/unit/order_clause_spec.rb
+++ b/spec/unit/order_clause_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::OrderClause do
   subject { described_class.new(config, clause) }
 

--- a/spec/unit/page_controller_spec.rb
+++ b/spec/unit/page_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::PageController do
   let(:controller) { ActiveAdmin::PageController.new }
 end

--- a/spec/unit/page_spec.rb
+++ b/spec/unit/page_spec.rb
@@ -1,4 +1,3 @@
-require 'rails_helper'
 require File.expand_path('config_shared_examples', File.dirname(__FILE__))
 
 module ActiveAdmin

--- a/spec/unit/pretty_format_spec.rb
+++ b/spec/unit/pretty_format_spec.rb
@@ -1,4 +1,3 @@
-require 'rails_helper'
 require 'active_admin/view_helpers/display_helper'
 
 RSpec.describe "#pretty_format" do

--- a/spec/unit/pundit_adapter_spec.rb
+++ b/spec/unit/pundit_adapter_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 class DefaultPolicy < ApplicationPolicy
   def respond_to_missing?(method, include_private = false)
     method.to_s[0...3] == "foo" || super

--- a/spec/unit/resource/action_items_spec.rb
+++ b/spec/unit/resource/action_items_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Resource::ActionItems do
 
   let(:resource) do

--- a/spec/unit/resource/attributes_spec.rb
+++ b/spec/unit/resource/attributes_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 module ActiveAdmin
   RSpec.describe Resource, "Attributes" do
     let(:application) { ActiveAdmin::Application.new }

--- a/spec/unit/resource/includes_spec.rb
+++ b/spec/unit/resource/includes_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 module ActiveAdmin
   RSpec.describe Resource, "Includes" do
     describe "#includes" do

--- a/spec/unit/resource/menu_spec.rb
+++ b/spec/unit/resource/menu_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 module ActiveAdmin
   RSpec.describe Resource, "Menu" do
 

--- a/spec/unit/resource/naming_spec.rb
+++ b/spec/unit/resource/naming_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 module ActiveAdmin
   RSpec.describe Resource, "Naming" do
 

--- a/spec/unit/resource/ordering_spec.rb
+++ b/spec/unit/resource/ordering_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 module ActiveAdmin
   RSpec.describe Resource, "Ordering" do
     describe "#order_by" do

--- a/spec/unit/resource/page_presenters_spec.rb
+++ b/spec/unit/resource/page_presenters_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Resource::PagePresenters do
 
   let(:namespace){ ActiveAdmin::Namespace.new(ActiveAdmin::Application.new, :admin) }

--- a/spec/unit/resource/pagination_spec.rb
+++ b/spec/unit/resource/pagination_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 module ActiveAdmin
   RSpec.describe Resource, "Pagination" do
 

--- a/spec/unit/resource/routes_spec.rb
+++ b/spec/unit/resource/routes_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Resource::Routes do
 
   after do

--- a/spec/unit/resource/scopes_spec.rb
+++ b/spec/unit/resource/scopes_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 module ActiveAdmin
   RSpec.describe Resource, "Scopes" do
 

--- a/spec/unit/resource/sidebars_spec.rb
+++ b/spec/unit/resource/sidebars_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Resource::Sidebars do
 
   let(:resource) do

--- a/spec/unit/resource_collection_spec.rb
+++ b/spec/unit/resource_collection_spec.rb
@@ -1,4 +1,3 @@
-require 'rails_helper'
 require 'active_admin/resource_collection'
 
 RSpec.describe ActiveAdmin::ResourceCollection do

--- a/spec/unit/resource_controller/data_access_spec.rb
+++ b/spec/unit/resource_controller/data_access_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::ResourceController::DataAccess do
   before do
     load_resources { config }

--- a/spec/unit/resource_controller/decorators_spec.rb
+++ b/spec/unit/resource_controller/decorators_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::ResourceController::Decorators do
   let(:controller_class) do
     Class.new do

--- a/spec/unit/resource_controller/sidebars_spec.rb
+++ b/spec/unit/resource_controller/sidebars_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::ResourceController::Sidebars, type: :controller do
   let(:klass){ Admin::PostsController }
 

--- a/spec/unit/resource_controller_spec.rb
+++ b/spec/unit/resource_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::ResourceController do
 
   let(:controller) { Admin::PostsController.new }

--- a/spec/unit/resource_registration_spec.rb
+++ b/spec/unit/resource_registration_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe "Registering an object to administer" do
   let(:application) { ActiveAdmin::Application.new }
 

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -1,4 +1,3 @@
-require 'rails_helper'
 require File.expand_path('config_shared_examples', File.dirname(__FILE__))
 
 module ActiveAdmin

--- a/spec/unit/routing_spec.rb
+++ b/spec/unit/routing_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin, "Routing", type: :routing do
 
   before do

--- a/spec/unit/scope_spec.rb
+++ b/spec/unit/scope_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Scope do
 
   describe "creating a scope" do

--- a/spec/unit/settings_node_spec.rb
+++ b/spec/unit/settings_node_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::SettingsNode do
   subject { ActiveAdmin::SettingsNode.build }
   let!(:child) { ActiveAdmin::SettingsNode.build(subject) }

--- a/spec/unit/view_factory_spec.rb
+++ b/spec/unit/view_factory_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 def it_should_have_view(key, value)
   it "should have #{value} for view key '#{key}'" do
     expect(subject.send(key)).to eq value

--- a/spec/unit/view_helpers/breadcrumbs_spec.rb
+++ b/spec/unit/view_helpers/breadcrumbs_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe "Breadcrumbs" do
 
   include ActiveAdmin::ViewHelpers

--- a/spec/unit/view_helpers/display_helper_spec.rb
+++ b/spec/unit/view_helpers/display_helper_spec.rb
@@ -1,4 +1,3 @@
-require 'rails_helper'
 require 'active_admin/view_helpers/active_admin_application_helper'
 require 'active_admin/view_helpers/auto_link_helper'
 require 'active_admin/view_helpers/display_helper'

--- a/spec/unit/view_helpers/download_format_links_helper_spec.rb
+++ b/spec/unit/view_helpers/download_format_links_helper_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::ViewHelpers::DownloadFormatLinksHelper do
   describe "class methods" do
     before :all do

--- a/spec/unit/view_helpers/fields_for_spec.rb
+++ b/spec/unit/view_helpers/fields_for_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::ViewHelpers::FormHelper, ".fields_for" do
   include ActiveAdmin::ViewHelpers::FormHelper
 

--- a/spec/unit/view_helpers/flash_helper_spec.rb
+++ b/spec/unit/view_helpers/flash_helper_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::ViewHelpers::FlashHelper do
 
   describe '.flash_messages' do

--- a/spec/unit/view_helpers/form_helper_spec.rb
+++ b/spec/unit/view_helpers/form_helper_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::ViewHelpers::FormHelper do
 
   describe '.active_admin_form_for' do

--- a/spec/unit/view_helpers/method_or_proc_helper_spec.rb
+++ b/spec/unit/view_helpers/method_or_proc_helper_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe MethodOrProcHelper do
   let(:receiver) { double }
 

--- a/spec/unit/views/components/attributes_table_spec.rb
+++ b/spec/unit/views/components/attributes_table_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Views::AttributesTable do
 
   describe "creating with the dsl" do

--- a/spec/unit/views/components/batch_action_selector_spec.rb
+++ b/spec/unit/views/components/batch_action_selector_spec.rb
@@ -1,4 +1,3 @@
-require 'rails_helper'
 require 'active_admin/batch_actions/views/batch_action_selector'
 
 RSpec.describe ActiveAdmin::BatchActions::BatchActionSelector do

--- a/spec/unit/views/components/blank_slate_spec.rb
+++ b/spec/unit/views/components/blank_slate_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Views::BlankSlate do
 
   describe "#blank_slate" do

--- a/spec/unit/views/components/columns_spec.rb
+++ b/spec/unit/views/components/columns_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Views::Columns do
 
   describe "Rendering zero columns" do

--- a/spec/unit/views/components/index_list_spec.rb
+++ b/spec/unit/views/components/index_list_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Views::IndexList do
 
   describe "#index_list_renderer" do

--- a/spec/unit/views/components/index_table_for_spec.rb
+++ b/spec/unit/views/components/index_table_for_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Views::IndexAsTable::IndexTableFor do
   describe 'creating with the dsl' do
     let(:collection) do

--- a/spec/unit/views/components/menu_item_spec.rb
+++ b/spec/unit/views/components/menu_item_spec.rb
@@ -1,4 +1,3 @@
-require 'rails_helper'
 require 'active_admin/menu_item'
 require 'active_admin/views/components/menu_item'
 

--- a/spec/unit/views/components/menu_spec.rb
+++ b/spec/unit/views/components/menu_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Views::Menu do
 
   let(:menu){ ActiveAdmin::Menu.new }

--- a/spec/unit/views/components/paginated_collection_spec.rb
+++ b/spec/unit/views/components/paginated_collection_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Views::PaginatedCollection do
   describe "creating with the dsl" do
 

--- a/spec/unit/views/components/panel_spec.rb
+++ b/spec/unit/views/components/panel_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Views::Panel do
   let(:arbre_panel) do
     render_arbre_component do

--- a/spec/unit/views/components/sidebar_section_spec.rb
+++ b/spec/unit/views/components/sidebar_section_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Views::SidebarSection do
 
   let(:options) { {} }

--- a/spec/unit/views/components/sidebar_spec.rb
+++ b/spec/unit/views/components/sidebar_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Views::Sidebar do
 
   let(:section) do

--- a/spec/unit/views/components/site_title_spec.rb
+++ b/spec/unit/views/components/site_title_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Views::SiteTitle do
 
   let(:helpers){ mock_action_view }

--- a/spec/unit/views/components/status_tag_spec.rb
+++ b/spec/unit/views/components/status_tag_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Views::StatusTag do
 
   describe "#status_tag" do

--- a/spec/unit/views/components/table_for_spec.rb
+++ b/spec/unit/views/components/table_for_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Views::TableFor do
   describe "creating with the dsl" do
 

--- a/spec/unit/views/components/tabs_spec.rb
+++ b/spec/unit/views/components/tabs_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Views::Tabs do
   describe "creating with the dsl" do
     context "when creating tabs with a symbol" do

--- a/spec/unit/views/components/unsupported_browser_spec.rb
+++ b/spec/unit/views/components/unsupported_browser_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Views::UnsupportedBrowser do
   let(:helpers){ mock_action_view }
   let(:namespace) { double :namespace, unsupported_browser_matcher: /MSIE [1-8]\.0/ }

--- a/spec/unit/views/index_as_blog_spec.rb
+++ b/spec/unit/views/index_as_blog_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 include ActiveAdmin
 RSpec.describe ActiveAdmin::Views::IndexAsBlog do
   subject { described_class.new }

--- a/spec/unit/views/pages/base_spec.rb
+++ b/spec/unit/views/pages/base_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Views::Pages::Base do
   class NewPage < ActiveAdmin::Views::Pages::Base
   end

--- a/spec/unit/views/pages/form_spec.rb
+++ b/spec/unit/views/pages/form_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Views::Pages::Form do
   describe "#title" do
     let!(:application){ ActiveAdmin::Application.new }

--- a/spec/unit/views/pages/index_spec.rb
+++ b/spec/unit/views/pages/index_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Views::Pages::Index do
   describe "#title" do
     let!(:application){ ActiveAdmin::Application.new }

--- a/spec/unit/views/pages/layout_spec.rb
+++ b/spec/unit/views/pages/layout_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Views::Pages::Layout do
 
   let(:assigns){ {} }

--- a/spec/unit/views/pages/show_spec.rb
+++ b/spec/unit/views/pages/show_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ActiveAdmin::Views::Pages::Show do
 
   describe "the resource" do


### PR DESCRIPTION
The helper is already required through the `.rspec` file. Their presence is unlikely to be a problem but can be annoying in some situations. For example, if you introduce a syntax error in the helper, you will get it printed hunders of times, one per file, since the require never succeeds and it's retried everytime a new spec file is loaded.