### PR TITLE
Bump rubies used in CI to latest versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ version: 2.1
 jobs:
   lint_and_docs:
     docker:
-      - image: circleci/ruby:2.5.1
+      - image: circleci/ruby:2.5.3
 
     environment:
       BUNDLE_GEMFILE: Gemfile
@@ -78,7 +78,7 @@ jobs:
 
   ruby23rails50:
     docker:
-      - image: circleci/ruby:2.3.7-node-browsers
+      - image: circleci/ruby:2.3.8-node-browsers
 
     environment:
       BUNDLE_GEMFILE: gemfiles/rails_50.gemfile
@@ -88,7 +88,7 @@ jobs:
 
   ruby23rails51:
     docker:
-      - image: circleci/ruby:2.3.7-node-browsers
+      - image: circleci/ruby:2.3.8-node-browsers
 
     environment:
       BUNDLE_GEMFILE: gemfiles/rails_51.gemfile
@@ -98,7 +98,7 @@ jobs:
 
   ruby23rails52:
     docker:
-      - image: circleci/ruby:2.3.7-node-browsers
+      - image: circleci/ruby:2.3.8-node-browsers
 
     environment:
       BUNDLE_GEMFILE: Gemfile
@@ -108,7 +108,7 @@ jobs:
 
   ruby24rails50:
     docker:
-      - image: circleci/ruby:2.4.4-node-browsers
+      - image: circleci/ruby:2.4.5-node-browsers
 
     environment:
       BUNDLE_GEMFILE: gemfiles/rails_50.gemfile
@@ -118,7 +118,7 @@ jobs:
 
   ruby24rails51:
     docker:
-      - image: circleci/ruby:2.4.4-node-browsers
+      - image: circleci/ruby:2.4.5-node-browsers
 
     environment:
       BUNDLE_GEMFILE: gemfiles/rails_51.gemfile
@@ -128,7 +128,7 @@ jobs:
 
   ruby24rails52:
     docker:
-      - image: circleci/ruby:2.4.4-node-browsers
+      - image: circleci/ruby:2.4.5-node-browsers
 
     environment:
       BUNDLE_GEMFILE: Gemfile
@@ -138,7 +138,7 @@ jobs:
 
   ruby25rails50:
     docker:
-      - image: circleci/ruby:2.5.1-node-browsers
+      - image: circleci/ruby:2.5.3-node-browsers
 
     environment:
       BUNDLE_GEMFILE: gemfiles/rails_50.gemfile
@@ -148,7 +148,7 @@ jobs:
 
   ruby25rails51:
     docker:
-      - image: circleci/ruby:2.5.1-node-browsers
+      - image: circleci/ruby:2.5.3-node-browsers
 
     environment:
       BUNDLE_GEMFILE: gemfiles/rails_51.gemfile
@@ -158,7 +158,7 @@ jobs:
 
   ruby25rails52:
     docker:
-      - image: circleci/ruby:2.5.1-node-browsers
+      - image: circleci/ruby:2.5.3-node-browsers
 
     environment:
       BUNDLE_GEMFILE: Gemfile


### PR DESCRIPTION
As suggested in https://github.com/activeadmin/activeadmin/pull/5531#discussion_r226872505.