### PR TITLE
Unify specifying label in show -> attributes_table

### DIFF
--- a/lib/active_admin/views/components/attributes_table.rb
+++ b/lib/active_admin/views/components/attributes_table.rb
@@ -22,6 +22,7 @@ module ActiveAdmin
       def row(*args, &block)
         title   = args[0]
         options = args.extract_options!
+        data  = args[1] || args[0]
         classes = [:row]
         if options[:class]
           classes << options[:class]
@@ -36,7 +37,7 @@ module ActiveAdmin
           end
           @collection.each do |record|
             td do
-              content_for(record, block || title)
+              content_for(record, block || data)
             end
           end
         end

--- a/lib/active_admin/views/components/attributes_table.rb
+++ b/lib/active_admin/views/components/attributes_table.rb
@@ -22,7 +22,7 @@ module ActiveAdmin
       def row(*args, &block)
         title   = args[0]
         options = args.extract_options!
-        data  = args[1] || args[0]
+        data    = args[1] || args[0]
         classes = [:row]
         if options[:class]
           classes << options[:class]

--- a/lib/active_admin/views/components/attributes_table.rb
+++ b/lib/active_admin/views/components/attributes_table.rb
@@ -22,7 +22,7 @@ module ActiveAdmin
       def row(*args, &block)
         title   = args[0]
         options = args.extract_options!
-        data    = args[1] || args[0]
+        data = args[1] || args[0]
         classes = [:row]
         if options[:class]
           classes << options[:class]


### PR DESCRIPTION
Up to now, the only way to specify a label in a row in attributes_table was by using the first argument. The data was then taken from executing a block:
```
attributes_table do
  row 'Renamed' do |r|
    r.username
  end
end
```

This pull request allows for syntax:
```
attributes_table do
  row 'Renamed', :username
end
```

The same syntax is used by index:
```
index do
    column 'Renamed', :username
end
```

Closes #3359, closes #167