### PR TITLE
Ignore vendor dir from style checks

### DIFF
--- a/tasks/lint.rake
+++ b/tasks/lint.rake
@@ -26,7 +26,7 @@ module LinterMixin
   private
 
   def applicable_files
-    Open3.capture2("git grep -Il ''")[0].split
+    Open3.capture2("git grep -Il ''")[0].split.reject { |file| file =~ %r{vendor/} }
   end
 
   def failure_message_for(offenses)


### PR DESCRIPTION
This tweak should get the failures in #5526 green.

We don't want to perform any style checks on vendored code, since it's not our code. It makes upgrading vendored libraries harder, and in any case, any improvements to them (including stylistic ones) should be proposed upstream, in my opinion.