### PR TITLE
Bump rubocop and other rubocop tweaks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,10 +10,7 @@ AllCops:
     - vendor/bundle/**/*
 
   Include:
-    - "**/*.rake"
-    - "**/Gemfile"
     - "gemfiles/*.gemfile"
-    - "**/Rakefile"
 
   DisplayCopNames: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,7 +20,7 @@ AllCops:
 
   StyleGuideCopsOnly: false
 
-Lint/EndAlignment:
+Layout/EndAlignment:
   Enabled: true
 
 Layout/AccessModifierIndentation:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,9 @@ AllCops:
 Layout/EndAlignment:
   Enabled: true
 
+Lint/ParenthesesAsGroupedExpression:
+  Enabled: true
+
 Layout/AccessModifierIndentation:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,9 @@
 ---
 
+inherit_mode:
+  merge:
+    - Include
+
 AllCops:
   DisabledByDefault: true
   TargetRubyVersion: 2.3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ AllCops:
     - vendor/bundle/**/*
 
   Include:
-    - "gemfiles/*.gemfile"
+    - gemfiles/*.gemfile
 
   DisplayCopNames: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,7 @@ AllCops:
 
   Include:
     - gemfiles/*.gemfile
+    - .simplecov
 
   DisplayCopNames: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,6 +51,10 @@ Layout/ExtraSpacing:
 Style/Encoding:
   Enabled: true
 
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  EnforcedStyle: never
+
 Style/HashSyntax:
   Enabled: true
 

--- a/.simplecov
+++ b/.simplecov
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # TODO: Always run simplecov again once
 # https://github.com/colszowka/simplecov/issues/404,
 # https://github.com/glebm/i18n-tasks/issues/221 are fixed

--- a/Gemfile.common
+++ b/Gemfile.common
@@ -12,7 +12,7 @@ gem 'pry' # Easily debug from your console with `binding.pry`
 gem 'pry-byebug', platforms: :mri
 
 # Code style
-gem 'rubocop', '0.51.0'
+gem 'rubocop', '0.59.2'
 gem 'mdl', '0.4.0'
 
 # Translations

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,6 +182,8 @@ GEM
       responders
     iso (0.2.2)
       i18n
+    jaro_winkler (1.5.1)
+    jaro_winkler (1.5.1-java)
     jasmine (2.9.0)
       jasmine-core (>= 2.9.0, < 3.0.0)
       phantomjs
@@ -334,11 +336,12 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rubocop (0.51.0)
+    rubocop (0.59.2)
+      jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.3.3.1, < 3.0)
+      parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
-      rainbow (>= 2.2.2, < 3.0)
+      rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.10.0)
@@ -430,7 +433,7 @@ DEPENDENCIES
   rake
   redcarpet
   rspec-rails
-  rubocop (= 0.51.0)
+  rubocop (= 0.59.2)
   selenium-webdriver
   shoulda-matchers (<= 2.8.0)
   simplecov

--- a/gemfiles/rails_42.gemfile.lock
+++ b/gemfiles/rails_42.gemfile.lock
@@ -167,6 +167,8 @@ GEM
       responders
     iso (0.2.2)
       i18n
+    jaro_winkler (1.5.1)
+    jaro_winkler (1.5.1-java)
     jasmine (2.9.0)
       jasmine-core (>= 2.9.0, < 3.0.0)
       phantomjs
@@ -312,11 +314,12 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rubocop (0.51.0)
+    rubocop (0.59.2)
+      jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.3.3.1, < 3.0)
+      parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
-      rainbow (>= 2.2.2, < 3.0)
+      rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.10.0)
@@ -402,7 +405,7 @@ DEPENDENCIES
   rake
   redcarpet
   rspec-rails
-  rubocop (= 0.51.0)
+  rubocop (= 0.59.2)
   selenium-webdriver
   shoulda-matchers (<= 2.8.0)
   simplecov

--- a/gemfiles/rails_50.gemfile.lock
+++ b/gemfiles/rails_50.gemfile.lock
@@ -175,6 +175,8 @@ GEM
       responders
     iso (0.2.2)
       i18n
+    jaro_winkler (1.5.1)
+    jaro_winkler (1.5.1-java)
     jasmine (2.9.0)
       jasmine-core (>= 2.9.0, < 3.0.0)
       phantomjs
@@ -321,11 +323,12 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rubocop (0.51.0)
+    rubocop (0.59.2)
+      jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.3.3.1, < 3.0)
+      parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
-      rainbow (>= 2.2.2, < 3.0)
+      rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.10.0)
@@ -416,7 +419,7 @@ DEPENDENCIES
   rake
   redcarpet
   rspec-rails
-  rubocop (= 0.51.0)
+  rubocop (= 0.59.2)
   selenium-webdriver
   shoulda-matchers (<= 2.8.0)
   simplecov

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -174,6 +174,8 @@ GEM
       responders
     iso (0.2.2)
       i18n
+    jaro_winkler (1.5.1)
+    jaro_winkler (1.5.1-java)
     jasmine (2.9.0)
       jasmine-core (>= 2.9.0, < 3.0.0)
       phantomjs
@@ -320,11 +322,12 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rubocop (0.51.0)
+    rubocop (0.59.2)
+      jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.3.3.1, < 3.0)
+      parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
-      rainbow (>= 2.2.2, < 3.0)
+      rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.10.0)
@@ -415,7 +418,7 @@ DEPENDENCIES
   rake
   redcarpet
   rspec-rails
-  rubocop (= 0.51.0)
+  rubocop (= 0.59.2)
   selenium-webdriver
   shoulda-matchers (<= 2.8.0)
   simplecov

--- a/spec/changelog_spec.rb
+++ b/spec/changelog_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Changelog" do
   subject(:changelog) do
     path = File.join(File.dirname(__dir__), "CHANGELOG.md")

--- a/spec/unit/filters/active_filter_spec.rb
+++ b/spec/unit/filters/active_filter_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe ActiveAdmin::Filters::ActiveFilter do
       label = "#{user.first_name}'s Post Title"
       resource.add_filter(:title, label: label)
 
-      expect(subject.label).to eq ("#{label} equals")
+      expect(subject.label).to eq("#{label} equals")
     end
 
     it 'should use the filter label as the label prefix' do
@@ -161,7 +161,7 @@ RSpec.describe ActiveAdmin::Filters::ActiveFilter do
   end
 
   context "the association uses a different primary_key than the related class' primary_key" do
-    let (:resource_klass) {
+    let(:resource_klass) {
       Class.new(Post) do
         belongs_to :kategory, class_name: "Category", primary_key: :name, foreign_key: :title
 

--- a/spec/unit/resource/page_presenters_spec.rb
+++ b/spec/unit/resource/page_presenters_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ActiveAdmin::Resource::PagePresenters do
   let(:resource){ namespace.register(Post) }
 
   it "should have an empty set of configs on initialize" do
-    expect(resource.page_presenters).to eq ({})
+    expect(resource.page_presenters).to eq({})
   end
 
   it "should add a show page presenter" do

--- a/spec/unit/views/components/attributes_table_spec.rb
+++ b/spec/unit/views/components/attributes_table_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe ActiveAdmin::Views::AttributesTable do
         let(:cols) { table.find_by_tag "col" }
 
         it "contains a col for each record (plus headers)" do
-          expect(cols.size).to eq (2 + 1)
+          expect(cols.size).to eq(2 + 1)
         end
 
         it "assigns an id to each col" do


### PR DESCRIPTION
Rubocop version was quite old already so I bumped it to the latest version.

Also I added a couple of cops:

* `Style/FrozenStringLiteralComment`. We were fully consistent in this regard until I accidentally added a couple of those. Let's keep the code free of those comments until we add full support for frozen string literals.

* `Lint/ParenthesesAsGroupedExpression`. This is because I noticed some code that was a bit hard to read on a review, and it was because of a style issue of this kind. Since I prefer not making style review comments and let those be handled by a bot, I propose to add this cop.