### PR TITLE
Backport fix bug in menu item links with method delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Master (unreleased)
+
+### Bug Fixes
+
+* Fix menu item link with method delete. [#5583][] by [@tiagotex][]
+
 ## 1.4.0 [☰](https://github.com/activeadmin/activeadmin/compare/v1.3.1...v1.4.0)
 
 ### Enhancements
@@ -337,6 +343,7 @@ Please check [0-6-stable][] for previous changes.
 [#5501]: https://github.com/activeadmin/activeadmin/pull/5501
 [#5517]: https://github.com/activeadmin/activeadmin/pull/5517
 [#5537]: https://github.com/activeadmin/activeadmin/pull/5537
+[#5583]: https://github.com/activeadmin/activeadmin/pull/5583
 
 [@5t111111]: https://github.com/5t111111
 [@aarek]: https://github.com/aarek

--- a/features/menu.feature
+++ b/features/menu.feature
@@ -38,6 +38,19 @@ Feature: Menu
     When I follow "Custom Menu"
     Then I should be on the admin dashboard page
 
+  Scenario: Add a non-resource menu item with method delete
+    Given a configuration of:
+    """
+      ActiveAdmin.application.namespace :admin do |admin|
+        admin.build_menu do |menu|
+          menu.add label: "Delete Menu", url: :admin_dashboard_path, html_options: { method: :delete }
+        end
+      end
+    """
+    When I am on the dashboard
+    Then I should see a menu item for "Delete Menu"
+     And I should see the element "a[data-method='delete']:contains('Delete Menu')"
+
   Scenario: Adding a resource as a sub menu item
     Given a configuration of:
     """

--- a/features/users/logging_in.feature
+++ b/features/users/logging_in.feature
@@ -3,11 +3,7 @@ Feature: User Logging In
   Logging in to the system as an admin user
 
   Background:
-    Given a configuration of:
-    """
-      ActiveAdmin.register Post
-    """
-    And I am logged out
+    Given I am logged out
     And an admin user "admin@example.com" exists
     When I go to the dashboard
 

--- a/features/users/logging_out.feature
+++ b/features/users/logging_out.feature
@@ -3,11 +3,7 @@ Feature: User Logging out
   Logging out of the system as an admin user
 
   Scenario: Logging out successfully
-    Given a configuration of:
-    """
-      ActiveAdmin.register Post
-    """
-    And I am logged in
+    Given I am logged in
     When I go to the dashboard
     And I follow "Logout"
     Then I should see "Login"

--- a/features/users/logging_out.feature
+++ b/features/users/logging_out.feature
@@ -3,7 +3,27 @@ Feature: User Logging out
   Logging out of the system as an admin user
 
   Scenario: Logging out successfully
-    Given I am logged in
+    Given a configuration of:
+    """
+      ActiveAdmin.setup do |config|
+        config.logout_link_method = :get
+      end
+    """
+    And I am logged in
     When I go to the dashboard
+    Then I should see the element "a[data-method='get']:contains('Logout')"
+    And I follow "Logout"
+    Then I should see "Login"
+
+  Scenario: Logging out sucessfully with delete method
+    Given a configuration of:
+    """
+      ActiveAdmin.setup do |config|
+        config.logout_link_method = :delete
+      end
+    """
+    And I am logged in
+    When I am on the dashboard
+    Then I should see the element "a[data-method='delete']:contains('Logout')"
     And I follow "Logout"
     Then I should see "Login"

--- a/features/users/resetting_password.feature
+++ b/features/users/resetting_password.feature
@@ -3,11 +3,7 @@ Feature: User Resetting Password
   Resetting my password as an admin user
 
   Background:
-    Given a configuration of:
-    """
-      ActiveAdmin.register Post
-    """
-    And I am logged out
+    Given I am logged out
     And an admin user "admin@example.com" exists
 
   Scenario: Resetting password successfully

--- a/lib/active_admin/views/components/menu_item.rb
+++ b/lib/active_admin/views/components/menu_item.rb
@@ -18,7 +18,7 @@ module ActiveAdmin
         add_class "current" if item.current? assigns[:current_tab]
 
         if url
-          a label, item.html_options.merge(href: url)
+          text_node link_to label, url, item.html_options
         else
           span label, item.html_options
         end


### PR DESCRIPTION
As suggested in https://github.com/activeadmin/activeadmin/pull/5583#issuecomment-441078851

To back port my change I also had to include your commit `
Remove unnecessary setup from session features`.

I'm not sure if this is the correct way to back port things since I've never done it before. Let me know if there's something I should fix.