### PR TITLE
Simplify development dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ version: 2.1
 .install_dependencies: &install_dependencies
   run:
     name: Install dependencies
-    command: bundle install --without development --path /home/circleci/project/vendor/bundle --retry 3 --jobs 3
+    command: bundle install --path /home/circleci/project/vendor/bundle --retry 3 --jobs 3
 
 .install_chromedriver: &install_chromedriver
   run:

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,26 @@ source "https://rubygems.org"
 
 eval_gemfile(File.expand_path("Gemfile.common", __dir__))
 
+group :release do
+  gem 'chandler', git: 'https://github.com/deivid-rodriguez/chandler', branch: 'submit_link_references' # Github releases from changelog
+end
+
+group :lint do
+  # Code style
+  gem 'rubocop', '0.60.0'
+  gem 'rubocop-rspec', '~> 1.30'
+  gem 'mdl', '0.5.0'
+
+  # Translations
+  gem 'i18n-tasks'
+  gem 'i18n-spec'
+end
+
+group :docs do
+  gem 'yard'     # Documentation generator
+  gem 'kramdown' # Markdown implementation (for yard)
+end
+
 gem "rails", "~> 5.2.x"
 gem "devise", "~> 4.4"
 gem "draper", "~> 3.0"

--- a/Gemfile.common
+++ b/Gemfile.common
@@ -1,12 +1,8 @@
 # Utility gems used in both development & test environments
 gem 'rake'
-
-# Debugging
 gem 'pry' # Easily debug from your console with `binding.pry`
-gem 'pry-byebug', platforms: :mri
-
-# Github releases from changelog
-gem 'chandler', git: 'https://github.com/deivid-rodriguez/chandler', branch: 'submit_link_references'
+gem 'pry-byebug', platforms: :mri # Step-by-step debugging
+gem 'chandler', git: 'https://github.com/deivid-rodriguez/chandler', branch: 'submit_link_references' # Github releases from changelog
 
 group :lint do
   # Code style

--- a/Gemfile.common
+++ b/Gemfile.common
@@ -19,16 +19,6 @@ end
 gem 'yard'     # Documentation generator
 gem 'kramdown' # Markdown implementation (for yard)
 
-group :development do
-  # Debugging
-  gem 'better_errors' # Web UI to debug exceptions. Go to /__better_errors to access the latest one
-
-  gem 'binding_of_caller', platforms: :mri # Retrieve the binding of a method's caller
-
-  # Performance
-  gem 'rack-mini-profiler', '>= 0.10.1' # Inline app profiler. See ?pp=help for options.
-end
-
 group :test do
   gem 'capybara', '~> 3.10'
 

--- a/Gemfile.common
+++ b/Gemfile.common
@@ -2,7 +2,10 @@
 gem 'rake'
 gem 'pry' # Easily debug from your console with `binding.pry`
 gem 'pry-byebug', platforms: :mri # Step-by-step debugging
-gem 'chandler', git: 'https://github.com/deivid-rodriguez/chandler', branch: 'submit_link_references' # Github releases from changelog
+
+group :release do
+  gem 'chandler', git: 'https://github.com/deivid-rodriguez/chandler', branch: 'submit_link_references' # Github releases from changelog
+end
 
 group :lint do
   # Code style
@@ -15,9 +18,10 @@ group :lint do
   gem 'i18n-spec'
 end
 
-# Documentation
-gem 'yard'     # Documentation generator
-gem 'kramdown' # Markdown implementation (for yard)
+group :docs do
+  gem 'yard'     # Documentation generator
+  gem 'kramdown' # Markdown implementation (for yard)
+end
 
 group :test do
   gem 'capybara', '~> 3.10'

--- a/Gemfile.common
+++ b/Gemfile.common
@@ -3,26 +3,6 @@ gem 'rake'
 gem 'pry' # Easily debug from your console with `binding.pry`
 gem 'pry-byebug', platforms: :mri # Step-by-step debugging
 
-group :release do
-  gem 'chandler', git: 'https://github.com/deivid-rodriguez/chandler', branch: 'submit_link_references' # Github releases from changelog
-end
-
-group :lint do
-  # Code style
-  gem 'rubocop', '0.60.0'
-  gem 'rubocop-rspec', '~> 1.30'
-  gem 'mdl', '0.5.0'
-
-  # Translations
-  gem 'i18n-tasks'
-  gem 'i18n-spec'
-end
-
-group :docs do
-  gem 'yard'     # Documentation generator
-  gem 'kramdown' # Markdown implementation (for yard)
-end
-
 group :test do
   gem 'capybara', '~> 3.10'
 

--- a/Gemfile.common
+++ b/Gemfile.common
@@ -1,11 +1,5 @@
-# Optional dependencies
-gem 'cancan'
-gem 'pundit'
-gem 'jruby-openssl', '~> 0.10.1', platforms: :jruby
-
 # Utility gems used in both development & test environments
 gem 'rake'
-gem 'parallel_tests', '~> 2.26'
 
 # Debugging
 gem 'pry' # Easily debug from your console with `binding.pry`
@@ -41,6 +35,12 @@ end
 
 group :test do
   gem 'capybara', '~> 3.10'
+
+  # Optional dependencies
+  gem 'cancan'
+  gem 'pundit'
+  gem 'jruby-openssl', '~> 0.10.1', platforms: :jruby
+
   gem 'simplecov', require: false # Test coverage generator. Go to /coverage/ after running tests
   gem 'cucumber-rails', '~> 1.5', require: false
   gem 'cucumber'
@@ -48,6 +48,7 @@ group :test do
   gem 'jasmine'
   gem 'jasmine-core', '2.9.1' # last release with Ruby 2.2 support.
   gem 'launchy'
+  gem 'parallel_tests', '~> 2.26'
   gem 'rails-i18n' # Provides default i18n for many languages
   gem 'rspec-rails'
   gem 'sqlite3', platforms: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
     builder (3.2.3)
     byebug (10.0.2)
     cancan (1.6.10)
-    capybara (3.11.1)
+    capybara (3.12.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,12 +89,6 @@ GEM
     backports (3.11.4)
     bcrypt (3.1.12)
     bcrypt (3.1.12-java)
-    better_errors (2.5.0)
-      coderay (>= 1.0.0)
-      erubi (>= 1.0.0)
-      rack (>= 0.9.0)
-    binding_of_caller (0.8.0)
-      debug_inspector (>= 0.0.1)
     builder (3.2.3)
     byebug (10.0.2)
     cancan (1.6.10)
@@ -134,7 +128,6 @@ GEM
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
     database_cleaner (1.7.0)
-    debug_inspector (0.0.3)
     devise (4.5.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -275,8 +268,6 @@ GEM
     pundit (2.0.0)
       activesupport (>= 3.0.0)
     rack (2.0.6)
-    rack-mini-profiler (1.0.0)
-      rack (>= 1.2.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.1)
@@ -408,8 +399,6 @@ PLATFORMS
 DEPENDENCIES
   activeadmin!
   activerecord-jdbcsqlite3-adapter (>= 52.0)
-  better_errors
-  binding_of_caller
   cancan
   capybara (~> 3.10)
   chandler!
@@ -430,7 +419,6 @@ DEPENDENCIES
   pry
   pry-byebug
   pundit
-  rack-mini-profiler (>= 0.10.1)
   rails (~> 5.2.x)
   rails-i18n
   rake

--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,14 @@
 require 'bundler/gem_tasks'
 
-import 'tasks/docs.rake'
 import 'tasks/gemfiles.rake'
-import 'tasks/lint.rake'
 import 'tasks/local.rake'
-import 'tasks/release.rake'
 import 'tasks/test.rake'
+
+if ENV['BUNDLE_GEMFILE'] == File.expand_path('Gemfile')
+  import 'tasks/docs.rake'
+  import 'tasks/lint.rake'
+  import 'tasks/release.rake'
+end
 
 task default: :test
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,11 @@
 require 'bundler/gem_tasks'
 require "chandler/tasks"
 
-# Import all our rake tasks
-FileList['tasks/**/*.rake'].each { |task| import task }
+import 'tasks/docs.rake'
+import 'tasks/gemfiles.rake'
+import 'tasks/lint.rake'
+import 'tasks/local.rake'
+import 'tasks/test.rake'
 
 #
 # Add chandler as a prerequisite for `rake release`

--- a/Rakefile
+++ b/Rakefile
@@ -1,16 +1,11 @@
 require 'bundler/gem_tasks'
-require "chandler/tasks"
 
 import 'tasks/docs.rake'
 import 'tasks/gemfiles.rake'
 import 'tasks/lint.rake'
 import 'tasks/local.rake'
+import 'tasks/release.rake'
 import 'tasks/test.rake'
-
-#
-# Add chandler as a prerequisite for `rake release`
-#
-task "release:rubygem_push" => "chandler:push"
 
 task default: :test
 

--- a/Rakefile
+++ b/Rakefile
@@ -11,14 +11,8 @@ task "release:rubygem_push" => "chandler:push"
 
 task default: :test
 
-begin
-  require 'jasmine'
-  load 'jasmine/tasks/jasmine.rake'
-rescue LoadError
-  task :jasmine do
-    abort 'Jasmine is not available. In order to run jasmine, you must: (sudo) gem install jasmine'
-  end
-end
+require 'jasmine'
+load 'jasmine/tasks/jasmine.rake'
 
 task :console do
   require 'irb'

--- a/gemfiles/rails_50.gemfile.lock
+++ b/gemfiles/rails_50.gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: https://github.com/deivid-rodriguez/chandler
-  revision: 71ca85925b54a1b1e6ba785efa450a012364efe6
-  branch: submit_link_references
-  specs:
-    chandler (0.7.0)
-      netrc
-      octokit (>= 2.2.0)
-
 PATH
   remote: ..
   specs:
@@ -77,7 +68,6 @@ GEM
     arbre (1.1.1)
       activesupport (>= 3.0.0)
     arel (7.1.4)
-    ast (2.4.0)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
@@ -138,11 +128,8 @@ GEM
       activemodel-serializers-xml (~> 1.0)
       activesupport (~> 5.0)
       request_store (~> 1.0)
-    erubi (1.7.1)
     erubis (2.7.0)
     execjs (2.7.0)
-    faraday (0.15.4)
-      multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
     ffi (1.9.25-java)
     formtastic (3.1.5)
@@ -154,30 +141,13 @@ GEM
     has_scope (0.7.2)
       actionpack (>= 4.1)
       activesupport (>= 4.1)
-    highline (2.0.0)
     i18n (1.1.1)
       concurrent-ruby (~> 1.0)
-    i18n-spec (0.6.0)
-      iso
-    i18n-tasks (0.9.28)
-      activesupport (>= 4.0.2)
-      ast (>= 2.1.0)
-      erubi
-      highline (>= 2.0.0)
-      i18n
-      parser (>= 2.2.3.0)
-      rails-i18n
-      rainbow (>= 2.2.2, < 4.0)
-      terminal-table (>= 1.5.1)
     inherited_resources (1.9.0)
       actionpack (>= 4.2, < 5.3)
       has_scope (~> 0.6)
       railties (>= 4.2, < 5.3)
       responders
-    iso (0.2.2)
-      i18n
-    jaro_winkler (1.5.1)
-    jaro_winkler (1.5.1-java)
     jasmine (2.9.0)
       jasmine-core (>= 2.9.0, < 3.0.0)
       phantomjs
@@ -204,7 +174,6 @@ GEM
       activerecord
       kaminari-core (= 1.1.1)
     kaminari-core (1.1.1)
-    kramdown (1.17.0)
     launchy (2.4.3)
       addressable (~> 2.3)
     launchy (2.4.3-java)
@@ -215,10 +184,6 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
-    mdl (0.5.0)
-      kramdown (~> 1.12, >= 1.12.0)
-      mixlib-cli (~> 1.7, >= 1.7.0)
-      mixlib-config (~> 2.2, >= 2.2.1)
     method_source (0.9.2)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
@@ -226,28 +191,18 @@ GEM
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
-    mixlib-cli (1.7.0)
-    mixlib-config (2.2.13)
-      tomlrb
     multi_json (1.13.1)
     multi_test (0.1.2)
-    multipart-post (2.0.0)
-    netrc (0.11.0)
     nio4r (2.3.1)
     nio4r (2.3.1-java)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     nokogiri (1.8.5-java)
-    octokit (4.13.0)
-      sawyer (~> 0.8.0, >= 0.5.3)
     orm_adapter (0.5.0)
     parallel (1.12.1)
     parallel_tests (2.27.0)
       parallel
-    parser (2.5.3.0)
-      ast (~> 2.4.0)
     phantomjs (2.1.1.0)
-    powerpack (0.1.2)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -290,7 +245,6 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rainbow (3.0.0)
     rake (12.3.1)
     ransack (2.1.0)
       actionpack (>= 5.0)
@@ -323,26 +277,12 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rubocop (0.60.0)
-      jaro_winkler (~> 1.5.1)
-      parallel (~> 1.10)
-      parser (>= 2.5, != 2.5.1.1)
-      powerpack (~> 0.1)
-      rainbow (>= 2.2.2, < 4.0)
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.4.0)
-    rubocop-rspec (1.30.1)
-      rubocop (>= 0.60.0)
-    ruby-progressbar (1.10.0)
     rubyzip (1.2.2)
     sass (3.7.2)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sawyer (0.8.1)
-      addressable (>= 2.3.5, < 2.6)
-      faraday (~> 0.8, < 1.0)
     selenium-webdriver (3.141.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
@@ -365,15 +305,11 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.13)
-    terminal-table (1.8.0)
-      unicode-display_width (~> 1.1, >= 1.1.1)
     thor (0.20.3)
     thread_safe (0.3.6)
     thread_safe (0.3.6-java)
-    tomlrb (1.2.7)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    unicode-display_width (1.4.0)
     warden (1.2.8)
       rack (>= 2.0.6)
     websocket-driver (0.6.5)
@@ -383,7 +319,6 @@ GEM
     websocket-extensions (0.1.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yard (0.9.16)
 
 PLATFORMS
   java
@@ -394,20 +329,15 @@ DEPENDENCIES
   activerecord-jdbcsqlite3-adapter (~> 50.0)
   cancan
   capybara (~> 3.10)
-  chandler!
   cucumber
   cucumber-rails (~> 1.5)
   database_cleaner
   devise (~> 4.0)
   draper (~> 3.0)
-  i18n-spec
-  i18n-tasks
   jasmine
   jasmine-core (= 2.9.1)
   jruby-openssl (~> 0.10.1)
-  kramdown
   launchy
-  mdl (= 0.5.0)
   parallel_tests (~> 2.26)
   pry
   pry-byebug
@@ -416,12 +346,9 @@ DEPENDENCIES
   rails-i18n
   rake
   rspec-rails
-  rubocop (= 0.60.0)
-  rubocop-rspec (~> 1.30)
   selenium-webdriver
   simplecov
   sqlite3
-  yard
 
 BUNDLED WITH
    1.17.1

--- a/gemfiles/rails_50.gemfile.lock
+++ b/gemfiles/rails_50.gemfile.lock
@@ -85,12 +85,6 @@ GEM
     backports (3.11.4)
     bcrypt (3.1.12)
     bcrypt (3.1.12-java)
-    better_errors (2.5.0)
-      coderay (>= 1.0.0)
-      erubi (>= 1.0.0)
-      rack (>= 0.9.0)
-    binding_of_caller (0.8.0)
-      debug_inspector (>= 0.0.1)
     builder (3.2.3)
     byebug (10.0.2)
     cancan (1.6.10)
@@ -130,7 +124,6 @@ GEM
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
     database_cleaner (1.7.0)
-    debug_inspector (0.0.3)
     devise (4.5.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -269,8 +262,6 @@ GEM
     pundit (2.0.0)
       activesupport (>= 3.0.0)
     rack (2.0.6)
-    rack-mini-profiler (1.0.0)
-      rack (>= 1.2.0)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (5.0.7)
@@ -401,8 +392,6 @@ PLATFORMS
 DEPENDENCIES
   activeadmin!
   activerecord-jdbcsqlite3-adapter (~> 50.0)
-  better_errors
-  binding_of_caller
   cancan
   capybara (~> 3.10)
   chandler!
@@ -423,7 +412,6 @@ DEPENDENCIES
   pry
   pry-byebug
   pundit
-  rack-mini-profiler (>= 0.10.1)
   rails (= 5.0.7)
   rails-i18n
   rake

--- a/gemfiles/rails_50.gemfile.lock
+++ b/gemfiles/rails_50.gemfile.lock
@@ -88,7 +88,7 @@ GEM
     builder (3.2.3)
     byebug (10.0.2)
     cancan (1.6.10)
-    capybara (3.11.1)
+    capybara (3.12.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -88,7 +88,7 @@ GEM
     builder (3.2.3)
     byebug (10.0.2)
     cancan (1.6.10)
-    capybara (3.11.1)
+    capybara (3.12.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -85,12 +85,6 @@ GEM
     backports (3.11.4)
     bcrypt (3.1.12)
     bcrypt (3.1.12-java)
-    better_errors (2.5.0)
-      coderay (>= 1.0.0)
-      erubi (>= 1.0.0)
-      rack (>= 0.9.0)
-    binding_of_caller (0.8.0)
-      debug_inspector (>= 0.0.1)
     builder (3.2.3)
     byebug (10.0.2)
     cancan (1.6.10)
@@ -130,7 +124,6 @@ GEM
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
     database_cleaner (1.7.0)
-    debug_inspector (0.0.3)
     devise (4.5.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -268,8 +261,6 @@ GEM
     pundit (2.0.0)
       activesupport (>= 3.0.0)
     rack (2.0.6)
-    rack-mini-profiler (1.0.0)
-      rack (>= 1.2.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.1.6)
@@ -400,8 +391,6 @@ PLATFORMS
 DEPENDENCIES
   activeadmin!
   activerecord-jdbcsqlite3-adapter (~> 51.0)
-  better_errors
-  binding_of_caller
   cancan
   capybara (~> 3.10)
   chandler!
@@ -422,7 +411,6 @@ DEPENDENCIES
   pry
   pry-byebug
   pundit
-  rack-mini-profiler (>= 0.10.1)
   rails (= 5.1.6)
   rails-i18n
   rake

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: https://github.com/deivid-rodriguez/chandler
-  revision: 71ca85925b54a1b1e6ba785efa450a012364efe6
-  branch: submit_link_references
-  specs:
-    chandler (0.7.0)
-      netrc
-      octokit (>= 2.2.0)
-
 PATH
   remote: ..
   specs:
@@ -77,7 +68,6 @@ GEM
     arbre (1.1.1)
       activesupport (>= 3.0.0)
     arel (8.0.0)
-    ast (2.4.0)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
@@ -140,8 +130,6 @@ GEM
       request_store (~> 1.0)
     erubi (1.7.1)
     execjs (2.7.0)
-    faraday (0.15.4)
-      multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
     ffi (1.9.25-java)
     formtastic (3.1.5)
@@ -153,30 +141,13 @@ GEM
     has_scope (0.7.2)
       actionpack (>= 4.1)
       activesupport (>= 4.1)
-    highline (2.0.0)
     i18n (1.1.1)
       concurrent-ruby (~> 1.0)
-    i18n-spec (0.6.0)
-      iso
-    i18n-tasks (0.9.28)
-      activesupport (>= 4.0.2)
-      ast (>= 2.1.0)
-      erubi
-      highline (>= 2.0.0)
-      i18n
-      parser (>= 2.2.3.0)
-      rails-i18n
-      rainbow (>= 2.2.2, < 4.0)
-      terminal-table (>= 1.5.1)
     inherited_resources (1.9.0)
       actionpack (>= 4.2, < 5.3)
       has_scope (~> 0.6)
       railties (>= 4.2, < 5.3)
       responders
-    iso (0.2.2)
-      i18n
-    jaro_winkler (1.5.1)
-    jaro_winkler (1.5.1-java)
     jasmine (2.9.0)
       jasmine-core (>= 2.9.0, < 3.0.0)
       phantomjs
@@ -203,7 +174,6 @@ GEM
       activerecord
       kaminari-core (= 1.1.1)
     kaminari-core (1.1.1)
-    kramdown (1.17.0)
     launchy (2.4.3)
       addressable (~> 2.3)
     launchy (2.4.3-java)
@@ -214,10 +184,6 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
-    mdl (0.5.0)
-      kramdown (~> 1.12, >= 1.12.0)
-      mixlib-cli (~> 1.7, >= 1.7.0)
-      mixlib-config (~> 2.2, >= 2.2.1)
     method_source (0.9.2)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
@@ -225,28 +191,18 @@ GEM
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
-    mixlib-cli (1.7.0)
-    mixlib-config (2.2.13)
-      tomlrb
     multi_json (1.13.1)
     multi_test (0.1.2)
-    multipart-post (2.0.0)
-    netrc (0.11.0)
     nio4r (2.3.1)
     nio4r (2.3.1-java)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     nokogiri (1.8.5-java)
-    octokit (4.13.0)
-      sawyer (~> 0.8.0, >= 0.5.3)
     orm_adapter (0.5.0)
     parallel (1.12.1)
     parallel_tests (2.27.0)
       parallel
-    parser (2.5.3.0)
-      ast (~> 2.4.0)
     phantomjs (2.1.1.0)
-    powerpack (0.1.2)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -289,7 +245,6 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rainbow (3.0.0)
     rake (12.3.1)
     ransack (2.1.0)
       actionpack (>= 5.0)
@@ -322,26 +277,12 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rubocop (0.60.0)
-      jaro_winkler (~> 1.5.1)
-      parallel (~> 1.10)
-      parser (>= 2.5, != 2.5.1.1)
-      powerpack (~> 0.1)
-      rainbow (>= 2.2.2, < 4.0)
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.4.0)
-    rubocop-rspec (1.30.1)
-      rubocop (>= 0.60.0)
-    ruby-progressbar (1.10.0)
     rubyzip (1.2.2)
     sass (3.7.2)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sawyer (0.8.1)
-      addressable (>= 2.3.5, < 2.6)
-      faraday (~> 0.8, < 1.0)
     selenium-webdriver (3.141.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
@@ -364,15 +305,11 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.13)
-    terminal-table (1.8.0)
-      unicode-display_width (~> 1.1, >= 1.1.1)
     thor (0.20.3)
     thread_safe (0.3.6)
     thread_safe (0.3.6-java)
-    tomlrb (1.2.7)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    unicode-display_width (1.4.0)
     warden (1.2.8)
       rack (>= 2.0.6)
     websocket-driver (0.6.5)
@@ -382,7 +319,6 @@ GEM
     websocket-extensions (0.1.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yard (0.9.16)
 
 PLATFORMS
   java
@@ -393,20 +329,15 @@ DEPENDENCIES
   activerecord-jdbcsqlite3-adapter (~> 51.0)
   cancan
   capybara (~> 3.10)
-  chandler!
   cucumber
   cucumber-rails (~> 1.5)
   database_cleaner
   devise (~> 4.3)
   draper (~> 3.0)
-  i18n-spec
-  i18n-tasks
   jasmine
   jasmine-core (= 2.9.1)
   jruby-openssl (~> 0.10.1)
-  kramdown
   launchy
-  mdl (= 0.5.0)
   parallel_tests (~> 2.26)
   pry
   pry-byebug
@@ -415,12 +346,9 @@ DEPENDENCIES
   rails-i18n
   rake
   rspec-rails
-  rubocop (= 0.60.0)
-  rubocop-rspec (~> 1.30)
   selenium-webdriver
   simplecov
   sqlite3
-  yard
 
 BUNDLED WITH
    1.17.1

--- a/tasks/release.rake
+++ b/tasks/release.rake
@@ -1,0 +1,6 @@
+require "chandler/tasks"
+
+#
+# Add chandler as a prerequisite for `rake release`
+#
+task "release:rubygem_push" => "chandler:push"


### PR DESCRIPTION
This PR tries to simplify our complex set of development dependencies, by:

* Removing some dependencies that I've personally never used when developing activeadmin, and I don't think the current devs use either?
* Move some dependencies to the proper group for them in the Gemfile.
* Move dependencies related to lint, docs, and release to the main Gemfile. These are only used by the main Gemfile in CI, and I'm not sure it's interesting to allow using them against the other Gemfiles.