### PR TITLE
Remove marginal use of shoulda-matchers

### DIFF
--- a/Gemfile.common
+++ b/Gemfile.common
@@ -49,7 +49,6 @@ group :test do
   gem 'rails-i18n' # Provides default i18n for many languages
   gem 'rspec-rails'
   gem 'i18n-spec'
-  gem 'shoulda-matchers', '<= 2.8.0'
   gem 'sqlite3', platforms: :mri
   gem 'selenium-webdriver'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -354,8 +354,6 @@ GEM
     selenium-webdriver (3.14.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2)
-    shoulda-matchers (2.8.0)
-      activesupport (>= 3.0.0)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -435,7 +433,6 @@ DEPENDENCIES
   rspec-rails
   rubocop (= 0.59.2)
   selenium-webdriver
-  shoulda-matchers (<= 2.8.0)
   simplecov
   sqlite3
   yard

--- a/gemfiles/rails_42.gemfile.lock
+++ b/gemfiles/rails_42.gemfile.lock
@@ -332,8 +332,6 @@ GEM
     selenium-webdriver (3.14.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2)
-    shoulda-matchers (2.8.0)
-      activesupport (>= 3.0.0)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -407,7 +405,6 @@ DEPENDENCIES
   rspec-rails
   rubocop (= 0.59.2)
   selenium-webdriver
-  shoulda-matchers (<= 2.8.0)
   simplecov
   sqlite3
   yard

--- a/gemfiles/rails_50.gemfile.lock
+++ b/gemfiles/rails_50.gemfile.lock
@@ -341,8 +341,6 @@ GEM
     selenium-webdriver (3.14.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2)
-    shoulda-matchers (2.8.0)
-      activesupport (>= 3.0.0)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -421,7 +419,6 @@ DEPENDENCIES
   rspec-rails
   rubocop (= 0.59.2)
   selenium-webdriver
-  shoulda-matchers (<= 2.8.0)
   simplecov
   sqlite3
   yard

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -340,8 +340,6 @@ GEM
     selenium-webdriver (3.14.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2)
-    shoulda-matchers (2.8.0)
-      activesupport (>= 3.0.0)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -420,7 +418,6 @@ DEPENDENCIES
   rspec-rails
   rubocop (= 0.59.2)
   selenium-webdriver
-  shoulda-matchers (<= 2.8.0)
   simplecov
   sqlite3
   yard

--- a/spec/unit/comments_spec.rb
+++ b/spec/unit/comments_spec.rb
@@ -8,12 +8,28 @@ RSpec.describe "Comments" do
 
     let(:user) { User.create!(first_name: "John", last_name: "Doe") }
 
-    it "has valid Associations and Validations" do
-      expect(comment).to belong_to :resource
-      expect(comment).to belong_to :author
-      expect(comment).to validate_presence_of :resource
-      expect(comment).to validate_presence_of :body
-      expect(comment).to validate_presence_of :namespace
+    let(:post) { Post.create!(title: "Hello World") }
+
+    it "belongs to a resource" do
+      comment.assign_attributes(resource_type: "Post", resource_id: post.id)
+
+      expect(comment.resource).to eq(post)
+    end
+
+    it "belongs to an author" do
+      comment.assign_attributes(author_type: "User", author_id: user.id)
+
+      expect(comment.author).to eq(user)
+    end
+
+    it "needs a body" do
+      expect(comment).to_not be_valid
+      expect(comment.errors[:body]).to eq(["can't be blank"])
+    end
+
+    it "needs a namespace" do
+      expect(comment).to_not be_valid
+      expect(comment.errors[:namespace]).to eq(["can't be blank"])
     end
 
     it "needs a resource" do
@@ -22,7 +38,6 @@ RSpec.describe "Comments" do
     end
 
     describe ".find_for_resource_in_namespace" do
-      let(:post) { Post.create!(title: "Hello World") }
       let(:namespace_name) { "admin" }
 
       before do


### PR DESCRIPTION
I noticed that our usage of the `shoulda-matchers` gem is very marginal, since we provide a single activerecord model. So I think it's better to remove it. Actually, I think I found a little bug while removing it? :smile: 