### PR TITLE
Update documentation to reference actions instead of default_actions

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -102,12 +102,12 @@
     <span class="n">column</span> <span class="s2">"Price"</span><span class="p">,</span> <span class="ss">sortable:</span> <span class="ss">:price</span> <span class="k">do</span> <span class="o">|</span><span class="n">product</span><span class="o">|</span>
       <span class="n">number_to_currency</span> <span class="n">product</span><span class="o">.</span><span class="n">price</span>
     <span class="k">end</span>
-    <span class="n">default_actions</span>
+    <span class="n">actions</span>
   <span class="k">end</span>
 
 <span class="k">end</span>
 </code>
-</pre>
+            </pre>
           </div>
         </div>
         <h2 class="getting-started-heading">


### PR DESCRIPTION
This pull request updates the documentation index page to reference `actions` instead of the obsolete `default_actions`.

Referenced issue: #5675 