### PR TITLE
Workaround jruby bug inside Capybara

### DIFF
--- a/Gemfile.common
+++ b/Gemfile.common
@@ -37,7 +37,7 @@ group :development do
 end
 
 group :test do
-  gem 'capybara', '~> 3.0'
+  gem 'capybara', git: 'https://github.com/deivid-rodriguez/capybara', branch: 'fix_jruby_issue'
   gem 'simplecov', require: false # Test coverage generator. Go to /coverage/ after running tests
   gem 'codecov', require: false # Test coverage website. Go to https://codecov.io
   gem 'cucumber-rails', '~> 1.5', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,16 @@
+GIT
+  remote: https://github.com/deivid-rodriguez/capybara
+  revision: b01b4ceaa7b7ee65b4a0c0d99eaf48bb2735f341
+  branch: fix_jruby_issue
+  specs:
+    capybara (3.9.0)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      xpath (~> 3.2)
+
 PATH
   remote: .
   specs:
@@ -93,13 +106,6 @@ GEM
     builder (3.2.3)
     byebug (10.0.2)
     cancan (1.6.10)
-    capybara (3.8.2)
-      addressable
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      xpath (~> 3.1)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     codecov (0.1.10)
@@ -390,7 +396,7 @@ GEM
     websocket-driver (0.7.0-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
-    xpath (3.1.0)
+    xpath (3.2.0)
       nokogiri (~> 1.8)
     yard (0.9.16)
 
@@ -405,7 +411,7 @@ DEPENDENCIES
   binding_of_caller
   bootsnap
   cancan
-  capybara (~> 3.0)
+  capybara!
   codecov
   cucumber
   cucumber-rails (~> 1.5)

--- a/gemfiles/rails_50.gemfile.lock
+++ b/gemfiles/rails_50.gemfile.lock
@@ -1,3 +1,16 @@
+GIT
+  remote: https://github.com/deivid-rodriguez/capybara
+  revision: b01b4ceaa7b7ee65b4a0c0d99eaf48bb2735f341
+  branch: fix_jruby_issue
+  specs:
+    capybara (3.9.0)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      xpath (~> 3.2)
+
 PATH
   remote: ..
   specs:
@@ -85,13 +98,6 @@ GEM
     builder (3.2.3)
     byebug (10.0.2)
     cancan (1.6.10)
-    capybara (3.8.2)
-      addressable
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      xpath (~> 3.1)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     codecov (0.1.10)
@@ -377,7 +383,7 @@ GEM
     websocket-driver (0.6.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
-    xpath (3.1.0)
+    xpath (3.2.0)
       nokogiri (~> 1.8)
     yard (0.9.16)
 
@@ -391,7 +397,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   cancan
-  capybara (~> 3.0)
+  capybara!
   codecov
   cucumber
   cucumber-rails (~> 1.5)

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -1,3 +1,16 @@
+GIT
+  remote: https://github.com/deivid-rodriguez/capybara
+  revision: b01b4ceaa7b7ee65b4a0c0d99eaf48bb2735f341
+  branch: fix_jruby_issue
+  specs:
+    capybara (3.9.0)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      xpath (~> 3.2)
+
 PATH
   remote: ..
   specs:
@@ -85,13 +98,6 @@ GEM
     builder (3.2.3)
     byebug (10.0.2)
     cancan (1.6.10)
-    capybara (3.8.2)
-      addressable
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      xpath (~> 3.1)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     codecov (0.1.10)
@@ -376,7 +382,7 @@ GEM
     websocket-driver (0.6.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
-    xpath (3.1.0)
+    xpath (3.2.0)
       nokogiri (~> 1.8)
     yard (0.9.16)
 
@@ -390,7 +396,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   cancan
-  capybara (~> 3.0)
+  capybara!
   codecov
   cucumber
   cucumber-rails (~> 1.5)


### PR DESCRIPTION
This should get the jruby build green. It took me a while but I pinpointed the issue to a change introduced in Capybara 3.0 that made it hit a jruby bug.

See https://github.com/teamcapybara/capybara/issues/2115 for more information.

Hopefully this is addressed in capybara so we can stop pointing to my fork, but for now I'd like to get the build green :)