### PR TITLE
Add ability to set custom content to page head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Enhancements
 
+* Add your own content to the site `<head>`, like analytics [#5590] by [@buren]
+
+  ```ruby
+  ActiveAdmin.setup do |config|
+    config.head = ''.html_safe
+  end
+  ```
+
 #### Minor
 
 * Add better support for rendering lists. [#5370] by [@dkniffin]
@@ -399,6 +407,7 @@ Please check [0-6-stable] for previous changes.
 [#5631]: https://github.com/activeadmin/activeadmin/pull/5631
 [#5632]: https://github.com/activeadmin/activeadmin/pull/5632
 [#5650]: https://github.com/activeadmin/activeadmin/pull/5650
+[#5590]: https://github.com/activeadmin/activeadmin/pull/5590
 
 [@5t111111]: https://github.com/5t111111
 [@aarek]: https://github.com/aarek

--- a/features/head.feature
+++ b/features/head.feature
@@ -1,0 +1,25 @@
+@head
+Feature: Head
+
+  As a developer
+  In order to add something to the site head
+  I want to set it in the configuration
+
+  Background:
+    Given I am logged in
+
+  Scenario: Set the head in the configuration
+    Given a configuration of:
+    """
+      ActiveAdmin.application.head = '<meta name="custom_meta" content="custom_value">'.html_safe
+    """
+    When I am on the dashboard
+    Then the site should contain a meta tag with name "custom_meta" and content "custom_value"
+
+  Scenario: Set the head to a proc
+    Given a configuration of:
+    """
+      ActiveAdmin.application.head = proc { '<meta name="custom_meta" content="custom_value">'.html_safe }
+    """
+    When I am on the dashboard
+    Then the site should contain a meta tag with name "custom_meta" and content "custom_value"

--- a/features/step_definitions/head_steps.rb
+++ b/features/step_definitions/head_steps.rb
@@ -1,0 +1,9 @@
+Around '@head' do |scenario, block|
+  previous_head = ActiveAdmin.application.head
+
+  begin
+    block.call
+  ensure
+    ActiveAdmin.application.head = previous_head
+  end
+end

--- a/lib/active_admin/namespace_settings.rb
+++ b/lib/active_admin/namespace_settings.rb
@@ -17,6 +17,9 @@ module ActiveAdmin
     # Set the site title image displayed in the main layout (has precendence over :site_title)
     register :site_title_image, "", :string_symbol_or_proc
 
+    # Add to the site head
+    register :head, "", :string_symbol_or_proc
+
     # Set the site footer text (defaults to Powered by ActiveAdmin text with version)
     register :footer, "", :string_symbol_or_proc
 

--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -26,6 +26,8 @@ module ActiveAdmin
           within head do
             html_title [title, helpers.active_admin_namespace.site_title(self)].compact.join(" | ")
 
+            text_node(active_admin_namespace.head)
+
             active_admin_application.stylesheets.each do |style, options|
               text_node stylesheet_link_tag(style, options).html_safe
             end

--- a/lib/generators/active_admin/install/templates/active_admin.rb.erb
+++ b/lib/generators/active_admin/install/templates/active_admin.rb.erb
@@ -289,6 +289,13 @@ ActiveAdmin.setup do |config|
   #
   # config.include_default_association_filters = true
 
+  # == Head
+  #
+  # You can add your own content to the site head like analytics. Make sure
+  # you only pass content you trust.
+  #
+  # config.head = ''.html_safe
+
   # == Footer
   #
   # By default, the footer shows the current Active Admin version. You can


### PR DESCRIPTION
My use case is that I want to be able to add custom content to the `<head>` tag. Could be scripts like Google Analytics etc.

It adds `ActiveAdmin.application.head` and follows the same configuration pattern as `footer`.