### PR TITLE
Cucumber config tweaks

### DIFF
--- a/bin/parallel_cucumber
+++ b/bin/parallel_cucumber
@@ -2,7 +2,7 @@
 
 require "bundler/setup"
 
-%w[--serialize-stdout --combine-stderr --verbose].each do |flag|
+["--serialize-stdout", "--combine-stderr", "--verbose", "--test-options", "-p default"].each do |flag|
   ARGV << flag unless ARGV.include?(flag)
 end
 

--- a/cucumber.yml
+++ b/cucumber.yml
@@ -1,5 +1,6 @@
 <%
-  std_opts = "--format progress --order random"
+  std_format = ENV["CI"] ? "summary" : "progress"
+  std_opts = "--format #{std_format} --order random"
   default_opts = std_opts + " --format ParallelTests::Gherkin::RuntimeLogger --out tmp/parallel_runtime_cucumber.log"
 %>
 


### PR DESCRIPTION
This PR introduces a couple of small tweaks on our cucumber config:

* Previous binstub was not actually loading the default cucumber profile. That was unexpected and https://github.com/activeadmin/activeadmin/commit/47405d9994a94761d5a88476b793c6e663d3ea87 should fix it.

* Switch to use the more informative `summary` format in CI, as opposed to only displaying dots, thus not giving any information about context of failures.