### PR TITLE
Batch action regression when passing form as proc/lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 * Prevent leaking hashed passwords via user CSV export and adds a config option for sensitive attributes. [#5486] by [@chrp]
 
+### Bug Fixes
+
+* Fix `form` parameter to `batch_action` no longer accepting procs. [#5611] by [@buren] and [@deivid-rodriguez]
+* Fix passing a proc to `scope_to`. [#5611] by [@deivid-rodriguez]
+
 ### Removals
 
 * Rails 4.2 support has been dropped. [#5104] by [@javierjulio] and [@deivid-rodriguez]
@@ -373,6 +378,7 @@ Please check [0-6-stable] for previous changes.
 [#5537]: https://github.com/activeadmin/activeadmin/pull/5537
 [#5583]: https://github.com/activeadmin/activeadmin/pull/5583
 [#5608]: https://github.com/activeadmin/activeadmin/pull/5608
+[#5611]: https://github.com/activeadmin/activeadmin/pull/5611
 
 [@5t111111]: https://github.com/5t111111
 [@aarek]: https://github.com/aarek
@@ -381,6 +387,7 @@ Please check [0-6-stable] for previous changes.
 [@andreslemik]: https://github.com/andreslemik
 [@blocknotes]: https://github.com/blocknotes
 [@bolshakov]: https://github.com/bolshakov
+[@buren]: https://github.com/buren
 [@chancancode]: https://github.com/chancancode
 [@chumakoff]: https://github.com/chumakoff
 [@craigmcnamara]: https://github.com/craigmcnamara

--- a/features/index/batch_actions.feature
+++ b/features/index/batch_actions.feature
@@ -127,6 +127,20 @@ Feature: Batch Actions
     Given I submit the batch action form with "flag"
     Then I should see a flash with "Successfully flagged 10 posts"
 
+  Scenario: Using a custom batch action with form as proc
+    Given 10 posts exist
+    And an index configuration of:
+      """
+      ActiveAdmin.register Post do
+        batch_action(:flag, form: -> { {type: ["a", "b"]} }) do
+          redirect_to collection_path, notice: "Successfully flagged 10 posts"
+        end
+      end
+      """
+    When I check the 1st record
+    Given I submit the batch action form with "flag"
+    Then I should see a flash with "Successfully flagged 10 posts"
+
   Scenario: Disabling batch actions for a resource
     Given 10 posts exist
     And an index configuration of:

--- a/features/index/batch_actions.feature
+++ b/features/index/batch_actions.feature
@@ -132,7 +132,7 @@ Feature: Batch Actions
     And an index configuration of:
       """
       ActiveAdmin.register Post do
-        batch_action(:flag, form: -> { {type: ["a", "b"]} }) do
+        batch_action(:flag, form: -> { {type: params[:type]} }) do
           redirect_to collection_path, notice: "Successfully flagged 10 posts"
         end
       end

--- a/features/index/batch_actions.feature
+++ b/features/index/batch_actions.feature
@@ -113,6 +113,20 @@ Feature: Batch Actions
     Given I submit the batch action form with "flag"
     Then I should see a flash with "Successfully flagged 10 posts"
 
+  Scenario: Using a custom batch action with form as Hash
+    Given 10 posts exist
+    And an index configuration of:
+      """
+      ActiveAdmin.register Post do
+        batch_action(:flag, form: {type: ["a", "b"]}) do
+          redirect_to collection_path, notice: "Successfully flagged 10 posts"
+        end
+      end
+      """
+    When I check the 1st record
+    Given I submit the batch action form with "flag"
+    Then I should see a flash with "Successfully flagged 10 posts"
+
   Scenario: Disabling batch actions for a resource
     Given 10 posts exist
     And an index configuration of:

--- a/features/index/index_scope_to.feature
+++ b/features/index/index_scope_to.feature
@@ -31,6 +31,28 @@ Feature: Index Scope To
     When I follow "Published"
     Then I should see 1 posts in the table
 
+  Scenario: Viewing the default scope counts when using proc
+    Given an index configuration of:
+      """
+      ActiveAdmin.register Post do
+        # Scope section to a specific author
+        scope_to ->{ User.find_by_first_name_and_last_name "John", "Doe" }
+
+        # Set up some scopes
+        scope :all, default: true
+        scope :published do |posts|
+          posts.where "published_date IS NOT NULL"
+        end
+      end
+      """
+    When I am on the index page for posts
+    Then I should see the scope "All" selected
+    And I should see the scope "All" with the count 2
+    And I should see 2 posts in the table
+
+    When I follow "Published"
+    Then I should see 1 posts in the table
+
   Scenario: Viewing the index with conditional scope :if
     Given an index configuration of:
       """

--- a/features/index/index_scope_to.feature
+++ b/features/index/index_scope_to.feature
@@ -6,6 +6,8 @@ Feature: Index Scope To
     Given 10 posts exist
     And a post with the title "Hello World" written by "John Doe" exists
     And a published post with the title "Hello World" written by "John Doe" exists
+
+  Scenario: Viewing the default scope counts
     Given an index configuration of:
       """
       ActiveAdmin.register Post do
@@ -21,8 +23,6 @@ Feature: Index Scope To
         end
       end
       """
-
-  Scenario: Viewing the default scope counts
     When I am on the index page for posts
     Then I should see the scope "All" selected
     And I should see the scope "All" with the count 2

--- a/lib/active_admin/batch_actions/controller.rb
+++ b/lib/active_admin/batch_actions/controller.rb
@@ -7,8 +7,6 @@ module ActiveAdmin
         if action_present?
           selection  =            params[:collection_selection] || []
           inputs     = JSON.parse params[:batch_action_inputs]  || '{}'
-          valid_keys = MethodOrProcHelper.call_method_or_exec_proc(current_batch_action.inputs).try(:keys)
-          inputs     = inputs.with_indifferent_access.slice *valid_keys
           instance_exec selection, inputs, &current_batch_action.block
         else
           raise "Couldn't find batch action \"#{params[:batch_action]}\""

--- a/lib/active_admin/batch_actions/controller.rb
+++ b/lib/active_admin/batch_actions/controller.rb
@@ -7,7 +7,7 @@ module ActiveAdmin
         if action_present?
           selection  =            params[:collection_selection] || []
           inputs     = JSON.parse params[:batch_action_inputs]  || '{}'
-          valid_keys = MethodOrProcHelper.call_method_or_exec_proc(current_batch_action.inputs).try(:keys)
+          valid_keys = MethodOrProcHelper.render_in_context(self, current_batch_action.inputs).try(:keys)
           inputs     = inputs.with_indifferent_access.slice *valid_keys
           instance_exec selection, inputs, &current_batch_action.block
         else

--- a/lib/active_admin/batch_actions/controller.rb
+++ b/lib/active_admin/batch_actions/controller.rb
@@ -7,6 +7,8 @@ module ActiveAdmin
         if action_present?
           selection  =            params[:collection_selection] || []
           inputs     = JSON.parse params[:batch_action_inputs]  || '{}'
+          valid_keys = MethodOrProcHelper.call_method_or_exec_proc(current_batch_action.inputs).try(:keys)
+          inputs     = inputs.with_indifferent_access.slice *valid_keys
           instance_exec selection, inputs, &current_batch_action.block
         else
           raise "Couldn't find batch action \"#{params[:batch_action]}\""

--- a/lib/active_admin/batch_actions/controller.rb
+++ b/lib/active_admin/batch_actions/controller.rb
@@ -7,7 +7,7 @@ module ActiveAdmin
         if action_present?
           selection  =            params[:collection_selection] || []
           inputs     = JSON.parse params[:batch_action_inputs]  || '{}'
-          valid_keys = StringSymbolOrProcSetting.new(current_batch_action.inputs).value(self).try(:keys)
+          valid_keys = MethodOrProcHelper.call_method_or_exec_proc(current_batch_action.inputs).try(:keys)
           inputs     = inputs.with_indifferent_access.slice *valid_keys
           instance_exec selection, inputs, &current_batch_action.block
         else

--- a/lib/active_admin/resource_controller/scoping.rb
+++ b/lib/active_admin/resource_controller/scoping.rb
@@ -15,7 +15,7 @@ module ActiveAdmin
       # Collection can be scoped conditionally with an :if or :unless proc.
       def begin_of_association_chain
         return nil unless active_admin_config.scope_to?(self)
-        StringSymbolOrProcSetting.new(active_admin_config.scope_to_method).value(self)
+        MethodOrProcHelper.render_in_context(self, active_admin_config.scope_to_method)
       end
 
       # Overriding from InheritedResources::BaseHelpers

--- a/lib/active_admin/view_helpers/method_or_proc_helper.rb
+++ b/lib/active_admin/view_helpers/method_or_proc_helper.rb
@@ -1,6 +1,8 @@
 # Utility methods for internal use.
 # @private
 module MethodOrProcHelper
+  extend self
+
   # This method will either call the symbol on self or instance_exec the Proc
   # within self. Any args will be passed along to the method dispatch.
   #

--- a/lib/active_admin/view_helpers/method_or_proc_helper.rb
+++ b/lib/active_admin/view_helpers/method_or_proc_helper.rb
@@ -1,6 +1,7 @@
 # Utility methods for internal use.
 # @private
 module MethodOrProcHelper
+  extend self
 
   # This method will either call the symbol on self or instance_exec the Proc
   # within self. Any args will be passed along to the method dispatch.

--- a/lib/active_admin/view_helpers/method_or_proc_helper.rb
+++ b/lib/active_admin/view_helpers/method_or_proc_helper.rb
@@ -1,8 +1,6 @@
 # Utility methods for internal use.
 # @private
 module MethodOrProcHelper
-  extend self
-
   # This method will either call the symbol on self or instance_exec the Proc
   # within self. Any args will be passed along to the method dispatch.
   #

--- a/spec/unit/resource_controller_spec.rb
+++ b/spec/unit/resource_controller_spec.rb
@@ -254,6 +254,19 @@ RSpec.describe "A specific resource controller", type: :controller do
       end
     end
 
+    describe "when params batch_action matches existing BatchAction and form inputs defined" do
+      let(:batch_action) { ActiveAdmin::BatchAction.new :flag, "Flag", form: { type: ["a", "b"] }, &batch_action_block }
+
+      let(:http_params) do
+        { batch_action: "flag", collection_selection: ["1"], batch_action_inputs: '{ "type": "a", "bogus": "param" }' }
+      end
+
+      it "should filter permitted params" do
+        expect(controller).to receive(:instance_exec).with(["1"], { "type" => "a" })
+        controller.batch_action
+      end
+    end
+
     describe "when params batch_action doesn't match a BatchAction" do
       let(:http_params) do
         { batch_action: "derp", collection_selection: ["1"] }

--- a/spec/unit/resource_controller_spec.rb
+++ b/spec/unit/resource_controller_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe "A specific resource controller", type: :controller do
   end
 
   describe "performing batch_action" do
-    let(:batch_action) { ActiveAdmin::BatchAction.new :flag, "Flag", &batch_action_block }
+    let(:batch_action) { ActiveAdmin::BatchAction.new *batch_action_args, &batch_action_block }
     let(:batch_action_block) { proc { self.instance_variable_set :@block_context, self.class } }
     let(:params) { ActionController::Parameters.new(http_params) }
 
@@ -239,6 +239,8 @@ RSpec.describe "A specific resource controller", type: :controller do
     end
 
     describe "when params batch_action matches existing BatchAction" do
+      let(:batch_action_args) { [:flag, "Flag"] }
+
       let(:http_params) do
         { batch_action: "flag", collection_selection: ["1"] }
       end
@@ -255,7 +257,7 @@ RSpec.describe "A specific resource controller", type: :controller do
     end
 
     describe "when params batch_action matches existing BatchAction and form inputs defined" do
-      let(:batch_action) { ActiveAdmin::BatchAction.new :flag, "Flag", form: { type: ["a", "b"] }, &batch_action_block }
+      let(:batch_action_args) { [:flag, "Flag", { form: { type: ["a", "b"] } }] }
 
       let(:http_params) do
         { batch_action: "flag", collection_selection: ["1"], batch_action_inputs: '{ "type": "a", "bogus": "param" }' }
@@ -268,6 +270,8 @@ RSpec.describe "A specific resource controller", type: :controller do
     end
 
     describe "when params batch_action doesn't match a BatchAction" do
+      let(:batch_action_args) { [:flag, "Flag"] }
+
       let(:http_params) do
         { batch_action: "derp", collection_selection: ["1"] }
       end
@@ -280,6 +284,8 @@ RSpec.describe "A specific resource controller", type: :controller do
     end
 
     describe "when params batch_action is blank" do
+      let(:batch_action_args) { [:flag, "Flag"] }
+
       let(:http_params) do
         { collection_selection: ["1"] }
       end


### PR DESCRIPTION
Given

```ruby
# form = {type: ["a", "b"]}      # Works as intended
form = -> { {type: ["a", "b"]} } # ArgumentError

ActiveAdmin.register Post do
  batch_action(:flag, form: form) do
    redirect_to collection_path, notice: "Successfully flagged 10 posts"
  end
end
```

it will fail with `ArgumentError, wrong number of arguments (given 1, expected 0)`.
However if we instead pass a `Hash` instead of `proc`/`lambda` to `:form` then it works as intended.

I've added a passing feature test for the `Hash` case and a failing one for the `proc`/`lambda` case.

---

_Update_: This bug is _not_ present in `v1.3.x`, but _is_ present in `v1.4.x` - it was introduced in `v.1.4.0`.