### PR TITLE
Fix bug report spec to not print stuff on jruby

### DIFF
--- a/spec/bug_report_templates_spec.rb
+++ b/spec/bug_report_templates_spec.rb
@@ -1,11 +1,14 @@
+require 'open3'
+
 RSpec.describe 'bug_report_templates' do
   subject do
     Bundler.with_original_env do
       Dir.chdir(chdir_path) do
-        system({'ACTIVE_ADMIN_PATH' => active_admin_root},
-               Gem.ruby,
-               template_path,
-               out: File::NULL)
+        Open3.capture2e(
+          {'ACTIVE_ADMIN_PATH' => active_admin_root},
+          Gem.ruby,
+          template_path
+        )[1]
       end
     end
   end


### PR DESCRIPTION
And an associated warning: the `out:` argument to `system` is unsupported there. See for example https://travis-ci.org/activeadmin/activeadmin/jobs/442915169#L1445-L1656.

Taken from #5514.