### PR TITLE
Fix jruby errors and warnings

### DIFF
--- a/Gemfile.common
+++ b/Gemfile.common
@@ -26,9 +26,6 @@ gem 'yard'                        # Documentation generator
 gem 'redcarpet', platforms: :mri  # Markdown implementation (for yard)
 gem 'kramdown', platforms: :jruby # Markdown implementation (for yard)
 
-# Application server
-gem 'puma', '~> 3.12'
-
 group :development do
   # Debugging
   gem 'better_errors' # Web UI to debug exceptions. Go to /__better_errors to access the latest one

--- a/Gemfile.common
+++ b/Gemfile.common
@@ -11,12 +11,15 @@ gem 'parallel_tests'
 gem 'pry' # Easily debug from your console with `binding.pry`
 gem 'pry-byebug', platforms: :mri
 
-# Code style
-gem 'rubocop', '0.59.2'
-gem 'mdl', '0.4.0'
+group :lint do
+  # Code style
+  gem 'rubocop', '0.59.2'
+  gem 'mdl', '0.4.0'
 
-# Translations
-gem 'i18n-tasks'
+  # Translations
+  gem 'i18n-tasks'
+  gem 'i18n-spec'
+end
 
 # Documentation
 gem 'yard'                        # Documentation generator
@@ -48,7 +51,6 @@ group :test do
   gem 'launchy'
   gem 'rails-i18n' # Provides default i18n for many languages
   gem 'rspec-rails'
-  gem 'i18n-spec'
   gem 'sqlite3', platforms: :mri
   gem 'selenium-webdriver'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,8 +272,6 @@ GEM
       byebug (~> 10.0)
       pry (~> 0.10)
     public_suffix (3.0.3)
-    puma (3.12.0)
-    puma (3.12.0-java)
     pundit (2.0.0)
       activesupport (>= 3.0.0)
     rack (2.0.5)
@@ -430,7 +428,6 @@ DEPENDENCIES
   parallel_tests
   pry
   pry-byebug
-  puma (~> 3.12)
   pundit
   rack-mini-profiler (>= 0.10.1)
   rails (~> 5.2.x)

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -66,7 +66,7 @@ end
 
 Capybara.javascript_driver = :chrome
 
-Capybara.server = :puma, { Silent: true }
+Capybara.server = :webrick
 
 Capybara.asset_host = 'http://localhost:3000'
 

--- a/gemfiles/rails_50.gemfile.lock
+++ b/gemfiles/rails_50.gemfile.lock
@@ -260,8 +260,6 @@ GEM
       byebug (~> 10.0)
       pry (~> 0.10)
     public_suffix (3.0.3)
-    puma (3.12.0)
-    puma (3.12.0-java)
     pundit (2.0.0)
       activesupport (>= 3.0.0)
     rack (2.0.5)
@@ -416,7 +414,6 @@ DEPENDENCIES
   parallel_tests
   pry
   pry-byebug
-  puma (~> 3.12)
   pundit
   rack-mini-profiler (>= 0.10.1)
   rails (= 5.0.6)

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -259,8 +259,6 @@ GEM
       byebug (~> 10.0)
       pry (~> 0.10)
     public_suffix (3.0.3)
-    puma (3.12.0)
-    puma (3.12.0-java)
     pundit (2.0.0)
       activesupport (>= 3.0.0)
     rack (2.0.5)
@@ -415,7 +413,6 @@ DEPENDENCIES
   parallel_tests
   pry
   pry-byebug
-  puma (~> 3.12)
   pundit
   rack-mini-profiler (>= 0.10.1)
   rails (= 5.1.4)


### PR DESCRIPTION
This PR fixes some warnings and errors that are printed to the screen when running specs under jruby:

* One is a `parser` ruby version mismatch warning that comes from requiring rubocop. I fixed it by not requiring rubocop (or other lint tools, since I was at it) unless necessary.
* The other one is some errors printed by `puma`. They don't seem to affect the outcome of the build, but they're annoying. I tried using the `webrick` server that comes with ruby and it works just fine with similar run times, so I propose to use that. `webrick` is not something people use in production, but I don't think using `puma` here brings a lot of benefits.