### PR TITLE
Inform number of processors to test app job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ version: 2.1
 .create_test_app: &create_test_app
   run:
     name: Create test app
-    command: bundle exec rake setup
+    command: PARALLEL_TEST_PROCESSORS=4 bundle exec rake setup
 
 .save_test_app_to_workspace: &save_test_app_to_workspace
   persist_to_workspace:


### PR DESCRIPTION
We have some instability in CircleCI at the moment and I think it might be due to this. On #5530 I moved some parallel tasks to the test app creation job, so we need to explicitly inform that task about the real number of processors, since in this environment it is not guessed properly.