### PR TITLE
Add stuff for managing gemfiles

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,10 @@ steps: &steps
   - checkout
 
   - run:
+      name: Install a specific bundler version
+      command: gem install bundler -v 1.16.6
+
+  - run:
       name: Cat current Gemfile to a specific file so caching works
       command: cat "$BUNDLE_GEMFILE.lock" > current_gemfile.lock
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_script:
 
 before_install:
   - gem update --system # use the very latest Rubygems
-  - gem install bundler # use the very latest Bundler
+  - gem install bundler -v 1.16.6
   - rm "${BUNDLE_GEMFILE}.lock"
 
 script:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -444,4 +444,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.16.5
+   1.16.6

--- a/gemfiles/rails_50.gemfile.lock
+++ b/gemfiles/rails_50.gemfile.lock
@@ -430,4 +430,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.16.5
+   1.16.6

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -429,4 +429,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.16.5
+   1.16.6

--- a/spec/gemfiles_spec.rb
+++ b/spec/gemfiles_spec.rb
@@ -1,0 +1,23 @@
+require "open3"
+
+RSpec.describe "Gemfile sanity" do
+  shared_examples_for "a sane gemfile" do |gemfile|
+    it "is up to date" do
+      current_lockfile = File.read("#{gemfile}.lock")
+
+      new_lockfile = Bundler.with_original_env do
+        `BUNDLE_GEMFILE=#{gemfile} bundle lock --print`
+      end
+
+      msg = "Please update #{gemfile}'s lock file with `BUNDLE_GEMFILE=#{gemfile} bundle install` and commit the result"
+
+      expect(current_lockfile).to eq(new_lockfile), msg
+    end
+  end
+
+  it_behaves_like "a sane gemfile", "Gemfile"
+
+  Dir.glob("gemfiles/*.gemfile").each do |gemfile|
+    it_behaves_like "a sane gemfile", gemfile
+  end
+end

--- a/tasks/gemfiles.rake
+++ b/tasks/gemfiles.rake
@@ -1,0 +1,8 @@
+desc "Bundle all Gemfiles"
+task :bundle do
+  ["Gemfile", *Dir.glob("gemfiles/*.gemfile")].each do |gemfile|
+    Bundler.with_original_env do
+      system({ "BUNDLE_GEMFILE" => gemfile }, "bundle install")
+    end
+  end
+end


### PR DESCRIPTION
Having multiple gemfiles and lock files in the repo is useful for environment determinism, but it takes a bit of work to keep up to date.

This PR adds some tools to facilitate that:

* A spec to check that lockfiles are kept in sync.
* A task to bundle them all in one command: `bundle exec rake bundle`.

This way PRs adding or removing dependencies (like #5512), should be easier to handle.