### PR TITLE
RSpec documentation format in CI

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
+--format <%= ENV['CI'] ? 'documentation' : 'progress' %>
 --require spec_helper


### PR DESCRIPTION
This is equivalent to #5635, but for RSpec, namely, use the more informative "documentation" format in CI.