### PR TITLE
Keep reference only to CanCanCan

### DIFF
--- a/docs/13-authorization-adapter.md
+++ b/docs/13-authorization-adapter.md
@@ -180,8 +180,7 @@ end
 
 Sub-classing `ActiveAdmin::AuthorizationAdapter` is fairly low level. Many times
 it's nicer to have a simpler DSL for managing authorization. Active Admin
-provides an adapter out of the box for [CanCan](https://github.com/ryanb/cancan)
-and [CanCanCan](https://github.com/CanCanCommunity/cancancan).
+provides an adapter out of the box for [CanCanCan](https://github.com/CanCanCommunity/cancancan).
 
 To use the CanCan adapter, update the configuration in the Active Admin
 initializer:
@@ -221,7 +220,7 @@ changed from the initializer:
 config.cancan_ability_class = "MyCustomAbility"
 ```
 
-Now you can simply use CanCan or CanCanCan the way that you would expect and
+Now you can simply use CanCanCan the way that you would expect and
 Active Admin will use it for authorization:
 
 ```ruby
@@ -240,7 +239,6 @@ end
 ```
 
 To view more details about the API's, visit project pages of
-[CanCan](https://github.com/ryanb/cancan) and
 [CanCanCan](https://github.com/CanCanCommunity/cancancan).
 
 ## Using the Pundit Adapter


### PR DESCRIPTION
The old CanCan is not maintained since many years. Keep a reference only to the actively maintained version, in order to avoid confusion amongst new users. kudos to Ryan Bates ❤️ 