### PR TITLE
Bump test gems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2.1
 .install_bundler: &install_bundler
   run:
     name: Install a specific bundler version
-    command: gem install bundler -v 1.16.6
+    command: gem install bundler -v 1.17.1
 
 .copy_current_gemfile: &copy_current_gemfile
   run:

--- a/Gemfile.common
+++ b/Gemfile.common
@@ -5,7 +5,7 @@ gem 'jruby-openssl', '~> 0.10.1', platforms: :jruby
 
 # Utility gems used in both development & test environments
 gem 'rake'
-gem 'parallel_tests'
+gem 'parallel_tests', '~> 2.26'
 
 # Debugging
 gem 'pry' # Easily debug from your console with `binding.pry`

--- a/Gemfile.common
+++ b/Gemfile.common
@@ -37,7 +37,7 @@ group :development do
 end
 
 group :test do
-  gem 'capybara', git: 'https://github.com/teamcapybara/capybara'
+  gem 'capybara', '~> 3.10'
   gem 'simplecov', require: false # Test coverage generator. Go to /coverage/ after running tests
   gem 'codecov', require: false # Test coverage website. Go to https://codecov.io
   gem 'cucumber-rails', '~> 1.5', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -435,4 +435,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.16.6
+   1.17.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,3 @@
-GIT
-  remote: https://github.com/teamcapybara/capybara
-  revision: 057b552f5be85f7c82e57bbc8179f65eba8a0a94
-  specs:
-    capybara (3.9.0)
-      addressable
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      regexp_parser (~> 1.2)
-      xpath (~> 3.2)
-
 PATH
   remote: .
   specs:
@@ -102,6 +89,14 @@ GEM
     builder (3.2.3)
     byebug (10.0.2)
     cancan (1.6.10)
+    capybara (3.10.0)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.2)
+      xpath (~> 3.2)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     codecov (0.1.13)
@@ -403,7 +398,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   cancan
-  capybara!
+  capybara (~> 3.10)
   codecov
   cucumber
   cucumber-rails (~> 1.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,7 +249,7 @@ GEM
     nokogiri (1.8.4-java)
     orm_adapter (0.5.0)
     parallel (1.12.1)
-    parallel_tests (2.25.0)
+    parallel_tests (2.26.0)
       parallel
     parser (2.5.1.2)
       ast (~> 2.4.0)
@@ -418,7 +418,7 @@ DEPENDENCIES
   kramdown
   launchy
   mdl (= 0.4.0)
-  parallel_tests
+  parallel_tests (~> 2.26)
   pry
   pry-byebug
   pundit

--- a/gemfiles/rails_50.gemfile.lock
+++ b/gemfiles/rails_50.gemfile.lock
@@ -243,7 +243,7 @@ GEM
     nokogiri (1.8.4-java)
     orm_adapter (0.5.0)
     parallel (1.12.1)
-    parallel_tests (2.25.0)
+    parallel_tests (2.26.0)
       parallel
     parser (2.5.1.2)
       ast (~> 2.4.0)
@@ -411,7 +411,7 @@ DEPENDENCIES
   kramdown
   launchy
   mdl (= 0.4.0)
-  parallel_tests
+  parallel_tests (~> 2.26)
   pry
   pry-byebug
   pundit

--- a/gemfiles/rails_50.gemfile.lock
+++ b/gemfiles/rails_50.gemfile.lock
@@ -428,4 +428,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.16.6
+   1.17.1

--- a/gemfiles/rails_50.gemfile.lock
+++ b/gemfiles/rails_50.gemfile.lock
@@ -1,16 +1,3 @@
-GIT
-  remote: https://github.com/teamcapybara/capybara
-  revision: 057b552f5be85f7c82e57bbc8179f65eba8a0a94
-  specs:
-    capybara (3.9.0)
-      addressable
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      regexp_parser (~> 1.2)
-      xpath (~> 3.2)
-
 PATH
   remote: ..
   specs:
@@ -98,6 +85,14 @@ GEM
     builder (3.2.3)
     byebug (10.0.2)
     cancan (1.6.10)
+    capybara (3.10.0)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.2)
+      xpath (~> 3.2)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     codecov (0.1.13)
@@ -396,7 +391,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   cancan
-  capybara!
+  capybara (~> 3.10)
   codecov
   cucumber
   cucumber-rails (~> 1.5)

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -242,7 +242,7 @@ GEM
     nokogiri (1.8.4-java)
     orm_adapter (0.5.0)
     parallel (1.12.1)
-    parallel_tests (2.25.0)
+    parallel_tests (2.26.0)
       parallel
     parser (2.5.1.2)
       ast (~> 2.4.0)
@@ -410,7 +410,7 @@ DEPENDENCIES
   kramdown
   launchy
   mdl (= 0.4.0)
-  parallel_tests
+  parallel_tests (~> 2.26)
   pry
   pry-byebug
   pundit

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -1,16 +1,3 @@
-GIT
-  remote: https://github.com/teamcapybara/capybara
-  revision: 057b552f5be85f7c82e57bbc8179f65eba8a0a94
-  specs:
-    capybara (3.9.0)
-      addressable
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      regexp_parser (~> 1.2)
-      xpath (~> 3.2)
-
 PATH
   remote: ..
   specs:
@@ -98,6 +85,14 @@ GEM
     builder (3.2.3)
     byebug (10.0.2)
     cancan (1.6.10)
+    capybara (3.10.0)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.2)
+      xpath (~> 3.2)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     codecov (0.1.13)
@@ -395,7 +390,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   cancan
-  capybara!
+  capybara (~> 3.10)
   codecov
   cucumber
   cucumber-rails (~> 1.5)

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -427,4 +427,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.16.6
+   1.17.1

--- a/tasks/gemfiles.rake
+++ b/tasks/gemfiles.rake
@@ -1,8 +1,8 @@
 desc "Bundle all Gemfiles"
-task :bundle do
+task :bundle do |_t, opts|
   ["Gemfile", *Dir.glob("gemfiles/*.gemfile")].each do |gemfile|
     Bundler.with_original_env do
-      system({ "BUNDLE_GEMFILE" => gemfile }, "bundle install")
+      system({ "BUNDLE_GEMFILE" => gemfile }, "bundle", opts)
     end
   end
 end


### PR DESCRIPTION
This is a little follow up to the recent improvements in the test system.

* Bumps parallel_tests to 2.26.0 since it fixes some annoying warnings about cucumber formatters.
* Bumps capybara to 3.10.0 so we no longer need to point to master to pick up our recent fixes.
* Bumps the bundler we use to the latest 1.17.1 since it's great.