### PR TITLE
Remove one shelling out level in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,9 @@ version: 2.1
 .run_tests: &run_tests
   run:
     name: Run tests
-    command: COVERAGE=true PARALLEL_TEST_PROCESSORS=4 bundle exec rake test
+    command: |
+      COVERAGE=true PARALLEL_TEST_PROCESSORS=4 bin/parallel_rspec spec/
+      COVERAGE=true PARALLEL_TEST_PROCESSORS=4 bin/parallel_cucumber features/
 
 .save_test_times: &save_test_times
   save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -333,7 +333,7 @@ jobs:
 
   jruby92rails50:
     docker:
-      - image: circleci/jruby:9.2.4.0-node-browsers
+      - image: circleci/jruby:9.2.4.1-node-browsers
 
     environment:
       BUNDLE_GEMFILE: gemfiles/rails_50.gemfile
@@ -344,7 +344,7 @@ jobs:
 
   jruby92rails51:
     docker:
-      - image: circleci/jruby:9.2.4.0-node-browsers
+      - image: circleci/jruby:9.2.4.1-node-browsers
 
     environment:
       BUNDLE_GEMFILE: gemfiles/rails_51.gemfile
@@ -355,7 +355,7 @@ jobs:
 
   jruby92rails52:
     docker:
-      - image: circleci/jruby:9.2.4.0-node-browsers
+      - image: circleci/jruby:9.2.4.1-node-browsers
 
     environment:
       BUNDLE_GEMFILE: Gemfile

--- a/bin/parallel_cucumber
+++ b/bin/parallel_cucumber
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+
+%w[--serialize-stdout --combine-stderr --verbose].each do |flag|
+  ARGV << flag unless ARGV.include?(flag)
+end
+
+load Gem.bin_path("parallel_tests", "parallel_cucumber")

--- a/bin/parallel_rspec
+++ b/bin/parallel_rspec
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+
+%w[--serialize-stdout --combine-stderr --verbose].each do |flag|
+  ARGV << flag unless ARGV.include?(flag)
+end
+
+load Gem.bin_path("parallel_tests", "parallel_rspec")

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -135,6 +135,7 @@ RSpec.describe ActiveAdmin::Application do
         FileUtils.touch(test_file)
         expect(application.files).to include(test_file)
       ensure
+        ActiveSupport::Dependencies.clear
         FileUtils.remove_entry_secure(test_dir, force: true)
       end
     end

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -10,14 +10,14 @@ end
 
 desc "Run the specs in parallel"
 task :spec do
-  sh("parallel_rspec --serialize-stdout --combine-stderr --verbose spec/")
+  sh("bin/parallel_rspec spec/")
 end
 
 namespace :spec do
   %i(unit request).each do |type|
     desc "Run the #{type} specs in parallel"
     task type do
-      sh("parallel_rspec --serialize-stdout --combine-stderr --verbose spec/#{type}")
+      sh("bin/parallel_rspec spec/#{type}")
     end
   end
 end
@@ -28,7 +28,7 @@ task cucumber: [:"cucumber:regular", :"cucumber:reloading"]
 namespace :cucumber do
   desc "Run the standard cucumber scenarios in parallel"
   task :regular do
-    sh("parallel_cucumber --serialize-stdout --combine-stderr --verbose features/")
+    sh("bin/parallel_cucumber features/")
   end
 
   desc "Run the cucumber scenarios that test reloading"


### PR DESCRIPTION
Trying to make jruby less flaky. We're getting a lot of "killed" errors, so I'm trying this based on https://github.com/jruby/jruby/issues/3739#issuecomment-199156622. According to that issue, this should've already been fixed on `jruby-launcher`, but I'm unclear how that library is distributed, so I'll try this directly anyways and see if it does the trick.