### PR TITLE
Detach previous batch_action click handler before attaching new one (es6)

### DIFF
--- a/app/assets/javascripts/active_admin/lib/batch_actions.es6
+++ b/app/assets/javascripts/active_admin/lib/batch_actions.es6
@@ -3,7 +3,7 @@ const onDOMReady = function() {
   // Use ActiveAdmin.modal_dialog to prompt user if
   // confirmation is required for current Batch Action
   //
-  $('.batch_actions_selector li a').click(function(event){
+  $('.batch_actions_selector li a').off('click').on('click', function(event){
     let message;
     event.stopPropagation(); // prevent Rails UJS click event
     event.preventDefault();


### PR DESCRIPTION
Following #5553 and #5562, here is the es6 version of the same patch to ensures any previously attached click handler is being removed (including own batch_actions handler) before attaching own handler.