### PR TITLE
Remove todo note

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -114,5 +114,5 @@ Around '@silent_unpermitted_params_failure' do |scenario, block|
 end
 
 Around '@locale_manipulation' do |scenario, block|
-  I18n.with_locale(:en) { block.call }
+  I18n.with_locale(:en, &block)
 end

--- a/spec/support/active_admin_integration_spec_helper.rb
+++ b/spec/support/active_admin_integration_spec_helper.rb
@@ -61,8 +61,6 @@ module ActiveAdminIntegrationSpecHelper
     # If no translations have been loaded, any later calls to `I18n.t` will
     # cause the full translation hash to be loaded, possibly overwritting what
     # we've loaded via `store_translations`. We use this hack to prevent that.
-    # TODO: Might not be necessary anymore once
-    # https://github.com/svenfuchs/i18n/pull/353 lands.
     I18n.backend.send(:init_translations)
     I18n.backend.store_translations I18n.locale, translation
     yield

--- a/spec/unit/pretty_format_spec.rb
+++ b/spec/unit/pretty_format_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "#pretty_format" do
 
     context "with non-English locale" do
       around do |example|
-        I18n.with_locale(:es) { example.call }
+        I18n.with_locale(:es, &example)
       end
 
       it "formats it with the default long format" do


### PR DESCRIPTION
The mentioned PR has already been released, but doesn't change things. And I don't see an obvious way of avoiding the hack, so let's remove the TODO note. The other changes are just a small simplification I saw while having a look at this.