### PR TITLE
Fix double validation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   be explicitly specified when a block is passed to column) [#5464][] by
   [@chumakoff][]
 * Fixed `if:` scope option when a lambda is passed [#5501][] by [@deivid-rodriguez][]
+* Comment validation adding redundant errors when resource is missing [#5516][] by [@deivid-rodriguez][]
 
 ## 1.3.0 [☰](https://github.com/activeadmin/activeadmin/compare/v1.2.1...v1.3.0)
 
@@ -299,6 +300,7 @@ Please check [0-6-stable][] for previous changes.
 [#5464]: https://github.com/activeadmin/activeadmin/pull/5464
 [#5501]: https://github.com/activeadmin/activeadmin/pull/5501
 [#5408]: https://github.com/activeadmin/activeadmin/pull/5408
+[#5516]: https://github.com/activeadmin/activeadmin/pull/5516
 
 [@5t111111]: https://github.com/5t111111
 [@aarek]: https://github.com/aarek

--- a/lib/active_admin/dependency.rb
+++ b/lib/active_admin/dependency.rb
@@ -134,6 +134,14 @@ module ActiveAdmin
       end
 
       class Rails < Base
+        def optional_belongs_to_flag
+          if Dependency.rails5?
+            { optional: true }
+          else
+            { required: false }
+          end
+        end
+
         def parameterize(string)
           if Dependency.rails5?
             string.parameterize separator: '_'

--- a/lib/active_admin/orm/active_record/comments/comment.rb
+++ b/lib/active_admin/orm/active_record/comments/comment.rb
@@ -3,7 +3,7 @@ module ActiveAdmin
 
     self.table_name = "#{table_name_prefix}active_admin_comments#{table_name_suffix}"
 
-    belongs_to :resource, polymorphic: true
+    belongs_to :resource, { polymorphic: true }.merge(ActiveAdmin::Dependency.rails.optional_belongs_to_flag)
     belongs_to :author,   polymorphic: true
 
     validates_presence_of :body, :namespace, :resource

--- a/spec/unit/comments_spec.rb
+++ b/spec/unit/comments_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe "Comments" do
       expect(comment).to validate_presence_of :namespace
     end
 
+    it "needs a resource" do
+      expect(comment).to_not be_valid
+      expect(comment.errors[:resource]).to eq(["can't be blank"])
+    end
+
     describe ".find_for_resource_in_namespace" do
       let(:post) { Post.create!(title: "Hello World") }
       let(:namespace_name) { "admin" }

--- a/spec/unit/comments_spec.rb
+++ b/spec/unit/comments_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Comments" do
   let(:application) { ActiveAdmin::Application.new }
 
   describe ActiveAdmin::Comment do
-    subject(:comment){ ActiveAdmin::Comment.new }
+    let(:comment){ ActiveAdmin::Comment.new }
 
     let(:user) { User.create!(first_name: "John", last_name: "Doe") }
 


### PR DESCRIPTION
While working on #5516, I found a small bug. If a comment is somehow missing its associated resource, activerecord validations will add two redundant errors to the comment. That could cause, for example, double error messages on a form. I don't think it can be reproduced with the current UI, but I fixed it anyways.

Extracted from #5516.