### PR TITLE
Final CI tweaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ version: 2.1
 .run_lints: &run_lints
   run:
     name: Run lints
-    command: bundle exec rake lint
+    command: COVERAGE=true bundle exec rake lint
 
 .run_bug_report_template: &run_bug_report_template
   run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,8 +78,18 @@ version: 2.1
 
 .run_tests: &run_tests
   run:
-    name: Run tests
-    command: COVERAGE=true PARALLEL_TEST_PROCESSORS=4 bundle exec rake spec cucumber
+    name: Run RSpec tests
+    command: |
+      COVERAGE=true PARALLEL_TEST_PROCESSORS=4 bin/parallel_rspec spec/
+      COVERAGE=true RSPEC_FILESYSTEM_CHANGES=true bin/rspec
+
+.run_features: &run_features
+  run:
+    name: Run Cucumber features
+    command: |
+      COVERAGE=true PARALLEL_TEST_PROCESSORS=4 bin/parallel_cucumber features/
+      COVERAGE=true bin/cucumber --profile filesystem-changes
+      COVERAGE=true bin/cucumber --profile class-reloading
 
 .save_test_times: &save_test_times
   save_cache:
@@ -115,6 +125,7 @@ version: 2.1
   - *restore_test_times
   - *restore_coverage
   - *run_tests
+  - *run_features
   - *format_coverage
   - *save_coverage
   - *save_test_times

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ version: 2.1
 .create_test_app: &create_test_app
   run:
     name: Create test app
-    command: PARALLEL_TEST_PROCESSORS=4 bundle exec rake setup
+    command: PARALLEL_TEST_PROCESSORS=4 bin/rake setup
 
 .restore_coverage: &restore_coverage
   attach_workspace:
@@ -101,12 +101,12 @@ version: 2.1
 .generate_docs: &generate_docs
   run:
     name: Generate docs
-    command: bundle exec rake docs:build
+    command: bin/rake docs:build
 
 .run_lints: &run_lints
   run:
     name: Run lints
-    command: COVERAGE=true bundle exec rake lint
+    command: COVERAGE=true bin/rake lint
 
 .run_bug_report_template: &run_bug_report_template
   run:

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --format <%= ENV['CI'] ? 'documentation' : 'progress' %>
 --require spec_helper
+<%= "--require #{__dir__}/spec/support/simplecov_changes_env.rb --tag changes_filesystem" if ENV['RSPEC_FILESYSTEM_CHANGES'] %>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ bundle install
 Now you should be able to run the entire suite using:
 
 ```sh
-bundle exec rake
+bin/rake
 ```
 
 The test run will generate a sample Rails application in `tmp/rails` to run the
@@ -91,7 +91,7 @@ a look at your changes in a browser.
 To boot up a test Rails app:
 
 ```sh
-bundle exec rake local server
+bin/rake local server
 ```
 
 This will automatically create a Rails app if none already exists, and store it
@@ -107,21 +107,21 @@ If you need to perform any other commands on the test application, just pass
 them to the `local` rake task. For example, to boot the rails console:
 
 ```sh
-bundle exec rake local console
+bin/rake local console
 ```
 
 Or to migrate the database:
 
 ```sh
-bundle exec rake local db:migrate
+bin/rake local db:migrate
 ```
 
 ### Get the style right
 
 Your patch should follow the same conventions & pass the same code quality
-checks as the rest of the project. `bundle exec rake lint` will give you
-feedback in this regard. You can check & fix style issues by running each linter
-individually. Run `bundle exec rake -T lint` to see the available linters.
+checks as the rest of the project. `bin/rake lint` will give you feedback in
+this regard. You can check & fix style issues by running each linter
+individually. Run `bin/rake -T lint` to see the available linters.
 
 ### Make a Pull Request
 
@@ -200,7 +200,7 @@ Maintainers need to do the following to push out a release:
 * Make sure you have [chandler] properly configured. Chandler is used to
   automatically submit github release notes from the changelog right after
   pushing the gem to rubygems.
-* `bundle exec rake release`
+* `bin/rake release`
 
 [chandler]: https://github.com/mattbrictson/chandler#2-configure-credentials
 [chromedriver]: https://sites.google.com/a/chromium.org/chromedriver/getting-started

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ import 'tasks/gemfiles.rake'
 import 'tasks/local.rake'
 import 'tasks/test.rake'
 
-if ENV['BUNDLE_GEMFILE'] == File.expand_path('Gemfile')
+if File.expand_path(ENV['BUNDLE_GEMFILE']) == File.expand_path('Gemfile')
   import 'tasks/docs.rake'
   import 'tasks/lint.rake'
   import 'tasks/release.rake'

--- a/bin/cucumber
+++ b/bin/cucumber
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+
+load Gem.bin_path("cucumber", "cucumber")

--- a/bin/rake
+++ b/bin/rake
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+
+load Gem.bin_path("rake", "rake")

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+
+load Gem.bin_path("rspec-core", "rspec")

--- a/spec/changelog_spec.lint.rb
+++ b/spec/changelog_spec.lint.rb
@@ -4,8 +4,7 @@ require "kramdown"
 
 RSpec.describe "Changelog" do
   subject(:changelog) do
-    path = File.join(File.dirname(__dir__), "CHANGELOG.md")
-    File.read(path)
+    File.read("CHANGELOG.md")
   end
 
   it 'uses the simplest style for implicit links' do

--- a/tasks/lint.rake
+++ b/tasks/lint.rake
@@ -143,7 +143,6 @@ namespace :lint do
     puts "Linting project files..."
 
     sh(
-      { "COVERAGE" => "true" },
       "bin/rspec",
       "spec/gemfiles_spec.lint.rb",
       "spec/changelog_spec.lint.rb",

--- a/tasks/lint.rake
+++ b/tasks/lint.rake
@@ -144,7 +144,7 @@ namespace :lint do
 
     sh(
       { "COVERAGE" => "true" },
-      "rspec",
+      "bin/rspec",
       "spec/gemfiles_spec.lint.rb",
       "spec/changelog_spec.lint.rb",
       "spec/i18n_spec.lint.rb"

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -21,7 +21,7 @@ namespace :spec do
 
   desc "Run the specs that change the filesystem sequentially"
   task :filesystem_changes do
-    sh("bin/rspec --require #{File.dirname(__dir__)}/spec/support/simplecov_changes_env.rb --tag changes_filesystem")
+    sh({ "RSPEC_FILESYSTEM_CHANGES" => "true" }, "bin/rspec")
   end
 end
 

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -21,7 +21,7 @@ namespace :spec do
 
   desc "Run the specs that change the filesystem sequentially"
   task :filesystem_changes do
-    sh("rspec --require #{File.dirname(__dir__)}/spec/support/simplecov_changes_env.rb --tag changes_filesystem")
+    sh("bin/rspec --require #{File.dirname(__dir__)}/spec/support/simplecov_changes_env.rb --tag changes_filesystem")
   end
 end
 
@@ -39,11 +39,11 @@ namespace :cucumber do
 
   desc "Run the cucumber scenarios that change the filesystem sequentially"
   task :filesystem_changes do
-    sh("cucumber --profile filesystem-changes")
+    sh("bin/cucumber --profile filesystem-changes")
   end
 
   desc "Run the cucumber scenarios that test reloading"
   task :reloading do
-    sh("cucumber --profile class-reloading")
+    sh("bin/cucumber --profile class-reloading")
   end
 end


### PR DESCRIPTION
#5640 seems to have worked to remove the test suite flakyness, but reintroduced another kind of [jruby specific failures](https://circleci.com/workflow-run/f0dff59e-14bb-40b7-8fbc-6e64e6788540), where the run abruptly aborts with a "killed" message. #5640 basically undid #5626, so I'm removing the shelling out again in this PR.

~There's some separate changes in here to improve the specs that check gemfile consistency. I can extract those to a separate PR if needed.~ Removed from this PR.