### PR TITLE
Move test app location to tmp/

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,16 +40,16 @@ version: 2.1
 
 .restore_coverage: &restore_coverage
   attach_workspace:
-    at: tmp
+    at: coverage
 
 .format_coverage: &format_coverage
   run:
     name: Format coverage
-    command: tmp/test-reporter format-coverage --input-type simplecov --output tmp/codeclimate.$CIRCLE_JOB.json
+    command: coverage/test-reporter format-coverage --input-type simplecov --output coverage/codeclimate.$CIRCLE_JOB.json
 
 .save_coverage: &save_coverage
   persist_to_workspace:
-      root: tmp
+      root: coverage
       paths:
         - codeclimate.*.json
 
@@ -57,8 +57,8 @@ version: 2.1
   run:
     name: Upload coverage results to Code Climate
     command: |
-      tmp/test-reporter sum-coverage tmp/codeclimate.*.json --parts 16 --output tmp/codeclimate.total.json
-      tmp/test-reporter upload-coverage --input tmp/codeclimate.total.json
+      coverage/test-reporter sum-coverage coverage/codeclimate.*.json --parts 16 --output coverage/codeclimate.total.json
+      coverage/test-reporter upload-coverage --input coverage/codeclimate.total.json
 
 .save_test_app_to_workspace: &save_test_app_to_workspace
   persist_to_workspace:
@@ -140,12 +140,12 @@ jobs:
       - run:
           name: Download Code Climate test-reporter
           command: |
-            mkdir tmp
-            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-0.6.3-linux-amd64 > tmp/test-reporter
-            chmod +x tmp/test-reporter
+            mkdir coverage
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-0.6.3-linux-amd64 > coverage/test-reporter
+            chmod +x coverage/test-reporter
 
       - persist_to_workspace:
-          root: tmp
+          root: coverage
           paths:
             - test-reporter
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,13 +62,13 @@ version: 2.1
 
 .save_test_app_to_workspace: &save_test_app_to_workspace
   persist_to_workspace:
-    root: spec/rails
+    root: tmp/rails
     paths:
       - rails-*
 
 .restore_test_app_from_workspace: &restore_test_app_from_workspace
   attach_workspace:
-    at: spec/rails
+    at: tmp/rails
 
 .restore_test_times: &restore_test_times
   restore_cache:

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ pkg
 
 ## Project (specific)
 .bundle
-spec/rails
 .test-rails-apps
 public
 .rspec_failures

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ AllCops:
   TargetRubyVersion: 2.3
 
   Exclude:
-    - spec/rails/**/*
+    - tmp/rails/**/*
     - gemfiles/vendor/bundle/**/*
     - vendor/bundle/**/*
 

--- a/.simplecov
+++ b/.simplecov
@@ -1,5 +1,5 @@
 SimpleCov.start do
-  add_filter 'spec/rails/'
+  add_filter 'tmp/rails/'
 end
 
 if ENV['CI'] == 'true'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Now you should be able to run the entire suite using:
 bundle exec rake
 ```
 
-The test run will generate a sample Rails application in `spec/rails` to run the
+The test run will generate a sample Rails application in `tmp/rails` to run the
 tests against.
 
 If your tests are passing locally but they're failing on CircleCI, it's probably

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -6,7 +6,7 @@ Dir["#{File.expand_path('../step_definitions', __dir__)}/*.rb"].each do |f|
   require f
 end
 
-require_relative "../../spec/rails/rails-#{Gem.loaded_specs["rails"].version}/config/environment"
+require_relative "../../tmp/rails/rails-#{Gem.loaded_specs["rails"].version}/config/environment"
 
 require_relative 'rails'
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 ENV['RAILS_ENV'] = 'test'
 
-require_relative "rails/rails-#{Gem.loaded_specs["rails"].version}/config/environment"
+require_relative "../tmp/rails/rails-#{Gem.loaded_specs["rails"].version}/config/environment"
 
 require 'rspec/rails'
 

--- a/tasks/application_generator.rb
+++ b/tasks/application_generator.rb
@@ -38,7 +38,7 @@ module ActiveAdmin
     private
 
     def base_dir
-      @base_dir ||= rails_env == 'test' ? 'spec/rails' : '.test-rails-apps'
+      @base_dir ||= rails_env == 'test' ? 'tmp/rails' : '.test-rails-apps'
     end
 
     def app_dir


### PR DESCRIPTION
If we keep it in spec/, test files from generated applications are
loaded by rspec, which is unintended.

You can see this in the test logged output. For example:

### Before

```
4 processes for 106 specs, ~ 26 specs per process

bundle exec rspec --color --tty -O .rspec_parallel spec/rails/rails-5.0.7.1/spec/models/category_spec.rb spec/rails/rails-5.0.7.1/spec/models/store_spec.rb spec/requests/memory_spec.rb spec/requests/stylesheets_spec.rb spec/unit/application_spec.rb spec/unit/authorization/controller_authorization_spec.rb spec/unit/controller_filters_spec.rb spec/unit/csv_builder_spec.rb spec/unit/dynamic_settings_spec.rb spec/unit/filters/active_spec.rb spec/unit/menu_spec.rb spec/unit/page_spec.rb spec/unit/resource/page_presenters_spec.rb spec/unit/resource/scopes_spec.rb spec/unit/resource_collection_spec.rb spec/unit/resource_controller/data_access_spec.rb spec/unit/routing_spec.rb spec/unit/view_helpers/download_format_links_helper_spec.rb spec/unit/view_helpers/flash_helper_spec.rb spec/unit/view_helpers/form_helper_spec.rb spec/unit/views/components/batch_action_selector_spec.rb spec/unit/views/components/index_list_spec.rb spec/unit/views/components/menu_item_spec.rb spec/unit/views/components/site_title_spec.rb spec/unit/views/pages/form_spec.rb spec/unit/views/pages/layout_spec.rb 2>&1
```

### After

```
4 processes for 96 specs, ~ 24 specs per process

bundle exec rspec --color --tty -O .rspec_parallel spec/requests/memory_spec.rb spec/requests/stylesheets_spec.rb spec/unit/application_spec.rb spec/unit/authorization/controller_authorization_spec.rb spec/unit/controller_filters_spec.rb spec/unit/csv_builder_spec.rb spec/unit/dynamic_settings_spec.rb spec/unit/filters/active_spec.rb spec/unit/menu_spec.rb spec/unit/page_spec.rb spec/unit/resource/page_presenters_spec.rb spec/unit/resource/scopes_spec.rb spec/unit/resource_collection_spec.rb spec/unit/resource_controller/data_access_spec.rb spec/unit/routing_spec.rb spec/unit/view_helpers/download_format_links_helper_spec.rb spec/unit/view_helpers/flash_helper_spec.rb spec/unit/view_helpers/form_helper_spec.rb spec/unit/views/components/batch_action_selector_spec.rb spec/unit/views/components/index_list_spec.rb spec/unit/views/components/menu_item_spec.rb spec/unit/views/components/site_title_spec.rb spec/unit/views/pages/form_spec.rb spec/unit/views/pages/layout_spec.rb 2>&1
```
