### PR TITLE
Fix bug in menu item link with method delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
   convert that file to plain JS (`//= require active_admin/base` if you
   didn't add any stuff to it).
 
+### Bug Fixes
+
+* Fix menu item link with method delete. [#5583][] by [@tiagotex][]
+
 ## 1.4.0 [☰](https://github.com/activeadmin/activeadmin/compare/v1.3.1...v1.4.0)
 
 ### Enhancements
@@ -357,6 +361,7 @@ Please check [0-6-stable][] for previous changes.
 [#5501]: https://github.com/activeadmin/activeadmin/pull/5501
 [#5517]: https://github.com/activeadmin/activeadmin/pull/5517
 [#5537]: https://github.com/activeadmin/activeadmin/pull/5537
+[#5583]: https://github.com/activeadmin/activeadmin/pull/5583
 
 [@5t111111]: https://github.com/5t111111
 [@aarek]: https://github.com/aarek

--- a/features/menu.feature
+++ b/features/menu.feature
@@ -38,6 +38,19 @@ Feature: Menu
     When I follow "Custom Menu"
     Then I should be on the admin dashboard page
 
+  Scenario: Add a non-resource menu item with method delete
+    Given a configuration of:
+    """
+      ActiveAdmin.application.namespace :admin do |admin|
+        admin.build_menu do |menu|
+          menu.add label: "Delete Menu", url: :admin_dashboard_path, html_options: { method: :delete }
+        end
+      end
+    """
+    When I am on the dashboard
+    Then I should see a menu item for "Delete Menu"
+     And I should see the element "a[data-method='delete']:contains('Delete Menu')"
+
   Scenario: Adding a resource as a sub menu item
     Given a configuration of:
     """

--- a/features/users/logging_out.feature
+++ b/features/users/logging_out.feature
@@ -3,7 +3,27 @@ Feature: User Logging out
   Logging out of the system as an admin user
 
   Scenario: Logging out successfully
-    Given I am logged in
+    Given a configuration of:
+    """
+      ActiveAdmin.setup do |config|
+        config.logout_link_method = :get
+      end
+    """
+    And I am logged in
     When I go to the dashboard
+    Then I should see the element "a[data-method='get']:contains('Logout')"
+    And I follow "Logout"
+    Then I should see "Login"
+
+  Scenario: Logging out sucessfully with delete method
+    Given a configuration of:
+    """
+      ActiveAdmin.setup do |config|
+        config.logout_link_method = :delete
+      end
+    """
+    And I am logged in
+    When I am on the dashboard
+    Then I should see the element "a[data-method='delete']:contains('Logout')"
     And I follow "Logout"
     Then I should see "Login"

--- a/lib/active_admin/views/components/menu_item.rb
+++ b/lib/active_admin/views/components/menu_item.rb
@@ -18,7 +18,7 @@ module ActiveAdmin
         add_class "current" if item.current? assigns[:current_tab]
 
         if url
-          a label, item.html_options.merge(href: url)
+          text_node link_to label, url, item.html_options
         else
           span label, item.html_options
         end


### PR DESCRIPTION
Menu item links with method delete send a post request instead of a delete request.

In active admin 1.3.1
```html
<a rel="nofollow" data-method="delete" href="/users/sign_out">Logout</a>
```
In active admin 1.4.0
```html
<a method="delete" href="/users/sign_out">Logout</a>
```

This regression was introduced in https://github.com/activeadmin/activeadmin/commit/8e5c00d11ff67ffef7f761807acc6953c6c69ea7#diff-4a22354c40f395659ed3fd7cad761bf5R47

Browsers don't support the DELETE Verb,but rails uses it, so `link_to` puts the verb in `data-method` instead of the traditional `method` allowing rails to do it's magic. Source: https://stackoverflow.com/a/7465962

This restores the behavior present in 1.3.1

I created a feature test but I'm not sure this is the correct way to test this, would you suggest another way?