### PR TITLE
Fix gemfile consistency checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ version: 2.1
 .install_dependencies: &install_dependencies
   run:
     name: Install dependencies
-    command: bundle install --path /home/circleci/project/vendor/bundle --retry 3 --jobs 3
+    command: bin/bundle install --path /home/circleci/project/vendor/bundle --retry 3 --jobs 3
 
 .install_chromedriver: &install_chromedriver
   run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2.1
 .install_bundler: &install_bundler
   run:
     name: Install a specific bundler version
-    command: gem install bundler -v 1.17.1
+    command: gem install bundler -v 1.17.3
 
 .copy_current_gemfile: &copy_current_gemfile
   run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,11 @@
 
 version: 2.1
 
+.install_rubygems: &install_rubygems
+  run:
+    name: Install a specific rubygems version
+    command: gem update --system 3.0.2
+
 .install_bundler: &install_bundler
   run:
     name: Install a specific bundler version
@@ -115,6 +120,7 @@ version: 2.1
 
 .test_steps: &test_steps
   - checkout
+  - *install_rubygems
   - *install_bundler
   - *copy_current_gemfile
   - *restore_cache
@@ -132,6 +138,7 @@ version: 2.1
 
 .test_app_steps: &test_app_steps
   - checkout
+  - *install_rubygems
   - *install_bundler
   - *copy_current_gemfile
   - *restore_cache
@@ -207,6 +214,7 @@ jobs:
 
     steps:
       - checkout
+      - *install_rubygems
       - *install_bundler
       - *copy_current_gemfile
       - *restore_cache

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ scenarios.
 Now install the development dependencies:
 
 ```sh
-bundle install
+bin/bundle install
 ```
 
 Now you should be able to run the entire suite using:
@@ -49,7 +49,7 @@ because of some breaking change or problem with the latest version of some
 dependency. You should be able to reproduce the issue locally by:
 
 * Removing the `Gemfile.lock` file.
-* Running `bundle install`.
+* Running `bin/bundle install`.
 * Re-running the tests again like you did previously.
 
 This is not your fault though, so if this happens feel free to investigate, but

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -431,4 +431,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,9 @@ import 'tasks/gemfiles.rake'
 import 'tasks/local.rake'
 import 'tasks/test.rake'
 
-if File.expand_path(ENV['BUNDLE_GEMFILE']) == File.expand_path('Gemfile')
+gemfile = ENV['BUNDLE_GEMFILE']
+
+if gemfile.nil? || File.expand_path(gemfile) == File.expand_path('Gemfile')
   import 'tasks/docs.rake'
   import 'tasks/lint.rake'
   import 'tasks/release.rake'

--- a/bin/bundle
+++ b/bin/bundle
@@ -1,0 +1,49 @@
+#!/usr/bin/env ruby
+
+require "rubygems"
+
+m = Module.new do
+  extend self
+
+  def invoked_as_script?
+    File.expand_path($PROGRAM_NAME) == File.expand_path(__FILE__)
+  end
+
+  def gemfile
+    gemfile = ENV["BUNDLE_GEMFILE"]
+    return gemfile if gemfile && !gemfile.empty?
+
+    File.expand_path("../Gemfile", __dir__)
+  end
+
+  def lockfile
+    "#{gemfile}.lock"
+  end
+
+  def lockfile_version
+    return unless File.file?(lockfile)
+    lockfile_contents = File.read(lockfile)
+
+    regexp = /\n\nBUNDLED WITH\n\s{2,}(#{Gem::Version::VERSION_PATTERN})\n/
+
+    regexp.match(lockfile_contents)[1]
+  end
+
+  def bundler_version
+    @bundler_version ||= lockfile_version
+  end
+
+  def load_bundler!
+    ENV["BUNDLE_GEMFILE"] ||= gemfile
+
+    activate_bundler(bundler_version)
+  end
+
+  def activate_bundler(bundler_version)
+    gem "bundler", bundler_version
+  end
+end
+
+m.load_bundler!
+
+load Gem.bin_path("bundler", "bundle") if m.invoked_as_script?

--- a/bin/cucumber
+++ b/bin/cucumber
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+load File.expand_path("bundle", __dir__)
+
 require "bundler/setup"
 
 load Gem.bin_path("cucumber", "cucumber")

--- a/bin/parallel_cucumber
+++ b/bin/parallel_cucumber
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+load File.expand_path("bundle", __dir__)
+
 require "bundler/setup"
 
 ["--serialize-stdout", "--combine-stderr", "--verbose", "--test-options", "-p default"].each do |flag|

--- a/bin/parallel_rspec
+++ b/bin/parallel_rspec
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+load File.expand_path("bundle", __dir__)
+
 require "bundler/setup"
 
 %w[--serialize-stdout --combine-stderr --verbose].each do |flag|

--- a/bin/rake
+++ b/bin/rake
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+load File.expand_path("bundle", __dir__)
+
 require "bundler/setup"
 
 load Gem.bin_path("rake", "rake")

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+load File.expand_path("bundle", __dir__)
+
 require "bundler/setup"
 
 load Gem.bin_path("rspec-core", "rspec")

--- a/gemfiles/rails_50.gemfile.lock
+++ b/gemfiles/rails_50.gemfile.lock
@@ -351,4 +351,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -351,4 +351,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/spec/gemfiles_spec.lint.rb
+++ b/spec/gemfiles_spec.lint.rb
@@ -4,10 +4,10 @@ RSpec.describe "Gemfile sanity" do
       current_lockfile = File.read("#{gemfile}.lock")
 
       new_lockfile = Bundler.with_original_env do
-        `BUNDLE_GEMFILE=#{gemfile} bundle lock --print`
+        `BUNDLE_GEMFILE=#{gemfile} bin/bundle lock --print`
       end
 
-      msg = "Please update #{gemfile}'s lock file with `BUNDLE_GEMFILE=#{gemfile} bundle install` and commit the result"
+      msg = "Please update #{gemfile}'s lock file with `BUNDLE_GEMFILE=#{gemfile} bin/bundle install` and commit the result"
 
       expect(current_lockfile).to eq(new_lockfile), msg
     end


### PR DESCRIPTION
The release of bundler 1.17.2 broke our build because whereas our gemfiles are currently locked to 1.17.1, the new docker images already include (and use) bundler 1.17.2. That causes source control changes in the locked version when running `bundle install` and makes the checks fail.

This PR introduces binstubs which are meant precisely to avoid this kind of mismatches.