### PR TITLE
Replace cancan with cancancan

### DIFF
--- a/docs/0-installation.md
+++ b/docs/0-installation.md
@@ -11,7 +11,7 @@ gem 'activeadmin'
 
 # Plus integrations with:
 gem 'devise'
-gem 'cancan' # or cancancan
+gem 'cancancan'
 gem 'draper'
 gem 'pundit'
 ```


### PR DESCRIPTION
cancan project is deprecated and not updated since some years. Switch to `cancancan` (maintained version) to avoid confusion.