### PR TITLE
Fix bundler caching on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ steps: &steps
 
   - run:
       name: Install dependencies
-      command: bundle install --without development --path vendor/bundle --retry 3 --jobs 3
+      command: bundle install --without development --path /home/circleci/project/vendor/bundle --retry 3 --jobs 3
 
   - run:
       name: Install chromedriver

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ steps: &steps
 
   - restore_cache:
       keys:
-        - bundler-dependencies-{{ checksum "current_gemfile.lock" }}
+        - bundler-dependencies-{{ checksum "current_gemfile.lock" }}-{{ .Environment.CIRCLE_JOB }}
 
   - run:
       name: Install dependencies
@@ -26,7 +26,7 @@ steps: &steps
       command: bin/install_chromedriver.sh
 
   - save_cache:
-      key: bundler-dependencies-{{ checksum "current_gemfile.lock" }}
+      key: bundler-dependencies-{{ checksum "current_gemfile.lock" }}-{{ .Environment.CIRCLE_JOB }}
       paths:
         - vendor/bundle
 

--- a/Gemfile.common
+++ b/Gemfile.common
@@ -37,7 +37,7 @@ group :development do
 end
 
 group :test do
-  gem 'capybara', git: 'https://github.com/deivid-rodriguez/capybara', branch: 'fix_jruby_issue'
+  gem 'capybara', git: 'https://github.com/teamcapybara/capybara'
   gem 'simplecov', require: false # Test coverage generator. Go to /coverage/ after running tests
   gem 'codecov', require: false # Test coverage website. Go to https://codecov.io
   gem 'cucumber-rails', '~> 1.5', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GIT
-  remote: https://github.com/deivid-rodriguez/capybara
-  revision: b01b4ceaa7b7ee65b4a0c0d99eaf48bb2735f341
-  branch: fix_jruby_issue
+  remote: https://github.com/teamcapybara/capybara
+  revision: 057b552f5be85f7c82e57bbc8179f65eba8a0a94
   specs:
     capybara (3.9.0)
       addressable
@@ -9,6 +8,7 @@ GIT
       nokogiri (~> 1.8)
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
+      regexp_parser (~> 1.2)
       xpath (~> 3.2)
 
 PATH
@@ -320,6 +320,7 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     redcarpet (3.4.0)
+    regexp_parser (1.2.0)
     request_store (1.4.1)
       rack (>= 1.4)
     responders (2.4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,7 +108,7 @@ GEM
     cancan (1.6.10)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    codecov (0.1.10)
+    codecov (0.1.13)
       json
       simplecov
       url

--- a/gemfiles/rails_50.gemfile.lock
+++ b/gemfiles/rails_50.gemfile.lock
@@ -1,7 +1,6 @@
 GIT
-  remote: https://github.com/deivid-rodriguez/capybara
-  revision: b01b4ceaa7b7ee65b4a0c0d99eaf48bb2735f341
-  branch: fix_jruby_issue
+  remote: https://github.com/teamcapybara/capybara
+  revision: 057b552f5be85f7c82e57bbc8179f65eba8a0a94
   specs:
     capybara (3.9.0)
       addressable
@@ -9,6 +8,7 @@ GIT
       nokogiri (~> 1.8)
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
+      regexp_parser (~> 1.2)
       xpath (~> 3.2)
 
 PATH
@@ -307,6 +307,7 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     redcarpet (3.4.0)
+    regexp_parser (1.2.0)
     request_store (1.4.1)
       rack (>= 1.4)
     responders (2.4.0)

--- a/gemfiles/rails_50.gemfile.lock
+++ b/gemfiles/rails_50.gemfile.lock
@@ -100,7 +100,7 @@ GEM
     cancan (1.6.10)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    codecov (0.1.10)
+    codecov (0.1.13)
       json
       simplecov
       url

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -100,7 +100,7 @@ GEM
     cancan (1.6.10)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    codecov (0.1.10)
+    codecov (0.1.13)
       json
       simplecov
       url

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -1,7 +1,6 @@
 GIT
-  remote: https://github.com/deivid-rodriguez/capybara
-  revision: b01b4ceaa7b7ee65b4a0c0d99eaf48bb2735f341
-  branch: fix_jruby_issue
+  remote: https://github.com/teamcapybara/capybara
+  revision: 057b552f5be85f7c82e57bbc8179f65eba8a0a94
   specs:
     capybara (3.9.0)
       addressable
@@ -9,6 +8,7 @@ GIT
       nokogiri (~> 1.8)
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
+      regexp_parser (~> 1.2)
       xpath (~> 3.2)
 
 PATH
@@ -306,6 +306,7 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     redcarpet (3.4.0)
+    regexp_parser (1.2.0)
     request_store (1.4.1)
       rack (>= 1.4)
     responders (2.4.0)


### PR DESCRIPTION
While working on #5530, I noticed that bundler caching on CircleCI is not working for gemfiles in the `gemfiles/` folder. I'm hoping these changes will fix that. It should cut down CI time by between 30s and 1'30s per job.