### PR TITLE
Better selenium capybara driver

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -31,9 +31,7 @@ After '@debug' do |scenario|
   # :nocov:
 end
 
-require 'capybara/rails'
 require 'capybara/cucumber'
-require 'capybara/session'
 
 Capybara.register_driver :chrome do |app|
   Capybara::Selenium::Driver.load_selenium

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -34,13 +34,13 @@ end
 require 'capybara/rails'
 require 'capybara/cucumber'
 require 'capybara/session'
-require 'selenium-webdriver'
 
-# copied from https://about.gitlab.com/2017/12/19/moving-to-headless-chrome/
 Capybara.register_driver :chrome do |app|
-  options = Selenium::WebDriver::Chrome::Options.new(
-    args: %w[headless disable-gpu no-sandbox]
-  )
+  Capybara::Selenium::Driver.load_selenium
+
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.args << '--headless'
+
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -41,7 +41,10 @@ Capybara.register_driver :chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
   options.args << '--headless'
 
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+  http_client = Selenium::WebDriver::Remote::Http::Default.new
+  http_client.read_timeout = 180
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options, http_client: http_client)
 end
 
 Capybara.javascript_driver = :chrome

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -13,7 +13,7 @@ require_relative 'rails'
 require 'rspec/mocks'
 World(RSpec::Mocks::ExampleMethods)
 
-Around do |scenario, block|
+Around '@mocks' do |scenario, block|
   RSpec::Mocks.setup
 
   block.call

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -31,7 +31,21 @@ After '@debug' do |scenario|
   # :nocov:
 end
 
-require 'capybara/cucumber'
+require 'capybara/dsl'
+
+World(Capybara::DSL)
+
+After do
+  Capybara.reset_sessions!
+end
+
+Before do
+  Capybara.use_default_driver
+end
+
+Before '@javascript' do
+  Capybara.current_driver = Capybara.javascript_driver
+end
 
 Capybara.register_driver :chrome do |app|
   Capybara::Selenium::Driver.load_selenium

--- a/features/users/resetting_password.feature
+++ b/features/users/resetting_password.feature
@@ -13,6 +13,7 @@ Feature: User Resetting Password
     And I press "Reset My Password"
     Then I should see "You will receive an email with instructions on how to reset your password in a few minutes."
 
+  @mocks
   Scenario: Changing password after resetting
     When "admin@example.com" requests a password reset with token "foobarbaz"
     When I go to the admin password reset form with token "foobarbaz"
@@ -21,6 +22,7 @@ Feature: User Resetting Password
     And I press "Change my password"
     Then I should see "success"
 
+  @mocks
   Scenario: Changing password after resetting with errors
     When "admin@example.com" requests a password reset with token "foobarbaz" but it expires
     When I go to the admin password reset form with token "foobarbaz"

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -10,14 +10,14 @@ end
 
 desc "Run the specs in parallel"
 task :spec do
-  sh("parallel_rspec --serialize-stdout --verbose spec/")
+  sh("parallel_rspec --serialize-stdout --combine-stderr --verbose spec/")
 end
 
 namespace :spec do
   %i(unit request).each do |type|
     desc "Run the #{type} specs in parallel"
     task type do
-      sh("parallel_rspec --serialize-stdout --verbose spec/#{type}")
+      sh("parallel_rspec --serialize-stdout --combine-stderr --verbose spec/#{type}")
     end
   end
 end
@@ -28,7 +28,7 @@ task cucumber: [:"cucumber:regular", :"cucumber:reloading"]
 namespace :cucumber do
   desc "Run the standard cucumber scenarios in parallel"
   task :regular do
-    sh("parallel_cucumber --serialize-stdout --verbose features/")
+    sh("parallel_cucumber --serialize-stdout --combine-stderr --verbose features/")
   end
 
   desc "Run the cucumber scenarios that test reloading"


### PR DESCRIPTION
This PR catches up with the official way upstream capybara uses to register a chrome headless driver, and also increases selenium's default timeout to try to fix random CI failures like https://circleci.com/gh/activeadmin/activeadmin/6357.