### PR TITLE
Nicer runtime dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,17 +11,17 @@ PATH
   remote: .
   specs:
     activeadmin (2.0.0.alpha)
-      arbre (>= 1.1.1)
+      arbre (~> 1.1, >= 1.1.1)
       formtastic (~> 3.1)
-      formtastic_i18n
-      inherited_resources (>= 1.7.0)
-      jquery-rails (>= 4.2.0)
-      kaminari (>= 1.0.1)
+      formtastic_i18n (~> 0.4)
+      inherited_resources (~> 1.7)
+      jquery-rails (~> 4.2)
+      kaminari (~> 1.0, >= 1.0.1)
       railties (>= 5.0, < 5.3)
-      ransack (>= 2.1.1)
+      ransack (~> 2.1, >= 2.1.1)
       sass (~> 3.4)
       sprockets (>= 3.0, < 4.1)
-      sprockets-es6 (>= 0.9.2)
+      sprockets-es6 (~> 0.9, >= 0.9.2)
 
 GEM
   remote: https://rubygems.org/

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -19,15 +19,15 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.3'
 
-  s.add_dependency 'arbre', '>= 1.1.1'
+  s.add_dependency 'arbre', '~> 1.1', '>= 1.1.1'
   s.add_dependency 'formtastic', '~> 3.1'
-  s.add_dependency 'formtastic_i18n'
-  s.add_dependency 'inherited_resources', '>= 1.7.0'
-  s.add_dependency 'jquery-rails', '>= 4.2.0'
-  s.add_dependency 'kaminari', '>= 1.0.1'
+  s.add_dependency 'formtastic_i18n', '~> 0.4'
+  s.add_dependency 'inherited_resources', '~> 1.7'
+  s.add_dependency 'jquery-rails', '~> 4.2'
+  s.add_dependency 'kaminari', '~> 1.0', '>= 1.0.1'
   s.add_dependency 'railties', '>= 5.0', '< 5.3'
-  s.add_dependency 'ransack', '>= 2.1.1'
+  s.add_dependency 'ransack', '~> 2.1', '>= 2.1.1'
   s.add_dependency 'sass', '~> 3.4'
   s.add_dependency 'sprockets', '>= 3.0', '< 4.1'
-  s.add_dependency 'sprockets-es6', '>= 0.9.2'
+  s.add_dependency 'sprockets-es6', '~> 0.9', '>= 0.9.2'
 end

--- a/gemfiles/rails_50.gemfile.lock
+++ b/gemfiles/rails_50.gemfile.lock
@@ -2,17 +2,17 @@ PATH
   remote: ..
   specs:
     activeadmin (2.0.0.alpha)
-      arbre (>= 1.1.1)
+      arbre (~> 1.1, >= 1.1.1)
       formtastic (~> 3.1)
-      formtastic_i18n
-      inherited_resources (>= 1.7.0)
-      jquery-rails (>= 4.2.0)
-      kaminari (>= 1.0.1)
+      formtastic_i18n (~> 0.4)
+      inherited_resources (~> 1.7)
+      jquery-rails (~> 4.2)
+      kaminari (~> 1.0, >= 1.0.1)
       railties (>= 5.0, < 5.3)
-      ransack (>= 2.1.1)
+      ransack (~> 2.1, >= 2.1.1)
       sass (~> 3.4)
       sprockets (>= 3.0, < 4.1)
-      sprockets-es6 (>= 0.9.2)
+      sprockets-es6 (~> 0.9, >= 0.9.2)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -2,17 +2,17 @@ PATH
   remote: ..
   specs:
     activeadmin (2.0.0.alpha)
-      arbre (>= 1.1.1)
+      arbre (~> 1.1, >= 1.1.1)
       formtastic (~> 3.1)
-      formtastic_i18n
-      inherited_resources (>= 1.7.0)
-      jquery-rails (>= 4.2.0)
-      kaminari (>= 1.0.1)
+      formtastic_i18n (~> 0.4)
+      inherited_resources (~> 1.7)
+      jquery-rails (~> 4.2)
+      kaminari (~> 1.0, >= 1.0.1)
       railties (>= 5.0, < 5.3)
-      ransack (>= 2.1.1)
+      ransack (~> 2.1, >= 2.1.1)
       sass (~> 3.4)
       sprockets (>= 3.0, < 4.1)
-      sprockets-es6 (>= 0.9.2)
+      sprockets-es6 (~> 0.9, >= 0.9.2)
 
 GEM
   remote: https://rubygems.org/

--- a/spec/gemfiles_spec.lint.rb
+++ b/spec/gemfiles_spec.lint.rb
@@ -1,5 +1,3 @@
-require "open3"
-
 RSpec.describe "Gemfile sanity" do
   shared_examples_for "a sane gemfile" do |gemfile|
     it "is up to date" do

--- a/spec/gemspec_spec.lint.rb
+++ b/spec/gemspec_spec.lint.rb
@@ -14,7 +14,7 @@ RSpec.describe "gemspec sanity" do
     expect(build[1]).not_to include("WARNING")
   end
 
-  it "suceeds" do
+  it "succeeds" do
     expect(build[2]).to be_success
   end
 end

--- a/spec/gemspec_spec.lint.rb
+++ b/spec/gemspec_spec.lint.rb
@@ -1,0 +1,20 @@
+require "open3"
+require "active_admin/version"
+
+RSpec.describe "gemspec sanity" do
+  after do
+    File.delete("activeadmin-#{ActiveAdmin::VERSION}.gem")
+  end
+
+  let(:build) do
+    Open3.capture3("gem build activeadmin.gemspec")
+  end
+
+  it "has no warnings" do
+    expect(build[1]).not_to include("WARNING")
+  end
+
+  it "suceeds" do
+    expect(build[2]).to be_success
+  end
+end


### PR DESCRIPTION
Currently running `gem build activeadmin.gemspec` display a bunch of open-ended dependency warnings. The warnings are true. Most of our dependencies are open-ended, so if a dependency released a backwards incompatible version, even if it followed semantic versioning, activeadmin would pick it up and break.

So, I'm proposing to bound our dependencies so that it's less likely that 3rd party releases break activeadmin.

I also added a check to ensure the `gem build activeadmin.gemspec` builds without warnings going forward.