### PR TITLE
Disable codeclimate quality checks

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,34 @@
+---
+
+version: "2"
+
+checks:
+  argument-count:
+    enabled: false
+
+  complex-logic:
+    enabled: false
+
+  file-lines:
+    enabled: false
+
+  method-complexity:
+    enabled: false
+
+  method-count:
+    enabled: false
+
+  method-lines:
+    enabled: false
+
+  nested-control-flow:
+    enabled: false
+
+  return-statements:
+    enabled: false
+
+  similar-code:
+    enabled: false
+
+  identical-code:
+    enabled: false


### PR DESCRIPTION
Codeclimate status checks were not working. I reinstalled them and they seem to be working now, but we want to ignore the "standard" codeclimate check, and use only the ones related to code coverage, since we only introduced it as a replacement of codecov.