### PR TITLE
Refactor weird specs

### DIFF
--- a/spec/support/active_admin_integration_spec_helper.rb
+++ b/spec/support/active_admin_integration_spec_helper.rb
@@ -43,18 +43,18 @@ module ActiveAdminIntegrationSpecHelper
     arbre(assigns, helpers, &block).children.first
   end
 
-  # Returns a fake action view instance to use with our renderers
-  def mock_action_view
-    controller = ActionView::TestCase::TestController.new
-    #this line needed because of rails bug https://github.com/rails/rails/commit/d8e98897b5703ac49bf0764da71a06d64ecda9b0
-    controller.params = ActionController::Parameters.new
-    MockActionView.new(ActionController::Base.view_paths, {}, controller)
-  end
-
   # A mock action view to test view helpers
   class MockActionView < ::ActionView::Base
     include ActiveAdmin::ViewHelpers
     include Rails.application.routes.url_helpers
+  end
+
+  # Returns a fake action view instance to use with our renderers
+  def mock_action_view(base = MockActionView)
+    controller = ActionView::TestCase::TestController.new
+    #this line needed because of rails bug https://github.com/rails/rails/commit/d8e98897b5703ac49bf0764da71a06d64ecda9b0
+    controller.params = ActionController::Parameters.new
+    base.new(ActionController::Base.view_paths, {}, controller)
   end
 
   def with_translation(translation)

--- a/spec/support/active_admin_integration_spec_helper.rb
+++ b/spec/support/active_admin_integration_spec_helper.rb
@@ -50,7 +50,6 @@ module ActiveAdminIntegrationSpecHelper
     controller.params = ActionController::Parameters.new
     MockActionView.new(ActionController::Base.view_paths, assigns, controller)
   end
-  alias_method :action_view, :mock_action_view
 
   # A mock action view to test view helpers
   class MockActionView < ::ActionView::Base

--- a/spec/support/active_admin_integration_spec_helper.rb
+++ b/spec/support/active_admin_integration_spec_helper.rb
@@ -44,11 +44,11 @@ module ActiveAdminIntegrationSpecHelper
   end
 
   # Returns a fake action view instance to use with our renderers
-  def mock_action_view(assigns = {})
+  def mock_action_view
     controller = ActionView::TestCase::TestController.new
     #this line needed because of rails bug https://github.com/rails/rails/commit/d8e98897b5703ac49bf0764da71a06d64ecda9b0
     controller.params = ActionController::Parameters.new
-    MockActionView.new(ActionController::Base.view_paths, assigns, controller)
+    MockActionView.new(ActionController::Base.view_paths, {}, controller)
   end
 
   # A mock action view to test view helpers

--- a/spec/unit/auto_link_spec.rb
+++ b/spec/unit/auto_link_spec.rb
@@ -3,17 +3,27 @@ require 'active_admin/view_helpers/auto_link_helper'
 require 'active_admin/view_helpers/display_helper'
 require 'active_admin/view_helpers/method_or_proc_helper'
 
-RSpec.describe "auto linking resources", type: :view do
-  include ActiveAdmin::ViewHelpers::ActiveAdminApplicationHelper
-  include ActiveAdmin::ViewHelpers::AutoLinkHelper
-  include ActiveAdmin::ViewHelpers::DisplayHelper
-  include MethodOrProcHelper
+RSpec.describe "#auto_link" do
+  let(:view_klass) do
+    Class.new(ActionView::Base) do
+      include ActiveAdmin::ViewHelpers::ActiveAdminApplicationHelper
+      include ActiveAdmin::ViewHelpers::AutoLinkHelper
+      include ActiveAdmin::ViewHelpers::DisplayHelper
+      include MethodOrProcHelper
+    end
+  end
+
+  let(:view) { mock_action_view(view_klass) }
+
+  let(:linked_post) { view.auto_link(post) }
 
   let(:active_admin_namespace){ ActiveAdmin.application.namespace(:admin) }
   let(:post){ Post.create! title: "Hello World" }
 
   before do
-    allow(self).to receive(:authorized?).and_return(true)
+    allow(view).to receive(:authorized?).and_return(true)
+    allow(view).to receive(:active_admin_namespace).and_return(active_admin_namespace)
+    allow(view).to receive(:url_options).and_return({})
   end
 
   context "when the resource is not registered" do
@@ -22,7 +32,7 @@ RSpec.describe "auto linking resources", type: :view do
     end
 
     it "should return the display name of the object" do
-      expect(auto_link(post)).to eq "Hello World"
+      expect(linked_post).to eq "Hello World"
     end
   end
 
@@ -34,24 +44,24 @@ RSpec.describe "auto linking resources", type: :view do
     end
 
     it "should return a link with the display name of the object" do
-      expect(auto_link(post)).to \
+      expect(linked_post).to \
           match(%r{<a href="/admin/posts/\d+">Hello World</a>})
     end
 
     it "should keep locale in the url if present" do
-      expect(self).to receive(:url_options).and_return(locale: 'en')
+      expect(view).to receive(:url_options).and_return(locale: 'en')
 
-      expect(auto_link(post)).to \
+      expect(linked_post).to \
           match(%r{<a href="/admin/posts/\d+\?locale=en">Hello World</a>})
     end
 
     context "but the user doesn't have access" do
       before do
-        allow(self).to receive(:authorized?).and_return(false)
+        allow(view).to receive(:authorized?).and_return(false)
       end
 
       it "should return the display name of the object" do
-        expect(auto_link(post)).to eq "Hello World"
+        expect(linked_post).to eq "Hello World"
       end
     end
   end
@@ -64,14 +74,14 @@ RSpec.describe "auto linking resources", type: :view do
     end
 
     it "should fallback to edit" do
-      expect(auto_link(post)).to \
+      expect(linked_post).to \
         match(%r{<a href="/admin/posts/\d+/edit">Hello World</a>})
     end
 
     it "should keep locale in the url if present" do
-      expect(self).to receive(:url_options).and_return(locale: 'en')
+      expect(view).to receive(:url_options).and_return(locale: 'en')
 
-      expect(auto_link(post)).to \
+      expect(linked_post).to \
         match(%r{<a href="/admin/posts/\d+/edit\?locale=en">Hello World</a>})
     end
   end
@@ -85,7 +95,7 @@ RSpec.describe "auto linking resources", type: :view do
       end
 
       it "should return the display name of the object" do
-        expect(auto_link(post)).to eq "Hello World"
+        expect(linked_post).to eq "Hello World"
       end
     end
   end

--- a/spec/unit/filters/filter_form_builder_spec.rb
+++ b/spec/unit/filters/filter_form_builder_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
   # Setup an ActionView::Base object which can be used for
   # generating the form for.
   let(:helpers) do
-    view = action_view
+    view = mock_action_view
     def view.collection_path
       "/posts"
     end
@@ -366,7 +366,7 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
     # Setup an ActionView::Base object which can be used for
     # generating the form for.
     let(:helpers) do
-      view = action_view
+      view = mock_action_view
       def view.collection_path
         "/categories"
       end

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
   # Setup an ActionView::Base object which can be used for
   # generating the form for.
   let(:helpers) do
-    view = action_view
+    view = mock_action_view
     def view.posts_path
       "/posts"
     end

--- a/spec/unit/pretty_format_spec.rb
+++ b/spec/unit/pretty_format_spec.rb
@@ -1,26 +1,66 @@
 require 'active_admin/view_helpers/display_helper'
 
 RSpec.describe "#pretty_format" do
-  include ActiveAdmin::ViewHelpers::DisplayHelper
-
-  def method_missing(*args, &block)
-    mock_action_view.send *args, &block
-  end
-
-  ['hello', 23, 5.67, 10**30, :foo, Arbre::Element.new.br].each do |obj|
-    it "should call `to_s` on #{obj.class}s" do
-      expect(pretty_format(obj)).to eq obj.to_s
+  let(:view_klass) do
+    Class.new(ActionView::Base) do
+      include ActiveAdmin::ViewHelpers
     end
   end
 
-  shared_examples_for 'a time-ish object' do |t|
+  let(:view) { mock_action_view(view_klass) }
+
+  let(:formatted_obj) { view.pretty_format(obj) }
+
+  shared_examples_for 'an object convertible to string' do
+    it "should call `to_s` on the given object" do
+      expect(formatted_obj).to eq obj.to_s
+    end
+  end
+
+  context 'when given a string' do
+    let(:obj) { 'hello' }
+
+    it_behaves_like 'an object convertible to string'
+  end
+
+  context 'when given an integer' do
+    let(:obj) { 23 }
+
+    it_behaves_like 'an object convertible to string'
+  end
+
+  context 'when given a float' do
+    let(:obj) { 5.67 }
+
+    it_behaves_like 'an object convertible to string'
+  end
+
+  context 'when given an exponential' do
+    let(:obj) { 10**30 }
+
+    it_behaves_like 'an object convertible to string'
+  end
+
+  context 'when given a symbol' do
+    let(:obj) { :foo }
+
+    it_behaves_like 'an object convertible to string'
+  end
+
+  context 'when given an arbre element' do
+    let(:obj) { Arbre::Element.new.br }
+
+    it_behaves_like 'an object convertible to string'
+  end
+
+  shared_examples_for 'a time-ish object' do
     it "formats it with the default long format" do
-      expect(pretty_format(t)).to eq "February 28, 1985 20:15"
+      expect(formatted_obj).to eq "February 28, 1985 20:15"
     end
 
     it "formats it with a customized long format" do
       with_translation time: { formats: { long: "%B %d, %Y, %l:%M%P" } } do
-        expect(pretty_format(t)).to eq "February 28, 1985,  8:15pm"
+        expect(formatted_obj).to eq "February 28, 1985,  8:15pm"
       end
     end
 
@@ -33,12 +73,12 @@ RSpec.describe "#pretty_format" do
       end
 
       it "formats it with the default custom format" do
-        expect(pretty_format(t)).to eq "28 Feb 20:15"
+        expect(formatted_obj).to eq "28 Feb 20:15"
       end
 
       it "formats it with i18n custom format" do
         with_translation time: { formats: { short: "%-m %d %Y" } } do
-          expect(pretty_format(t)).to eq "2 28 1985"
+          expect(formatted_obj).to eq "2 28 1985"
         end
       end
     end
@@ -49,33 +89,44 @@ RSpec.describe "#pretty_format" do
       end
 
       it "formats it with the default long format" do
-        expect(pretty_format(t)).to eq "28 de febrero de 1985 20:15"
+        expect(formatted_obj).to eq "28 de febrero de 1985 20:15"
       end
 
       it "formats it with a customized long format" do
         with_translation time: { formats: { long: "El %d de %B de %Y a las %H horas y %M minutos" } } do
-          expect(pretty_format(t)).to eq "El 28 de febrero de 1985 a las 20 horas y 15 minutos"
+          expect(formatted_obj).to eq "El 28 de febrero de 1985 a las 20 horas y 15 minutos"
         end
       end
     end
   end
 
-  it_behaves_like 'a time-ish object', Time.utc(1985, "feb", 28, 20, 15, 1)
-  it_behaves_like 'a time-ish object', DateTime.new(1985, 2, 28, 20, 15, 1)
+  context 'when given a Time in utc' do
+    let(:obj) { Time.utc(1985, "feb", 28, 20, 15, 1) }
+
+    it_behaves_like 'a time-ish object'
+  end
+
+  context 'when given a DateTime' do
+    let(:obj) { DateTime.new(1985, 2, 28, 20, 15, 1) }
+
+    it_behaves_like 'a time-ish object'
+  end
 
   context "given an ActiveRecord object" do
+    let(:obj) { Post.new }
+
     it "should delegate to auto_link" do
-      post = Post.new
-      expect(self).to receive(:auto_link).with(post) { "model name" }
-      expect(pretty_format(post)).to eq "model name"
+      expect(view).to receive(:auto_link).with(obj).and_return("model name")
+      expect(formatted_obj).to eq "model name"
     end
   end
 
   context "given an arbitrary object" do
+    let(:obj)  { Class.new.new }
+
     it "should delegate to `display_name`" do
-      something = Class.new.new
-      expect(self).to receive(:display_name).with(something) { "I'm not famous" }
-      expect(pretty_format(something)).to eq "I'm not famous"
+      expect(view).to receive(:display_name).with(obj) { "I'm not famous" }
+      expect(formatted_obj).to eq "I'm not famous"
     end
   end
 end

--- a/spec/unit/routing_spec.rb
+++ b/spec/unit/routing_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe ActiveAdmin, "Routing", type: :routing do
+RSpec.describe "Routing", type: :routing do
 
   before do
     load_defaults!

--- a/spec/unit/view_helpers/flash_helper_spec.rb
+++ b/spec/unit/view_helpers/flash_helper_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe ActiveAdmin::ViewHelpers::FlashHelper do
 
   describe '.flash_messages' do
-    let(:view) { action_view }
+    let(:view) { mock_action_view }
 
     it "should not include 'timedout' flash messages by default" do
       view.request.flash[:alert] = "Alert"

--- a/spec/unit/view_helpers/form_helper_spec.rb
+++ b/spec/unit/view_helpers/form_helper_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe ActiveAdmin::ViewHelpers::FormHelper do
 
   describe '.active_admin_form_for' do
-    let(:view) { action_view }
+    let(:view) { mock_action_view }
     let(:resource) { double 'resource' }
     let(:default_options) { { builder: ActiveAdmin::FormBuilder } }
 
@@ -20,7 +20,7 @@ RSpec.describe ActiveAdmin::ViewHelpers::FormHelper do
   end
 
   describe ".hidden_field_tags_for" do
-    let(:view) { action_view }
+    let(:view) { mock_action_view }
 
     it "should render hidden field tags for params" do
       html = Capybara.string view.hidden_field_tags_for(ActionController::Parameters.new(scope: "All", filter: "None"))

--- a/spec/unit/views/components/attributes_table_spec.rb
+++ b/spec/unit/views/components/attributes_table_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe ActiveAdmin::Views::AttributesTable do
 
   describe "creating with the dsl" do
-    let(:helpers) { action_view }
+    let(:helpers) { mock_action_view }
 
     let(:post) do
       post = Post.new title: "Hello World", body: nil


### PR DESCRIPTION
The jruby bug we were hitting before #5520 were hitting specs that were a bit "weird". They were including activeadmin modules directly into RSpec examples, that are dynamic classes, and stubbing method calls to `self` on them. Rewriting the specs to be a little bit more "standard" made the bug no longer hit them.

I ended up finding the real culprit, but the rewritten specs look better to me anyways, so I propose to include these changes.