### PR TITLE
Bump capybara to latest 3.8 version

### DIFF
--- a/Gemfile.common
+++ b/Gemfile.common
@@ -23,6 +23,9 @@ gem 'yard'                        # Documentation generator
 gem 'redcarpet', platforms: :mri  # Markdown implementation (for yard)
 gem 'kramdown', platforms: :jruby # Markdown implementation (for yard)
 
+# Application server
+gem 'puma', '~> 3.12'
+
 group :development do
   # Debugging
   gem 'better_errors' # Web UI to debug exceptions. Go to /__better_errors to access the latest one
@@ -34,7 +37,7 @@ group :development do
 end
 
 group :test do
-  gem 'capybara', '< 3.0'
+  gem 'capybara', '~> 3.0'
   gem 'simplecov', require: false # Test coverage generator. Go to /coverage/ after running tests
   gem 'codecov', require: false # Test coverage website. Go to https://codecov.io
   gem 'cucumber-rails', '~> 1.5', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,13 +93,13 @@ GEM
     builder (3.2.3)
     byebug (10.0.2)
     cancan (1.6.10)
-    capybara (2.18.0)
+    capybara (3.8.2)
       addressable
       mini_mime (>= 0.1.3)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (>= 2.0, < 4.0)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      xpath (~> 3.1)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     codecov (0.1.10)
@@ -264,6 +264,8 @@ GEM
       byebug (~> 10.0)
       pry (~> 0.10)
     public_suffix (3.0.3)
+    puma (3.12.0)
+    puma (3.12.0-java)
     pundit (2.0.0)
       activesupport (>= 3.0.0)
     rack (2.0.5)
@@ -402,7 +404,7 @@ DEPENDENCIES
   binding_of_caller
   bootsnap
   cancan
-  capybara (< 3.0)
+  capybara (~> 3.0)
   codecov
   cucumber
   cucumber-rails (~> 1.5)
@@ -420,6 +422,7 @@ DEPENDENCIES
   parallel_tests
   pry
   pry-byebug
+  puma (~> 3.12)
   pundit
   rack-mini-profiler (>= 0.10.1)
   rails (~> 5.2.x)

--- a/features/index/filters.feature
+++ b/features/index/filters.feature
@@ -63,10 +63,10 @@ Feature: Index Filtering
     And I press "Filter"
 
     Then I follow "2"
-    Then I should see "Displaying Posts 3 - 4 of 7 in total"
+    Then I should see "Displaying Posts 3 - 4 of 7 in total"
 
     Then I follow "3"
-    Then I should see "Displaying Posts 5 - 6 of 7 in total"
+    Then I should see "Displaying Posts 5 - 6 of 7 in total"
 
   Scenario: Filtering posts while not on the first page
     Given 9 posts exist
@@ -77,7 +77,7 @@ Feature: Index Filtering
       end
     """
     When I follow "2"
-    Then I should see "Displaying Posts 6 - 9 of 9 in total"
+    Then I should see "Displaying Posts 6 - 9 of 9 in total"
 
     When I fill in "Title" with "Hello World 2"
     And I press "Filter"

--- a/features/index/pagination.feature
+++ b/features/index/pagination.feature
@@ -30,7 +30,7 @@ Feature: Index Pagination
     Given 3 posts exist
     When I am on the index page for posts
     Then I should see pagination with 2 pages
-    And I should see "Displaying Posts 1 - 2 of 3 in total"
+    And I should see "Displaying Posts 1 - 2 of 3 in total"
 
   Scenario: Viewing index with pagination disabled
     Given an index configuration of:
@@ -54,10 +54,10 @@ Feature: Index Pagination
     """
     Given 11 posts exist
     When I am on the index page for posts
-    Then I should see "Displaying Posts 1 - 10"
+    Then I should see "Displaying Posts 1 - 10"
     And I should not see "11 in total"
     And I should see the pagination "Next" link
 
     When I follow "Next"
-    Then I should see "Displaying Posts 11 - 11"
+    Then I should see "Displaying Posts 11 - 11"
     And I should not see the pagination "Next" link

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -47,6 +47,10 @@ Around do |scenario, block|
   end
 end
 
+After '@debug' do |scenario|
+  save_and_open_page if scenario.failed?
+end
+
 require 'capybara/rails'
 require 'capybara/cucumber'
 require 'capybara/session'
@@ -63,6 +67,8 @@ end
 Capybara.javascript_driver = :chrome
 
 Capybara.server = :puma, { Silent: true }
+
+Capybara.asset_host = 'http://localhost:3000'
 
 # Capybara defaults to XPath selectors rather than Webrat's default of CSS3. In
 # order to ease the transition to Capybara we set the default here. If you'd

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -62,6 +62,8 @@ end
 
 Capybara.javascript_driver = :chrome
 
+Capybara.server = :puma, { Silent: true }
+
 # Capybara defaults to XPath selectors rather than Webrat's default of CSS3. In
 # order to ease the transition to Capybara we set the default here. If you'd
 # prefer to use XPath just remove this line and adjust any selectors in your

--- a/gemfiles/rails_42.gemfile.lock
+++ b/gemfiles/rails_42.gemfile.lock
@@ -78,13 +78,13 @@ GEM
     builder (3.2.3)
     byebug (10.0.2)
     cancan (1.6.10)
-    capybara (2.18.0)
+    capybara (3.8.2)
       addressable
       mini_mime (>= 0.1.3)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (>= 2.0, < 4.0)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      xpath (~> 3.1)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     codecov (0.1.10)
@@ -242,6 +242,8 @@ GEM
       byebug (~> 10.0)
       pry (~> 0.10)
     public_suffix (3.0.3)
+    puma (3.12.0)
+    puma (3.12.0-java)
     pundit (2.0.0)
       activesupport (>= 3.0.0)
     rack (1.6.10)
@@ -374,7 +376,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   cancan
-  capybara (< 3.0)
+  capybara (~> 3.0)
   codecov
   cucumber
   cucumber-rails (~> 1.5)
@@ -391,6 +393,7 @@ DEPENDENCIES
   mdl (= 0.4.0)
   parallel_tests
   pry-byebug
+  puma (~> 3.12)
   pundit
   rack-mini-profiler (>= 0.10.1)
   rails (= 4.2.10)

--- a/gemfiles/rails_42.gemfile.lock
+++ b/gemfiles/rails_42.gemfile.lock
@@ -392,6 +392,7 @@ DEPENDENCIES
   launchy
   mdl (= 0.4.0)
   parallel_tests
+  pry
   pry-byebug
   puma (~> 3.12)
   pundit

--- a/gemfiles/rails_50.gemfile.lock
+++ b/gemfiles/rails_50.gemfile.lock
@@ -85,13 +85,13 @@ GEM
     builder (3.2.3)
     byebug (10.0.2)
     cancan (1.6.10)
-    capybara (2.18.0)
+    capybara (3.8.2)
       addressable
       mini_mime (>= 0.1.3)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (>= 2.0, < 4.0)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      xpath (~> 3.1)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     codecov (0.1.10)
@@ -252,6 +252,8 @@ GEM
       byebug (~> 10.0)
       pry (~> 0.10)
     public_suffix (3.0.3)
+    puma (3.12.0)
+    puma (3.12.0-java)
     pundit (2.0.0)
       activesupport (>= 3.0.0)
     rack (2.0.5)
@@ -388,7 +390,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   cancan
-  capybara (< 3.0)
+  capybara (~> 3.0)
   codecov
   cucumber
   cucumber-rails (~> 1.5)
@@ -405,6 +407,7 @@ DEPENDENCIES
   mdl (= 0.4.0)
   parallel_tests
   pry-byebug
+  puma (~> 3.12)
   pundit
   rack-mini-profiler (>= 0.10.1)
   rails (= 5.0.6)

--- a/gemfiles/rails_50.gemfile.lock
+++ b/gemfiles/rails_50.gemfile.lock
@@ -406,6 +406,7 @@ DEPENDENCIES
   launchy
   mdl (= 0.4.0)
   parallel_tests
+  pry
   pry-byebug
   puma (~> 3.12)
   pundit

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -405,6 +405,7 @@ DEPENDENCIES
   launchy
   mdl (= 0.4.0)
   parallel_tests
+  pry
   pry-byebug
   puma (~> 3.12)
   pundit

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -85,13 +85,13 @@ GEM
     builder (3.2.3)
     byebug (10.0.2)
     cancan (1.6.10)
-    capybara (2.18.0)
+    capybara (3.8.2)
       addressable
       mini_mime (>= 0.1.3)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (>= 2.0, < 4.0)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      xpath (~> 3.1)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     codecov (0.1.10)
@@ -251,6 +251,8 @@ GEM
       byebug (~> 10.0)
       pry (~> 0.10)
     public_suffix (3.0.3)
+    puma (3.12.0)
+    puma (3.12.0-java)
     pundit (2.0.0)
       activesupport (>= 3.0.0)
     rack (2.0.5)
@@ -387,7 +389,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   cancan
-  capybara (< 3.0)
+  capybara (~> 3.0)
   codecov
   cucumber
   cucumber-rails (~> 1.5)
@@ -404,6 +406,7 @@ DEPENDENCIES
   mdl (= 0.4.0)
   parallel_tests
   pry-byebug
+  puma (~> 3.12)
   pundit
   rack-mini-profiler (>= 0.10.1)
   rails (= 5.1.4)


### PR DESCRIPTION
As you can imagine by the diff in the specs, it was a lot of fun to figure it out :rofl:. Those were `&nbsp;` characters (I guess copied direcly from the HTML?) and not just whitespaces. And capybara doesn't like those because it just checks for the actual output the user sees.