### PR TITLE
Use chandler to automate GitHub releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,7 +225,7 @@ index download_links: ->{ can?(:view_all_download_links) || [:pdf] }
 ```
 
 * Comments menu can be customized via configuration passed to `config.comments_menu`. [#4187][] by [@drn][]
-* Added `config.route_options` to namespace to customize routes. [#4731][] by [@stereoscott[]]
+* Added `config.route_options` to namespace to customize routes. [#4731][] by [@stereoscott][]
 
 ### Security Fixes
 
@@ -418,6 +418,7 @@ Please check [0-6-stable][] for previous changes.
 [@shekibobo]: https://github.com/shekibobo
 [@shouya]: https://github.com/shouya
 [@stefsava]: https://github.com/stefsava
+[@stereoscott]: https://github.com/stereoscott
 [@tiagotex]: https://github.com/tiagotex
 [@timoschilling]: https://github.com/timoschilling
 [@TimPetricola]: https://github.com/TimPetricola

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@
 
 ### Security Fixes
 
-* Prevent leaking hashed passwords via user CSV export and adds a config option for sensitive attributes. [#5486][] by [@chrp][]
+* Prevent leaking hashed passwords via user CSV export and adds a config option for sensitive attributes. [#5486] by [@chrp]
 
 ### Removals
 
-* Rails 4.2 support has been dropped. [#5104][] by [@javierjulio][] and [@deivid-rodriguez][]
-* Dependency on coffee-rails has been removed. [#5081][] by [@javierjulio][]
+* Rails 4.2 support has been dropped. [#5104] by [@javierjulio] and [@deivid-rodriguez]
+* Dependency on coffee-rails has been removed. [#5081] by [@javierjulio]
   If your application uses coffescript but was relying on ActiveAdmin to provide
   the dependency, you need to add the `coffee-script` gem to your `Gemfile` to
   restore it. If your only usage of coffescript was the
@@ -21,13 +21,13 @@
 
 ### Bug Fixes
 
-* Fix `input_html` filter option evaluated only once. [#5377][] by [@kjeldahl][]
+* Fix `input_html` filter option evaluated only once. [#5377] by [@kjeldahl]
 
 ## 1.4.1 [☰](https://github.com/activeadmin/activeadmin/compare/v1.4.0...v1.4.1)
 
 ### Bug Fixes
 
-* Fix menu item link with method delete. [#5583][] by [@tiagotex][]
+* Fix menu item link with method delete. [#5583] by [@tiagotex]
 
 ## 1.4.0 [☰](https://github.com/activeadmin/activeadmin/compare/v1.3.1...v1.4.0)
 
@@ -35,38 +35,38 @@
 
 #### Minor
 
-* Add missing I18n for comments. [#5458][], [#5461][] by [@mauriciopasquier][]
-* Fix batch_actions.delete_confirmation translation in zh-CN.yml. [#5453][] by [@ShallmentMo][]
-* Add some missing italian translations. [#5433][] by [@stefsava][]
-* Enhance some chinese translations. [#5413][] by [@shouya][]
-* Add missing filter predicate translations to nb. [#5357][] by [@rogerkk][]
-* Add missing norwegian comment translations. [#5375][] by [@rogerkk][]
-* Add missing dutch translations. [#5368][] by [@dennisvdvliet][]
-* Add missing german translations. [#5341][] by [@eikes][]
-* Add missing spanish translation. [#5336][] by [@mconiglio][]
-* Add from and to predicates for russian language. [#5330][] by [@glebtv][]
-* Fix typo in finnish translation. [#5320][] by [@JiiHu][]
-* Add missing turkish translations. [#5295][] by [@kobeumut][]
-* Add missing chinese translations. [#5266][] by [@jasl][]
-* Allow proc label in datepicker input. [#5408][] by [@tiagotex][]
-* Add `group` attribute to scopes in order to show them in grouped. [#5359][] by [@leio10][]
-* Add missing polish translations and improve existing ones. [#5537][] by [@Wowu][]
-* Add `priority` option to `action_item`. [#5334][] by [@andreslemik][]
+* Add missing I18n for comments. [#5458], [#5461] by [@mauriciopasquier]
+* Fix batch_actions.delete_confirmation translation in zh-CN.yml. [#5453] by [@ShallmentMo]
+* Add some missing italian translations. [#5433] by [@stefsava]
+* Enhance some chinese translations. [#5413] by [@shouya]
+* Add missing filter predicate translations to nb. [#5357] by [@rogerkk]
+* Add missing norwegian comment translations. [#5375] by [@rogerkk]
+* Add missing dutch translations. [#5368] by [@dennisvdvliet]
+* Add missing german translations. [#5341] by [@eikes]
+* Add missing spanish translation. [#5336] by [@mconiglio]
+* Add from and to predicates for russian language. [#5330] by [@glebtv]
+* Fix typo in finnish translation. [#5320] by [@JiiHu]
+* Add missing turkish translations. [#5295] by [@kobeumut]
+* Add missing chinese translations. [#5266] by [@jasl]
+* Allow proc label in datepicker input. [#5408] by [@tiagotex]
+* Add `group` attribute to scopes in order to show them in grouped. [#5359] by [@leio10]
+* Add missing polish translations and improve existing ones. [#5537] by [@Wowu]
+* Add `priority` option to `action_item`. [#5334] by [@andreslemik]
 
 ### Bug Fixes
 
-* Fixed the string representation of the resolved `sort_key` when no explicit `sortable` attribute is passed. [#5464][] by [@chumakoff][]
-* Fixed docs on the column `sortable` attribute (which actually doesn't have to be explicitly specified when a block is passed to column). [#5464][] by [@chumakoff][]
-* Fixed `if:` scope option when a lambda is passed. [#5501][] by [@deivid-rodriguez][]
-* Comment validation adding redundant errors when resource is missing. [#5517][] by [@deivid-rodriguez][]
-* Fixed resource filtering by association when the resource has custom primary key. [#5446][] by [@wasifhossain][]
-* Fixed "create anoter" checkbox styling. [#5324][] by [@faucct][]
+* Fixed the string representation of the resolved `sort_key` when no explicit `sortable` attribute is passed. [#5464] by [@chumakoff]
+* Fixed docs on the column `sortable` attribute (which actually doesn't have to be explicitly specified when a block is passed to column). [#5464] by [@chumakoff]
+* Fixed `if:` scope option when a lambda is passed. [#5501] by [@deivid-rodriguez]
+* Comment validation adding redundant errors when resource is missing. [#5517] by [@deivid-rodriguez]
+* Fixed resource filtering by association when the resource has custom primary key. [#5446] by [@wasifhossain]
+* Fixed "create anoter" checkbox styling. [#5324] by [@faucct]
 
 ## 1.3.1 [☰](https://github.com/activeadmin/activeadmin/compare/v1.3.0...v1.3.1)
 
 ### Bug Fixes
 
-* gemspec should have more permissive ransack dependency. [#5448][] by [@varyonic][]
+* gemspec should have more permissive ransack dependency. [#5448] by [@varyonic]
 
 ## 1.3.0 [☰](https://github.com/activeadmin/activeadmin/compare/v1.2.1...v1.3.0)
 
@@ -74,13 +74,13 @@
 
 #### Major
 
-* Rails 5.2 support [#5343][] by [@varyonic][], [#5399][], [#5401][] by [@zorab47][]
+* Rails 5.2 support [#5343] by [@varyonic], [#5399], [#5401] by [@zorab47]
 
 ## 1.2.1 [☰](https://github.com/activeadmin/activeadmin/compare/v1.2.0...v1.2.1)
 
 ### Bug Fixes
 
-* Resolve issue with [#5275][] preventing XSS in filters sidebar. [#5299][] by [@faucct][]
+* Resolve issue with [#5275] preventing XSS in filters sidebar. [#5299] by [@faucct]
 
 ## 1.2.0 [☰](https://github.com/activeadmin/activeadmin/compare/v1.1.0...v1.2.0)
 
@@ -88,41 +88,41 @@
 
 #### Minor
 
-* Do not display pagination info when there are no comments. [#5119][] by [@alex-bogomolov][]
-* Revert generated config files to pluralized. [#5120][] by [@varyonic][], [#5137][] by [@deivid-rodriguez][]
-* Warn when action definition overwrites controller method. [#5167][] by [@aarek][]
-* Better performance of comments show view. [#5208][] by [@dhyegofernando][]
-* Mitigate memory bloat [#4118][] with CSV exports. [#5251][] by [@f1sherman][]
-* Fix issue applying custom decorations. [#5253][] by [@faucct][]
-* Brazilian locale updated. [#5125][] by [@renotocn][]
-* Japanese locale updated. [#5143][] by [@5t111111][], [#5157][] by [@innparusu95][]
-* Italian locale updated. [#5180][] by [@blocknotes][]
-* Swedish locale updated. [#5187][] by [@jawa][]
-* Vietnamese locale updated. [#5194][] by [@Nguyenanh][]
-* Esperanto locale added. [#5210][] by [@RobinvanderVliet][]
+* Do not display pagination info when there are no comments. [#5119] by [@alex-bogomolov]
+* Revert generated config files to pluralized. [#5120] by [@varyonic], [#5137] by [@deivid-rodriguez]
+* Warn when action definition overwrites controller method. [#5167] by [@aarek]
+* Better performance of comments show view. [#5208] by [@dhyegofernando]
+* Mitigate memory bloat [#4118] with CSV exports. [#5251] by [@f1sherman]
+* Fix issue applying custom decorations. [#5253] by [@faucct]
+* Brazilian locale updated. [#5125] by [@renotocn]
+* Japanese locale updated. [#5143] by [@5t111111], [#5157] by [@innparusu95]
+* Italian locale updated. [#5180] by [@blocknotes]
+* Swedish locale updated. [#5187] by [@jawa]
+* Vietnamese locale updated. [#5194] by [@Nguyenanh]
+* Esperanto locale added. [#5210] by [@RobinvanderVliet]
 
 ### Bug Fixes
 
-* Fix a couple of issues rendering filter labels. [#5223][] by [@wspurgin][]
-* Prevent NameError when filtering on a namespaced association. [#5240][] by [@DanielHeath][]
-* Fix undefined method error in Ransack when building filters. [#5238][] by [@wspurgin][]
-* Fixed [#5198][] Prevent XSS on sidebar's current filter rendering. [#5275][] by [@deivid-rodriguez][]
-* Sanitize display_name. [#5284][] by [@markstory][]
+* Fix a couple of issues rendering filter labels. [#5223] by [@wspurgin]
+* Prevent NameError when filtering on a namespaced association. [#5240] by [@DanielHeath]
+* Fix undefined method error in Ransack when building filters. [#5238] by [@wspurgin]
+* Fixed [#5198] Prevent XSS on sidebar's current filter rendering. [#5275] by [@deivid-rodriguez]
+* Sanitize display_name. [#5284] by [@markstory]
 
 ## 1.1.0 [☰](https://github.com/activeadmin/activeadmin/compare/v1.0.0...v1.1.0)
 
 ### Bug Fixes
 
-* Fixed [#5093][] Handle table prefix & table suffix for `ActiveAdminComment` model
-* Fixed [#4173][] by including the default Kaminari templates. [#5069][] by [@javierjulio][]
-* Fixed [#5043][]. Do not crash in sidebar rendering when a default scope is not specified. [#5044][] by [@Fivell][]
-* Fixed [#3894][]. Make tab's component work with non-ascii titles. [#5046][] by [@Fivell][]
+* Fixed [#5093] Handle table prefix & table suffix for `ActiveAdminComment` model
+* Fixed [#4173] by including the default Kaminari templates. [#5069] by [@javierjulio]
+* Fixed [#5043]. Do not crash in sidebar rendering when a default scope is not specified. [#5044] by [@Fivell]
+* Fixed [#3894]. Make tab's component work with non-ascii titles. [#5046] by [@Fivell]
 
 ### Removals
 
-* Ruby 2.1 support has been dropped. [#5003][] by [@deivid-rodriguez][]
-* Replaced `sass-rails` with `sass` dependency. [#5037][] by [@javierjulio][]
-* Removed `jquery-ui-rails` as a dependency. [#5052][] by [@javierjulio][]
+* Ruby 2.1 support has been dropped. [#5003] by [@deivid-rodriguez]
+* Replaced `sass-rails` with `sass` dependency. [#5037] by [@javierjulio]
+* Removed `jquery-ui-rails` as a dependency. [#5052] by [@javierjulio]
   The specific jQuery UI assets used are now within the vendor directory. This
   will be replaced by alternatives and dropped entirely in a major release.
   Please remove any direct inclusions of `//= require jquery-ui`. This allows us
@@ -130,8 +130,8 @@
 
 ### Deprecations
 
-* Deprecated `config.register_stylesheet` and `config.register_javascript`. Import your CSS and JS files in `active_admin.scss` or `active_admin.js`. [#5060][] by [@javierjulio][]
-* Deprecated `type` param from `status_tag` and related CSS classes [#4989][] by [@javierjulio][]
+* Deprecated `config.register_stylesheet` and `config.register_javascript`. Import your CSS and JS files in `active_admin.scss` or `active_admin.js`. [#5060] by [@javierjulio]
+* Deprecated `type` param from `status_tag` and related CSS classes [#4989] by [@javierjulio]
   * The method signature has changed from:
 
     ```ruby
@@ -158,56 +158,56 @@
 
 #### Minor
 
-* Support proc as an input_html option value when declaring filters. [#5029][] by [@Fivell][]
-* Base localization support, better associations handling for active filters sidebar. [#4951][] by [@Fivell][]
-* Allow AA scopes to return paginated collections. [#4996][] by [@Fivell][]
-* Added `scopes_show_count` configuration to  setup show_count attribute for scopes globally. [#4950][] by [@Fivell][]
-* Allow custom panel title given with `attributes_table`. [#4940][] by [@ajw725][]
-* Allow passing a class to `action_item` block. [#4997][] by [@Fivell][]
-* Add pagination to the comments section. [#5088][] by [@alex-bogomolov][]
+* Support proc as an input_html option value when declaring filters. [#5029] by [@Fivell]
+* Base localization support, better associations handling for active filters sidebar. [#4951] by [@Fivell]
+* Allow AA scopes to return paginated collections. [#4996] by [@Fivell]
+* Added `scopes_show_count` configuration to  setup show_count attribute for scopes globally. [#4950] by [@Fivell]
+* Allow custom panel title given with `attributes_table`. [#4940] by [@ajw725]
+* Allow passing a class to `action_item` block. [#4997] by [@Fivell]
+* Add pagination to the comments section. [#5088] by [@alex-bogomolov]
 
 ## 1.0.0 [☰](https://github.com/activeadmin/activeadmin/compare/v0.6.3...master)
 
 ### Breaking Changes
 
-* Rename `allow_comments` to `comments` for more consistent naming. [#3695][] by [@pranas][]
-* JavaScript `window.AA` has been removed, use `window.ActiveAdmin`. [#3606][] by [@timoschilling][]
-* `f.form_buffers` has been removed. [#3486][] by [@varyonic][]
-* Iconic has been removed. [#3553][] by [@timoschilling][]
-* `config.show_comments_in_menu` has been removed, see `config.comments_menu`. [#4187][] by [@drn][]
-* Rails 3.2 & Ruby 1.9.3 support has been dropped. [#4848][] by [@deivid-rodriguez][]
-* Ruby 2.0.0 support has been dropped. [#4851][] by [@deivid-rodriguez][]
-* Rails 4.0 & 4.1 support has been dropped. [#4870][] by [@deivid-rodriguez][]
+* Rename `allow_comments` to `comments` for more consistent naming. [#3695] by [@pranas]
+* JavaScript `window.AA` has been removed, use `window.ActiveAdmin`. [#3606] by [@timoschilling]
+* `f.form_buffers` has been removed. [#3486] by [@varyonic]
+* Iconic has been removed. [#3553] by [@timoschilling]
+* `config.show_comments_in_menu` has been removed, see `config.comments_menu`. [#4187] by [@drn]
+* Rails 3.2 & Ruby 1.9.3 support has been dropped. [#4848] by [@deivid-rodriguez]
+* Ruby 2.0.0 support has been dropped. [#4851] by [@deivid-rodriguez]
+* Rails 4.0 & 4.1 support has been dropped. [#4870] by [@deivid-rodriguez]
 
 ### Enhancements
 
 #### Major
 
-* Migration from Metasearch to Ransack. [#1979][] by [@seanlinsley][]
-* Rails 4 support. [#2326][] by many people :heart:
-* Rails 4.2 support. [#3731][] by [@gonzedge][] and [@timoschilling][]
-* Rails 5 support. [#4254][] by [@seanlinsley][]
-* Rails 5.1 support. [#4882][] by [@varyonic][]
+* Migration from Metasearch to Ransack. [#1979] by [@seanlinsley]
+* Rails 4 support. [#2326] by many people :heart:
+* Rails 4.2 support. [#3731] by [@gonzedge] and [@timoschilling]
+* Rails 5 support. [#4254] by [@seanlinsley]
+* Rails 5.1 support. [#4882] by [@varyonic]
 
 #### Minor
 
-* "Create another" checkbox for the new resource page. [#4477][] by [@bolshakov][]
-* Page supports belongs_to. [#4759][] by [@Fivell][] and [@zorab47][]
-* Support for custom sorting strategies. [#4768][] by [@Fivell][]
-* Stream CSV downloads as they're generated. [#3038][] by [@craigmcnamara][]
-  * Disable streaming in development for easier debugging. [#3535][] by [@seanlinsley][]
-* Improved code reloading. [#3783][] by [@chancancode][]
-* Do not auto link to inaccessible actions. [#3686][] by [@pranas][]
-* Allow to enable comments on per-resource basis. [#3695][] by [@pranas][]
-* Unify DSL for index `actions` and `actions dropdown: true`. [#3463][] by [@timoschilling][]
-* Add DSL method `includes` for `ActiveRecord::Relation#includes`. [#3464][] by [@timoschilling][]
-* BOM (byte order mark) configurable for CSV download. [#3519][] by [@timoschilling][]
-* Column block on table index is now sortable by default. [#3075][] by [@dmitry][]
-* Allow Arbre to be used inside ActiveAdmin forms. [#3486][] by [@varyonic][]
-* Make AA ORM-agnostic. [#2545][] by [@johnnyshields][]
-* Add multi-record support to `attributes_table_for`. [#2544][] by [@zorab47][]
-* Table CSS classes are now prefixed to prevent clashes. [#2532][] by [@TimPetricola][]
-* Allow Inherited Resources shorthand for redirection. [#2001][] by [@seanlinsley][]
+* "Create another" checkbox for the new resource page. [#4477] by [@bolshakov]
+* Page supports belongs_to. [#4759] by [@Fivell] and [@zorab47]
+* Support for custom sorting strategies. [#4768] by [@Fivell]
+* Stream CSV downloads as they're generated. [#3038] by [@craigmcnamara]
+  * Disable streaming in development for easier debugging. [#3535] by [@seanlinsley]
+* Improved code reloading. [#3783] by [@chancancode]
+* Do not auto link to inaccessible actions. [#3686] by [@pranas]
+* Allow to enable comments on per-resource basis. [#3695] by [@pranas]
+* Unify DSL for index `actions` and `actions dropdown: true`. [#3463] by [@timoschilling]
+* Add DSL method `includes` for `ActiveRecord::Relation#includes`. [#3464] by [@timoschilling]
+* BOM (byte order mark) configurable for CSV download. [#3519] by [@timoschilling]
+* Column block on table index is now sortable by default. [#3075] by [@dmitry]
+* Allow Arbre to be used inside ActiveAdmin forms. [#3486] by [@varyonic]
+* Make AA ORM-agnostic. [#2545] by [@johnnyshields]
+* Add multi-record support to `attributes_table_for`. [#2544] by [@zorab47]
+* Table CSS classes are now prefixed to prevent clashes. [#2532] by [@TimPetricola]
+* Allow Inherited Resources shorthand for redirection. [#2001] by [@seanlinsley]
 
 ```ruby
     controller do
@@ -218,31 +218,31 @@
     end
 ```
 
-* Accept block for download links. [#2040][] by [@potatosalad][]
+* Accept block for download links. [#2040] by [@potatosalad]
 
 ```ruby
 index download_links: ->{ can?(:view_all_download_links) || [:pdf] }
 ```
 
-* Comments menu can be customized via configuration passed to `config.comments_menu`. [#4187][] by [@drn][]
-* Added `config.route_options` to namespace to customize routes. [#4731][] by [@stereoscott][]
+* Comments menu can be customized via configuration passed to `config.comments_menu`. [#4187] by [@drn]
+* Added `config.route_options` to namespace to customize routes. [#4731] by [@stereoscott]
 
 ### Security Fixes
 
-* Prevents access to formats that the user not permitted to see. [#4867][] by [@Fivell][] and [@timoschilling][]
-* Prevents potential DOS attack via Ruby symbols. [#1926][] by [@seanlinsley][]
+* Prevents access to formats that the user not permitted to see. [#4867] by [@Fivell] and [@timoschilling]
+* Prevents potential DOS attack via Ruby symbols. [#1926] by [@seanlinsley]
   * [this isn't an issue for those using Ruby >= 2.2](http://rubykaigi.org/2014/presentation/S-NarihiroNakamura)
 
 ### Bug Fixes
 
-* Fixes filters for `has_many :through` relationships. [#2541][] by [@shekibobo][]
-* "New" action item now only shows up on the index page. bf659bc by [@seanlinsley][]
-* Fixes comment creation bug with aliased resources. 9a082486 by [@seanlinsley][]
-* Fixes the deletion of `:if` and `:unless` from filters. [#2523][] by [@PChambino][]
+* Fixes filters for `has_many :through` relationships. [#2541] by [@shekibobo]
+* "New" action item now only shows up on the index page. bf659bc by [@seanlinsley]
+* Fixes comment creation bug with aliased resources. 9a082486 by [@seanlinsley]
+* Fixes the deletion of `:if` and `:unless` from filters. [#2523] by [@PChambino]
 
 ### Deprecations
 
-* `ActiveAdmin::Event` (`ActiveAdmin::EventDispatcher`). [#3435][] by [@timoschilling][]
+* `ActiveAdmin::Event` (`ActiveAdmin::EventDispatcher`). [#3435] by [@timoschilling]
   `ActiveAdmin::Event` will be removed in a future version, ActiveAdmin switched
   to use `ActiveSupport::Notifications`
   NOTE: The blog parameters has changed:
@@ -257,7 +257,7 @@ ActiveSupport::Notifications.publish ActiveAdmin::Application::BeforeLoadEvent, 
 
 ## Previous Changes
 
-Please check [0-6-stable][] for previous changes.
+Please check [0-6-stable] for previous changes.
 
 [0-6-stable]: https://github.com/activeadmin/activeadmin/blob/0-6-stable/CHANGELOG.md
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,7 +184,9 @@ Maintainers need to do the following to push out a release:
 
 * Make sure all pull requests are in and that changelog is current
 * Update `version.rb` file and changelog with new version number
-* Create a stable branch for that release:
+* If it's not a patch level release, create a stable branch for that release,
+  otherwise switch to the stable branch corresponding to the patch release you
+  want to ship:
 
   ```sh
   git checkout master

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,8 +197,12 @@ Maintainers need to do the following to push out a release:
   git push activeadmin N-N-stable:N-N-stable
   ```
 
+* Make sure you have [chandler] properly configured. Chandler is used to
+  automatically submit github release notes from the changelog right after
+  pushing the gem to rubygems.
 * `bundle exec rake release`
 
+[chandler]: https://github.com/mattbrictson/chandler#2-configure-credentials
 [chromedriver]: https://sites.google.com/a/chromium.org/chromedriver/getting-started
 [mailing list]: http://groups.google.com/group/activeadmin
 [Stack Overflow]: http://stackoverflow.com/questions/tagged/activeadmin

--- a/Gemfile.common
+++ b/Gemfile.common
@@ -11,6 +11,9 @@ gem 'parallel_tests', '~> 2.26'
 gem 'pry' # Easily debug from your console with `binding.pry`
 gem 'pry-byebug', platforms: :mri
 
+# Github releases from changelog
+gem 'chandler'
+
 group :lint do
   # Code style
   gem 'rubocop', '0.59.2'

--- a/Gemfile.common
+++ b/Gemfile.common
@@ -12,7 +12,7 @@ gem 'pry' # Easily debug from your console with `binding.pry`
 gem 'pry-byebug', platforms: :mri
 
 # Github releases from changelog
-gem 'chandler'
+gem 'chandler', git: 'https://github.com/deivid-rodriguez/chandler', branch: 'submit_link_references'
 
 group :lint do
   # Code style

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/deivid-rodriguez/chandler
+  revision: 71ca85925b54a1b1e6ba785efa450a012364efe6
+  branch: submit_link_references
+  specs:
+    chandler (0.7.0)
+      netrc
+      octokit (>= 2.2.0)
+
 PATH
   remote: .
   specs:
@@ -97,9 +106,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.2)
       xpath (~> 3.2)
-    chandler (0.7.0)
-      netrc
-      octokit (>= 2.2.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.2)
@@ -405,7 +411,7 @@ DEPENDENCIES
   binding_of_caller
   cancan
   capybara (~> 3.10)
-  chandler
+  chandler!
   cucumber
   cucumber-rails (~> 1.5)
   database_cleaner

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,9 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.2)
       xpath (~> 3.2)
+    chandler (0.7.0)
+      netrc
+      octokit (>= 2.2.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.2)
@@ -142,6 +145,8 @@ GEM
       request_store (~> 1.0)
     erubi (1.7.1)
     execjs (2.7.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
     ffi (1.9.25-java)
     formtastic (3.1.5)
@@ -233,11 +238,15 @@ GEM
       tomlrb
     multi_json (1.13.1)
     multi_test (0.1.2)
+    multipart-post (2.0.0)
+    netrc (0.11.0)
     nio4r (2.3.1)
     nio4r (2.3.1-java)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     nokogiri (1.8.5-java)
+    octokit (4.13.0)
+      sawyer (~> 0.8.0, >= 0.5.3)
     orm_adapter (0.5.0)
     parallel (1.12.1)
     parallel_tests (2.27.0)
@@ -340,6 +349,9 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
     selenium-webdriver (3.141.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
@@ -393,6 +405,7 @@ DEPENDENCIES
   binding_of_caller
   cancan
   capybara (~> 3.10)
+  chandler
   cucumber
   cucumber-rails (~> 1.5)
   database_cleaner

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,13 @@
 require 'bundler/gem_tasks'
+require "chandler/tasks"
 
 # Import all our rake tasks
 FileList['tasks/**/*.rake'].each { |task| import task }
+
+#
+# Add chandler as a prerequisite for `rake release`
+#
+task "release:rubygem_push" => "chandler:push"
 
 task default: :test
 

--- a/gemfiles/rails_50.gemfile.lock
+++ b/gemfiles/rails_50.gemfile.lock
@@ -93,6 +93,9 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.2)
       xpath (~> 3.2)
+    chandler (0.7.0)
+      netrc
+      octokit (>= 2.2.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.2)
@@ -139,6 +142,8 @@ GEM
     erubi (1.7.1)
     erubis (2.7.0)
     execjs (2.7.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
     ffi (1.9.25-java)
     formtastic (3.1.5)
@@ -227,11 +232,15 @@ GEM
       tomlrb
     multi_json (1.13.1)
     multi_test (0.1.2)
+    multipart-post (2.0.0)
+    netrc (0.11.0)
     nio4r (2.3.1)
     nio4r (2.3.1-java)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     nokogiri (1.8.5-java)
+    octokit (4.13.0)
+      sawyer (~> 0.8.0, >= 0.5.3)
     orm_adapter (0.5.0)
     parallel (1.12.1)
     parallel_tests (2.27.0)
@@ -333,6 +342,9 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
     selenium-webdriver (3.141.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
@@ -386,6 +398,7 @@ DEPENDENCIES
   binding_of_caller
   cancan
   capybara (~> 3.10)
+  chandler
   cucumber
   cucumber-rails (~> 1.5)
   database_cleaner

--- a/gemfiles/rails_50.gemfile.lock
+++ b/gemfiles/rails_50.gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/deivid-rodriguez/chandler
+  revision: 71ca85925b54a1b1e6ba785efa450a012364efe6
+  branch: submit_link_references
+  specs:
+    chandler (0.7.0)
+      netrc
+      octokit (>= 2.2.0)
+
 PATH
   remote: ..
   specs:
@@ -93,9 +102,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.2)
       xpath (~> 3.2)
-    chandler (0.7.0)
-      netrc
-      octokit (>= 2.2.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.2)
@@ -398,7 +404,7 @@ DEPENDENCIES
   binding_of_caller
   cancan
   capybara (~> 3.10)
-  chandler
+  chandler!
   cucumber
   cucumber-rails (~> 1.5)
   database_cleaner

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/deivid-rodriguez/chandler
+  revision: 71ca85925b54a1b1e6ba785efa450a012364efe6
+  branch: submit_link_references
+  specs:
+    chandler (0.7.0)
+      netrc
+      octokit (>= 2.2.0)
+
 PATH
   remote: ..
   specs:
@@ -93,9 +102,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.2)
       xpath (~> 3.2)
-    chandler (0.7.0)
-      netrc
-      octokit (>= 2.2.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.2)
@@ -397,7 +403,7 @@ DEPENDENCIES
   binding_of_caller
   cancan
   capybara (~> 3.10)
-  chandler
+  chandler!
   cucumber
   cucumber-rails (~> 1.5)
   database_cleaner

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -93,6 +93,9 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.2)
       xpath (~> 3.2)
+    chandler (0.7.0)
+      netrc
+      octokit (>= 2.2.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.2)
@@ -138,6 +141,8 @@ GEM
       request_store (~> 1.0)
     erubi (1.7.1)
     execjs (2.7.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
     ffi (1.9.25-java)
     formtastic (3.1.5)
@@ -226,11 +231,15 @@ GEM
       tomlrb
     multi_json (1.13.1)
     multi_test (0.1.2)
+    multipart-post (2.0.0)
+    netrc (0.11.0)
     nio4r (2.3.1)
     nio4r (2.3.1-java)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     nokogiri (1.8.5-java)
+    octokit (4.13.0)
+      sawyer (~> 0.8.0, >= 0.5.3)
     orm_adapter (0.5.0)
     parallel (1.12.1)
     parallel_tests (2.27.0)
@@ -332,6 +341,9 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
     selenium-webdriver (3.141.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
@@ -385,6 +397,7 @@ DEPENDENCIES
   binding_of_caller
   cancan
   capybara (~> 3.10)
+  chandler
   cucumber
   cucumber-rails (~> 1.5)
   database_cleaner

--- a/spec/changelog_spec.lint.rb
+++ b/spec/changelog_spec.lint.rb
@@ -17,6 +17,20 @@ RSpec.describe "Changelog" do
     expect(changelog).not_to match(/\[([^\]]+)\]\[\]/)
   end
 
+  it 'has definitions for all issue/pr references' do
+    implicit_link_names = changelog.scan(/\[#([0-9]+)\] /).flatten.uniq
+    implicit_link_names.each do |name|
+      expect(changelog).to include("[##{name}]: https://github.com/activeadmin/activeadmin/pull/#{name}").or include("[##{name}]: https://github.com/activeadmin/activeadmin/issues/#{name}")
+    end
+  end
+
+  it 'has definitions for users' do
+    implicit_link_names = changelog.scan(/ \[@([[:alnum:]]+)\]/).flatten.uniq
+    implicit_link_names.each do |name|
+      expect(changelog).to include("[@#{name}]: https://github.com/#{name}")
+    end
+  end
+
   describe 'entry' do
     let(:lines) { changelog.each_line }
 

--- a/spec/changelog_spec.lint.rb
+++ b/spec/changelog_spec.lint.rb
@@ -7,7 +7,7 @@ RSpec.describe "Changelog" do
   end
 
   it 'has definitions for all implicit links' do
-    implicit_link_names = changelog.scan(/\[([^\]]+)\]\[\]/).flatten.uniq
+    implicit_link_names = changelog.scan(/\[([^\\\[:]+)\]\[\]/).flatten.uniq
     implicit_link_names.each do |name|
       expect(changelog).to include("[#{name}]: https")
     end

--- a/spec/changelog_spec.lint.rb
+++ b/spec/changelog_spec.lint.rb
@@ -7,10 +7,14 @@ RSpec.describe "Changelog" do
   end
 
   it 'has definitions for all implicit links' do
-    implicit_link_names = changelog.scan(/\[([^\\\[:]+)\]\[\]/).flatten.uniq
+    implicit_link_names = changelog.scan(/\[([^\\\[:]+)\][^(]/).flatten.uniq
     implicit_link_names.each do |name|
       expect(changelog).to include("[#{name}]: https")
     end
+  end
+
+  it 'uses the simplest style for implicit links' do
+    expect(changelog).not_to match(/\[([^\]]+)\]\[\]/)
   end
 
   describe 'entry' do


### PR DESCRIPTION
It's very common to forget to create a Github release every time you release a new version to rubygems. It's also duplicate work since it basically consists of duplicating the relevant entries in the changelog. So, I'm adding [chandler](https://github.com/mattbrictson/chandler) to our release task so everything is done automatically upon release.

As part of this change, I'm simplifying the style for changelog links. This is because the [releases page](https://github.com/activeadmin/activeadmin/releases) autolinks users and PR references (just like in github comments), so the brackets end up being redundant. By simplifying the links, it reads slightly better. Chandler could probably reconcile this, but I think this works for now.