### PR TITLE
Remove the "allow-rescue" cucumber tag

### DIFF
--- a/features/authorization.feature
+++ b/features/authorization.feature
@@ -45,7 +45,6 @@ Feature: Authorizing Access
     """
     And I am on the index page for posts
 
-  @allow-rescue
   Scenario: Attempt to access a resource I am not authorized to see
     When I go to the last post's edit page
     Then I should see "You are not authorized to perform this action"
@@ -54,12 +53,10 @@ Feature: Authorizing Access
     When I follow "View"
     Then I should not see an action item link to "Edit"
 
-  @allow-rescue
   Scenario: Attempting to visit a Page without authorization
     When I go to the admin no access page
     Then I should see "You are not authorized to perform this action"
 
-  @allow-rescue
   Scenario: Viewing a page with authorization
     When I go to the admin dashboard page
     Then I should see "Dashboard"

--- a/features/authorization_cancan.feature
+++ b/features/authorization_cancan.feature
@@ -33,7 +33,6 @@ Feature: Authorizing Access using CanCan
     """
     And I am on the index page for posts
 
-  @allow-rescue
   Scenario: Attempt to access a resource I am not authorized to see
     When I go to the last post's edit page
     Then I should see "You are not authorized to perform this action"
@@ -42,12 +41,10 @@ Feature: Authorizing Access using CanCan
     When I follow "View"
     Then I should not see an action item link to "Edit"
 
-  @allow-rescue
   Scenario: Attempting to visit a Page without authorization
     When I go to the admin no access page
     Then I should see "You are not authorized to perform this action"
 
-  @allow-rescue
   Scenario: Viewing a page with authorization
     When I go to the admin dashboard page
     Then I should see "Dashboard"

--- a/features/authorization_pundit.feature
+++ b/features/authorization_pundit.feature
@@ -18,7 +18,6 @@ Feature: Authorizing Access using Pundit
     """
     And I am on the index page for posts
 
-  @allow-rescue
   Scenario: Attempt to access a resource I am not authorized to see
     When I go to the last post's edit page
     Then I should see "You are not authorized to perform this action"
@@ -27,12 +26,10 @@ Feature: Authorizing Access using Pundit
     When I follow "View"
     Then I should not see an action item link to "Edit"
 
-  @allow-rescue
   Scenario: Attempting to visit a Page without authorization
     When I go to the admin no access page
     Then I should see "You are not authorized to perform this action"
 
-  @allow-rescue
   Scenario: Viewing a page with authorization
     When I go to the admin dashboard page
     Then I should see "Dashboard"

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -71,17 +71,6 @@ Capybara.asset_host = 'http://localhost:3000'
 # steps to use the XPath syntax.
 Capybara.default_selector = :css
 
-# If you set this to false, any error raised from within your app will bubble
-# up to your step definition and out to cucumber unless you catch it somewhere
-# on the way. You can make Rails rescue errors and render error pages on a
-# per-scenario basis by tagging a scenario or feature with the @allow-rescue tag.
-#
-# If you set this to true, Rails will rescue all errors and render error
-# pages, more or less in the same way your application would behave in the
-# default production environment. It's not recommended to do this for all
-# of your scenarios, as this makes it hard to discover errors in your application.
-ActionController::Base.allow_rescue = false
-
 # Database resetting strategy
 DatabaseCleaner.strategy = :truncation
 Cucumber::Rails::Database.javascript_strategy = :truncation


### PR DESCRIPTION
None of the current tests seem to require this.