### PR TITLE
Tab ids will use non-ascii characters if title is non-ascii only

### DIFF
--- a/lib/active_admin/views/components/tabs.rb
+++ b/lib/active_admin/views/components/tabs.rb
@@ -16,6 +16,8 @@ module ActiveAdmin
 
       def build_menu_item(title, options, &block)
         fragment = options.fetch(:id, title.parameterize)
+        fragment = title.gsub(/[[:space:]]/, "") if fragment.blank?
+        raise "The tab title is not transliterable into an ascii only id that can be used as a url fragment for this tab. Either manually specify a tab id, or add the proper transliteration rules to your application." if fragment.blank?
         html_options = options.fetch(:html_options, {})
         li html_options do
           link_to title, "##{fragment}"


### PR DESCRIPTION
Also an error is raised if the id is blank

See discussion [here](https://github.com/activeadmin/activeadmin/issues/5484).