### PR TITLE
Lock bug report template versions

### DIFF
--- a/tasks/bug_report_template.rb
+++ b/tasks/bug_report_template.rb
@@ -11,7 +11,7 @@ gemfile(true) do
   end
 
   # Change Rails version if necessary.
-  gem 'rails', '5.2.1'
+  gem 'rails', '5.2.1.1'
 
   gem 'sass-rails', '5.0.7'
   gem 'sqlite3', '1.3.13', platform: :mri

--- a/tasks/bug_report_template.rb
+++ b/tasks/bug_report_template.rb
@@ -13,8 +13,8 @@ gemfile(true) do
   # Change Rails version if necessary.
   gem 'rails', '5.2.1'
 
-  gem 'sass-rails'
-  gem 'sqlite3', platform: :mri
+  gem 'sass-rails', '5.0.7'
+  gem 'sqlite3', '1.3.13', platform: :mri
   gem 'activerecord-jdbcsqlite3-adapter', "52.0", platform: :jruby
   gem 'jruby-openssl', '0.10.1', platform: :jruby
 end

--- a/tasks/bug_report_template.rb
+++ b/tasks/bug_report_template.rb
@@ -11,12 +11,12 @@ gemfile(true) do
   end
 
   # Change Rails version if necessary.
-  gem 'rails', '~> 5.2.1'
+  gem 'rails', '5.2.1'
 
   gem 'sass-rails'
   gem 'sqlite3', platform: :mri
-  gem 'activerecord-jdbcsqlite3-adapter', "~> 52.0", platform: :jruby
-  gem 'jruby-openssl', '~> 0.10.1', platform: :jruby
+  gem 'activerecord-jdbcsqlite3-adapter', "52.0", platform: :jruby
+  gem 'jruby-openssl', '0.10.1', platform: :jruby
 end
 
 require 'active_record'


### PR DESCRIPTION
The release of rails 5.2.2 is incompatible with latest ransack, and thus with activeadmin. A new compatible version of ransack [will be cut tomorrow](https://github.com/activerecord-hackery/ransack/pull/985), but the release of external dependencies should not break our tests. So this PR locks gem versions in the bug report template (since there's no lock file in this case), so that it runs against a consistent set of know working dependencies.  