### PR TITLE
Use collection length instead of running COUNTs for limited collections

### DIFF
--- a/lib/active_admin/helpers/collection.rb
+++ b/lib/active_admin/helpers/collection.rb
@@ -5,6 +5,7 @@ module ActiveAdmin
       # 2. correctly handles the Hash returned when `group by` is used
       def collection_size(c = collection)
         return c.count if c.is_a?(Array)
+        return c.length if c.limit_value
 
         c = c.except :select, :order
 

--- a/spec/unit/views/components/paginated_collection_spec.rb
+++ b/spec/unit/views/components/paginated_collection_spec.rb
@@ -241,6 +241,15 @@ RSpec.describe ActiveAdmin::Views::PaginatedCollection do
         .not_to make_database_queries(matching: "SELECT COUNT(*) FROM \"posts\"")
     end
 
+    it "makes no COUNT queries to figure out the last element of each page" do
+      require "db-query-matchers"
+
+      undecorated_collection = Post.all.page(1).per(30)
+
+      expect { paginated_collection(undecorated_collection) }
+        .not_to make_database_queries(matching: "SELECT COUNT(*) FROM (SELECT")
+    end
+
     context "when specifying per_page: array option" do
       let(:collection) do
         posts = 10.times.map { Post.new }


### PR DESCRIPTION
There have been many issues with this method's speed. While investigating some performance issues today, I've stumbled upon it as well and saw a lot of queries like:
```sql
SELECT COUNT(*) FROM (SELECT  1 AS one FROM `table` LIMIT 30 OFFSET 0) subquery_for_count
```
generated.

The purpose of this PR is not to issue such SELECTs for the main collection being rendered, where standard pagination methods are being applied. The collection will be loaded anyway, so we may simply check how many objects we have.
If the collection is unlimited (e.g. using `scope` to display a filtered collection), original behavior is preserved.