### PR TITLE
Backport fix for sample app generation

### DIFF
--- a/spec/support/rails_template_with_data.rb
+++ b/spec/support/rails_template_with_data.rb
@@ -318,7 +318,7 @@ append_file "db/seeds.rb", "\n\n" + <<-RUBY.strip_heredoc
     ActiveAdmin::Comment.create!(
       namespace: :admin,
       author: AdminUser.first,
-      body: "Test comment #{i}",
+      body: "Test comment \#{i}",
       resource: categories.sample
     )
   end


### PR DESCRIPTION
I don't think we'll release a 1.5 version and we'll go directly to 2.0. However, we might release 1.4.x bug fix releases, and being able to generate a sample application against 1-4-stable might help fixing any bugs that we want to fix on the branch.