### PR TITLE
Added workaround for non-transliteratable tab titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -398,6 +398,7 @@ Please check [0-6-stable] for previous changes.
 [#5627]: https://github.com/activeadmin/activeadmin/pull/5627
 [#5631]: https://github.com/activeadmin/activeadmin/pull/5631
 [#5632]: https://github.com/activeadmin/activeadmin/pull/5632
+[#5650]: https://github.com/activeadmin/activeadmin/pull/5650
 
 [@5t111111]: https://github.com/5t111111
 [@aarek]: https://github.com/aarek
@@ -458,3 +459,4 @@ Please check [0-6-stable] for previous changes.
 [@zorab47]: https://github.com/zorab47
 [@chrp]: https://github.com/chrp
 [@bartoszkopinski]: https://github.com/bartoszkopinski
+[@panasyuk]: https://github.com/panasyuk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Fix for paginated collections with `per_page: Array, pagination_total: false`. [#5627] by [@bartoszkopinski]
 * Restrict ransack requirement to >= 2.1.1 to play nice with Rails 5.2.2. [#5632] by [@deivid-rodriguez]
 * Bad interpolation variables on pagination keys in Lithuanian translation. [#5631] by [@deivid-rodriguez]
+* Tabs are not correctly created when using non-transliteratable characters as title. [#5650] by [@panasyuk]
 
 ### Removals
 

--- a/features/show/tabs.feature
+++ b/features/show/tabs.feature
@@ -35,11 +35,13 @@ Feature: Show - Tabs
     And I should see tab content "tab 1"
     And I should not see tab content "tab 2"
     And I should not see tab content "tab 3"
-    Then I follow "テスト"
-    And I should not see tab content "tab 1"
+
+    When I follow "テスト"
+    Then I should not see tab content "tab 1"
     And I should see tab content "tab 2"
     And I should not see tab content "tab 3"
-    Then I follow "🤗"
-    And I should not see tab content "tab 1"
+
+    When I follow "🤗"
+    Then I should not see tab content "tab 1"
     And I should not see tab content "tab 2"
     And I should see tab content "tab 3"

--- a/features/show/tabs.feature
+++ b/features/show/tabs.feature
@@ -18,14 +18,28 @@ Feature: Show - Tabs
             tab 'テスト', id: :test_non_ascii do
               span "tab 2"
             end
+
+            tab '🤗' do
+              span "tab 3"
+            end
           end
         end
       end
     """
 
-    Then I should see two tabs "Overview" and "テスト"
-    And I should see the element "#overview span"
-    And I should not see the element "#test_non_ascii span"
-    When I follow "テスト"
-    Then I should see the element "#test_non_ascii span"
-    And I should not see the element "#overview span"
+    Then I should see tabs:
+    | Tab title |
+    | Overview  |
+    | テスト     |
+    | 🤗        |
+    And I should see tab content "tab 1"
+    And I should not see tab content "tab 2"
+    And I should not see tab content "tab 3"
+    Then I follow "テスト"
+    And I should not see tab content "tab 1"
+    And I should see tab content "tab 2"
+    And I should not see tab content "tab 3"
+    Then I follow "🤗"
+    And I should not see tab content "tab 1"
+    And I should not see tab content "tab 2"
+    And I should see tab content "tab 3"

--- a/features/step_definitions/tab_steps.rb
+++ b/features/step_definitions/tab_steps.rb
@@ -1,8 +1,13 @@
-Then /^the "([^"]*)" tab should be selected$/ do |name|
-  step %{I should see "#{name}" within "ul#tabs li.current"}
+Then("I should see tabs:") do |table|
+  table.rows.each do |title, _|
+    step %{I should see "#{title}" within "#main_content .tabs .nav"}
+  end
 end
 
-Then(/^I should see two tabs "(.*?)" and "(.*?)"$/) do |tab_1, tab_2|
-  expect(page).to have_link(tab_1)
-  expect(page).to have_link(tab_2)
+Then("I should see tab content {string}") do |string|
+  step %{I should see "#{string}" within "#main_content .tabs .tab-content"}
+end
+
+Then("I should not see tab content {string}") do |string|
+  step %{I should not see "#{string}" within "#main_content .tabs .tab-content"}
 end

--- a/lib/active_admin/views/components/tabs.rb
+++ b/lib/active_admin/views/components/tabs.rb
@@ -32,7 +32,7 @@ module ActiveAdmin
 
       def fragmentize(string)
         result = string.parameterize
-        result = Base64.urlsafe_encode64(string) if result.blank?
+        result = URI.encode(string) if result.blank?
         result
       end
     end

--- a/lib/active_admin/views/components/tabs.rb
+++ b/lib/active_admin/views/components/tabs.rb
@@ -32,7 +32,7 @@ module ActiveAdmin
 
       def fragmentize(string)
         result = string.parameterize
-        result = string.hash if result.blank?
+        result = Base64.urlsafe_encode64(string, padding: false) if result.blank?
         result
       end
     end

--- a/lib/active_admin/views/components/tabs.rb
+++ b/lib/active_admin/views/components/tabs.rb
@@ -15,7 +15,8 @@ module ActiveAdmin
       end
 
       def build_menu_item(title, options, &block)
-        fragment = options.fetch(:id, title.parameterize)
+        fragment = options.fetch(:id, fragmentize(title))
+
         html_options = options.fetch(:html_options, {})
         li html_options do
           link_to title, "##{fragment}"
@@ -23,8 +24,16 @@ module ActiveAdmin
       end
 
       def build_content_item(title, options, &block)
-        options = options.reverse_merge(id: title.parameterize)
+        options = options.reverse_merge(id: fragmentize(title))
         div(options, &block)
+      end
+
+      private
+
+      def fragmentize(string)
+        result = string.parameterize
+        result = string.hash if result.blank?
+        result
       end
     end
   end

--- a/lib/active_admin/views/components/tabs.rb
+++ b/lib/active_admin/views/components/tabs.rb
@@ -32,7 +32,7 @@ module ActiveAdmin
 
       def fragmentize(string)
         result = string.parameterize
-        result = Base64.urlsafe_encode64(string, padding: false) if result.blank?
+        result = Base64.urlsafe_encode64(string) if result.blank?
         result
       end
     end

--- a/spec/unit/views/components/tabs_spec.rb
+++ b/spec/unit/views/components/tabs_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe ActiveAdmin::Views::Tabs do
       end
 
       it "should create a tab navigation bar based on the symbol" do
-        expect(tabs.find_by_tag('li').first.content).to include "Overview"
+        expect(tabs.find_by_tag('li').first.content).to include("Overview")
       end
 
       it "should create a tab with a span inside of it" do
@@ -71,7 +71,9 @@ RSpec.describe ActiveAdmin::Views::Tabs do
       let(:tabs) do
         render_arbre_component do
           tabs do
-            tab '🤗'
+            tab '🤗' do
+              'Tab content'
+            end
           end
         end
       end
@@ -82,14 +84,16 @@ RSpec.describe ActiveAdmin::Views::Tabs do
         expect(subject).to have_content('🤗')
       end
 
-      it "should have tab with id based on URL-safe Base64 representation of the string without padding" do
-        expected_fragment = Base64.urlsafe_encode64('🤗', padding: false)
-        expect(subject).to have_selector("div##{expected_fragment}")
+      it "should have tab with id based on URL-safe Base64 representation of the string" do
+        expected_fragment = Base64.urlsafe_encode64('🤗')
+        tab_content = subject.find('.tabs .tab-content div', text: 'Tab content')
+
+        expect(tab_content['id']).to eq(expected_fragment)
       end
 
-      it "should have link with fragment based on URL-safe Base64 representation of the string without padding" do
-        expected_fragment = Base64.urlsafe_encode64('🤗', padding: false)
-        expect(subject).to have_selector(%{a[href="##{expected_fragment}"]})
+      it "should have link with fragment based on URL-safe Base64 representation of the string" do
+        expected_fragment = Base64.urlsafe_encode64('🤗')
+        expect(subject).to have_link('🤗', href: "##{expected_fragment}")
       end
     end
   end

--- a/spec/unit/views/components/tabs_spec.rb
+++ b/spec/unit/views/components/tabs_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe ActiveAdmin::Views::Tabs do
         render_arbre_component do
           tabs do
             tab '🤗' do
-              'Tab content'
+              'content'
             end
           end
         end
@@ -84,16 +84,13 @@ RSpec.describe ActiveAdmin::Views::Tabs do
         expect(subject).to have_content('🤗')
       end
 
-      it "should have tab with id based on URL-safe Base64 representation of the string" do
-        expected_fragment = Base64.urlsafe_encode64('🤗')
-        tab_content = subject.find('.tabs .tab-content div', text: 'Tab content')
-
-        expect(tab_content['id']).to eq(expected_fragment)
+      it "should have tab with id based on URL-encoded string" do
+        tab_content = subject.find('.tabs .tab-content div', text: 'content')
+        expect(tab_content['id']).to eq(URI.encode('🤗'))
       end
 
-      it "should have link with fragment based on URL-safe Base64 representation of the string" do
-        expected_fragment = Base64.urlsafe_encode64('🤗')
-        expect(subject).to have_link('🤗', href: "##{expected_fragment}")
+      it "should have link with fragment based on URL-encoded string" do
+        expect(subject).to have_link('🤗', href: "##{URI.encode('🤗')}")
       end
     end
   end

--- a/spec/unit/views/components/tabs_spec.rb
+++ b/spec/unit/views/components/tabs_spec.rb
@@ -66,5 +66,29 @@ RSpec.describe ActiveAdmin::Views::Tabs do
         expect(tabs.find_by_tag('span').first.content).to eq('tab 1')
       end
     end
+
+    context "when creating a tab with non-transliteratable string" do
+      let(:tabs) do
+        render_arbre_component do
+          tabs do
+            tab '🤗'
+          end
+        end
+      end
+
+      let(:subject) { Capybara.string(tabs.to_s) }
+
+      it "should create a tab navigation bar based on the string" do
+        expect(subject).to have_content('🤗')
+      end
+
+      it "should have tab with id based on hash of the string" do
+        expect(subject).to have_selector("div##{'🤗'.hash}")
+      end
+
+      it "should have link with fragment based on hash of the string" do
+        expect(subject).to have_selector(%{a[href="##{'🤗'.hash}"]})
+      end
+    end
   end
 end

--- a/spec/unit/views/components/tabs_spec.rb
+++ b/spec/unit/views/components/tabs_spec.rb
@@ -82,12 +82,14 @@ RSpec.describe ActiveAdmin::Views::Tabs do
         expect(subject).to have_content('🤗')
       end
 
-      it "should have tab with id based on hash of the string" do
-        expect(subject).to have_selector("div##{'🤗'.hash}")
+      it "should have tab with id based on URL-safe Base64 representation of the string without padding" do
+        expected_fragment = Base64.urlsafe_encode64('🤗', padding: false)
+        expect(subject).to have_selector("div##{expected_fragment}")
       end
 
-      it "should have link with fragment based on hash of the string" do
-        expect(subject).to have_selector(%{a[href="##{'🤗'.hash}"]})
+      it "should have link with fragment based on URL-safe Base64 representation of the string without padding" do
+        expected_fragment = Base64.urlsafe_encode64('🤗', padding: false)
+        expect(subject).to have_selector(%{a[href="##{expected_fragment}"]})
       end
     end
   end


### PR DESCRIPTION
Fixed code that generates fragment link and id for tab content for non-transliteratable tab titles.

Fixes #5484.
Closes #5508.