### PR TITLE
Enable RSpec/HookArgument cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,8 @@ inherit_mode:
   merge:
     - Include
 
+require: rubocop-rspec
+
 AllCops:
   DisabledByDefault: true
   TargetRubyVersion: 2.3
@@ -54,6 +56,9 @@ Rails:
 Rails/FilePath:
   Enabled: true
   EnforcedStyle: slashes
+
+RSpec/HookArgument:
+  Enabled: true
 
 Style/Dir:
   Enabled: true

--- a/Gemfile.common
+++ b/Gemfile.common
@@ -17,6 +17,7 @@ gem 'chandler', git: 'https://github.com/deivid-rodriguez/chandler', branch: 'su
 group :lint do
   # Code style
   gem 'rubocop', '0.60.0'
+  gem 'rubocop-rspec', '~> 1.30'
   gem 'mdl', '0.5.0'
 
   # Translations

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -347,6 +347,8 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.4.0)
+    rubocop-rspec (1.30.1)
+      rubocop (>= 0.60.0)
     ruby-progressbar (1.10.0)
     rubyzip (1.2.2)
     sass (3.7.2)
@@ -434,6 +436,7 @@ DEPENDENCIES
   rake
   rspec-rails
   rubocop (= 0.60.0)
+  rubocop-rspec (~> 1.30)
   selenium-webdriver
   simplecov
   sqlite3

--- a/gemfiles/rails_50.gemfile.lock
+++ b/gemfiles/rails_50.gemfile.lock
@@ -340,6 +340,8 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.4.0)
+    rubocop-rspec (1.30.1)
+      rubocop (>= 0.60.0)
     ruby-progressbar (1.10.0)
     rubyzip (1.2.2)
     sass (3.7.2)
@@ -427,6 +429,7 @@ DEPENDENCIES
   rake
   rspec-rails
   rubocop (= 0.60.0)
+  rubocop-rspec (~> 1.30)
   selenium-webdriver
   simplecov
   sqlite3

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -339,6 +339,8 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.4.0)
+    rubocop-rspec (1.30.1)
+      rubocop (>= 0.60.0)
     ruby-progressbar (1.10.0)
     rubyzip (1.2.2)
     sass (3.7.2)
@@ -426,6 +428,7 @@ DEPENDENCIES
   rake
   rspec-rails
   rubocop (= 0.60.0)
+  rubocop-rspec (~> 1.30)
   selenium-webdriver
   simplecov
   sqlite3

--- a/spec/unit/action_builder_spec.rb
+++ b/spec/unit/action_builder_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'defining actions from registration blocks', type: :controller do
   end
 
   describe 'creates a member action' do
-    after(:each) do
+    after do
       klass.clear_member_actions!
     end
 
@@ -66,7 +66,7 @@ RSpec.describe 'defining actions from registration blocks', type: :controller do
   end
 
   describe 'creates a collection action' do
-    after(:each) do
+    after do
       klass.clear_collection_actions!
     end
 
@@ -122,7 +122,7 @@ RSpec.describe 'defining actions from registration blocks', type: :controller do
   end
 
   context 'when method with given name is already defined' do
-    around :each do |example|
+    around do |example|
       original_stderr = $stderr
       $stderr = StringIO.new
       example.run

--- a/spec/unit/resource/routes_spec.rb
+++ b/spec/unit/resource/routes_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ActiveAdmin::Resource::Routes do
   context "when in the root namespace" do
     let!(:config) { ActiveAdmin.register Category, namespace: false }
 
-    after(:each) do
+    after do
       application.namespace(:root).unload!
       application.namespaces.instance_variable_get(:@namespaces).delete(:root)
     end

--- a/spec/unit/routing_spec.rb
+++ b/spec/unit/routing_spec.rb
@@ -68,11 +68,11 @@ RSpec.describe "Routing", type: :routing do
     end
 
     context "when in root namespace" do
-      before(:each) do
+      before do
         load_resources { ActiveAdmin.register(Post, namespace: false) }
       end
 
-      after(:each) do
+      after do
         namespaces.instance_variable_get(:@namespaces).delete(:root)
       end
 
@@ -175,7 +175,7 @@ RSpec.describe "Routing", type: :routing do
 
   describe "page" do
     context "when default namespace" do
-      before(:each) do
+      before do
         load_resources { ActiveAdmin.register_page("Chocolate I lØve You!") }
       end
 
@@ -185,11 +185,11 @@ RSpec.describe "Routing", type: :routing do
     end
 
     context "when in the root namespace" do
-      before(:each) do
+      before do
         load_resources { ActiveAdmin.register_page("Chocolate I lØve You!", namespace: false) }
       end
 
-      after(:each) do
+      after do
         namespaces.instance_variable_get(:@namespaces).delete(:root)
       end
 
@@ -199,7 +199,7 @@ RSpec.describe "Routing", type: :routing do
     end
 
     context "when singular page name" do
-      before(:each) do
+      before do
         load_resources { ActiveAdmin.register_page("Log") }
       end
 


### PR DESCRIPTION
The `:each` argument to RSpec hooks is redundant. This cop enforces that we don't pass it.