### PR TITLE
Undeprecate external asset registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 #### Minor
 
 * Add better support for rendering lists. [#5370] by [@dkniffin]
+* Undeprecate `config.register_stylesheet` and `config.register_javascript` for lack of better solution for including external assets. It might be reevaluated in the future. [#5662] by [@deivid-rodriguez]
 
 ### Security Fixes
 
@@ -408,6 +409,7 @@ Please check [0-6-stable] for previous changes.
 [#5632]: https://github.com/activeadmin/activeadmin/pull/5632
 [#5650]: https://github.com/activeadmin/activeadmin/pull/5650
 [#5590]: https://github.com/activeadmin/activeadmin/pull/5590
+[#5662]: https://github.com/activeadmin/activeadmin/pull/5662
 
 [@5t111111]: https://github.com/5t111111
 [@aarek]: https://github.com/aarek

--- a/features/registering_assets.feature
+++ b/features/registering_assets.feature
@@ -17,10 +17,8 @@ Feature: Registering Assets
   Scenario: Registering a CSS file
     Given a configuration of:
     """
-      ActiveSupport::Deprecation.silence do
-        ActiveAdmin.application.register_stylesheet "some-random-css.css", media: :print
-        ActiveAdmin.register Post
-      end
+      ActiveAdmin.application.register_stylesheet "some-random-css.css", media: :print
+      ActiveAdmin.register Post
     """
     When I am on the index page for posts
     Then I should see the css file "some-random-css" of media "print"
@@ -28,10 +26,8 @@ Feature: Registering Assets
   Scenario: Registering a JS file
     Given a configuration of:
     """
-      ActiveSupport::Deprecation.silence do
-        ActiveAdmin.application.register_javascript "some-random-js.js"
-        ActiveAdmin.register Post
-      end
+      ActiveAdmin.application.register_javascript "some-random-js.js"
+      ActiveAdmin.register Post
     """
     When I am on the index page for posts
     Then I should see the js file "some-random-js"

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -165,9 +165,9 @@ module ActiveAdmin
     private
 
     def register_default_assets
-      stylesheets['active_admin.css'] = { media: 'screen' }
-      stylesheets['active_admin/print.css'] = { media: 'print' }
-      javascripts.add 'active_admin.js'
+      register_stylesheet 'active_admin.css', media: 'screen'
+      register_stylesheet 'active_admin/print.css', media: 'print'
+      register_javascript 'active_admin.js'
     end
 
     # Since app/admin is alphabetically before app/models, we have to remove it

--- a/lib/active_admin/asset_registration.rb
+++ b/lib/active_admin/asset_registration.rb
@@ -2,10 +2,6 @@ module ActiveAdmin
   module AssetRegistration
 
     def register_stylesheet(path, options = {})
-      Deprecation.warn <<-MSG.strip_heredoc
-        The `register_stylesheet` config is deprecated and will be removed
-        in v2. Import your "#{path}" stylesheet in the active_admin.scss.
-      MSG
       stylesheets[path] = options
     end
 
@@ -18,10 +14,6 @@ module ActiveAdmin
     end
 
     def register_javascript(name)
-      Deprecation.warn <<-MSG.strip_heredoc
-        The `register_javascript` config is deprecated and will be removed
-        in v2. Import your "#{name}" javascript in the active_admin.js.
-      MSG
       javascripts.add name
     end
 

--- a/spec/unit/asset_registration_spec.rb
+++ b/spec/unit/asset_registration_spec.rb
@@ -8,33 +8,13 @@ RSpec.describe ActiveAdmin::AssetRegistration do
     clear_javascripts!
   end
 
-  it "is deprecated" do
-    expect(ActiveAdmin::Deprecation).to receive(:warn).with(<<-MSG.strip_heredoc
-        The `register_stylesheet` config is deprecated and will be removed
-        in v2. Import your "sample_styles.css" stylesheet in the active_admin.scss.
-      MSG
-      )
-
-    register_stylesheet "sample_styles.css"
-
-    expect(ActiveAdmin::Deprecation).to receive(:warn).with(<<-MSG.strip_heredoc
-        The `register_javascript` config is deprecated and will be removed
-        in v2. Import your "sample_scripts.js" javascript in the active_admin.js.
-      MSG
-      )
-
-    register_javascript "sample_scripts.js"
-  end
-
   it "should register a stylesheet file" do
-    expect(ActiveAdmin::Deprecation).to receive(:warn).once
     register_stylesheet "active_admin.css"
     expect(stylesheets.length).to eq 1
     expect(stylesheets.keys.first).to eq "active_admin.css"
   end
 
   it "should clear all existing stylesheets" do
-    expect(ActiveAdmin::Deprecation).to receive(:warn).once
     register_stylesheet "active_admin.css"
     expect(stylesheets.length).to eq 1
     clear_stylesheets!
@@ -42,26 +22,22 @@ RSpec.describe ActiveAdmin::AssetRegistration do
   end
 
   it "should allow media option when registering stylesheet" do
-    expect(ActiveAdmin::Deprecation).to receive(:warn).once
     register_stylesheet "active_admin.css", media: :print
     expect(stylesheets.values.first[:media]).to eq :print
   end
 
   it "shouldn't register a stylesheet twice" do
-    expect(ActiveAdmin::Deprecation).to receive(:warn).twice
     register_stylesheet "active_admin.css"
     register_stylesheet "active_admin.css"
     expect(stylesheets.length).to eq 1
   end
 
   it "should register a javascript file" do
-    expect(ActiveAdmin::Deprecation).to receive(:warn).once
     register_javascript "active_admin.js"
     expect(javascripts).to eq ["active_admin.js"].to_set
   end
 
   it "should clear all existing javascripts" do
-    expect(ActiveAdmin::Deprecation).to receive(:warn).once
     register_javascript "active_admin.js"
     expect(javascripts).to eq ["active_admin.js"].to_set
     clear_javascripts!
@@ -69,7 +45,6 @@ RSpec.describe ActiveAdmin::AssetRegistration do
   end
 
   it "shouldn't register a javascript twice" do
-    expect(ActiveAdmin::Deprecation).to receive(:warn).twice
     register_javascript "active_admin.js"
     register_javascript "active_admin.js"
     expect(javascripts.length).to eq 1


### PR DESCRIPTION
We might reevaluate this in the future, but for now I'm reverting while we figure out good enough alternatives so we can unblock releasing other improvements.

Closes #5170.