### PR TITLE
Added allow_remove option to has_many DSL

### DIFF
--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -40,7 +40,7 @@ module ActiveAdmin
     attr_reader :assoc
     attr_reader :options
     attr_reader :heading, :sortable_column, :sortable_start
-    attr_reader :new_record, :destroy_option
+    attr_reader :new_record, :destroy_option, :remove_option
 
     def initialize(has_many_form, assoc, options)
       super has_many_form
@@ -72,6 +72,7 @@ module ActiveAdmin
       @sortable_start  = options.delete(:sortable_start) || 0
       @new_record = options.key?(:new_record) ? options.delete(:new_record) : true
       @destroy_option = options.delete(:allow_destroy)
+      @remove_option = options.key?(:allow_remove) ? options.delete(:allow_remove) : true
       options
     end
 
@@ -105,7 +106,7 @@ module ActiveAdmin
     end
 
     def has_many_actions(form_builder, contents)
-      if form_builder.object.new_record?
+      if form_builder.object.new_record? and remove_option
         contents << template.content_tag(:li) do
           template.link_to I18n.t('active_admin.has_many_remove'), "#", class: 'button has_many_remove'
         end


### PR DESCRIPTION
Allows the "remove nested resource" button in a form's nested resources to be disabled from within the DSL. This is useful in situations where you have a has_many relationship, but you still want to require at least one resource to be included, as you can force there to be at least one that appears in the form.