### PR TITLE
Split test app creation to a separate job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,6 +291,15 @@ jobs:
 workflows:
   version: 2
 
+  #
+  # The workflow has three types of jobs:
+  #
+  # * A lint job to run style checks.
+  # * Jobs that create test apps for each supported rails version.
+  # * Jobs that run tests, one for each supported [ruby_version, rails_version]
+  #   combination. Every test job for a specific rails version reuses the test
+  #   app created for that specific rails version.
+  #
   build:
     jobs:
       - lint_and_docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,10 +33,25 @@ version: 2.1
     paths:
       - vendor/bundle
 
+.create_test_app: &create_test_app
+  run:
+    name: Create test app
+    command: bundle exec rake setup
+
+.save_test_app_to_workspace: &save_test_app_to_workspace
+  persist_to_workspace:
+    root: spec/rails
+    paths:
+      - rails-*
+
+.restore_test_app_from_workspace: &restore_test_app_from_workspace
+  attach_workspace:
+    at: spec/rails
+
 .run_tests: &run_tests
   run:
     name: Run tests
-    command: COVERAGE=true bundle exec rake
+    command: COVERAGE=true bundle exec rake test
 
 .generate_docs: &generate_docs
   run:
@@ -56,9 +71,50 @@ version: 2.1
   - *install_dependencies
   - *install_chromedriver
   - *save_cache
+  - *restore_test_app_from_workspace
   - *run_tests
 
+.test_app_steps: &test_app_steps
+  - checkout
+  - *install_bundler
+  - *copy_current_gemfile
+  - *restore_cache
+  - *install_dependencies
+  - *save_cache
+  - *create_test_app
+  - *save_test_app_to_workspace
+
 jobs:
+  testapp50:
+    docker:
+      - image: circleci/ruby:2.5.3-node
+
+    environment:
+      BUNDLE_GEMFILE: gemfiles/rails_50.gemfile
+
+    steps:
+      *test_app_steps
+
+  testapp51:
+    docker:
+      - image: circleci/ruby:2.5.3-node
+
+    environment:
+      BUNDLE_GEMFILE: gemfiles/rails_51.gemfile
+
+    steps:
+      *test_app_steps
+
+  testapp52:
+    docker:
+      - image: circleci/ruby:2.5.3-node
+
+    environment:
+      BUNDLE_GEMFILE: Gemfile
+
+    steps:
+      *test_app_steps
+
   lint_and_docs:
     docker:
       - image: circleci/ruby:2.5.3
@@ -238,22 +294,67 @@ workflows:
   build:
     jobs:
       - lint_and_docs
-      - ruby23rails50
-      - ruby23rails51
-      - ruby23rails52
 
-      - ruby24rails50
-      - ruby24rails51
-      - ruby24rails52
+      - testapp50
+      - testapp51
+      - testapp52
 
-      - ruby25rails50
-      - ruby25rails51
-      - ruby25rails52
+      - ruby23rails50:
+          requires:
+            - testapp50
 
-      - jruby91rails50
-      - jruby91rails51
-      - jruby91rails52
+      - ruby23rails51:
+          requires:
+            - testapp51
 
-      - jruby92rails50
-      - jruby92rails51
-      - jruby92rails52
+      - ruby23rails52:
+          requires:
+            - testapp52
+
+      - ruby24rails50:
+          requires:
+            - testapp50
+
+      - ruby24rails51:
+          requires:
+            - testapp51
+
+      - ruby24rails52:
+          requires:
+            - testapp52
+
+      - ruby25rails50:
+          requires:
+            - testapp50
+
+      - ruby25rails51:
+          requires:
+            - testapp51
+
+      - ruby25rails52:
+          requires:
+            - testapp52
+
+      - jruby91rails50:
+          requires:
+            - testapp50
+
+      - jruby91rails51:
+          requires:
+            - testapp51
+
+      - jruby91rails52:
+          requires:
+            - testapp52
+
+      - jruby92rails50:
+          requires:
+            - testapp50
+
+      - jruby92rails51:
+          requires:
+            - testapp51
+
+      - jruby92rails52:
+          requires:
+            - testapp52

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source "https://rubygems.org"
 eval_gemfile(File.expand_path("Gemfile.common", __dir__))
 
 gem "rails", "~> 5.2.x"
-gem "bootsnap"
 gem "devise", "~> 4.4"
 gem "draper", "~> 3.0"
 gem "activerecord-jdbcsqlite3-adapter", ">= 52.0", platforms: :jruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,10 +99,6 @@ GEM
       rack (>= 0.9.0)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
-    bootsnap (1.3.2)
-      msgpack (~> 1.0)
-    bootsnap (1.3.2-java)
-      msgpack (~> 1.0)
     builder (3.2.3)
     byebug (10.0.2)
     cancan (1.6.10)
@@ -244,8 +240,6 @@ GEM
     mixlib-cli (1.7.0)
     mixlib-config (2.2.13)
       tomlrb
-    msgpack (1.2.4)
-    msgpack (1.2.4-java)
     multi_json (1.13.1)
     multi_test (0.1.2)
     nio4r (2.3.1)
@@ -408,7 +402,6 @@ DEPENDENCIES
   activerecord-jdbcsqlite3-adapter (>= 52.0)
   better_errors
   binding_of_caller
-  bootsnap
   cancan
   capybara!
   codecov

--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,7 @@ task :setup, [:parallel, :dir, :template] do |_t, opts|
     system "mkdir -p #{base_dir}"
     args = %W(
       -m spec/support/#{template}.rb
+      --skip-bootsnap
       --skip-bundle
       --skip-gemfile
       --skip-listen

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,12 @@
 require 'bundler/gem_tasks'
 
 desc 'Creates a test rails app for the specs to run against'
-task :setup, [:parallel, :dir, :template] do |_t, opts|
+task :setup, [:parallel, :rails_env, :template] do |_t, opts|
   require 'rails/version'
 
-  base_dir = opts[:dir] || 'spec/rails'
+  rails_env = opts[:rails_env] || 'test'
+
+  base_dir = rails_env == 'test' ? 'spec/rails' : '.test-rails-apps'
   app_dir = "#{base_dir}/rails-#{Rails::VERSION::STRING}"
   template = opts[:template] || 'rails_template'
 
@@ -25,7 +27,7 @@ task :setup, [:parallel, :dir, :template] do |_t, opts|
 
     command = ['bundle', 'exec', 'rails', 'new', app_dir, *args].join(' ')
 
-    env = { 'BUNDLE_GEMFILE' => ENV['BUNDLE_GEMFILE'] }
+    env = { 'BUNDLE_GEMFILE' => ENV['BUNDLE_GEMFILE'], 'RAILS_ENV' => rails_env }
     env['INSTALL_PARALLEL'] = 'yes' if opts[:parallel]
 
     Bundler.with_original_env { Kernel.exec(env, command) }

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -15,11 +15,6 @@ end
 require 'rails'
 ENV['RAILS_ROOT'] = File.expand_path("../../../spec/rails/rails-#{Rails.version}", __FILE__)
 
-# Create the test app if it doesn't exists
-unless File.exists?(ENV['RAILS_ROOT'])
-  system 'rake setup'
-end
-
 require 'active_record'
 require 'active_admin'
 require 'devise'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,11 +4,6 @@ ENV['RAILS_ENV'] = 'test'
 
 ENV['RAILS_ROOT'] = File.expand_path("../rails/rails-#{Gem.loaded_specs["rails"].version}", __FILE__)
 
-# Create the test app if it doesn't exists
-unless File.exists?(ENV['RAILS_ROOT'])
-  system 'rake setup'
-end
-
 require ENV['RAILS_ROOT'] + '/config/environment'
 
 require 'rspec/rails'

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -137,8 +137,7 @@ if ENV['RAILS_ENV'] != 'test'
   inject_into_file 'config/routes.rb', "\n  root to: redirect('admin')", after: /.*routes.draw do/
 end
 
-rake "db:drop db:create db:migrate", env: 'development'
-rake "db:drop db:create db:migrate", env: 'test'
+rake "db:drop db:create db:migrate", env: ENV['RAILS_ENV']
 
 if ENV['INSTALL_PARALLEL']
   inject_into_file 'config/database.yml', "<%= ENV['TEST_ENV_NUMBER'] %>", after: 'test.sqlite3'

--- a/tasks/local.rake
+++ b/tasks/local.rake
@@ -1,7 +1,7 @@
 desc 'Runs a command agains the local sample application'
 task :local do
   Rake::Task['setup'].invoke(false,
-                             '.test-rails-apps',
+                             'development',
                              'rails_template_with_data')
 
   app_folder = ".test-rails-apps/rails-#{Rails::VERSION::STRING}"

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -1,5 +1,5 @@
 desc "Run the full suite using 1 core"
-task test: [:spec, :cucumber]
+task test: [:setup, :spec, :cucumber]
 
 require 'rspec/core/rake_task'
 


### PR DESCRIPTION
This is some initial implementation of https://github.com/activeadmin/activeadmin/pull/5530#issuecomment-431696455.

It turns out that the main reason why jruby is so slow is the creation of the test app, because at lot of subprocesses are spawned, and jruby has a very slow startup. This should alleviate that by creating a single test app per supported Rails version.

I haven't actually tried any of this in CI, will see how it goes once Github is back up.