### PR TITLE
Detach previous batch_action click handler before attaching new one (coffeescript)

### DIFF
--- a/app/assets/javascripts/active_admin/lib/batch_actions.js.coffee
+++ b/app/assets/javascripts/active_admin/lib/batch_actions.js.coffee
@@ -2,7 +2,7 @@ onDOMReady = ->
   #
   # Use ActiveAdmin.modal_dialog to prompt user if confirmation is required for current Batch Action
   #
-  $('.batch_actions_selector li a').click (e)->
+  $('.batch_actions_selector li a').off('click').on 'click', (e)->
     e.stopPropagation() # prevent Rails UJS click event
     e.preventDefault()
     if message = $(@).data 'confirm'


### PR DESCRIPTION
Following #5553, here is a propositional change to solve batch action modal being opened twice when using turbolinks. This ensures any previously attached click handler is being removed (including own `batch_actions` handler) before attaching own handler.

I'm targeting `1-3-stable` branch as master has moved from coffeescript to es6, so that's the current stable branch in production. Patch could easily back ported to all `1-x-stable` branch, at your discretion. Incoming PR to solve that issue on master as well.