### PR TITLE
Unnecessary spec stuff removal

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,6 +15,7 @@ task :setup, [:parallel, :dir, :template] do |_t, opts|
     args = %W(
       -m spec/support/#{template}.rb
       --skip-bundle
+      --skip-gemfile
       --skip-listen
       --skip-turbolinks
       --skip-test-unit

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,8 +2,7 @@ require 'spec_helper'
 
 ENV['RAILS_ENV'] = 'test'
 
-require 'rails'
-ENV['RAILS_ROOT'] = File.expand_path("../rails/rails-#{Rails.version}", __FILE__)
+ENV['RAILS_ROOT'] = File.expand_path("../rails/rails-#{Gem.loaded_specs["rails"].version}", __FILE__)
 
 # Create the test app if it doesn't exists
 unless File.exists?(ENV['RAILS_ROOT'])

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,11 +9,6 @@ unless File.exists?(ENV['RAILS_ROOT'])
   system 'rake setup'
 end
 
-require 'active_record'
-require 'active_admin'
-require 'devise'
-ActiveAdmin.application.load_paths = [ENV['RAILS_ROOT'] + "/app/admin"]
-
 require ENV['RAILS_ROOT'] + '/config/environment'
 
 require 'rspec/rails'

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -122,12 +122,6 @@ gsub_file 'config/environments/test.rb', /  config.cache_classes = true/, <<-RUB
 
 RUBY
 
-# Add our local Active Admin to the application
-gem 'activeadmin', path: '../..'
-gem 'devise'
-
-run 'bundle install'
-
 # Setup Active Admin
 generate 'active_admin:install'
 

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -9,8 +9,12 @@ RSpec.describe ActiveAdmin::Application do
     expect(application.load_paths).to eq [File.expand_path('app/admin', application.app_path)]
   end
 
-  it "should remove app/admin from the autoload paths (Active Admin deals with loading)" do
-    expect(ActiveSupport::Dependencies.autoload_paths).to_not include(File.join(Rails.root, "app/admin"))
+  describe "#prepare" do
+    before { application.prepare! }
+
+    it "should remove app/admin from the autoload paths" do
+      expect(ActiveSupport::Dependencies.autoload_paths).to_not include(File.join(Rails.root, "app/admin"))
+    end
   end
 
   it "should store the site's title" do

--- a/tasks/local.rake
+++ b/tasks/local.rake
@@ -17,7 +17,8 @@ task :local do
   end
 
   command = ['bundle', 'exec', *argv].join(' ')
-  env = { 'BUNDLE_GEMFILE' => ENV['BUNDLE_GEMFILE'] }
+  gemfile = ENV['BUNDLE_GEMFILE'] || File.expand_path("../Gemfile", __dir__)
+  env = { 'BUNDLE_GEMFILE' => gemfile }
 
   Dir.chdir(app_folder) do
     Bundler.with_original_env { Kernel.exec(env, command) }


### PR DESCRIPTION
Test applications were generating, tweaking and installing a default Gemfile, but that `Gemfile` was not being used. So it's better not to generate it for faster development application generation and to reduce confusion.