### PR TITLE
Fix for per_page: Array, pagination_total: false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 * Prevent leaking hashed passwords via user CSV export and adds a config option for sensitive attributes. [#5486] by [@chrp]
 
+### Bug Fixes
+
+* Fix for paginated collections with `per_page: Array, pagination_total: false`. [#5627] by [@bartoszkopinski]
+
 ### Removals
 
 * Rails 4.2 support has been dropped. [#5104] by [@javierjulio] and [@deivid-rodriguez]
@@ -388,6 +392,7 @@ Please check [0-6-stable] for previous changes.
 [#5583]: https://github.com/activeadmin/activeadmin/pull/5583
 [#5608]: https://github.com/activeadmin/activeadmin/pull/5608
 [#5611]: https://github.com/activeadmin/activeadmin/pull/5611
+[#5627]: https://github.com/activeadmin/activeadmin/pull/5627
 
 [@5t111111]: https://github.com/5t111111
 [@aarek]: https://github.com/aarek
@@ -447,3 +452,4 @@ Please check [0-6-stable] for previous changes.
 [@wspurgin]: https://github.com/wspurgin
 [@zorab47]: https://github.com/zorab47
 [@chrp]: https://github.com/chrp
+[@bartoszkopinski]: https://github.com/bartoszkopinski

--- a/lib/active_admin/views/components/paginated_collection.rb
+++ b/lib/active_admin/views/components/paginated_collection.rb
@@ -102,7 +102,7 @@ module ActiveAdmin
           # you pass in the :total_pages option. We issue a query to determine
           # if there is another page or not, but the limit/offset make this
           # query fast.
-          offset = collection.offset(collection.current_page * @per_page.to_i).limit(1).count
+          offset = collection.offset(collection.current_page * collection.limit_value).limit(1).count
           options[:total_pages] = collection.current_page + offset
           options[:right] = 0
         end

--- a/spec/unit/views/components/paginated_collection_spec.rb
+++ b/spec/unit/views/components/paginated_collection_spec.rb
@@ -241,6 +241,15 @@ RSpec.describe ActiveAdmin::Views::PaginatedCollection do
         expect(pagination_html.content).to match(/Per page:/)
         expect(pagination_node).to have_css("select option", count: 3)
       end
+
+      context "with pagination_total: false" do
+        let(:pagination) { paginated_collection(collection, per_page: [1, 2, 3], pagination_total: false) }
+
+        it "should render per_page select tag" do
+          info = pagination.find_by_class('pagination_information').first.content.gsub('&nbsp;', ' ')
+          expect(info).to eq "Displaying posts <b>1 - 5</b>"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This is an attempt to fix a bug raised in #5463 that occurs for collections with `per_page` set to an array and `pagination_total` set to `false`:


```ruby
 NoMethodError:
   undefined method `to_i' for [1, 2, 3]:Array
   Did you mean?  to_s
                  to_a
                  to_h
 # ./lib/active_admin/views/components/paginated_collection.rb:105:in `build_pagination'
 # ./lib/active_admin/views/components/paginated_collection.rb:71:in `block in build_pagination_with_formats'
```

Fixes #5463.