### PR TITLE
Enable `belongs_to_required_by_default` in test app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ spec/rails
 .test-rails-apps
 public
 .rspec
+.rspec_failures
 .rails-version
 .rbenv-version
 .localeapp/*

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,6 +34,7 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.color = true
   config.order = :random
+  config.example_status_persistence_file_path = ".rspec_failures"
 
   devise = ActiveAdmin::Dependency.devise >= '4.2' ? Devise::Test::ControllerHelpers : Devise::TestHelpers
   config.include devise, type: :controller

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -10,8 +10,8 @@ generate :model, 'post title:string body:text published_date:date author_id:inte
   'position:integer custom_category_id:integer starred:boolean foo_id:integer'
 create_file 'app/models/post.rb', <<-RUBY.strip_heredoc, force: true
   class Post < ActiveRecord::Base
-    belongs_to :category, foreign_key: :custom_category_id
-    belongs_to :author, class_name: 'User'
+    belongs_to :category, foreign_key: :custom_category_id, optional: true
+    belongs_to :author, class_name: 'User', optional: true
     has_many :taggings
     has_many :tags, through: :taggings
     accepts_nested_attributes_for :author
@@ -98,8 +98,8 @@ RUBY
 generate :model, 'tagging post_id:integer tag_id:integer position:integer'
 create_file 'app/models/tagging.rb', <<-RUBY.strip_heredoc, force: true
   class Tagging < ActiveRecord::Base
-    belongs_to :post
-    belongs_to :tag
+    belongs_to :post, optional: true
+    belongs_to :tag, optional: true
 
     delegate :name, to: :tag, prefix: true
   end
@@ -112,10 +112,6 @@ gsub_file 'config/environments/test.rb', /  config.cache_classes = true/, <<-RUB
   config.assets.precompile += %w( some-random-css.css some-random-js.js a/favicon.ico )
 
   config.active_record.maintain_test_schema = false
-
-  if Rails::VERSION::MAJOR >= 5
-    config.active_record.belongs_to_required_by_default = false
-  end
 
 RUBY
 

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -6,12 +6,19 @@ create_file 'app/assets/stylesheets/some-random-css.css'
 create_file 'app/assets/javascripts/some-random-js.js'
 create_file 'app/assets/images/a/favicon.ico'
 
+belongs_to_optional_flag = if Rails::VERSION::MAJOR < 5
+                             "required: false"
+                           else
+                             "optional: true"
+                           end
+
 generate :model, 'post title:string body:text published_date:date author_id:integer ' +
   'position:integer custom_category_id:integer starred:boolean foo_id:integer'
+
 create_file 'app/models/post.rb', <<-RUBY.strip_heredoc, force: true
   class Post < ActiveRecord::Base
-    belongs_to :category, foreign_key: :custom_category_id, optional: true
-    belongs_to :author, class_name: 'User', optional: true
+    belongs_to :category, foreign_key: :custom_category_id, #{belongs_to_optional_flag}
+    belongs_to :author, class_name: 'User', #{belongs_to_optional_flag}
     has_many :taggings
     has_many :tags, through: :taggings
     accepts_nested_attributes_for :author
@@ -98,8 +105,8 @@ RUBY
 generate :model, 'tagging post_id:integer tag_id:integer position:integer'
 create_file 'app/models/tagging.rb', <<-RUBY.strip_heredoc, force: true
   class Tagging < ActiveRecord::Base
-    belongs_to :post, optional: true
-    belongs_to :tag, optional: true
+    belongs_to :post, #{belongs_to_optional_flag}
+    belongs_to :tag, #{belongs_to_optional_flag}
 
     delegate :name, to: :tag, prefix: true
   end

--- a/spec/unit/comments_spec.rb
+++ b/spec/unit/comments_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe "Comments" do
   describe ActiveAdmin::Comment do
     subject(:comment){ ActiveAdmin::Comment.new }
 
+    let(:user) { User.create!(first_name: "John", last_name: "Doe") }
+
     it "has valid Associations and Validations" do
       expect(comment).to belong_to :resource
       expect(comment).to belong_to :author
@@ -19,7 +21,8 @@ RSpec.describe "Comments" do
       let(:namespace_name) { "admin" }
 
       before do
-        @comment = ActiveAdmin::Comment.create! resource: post,
+        @comment = ActiveAdmin::Comment.create! author: user,
+                                                resource: post,
                                                 body: "A Comment",
                                                 namespace: namespace_name
       end
@@ -40,12 +43,14 @@ RSpec.describe "Comments" do
       end
 
       it "should return the most recent comment first by default" do
-        another_comment = ActiveAdmin::Comment.create! resource: post,
+        another_comment = ActiveAdmin::Comment.create! author: user,
+                                                       resource: post,
                                                        body: "Another Comment",
                                                        namespace: namespace_name,
                                                        created_at: @comment.created_at + 20.minutes
 
-        yet_another_comment = ActiveAdmin::Comment.create! resource: post,
+        yet_another_comment = ActiveAdmin::Comment.create! author: user,
+                                                           resource: post,
                                                            body: "Yet Another Comment",
                                                            namespace: namespace_name,
                                                            created_at: @comment.created_at + 10.minutes
@@ -69,6 +74,7 @@ RSpec.describe "Comments" do
 
         it "should return the correctly ordered comments" do
           another_comment = ActiveAdmin::Comment.create!(
+            author: user,
             resource: post,
             body: "Another Comment",
             namespace: namespace_name,
@@ -117,6 +123,7 @@ RSpec.describe "Comments" do
 
       it "should allow commenting" do
         comment = ActiveAdmin::Comment.create!(
+          author: user,
           resource: tag,
           body: "Another Comment",
           namespace: namespace_name)
@@ -131,6 +138,7 @@ RSpec.describe "Comments" do
 
       it "should assign child class as commented resource" do
         comment = ActiveAdmin::Comment.create!(
+          author: user,
           resource: publisher,
           body: "Lorem Ipsum",
           namespace: namespace_name)

--- a/spec/unit/resource_controller_spec.rb
+++ b/spec/unit/resource_controller_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe "A specific resource controller", type: :controller do
   describe 'retrieving the resource collection' do
     let(:config) { controller.class.active_admin_config }
     before do
-      Post.create!(title: "An incledibly unique Post Title") if Post.count == 0
+      Post.create!(title: "An incledibly unique Post Title")
       config.decorator_class_name = nil
       request = double 'Request', format: 'application/json'
       allow(controller).to receive(:params) { {} }


### PR DESCRIPTION
This is Rails default, so in order to better simulate real Rails applications, we should use it.

References #5360.