### PR TITLE
Simplify gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 tmp
 coverage
 .yardoc
+.ruby-version
 pkg
 
 ## Project (specific)

--- a/.gitignore
+++ b/.gitignore
@@ -1,46 +1,15 @@
-## Mac
-.DS_Store
-
-## Windows
-.Thumbs.db
-
-## TextMate
-*.tm_project
-*.tmproj
-tmtags
-
-## Emacs
-*~
-\#*
-.\#*
-
-## Vim
-*.swp
-# IDEA / RUBYMINE
-.idea
-
-## RVM
-.rvmrc
-.ruby-version
-.ruby-gemset
-
 ## Project (general)
-tags
 tmp
 coverage
-rdoc
-doc
 .yardoc
 pkg
 
 ## Project (specific)
 .bundle
 spec/rails
-*.sqlite3-journal
 .test-rails-apps
 public
 .rspec_failures
 .rails-version
 .rbenv-version
-.localeapp/*
 lib/bug_report_templates/tmp


### PR DESCRIPTION
This PR simplifies the gitignore file by removing stuff that I consider each developer should configure on her global gitignore instead.

But in reality this is just an excuse to open a PR and confirm that the configuration I changed for #5600 is not really working.