### PR TITLE
Using valid CSS for no-gradient mixin

### DIFF
--- a/app/assets/stylesheets/active_admin/mixins/_gradients.scss
+++ b/app/assets/stylesheets/active_admin/mixins/_gradients.scss
@@ -24,5 +24,5 @@ $secondary-gradient-stop: #dfe1e2 !default;
 }
 
 @mixin no-gradient {
-  background-color: none;
+  background: none;
 }


### PR DESCRIPTION
In my browser (Chrome latest) I was seeing warning around the line where we used `background-color: none;`.

![image](https://user-images.githubusercontent.com/325384/52048984-90de4380-2544-11e9-8cbc-d8d831ae70a6.png)

When I updated it to be `transparent` the visually ActiveAdmin stayed the same (I can take screenshots if you'd like) & the warning went away.