### PR TITLE
Reorganize README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you want to contribute through code or documentation, the [Contributing
 guide is the best place to start][contributing]. If you have questions, feel free
 to ask.
 
-If you want to support us financially, you can help fund the project
+If you want to support us financially, you can [help fund the project
 through a Tidelift subscription][tidelift]. By buying a Tidelift subscription
 you make sure your whole dependency stack is properly maintained, while also
 getting a comprehensive view of outdated dependencies, new releases, security

--- a/README.md
+++ b/README.md
@@ -39,9 +39,7 @@ is a good place to start. If you have questions, feel free to ask.
 
 Subscribe to [Tidelift][tidelift] to support Active Admin and get licensing assurances and timely security notifications.
 
-You can support us with a weekly tip via [Liberapay][liberapay.com].
-
-[![Support via Liberapay][liberapay_button]][liberapay_donate]
+You can also support us with a weekly tip via [Liberapay][liberapay.com].
 
 ## Dependencies
 
@@ -80,5 +78,3 @@ Tool                  | Description
 [stackoverflow]: http://stackoverflow.com/questions/tagged/activeadmin
 [contributing]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
 [liberapay.com]: https://liberapay.com
-[liberapay_button]: https://liberapay.com/assets/widgets/donate.svg
-[liberapay_donate]: https://liberapay.com/Active-Admin/donate

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you want to contribute through code or documentation, the [contributing
 guide][contributing] is a good place to start. If you have questions, feel free
 to ask.
 
-If you want to contribute economically, you can help funding the project
+If you want to support us financially, you can help fund the project
 through a [Tidelift subscription][tidelift]. By buying a Tidelift subscription
 you make sure your whole dependency stack is properly maintained, while also
 getting a comprenhensive view of outdated dependencies, new releases, security

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Tool                  | Description
 
 Thanks to [Greg Bell][Greg] for creating and sharing this project with the open source community.
 
-Thanks to [all the people that ever contributed to this project through code][contributors] or
+Thanks to [all the people that ever contributed through code][contributors] or
 other means such as bug reports, issue triaging, feature suggestions, code
 snippet tips, Slack discussions and so on.
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ snippet tips, slack dicussions and so on.
 
 Thanks to [Tidelift][tidelift] and all our Tidelift subscribers.
 
-Thanks to [Opencollective][opencollective contributors] and our Opencollective contributors.
+Thanks to [Open Collective][opencollective contributors] and all our Open Collective contributors.
 
 [Arbre]: https://github.com/activeadmin/arbre
 [Devise]: https://github.com/plataformatec/devise

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Thanks to [Greg Bell][Greg] for creating and sharing this project with the open 
 
 Thanks to [all the people that ever contributed to this project through code][contributors] or
 other means such as bug reports, issue triaging, feature suggestions, code
-snippet tips, slack dicussions and so on.
+snippet tips, Slack discussions and so on.
 
 Thanks to [Tidelift][tidelift] and all our Tidelift subscribers.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Google Groups, IRC #activeadmin and Gitter are not actively monitored.
 
 ## Want to contribute?
 
-If you want to contribute through code or documentation, the [contributing
+If you want to contribute through code or documentation, the [Contributing
 guide is the best place to start][contributing]. If you have questions, feel free
 to ask.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Google Groups, IRC #activeadmin and Gitter are not actively monitored.
 ## Want to contribute?
 
 If you want to contribute through code or documentation, the [contributing
-guide][contributing] is the best place to start. If you have questions, feel free
+guide is the best place to start][contributing]. If you have questions, feel free
 to ask.
 
 If you want to support us financially, you can help fund the project

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ guide is the best place to start][contributing]. If you have questions, feel fre
 to ask.
 
 If you want to support us financially, you can help fund the project
-through a [Tidelift subscription][tidelift]. By buying a Tidelift subscription
+through a Tidelift subscription][tidelift]. By buying a Tidelift subscription
 you make sure your whole dependency stack is properly maintained, while also
 getting a comprehensive view of outdated dependencies, new releases, security
 alerts, and licensing compatibility issues.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ to ask.
 If you want to support us financially, you can help fund the project
 through a [Tidelift subscription][tidelift]. By buying a Tidelift subscription
 you make sure your whole dependency stack is properly maintained, while also
-getting a comprenhensive view of outdated dependencies, new releases, security
+getting a comprehensive view of outdated dependencies, new releases, security
 alerts, and licensing compatibility issues.
 
 You can also support us with a weekly tip via [Liberapay].

--- a/README.md
+++ b/README.md
@@ -97,6 +97,6 @@ Thanks to [Opencollective][opencollective contributors] and our Opencollective c
 [contributing]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
 [Liberapay]: https://liberapay.com
 [Greg]: https://github.com/gregbell
-[code]: https://github.com/activeadmin/activeadmin/graphs/contributors
+[contributors]: https://github.com/activeadmin/activeadmin/graphs/contributors
 [opencollective page]: https://opencollective.com/activeadmin
 [opencollective contributors]: https://opencollective.com/activeadmin#contributors

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Tool                  | Description
 
 Thanks to [Greg] for creating and opensourcing this project.
 
-Thanks to all the people that ever contributed to this project through [code] or
+Thanks to [all the people that ever contributed to this project through code][contributors] or
 other means such as bug reports, issue triaging, feature suggestions, code
 snippet tips, slack dicussions and so on.
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Tool                  | Description
 
 ## Acknowledgements
 
-Thanks to [Greg] for creating and opensourcing this project.
+Thanks to [Greg Bell][Greg] for creating and sharing this project with the open source community.
 
 Thanks to [all the people that ever contributed to this project through code][contributors] or
 other means such as bug reports, issue triaging, feature suggestions, code

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Google Groups, IRC #activeadmin and Gitter are not actively monitored.
 ## Want to contribute?
 
 If you want to contribute through code or documentation, the [contributing
-guide][contributing] is a good place to start. If you have questions, feel free
+guide][contributing] is the best place to start. If you have questions, feel free
 to ask.
 
 If you want to support us financially, you can help fund the project

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ If you want to contribute through code or documentation, the [Contributing
 guide is the best place to start][contributing]. If you have questions, feel free
 to ask.
 
+## Want to support us?
+
 If you want to support us financially, you can [help fund the project
 through a Tidelift subscription][tidelift]. By buying a Tidelift subscription
 you make sure your whole dependency stack is properly maintained, while also

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Google Groups, IRC #activeadmin and Gitter are not actively monitored.
 
 ## Want to contribute?
 
+This project exists thanks to all the people who contribute, so thank you!
+
 The [contributing guide][contributing]
 is a good place to start. If you have questions, feel free to ask.
 

--- a/README.md
+++ b/README.md
@@ -34,12 +34,15 @@ Google Groups, IRC #activeadmin and Gitter are not actively monitored.
 
 This project exists thanks to all the people who contribute, so thank you!
 
-The [contributing guide][contributing]
-is a good place to start. If you have questions, feel free to ask.
+If you want to contribute through code or documentation, the [contributing
+guide][contributing] is a good place to start. If you have questions, feel free
+to ask.
 
-## Want to support us?
-
-Subscribe to [Tidelift][tidelift] to support Active Admin and get licensing assurances and timely security notifications.
+If you want to contribute economically, you can help funding the project
+through a [Tidelift subscription][tidelift]. By buying a Tidelift subscription
+you make sure your whole dependency stack is properly maintained, while also
+getting a comprenhensive view of outdated dependencies, new releases, security
+alerts, and licensing compatibility issues.
 
 You can also support us with a weekly tip via [Liberapay][liberapay.com].
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ you make sure your whole dependency stack is properly maintained, while also
 getting a comprenhensive view of outdated dependencies, new releases, security
 alerts, and licensing compatibility issues.
 
-You can also support us with a weekly tip via [Liberapay][liberapay.com].
+You can also support us with a weekly tip via [Liberapay].
 
 ## Dependencies
 
@@ -82,4 +82,4 @@ Tool                  | Description
 [wiki]: https://github.com/activeadmin/activeadmin/wiki
 [stackoverflow]: http://stackoverflow.com/questions/tagged/activeadmin
 [contributing]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
-[liberapay.com]: https://liberapay.com
+[Liberapay]: https://liberapay.com

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ alerts, and licensing compatibility issues.
 
 You can also support us with a weekly tip via [Liberapay].
 
+Finally, we have an [opencollective page] where you can become a backer or
+sponsor for the project, and also submit expenses to it.
+
 ## Dependencies
 
 We try not to reinvent the wheel, so Active Admin is built with other open source projects:
@@ -66,6 +69,8 @@ other means such as bug reports, issue triaging, feature suggestions, code
 snippet tips, slack dicussions and so on.
 
 Thanks to [Tidelift][tidelift] and our Tidelift subscriptors.
+
+Thanks to [Opencollective][opencollective contributors] and our Opencollective contributors.
 
 [Arbre]: https://github.com/activeadmin/arbre
 [Devise]: https://github.com/plataformatec/devise
@@ -93,3 +98,5 @@ Thanks to [Tidelift][tidelift] and our Tidelift subscriptors.
 [Liberapay]: https://liberapay.com
 [Greg]: https://github.com/gregbell
 [code]: https://github.com/activeadmin/activeadmin/graphs/contributors
+[opencollective page]: https://opencollective.com/activeadmin
+[opencollective contributors]: https://opencollective.com/activeadmin#contributors

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ alerts, and licensing compatibility issues.
 
 You can also support us with a weekly tip via [Liberapay].
 
-Finally, we have an [opencollective page] where you can become a backer or
+Finally, we have an [Open Collective][opencollective page] where you can become a backer or
 sponsor for the project, and also submit expenses to it.
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Thanks to [all the people that ever contributed to this project through code][co
 other means such as bug reports, issue triaging, feature suggestions, code
 snippet tips, slack dicussions and so on.
 
-Thanks to [Tidelift][tidelift] and our Tidelift subscriptors.
+Thanks to [Tidelift][tidelift] and all our Tidelift subscribers.
 
 Thanks to [Opencollective][opencollective contributors] and our Opencollective contributors.
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ Google Groups, IRC #activeadmin and Gitter are not actively monitored.
 
 ## Want to contribute?
 
-This project exists thanks to all the people who contribute, so thank you!
-
 If you want to contribute through code or documentation, the [contributing
 guide][contributing] is a good place to start. If you have questions, feel free
 to ask.
@@ -59,6 +57,16 @@ Tool                  | Description
 [Kaminari]            | Elegant pagination for any sort of collection
 [Ransack]             | Provides a simple search API to query your data
 
+## Acknowledgements
+
+Thanks to [Greg] for creating and opensourcing this project.
+
+Thanks to all the people that ever contributed to this project through [code] or
+other means such as bug reports, issue triaging, feature suggestions, code
+snippet tips, slack dicussions and so on.
+
+Thanks to [Tidelift][tidelift] and our Tidelift subscriptors.
+
 [Arbre]: https://github.com/activeadmin/arbre
 [Devise]: https://github.com/plataformatec/devise
 [Formtastic]: https://github.com/justinfrench/formtastic
@@ -83,3 +91,5 @@ Tool                  | Description
 [stackoverflow]: http://stackoverflow.com/questions/tagged/activeadmin
 [contributing]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
 [Liberapay]: https://liberapay.com
+[Greg]: https://github.com/gregbell
+[code]: https://github.com/activeadmin/activeadmin/graphs/contributors


### PR DESCRIPTION
This PR is motivated by #5648. I'm totally happy with the idea of having an opencollective page, but we need to stay fair towards Tidelift, which is our currently preferred means of funding.

This PR improves the contributing section by:

* Merging the "Want to contribute?" and "Want to support us?" section into a single one, since it's all about contributing after all.
* Adding some thanks in there, since we're grateful for all contributions :)
* Expanding a bit on what a Tidelift subscription means, and how it is a good thing for organizations.
* Reduce a bit the visibility of Liberapay, since it was previously more visible than Tidelift.

Supersedes #5648.
Closes #5559.