### PR TITLE
Bump Draper gem to released version 3.1.0

### DIFF
--- a/Gemfile.common
+++ b/Gemfile.common
@@ -8,8 +8,8 @@ gem 'pry-byebug', platform: :mri # Step-by-step debugging
 gem 'cancancan', git: 'https://github.com/CanCanCommunity/cancancan', branch: 'feature/3.0.0'
 gem 'pundit'
 gem 'jruby-openssl', '~> 0.10.1', platform: :jruby
-# Use the unreleased version of draper because is compatible with Rails 6
-gem 'draper', git: 'https://github.com/drapergem/draper'
+
+gem 'draper', '~> 3.1'
 gem "devise", '~> 4.6'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,17 +5,6 @@ GIT
   specs:
     cancancan (2.3.0)
 
-GIT
-  remote: https://github.com/drapergem/draper
-  revision: 157eb955072a941e6455e0121fca09a989fcbc21
-  specs:
-    draper (3.0.1)
-      actionpack (>= 5.0)
-      activemodel (>= 5.0)
-      activemodel-serializers-xml (>= 1.0)
-      activesupport (>= 5.0)
-      request_store (>= 1.0)
-
 PATH
   remote: .
   specs:
@@ -147,6 +136,12 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.3)
     docile (1.3.1)
+    draper (3.1.0)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
+      activemodel-serializers-xml (>= 1.0)
+      activesupport (>= 5.0)
+      request_store (>= 1.0)
     erubi (1.7.1)
     execjs (2.7.0)
     faraday (0.15.4)
@@ -411,7 +406,7 @@ DEPENDENCIES
   cucumber-rails (~> 1.5)
   database_cleaner
   devise (~> 4.6)
-  draper!
+  draper (~> 3.1)
   i18n-spec
   i18n-tasks
   jasmine

--- a/gemfiles/rails_50.gemfile.lock
+++ b/gemfiles/rails_50.gemfile.lock
@@ -5,17 +5,6 @@ GIT
   specs:
     cancancan (2.3.0)
 
-GIT
-  remote: https://github.com/drapergem/draper
-  revision: 157eb955072a941e6455e0121fca09a989fcbc21
-  specs:
-    draper (3.0.1)
-      actionpack (>= 5.0)
-      activemodel (>= 5.0)
-      activemodel-serializers-xml (>= 1.0)
-      activesupport (>= 5.0)
-      request_store (>= 1.0)
-
 PATH
   remote: ..
   specs:
@@ -139,6 +128,12 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.3)
     docile (1.3.1)
+    draper (3.1.0)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
+      activemodel-serializers-xml (>= 1.0)
+      activesupport (>= 5.0)
+      request_store (>= 1.0)
     erubis (2.7.0)
     execjs (2.7.0)
     ffi (1.9.25)
@@ -344,7 +339,7 @@ DEPENDENCIES
   cucumber-rails (~> 1.5)
   database_cleaner
   devise (~> 4.6)
-  draper!
+  draper (~> 3.1)
   jasmine
   jasmine-core (= 2.9.1)
   jruby-openssl (~> 0.10.1)

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -5,17 +5,6 @@ GIT
   specs:
     cancancan (2.3.0)
 
-GIT
-  remote: https://github.com/drapergem/draper
-  revision: 157eb955072a941e6455e0121fca09a989fcbc21
-  specs:
-    draper (3.0.1)
-      actionpack (>= 5.0)
-      activemodel (>= 5.0)
-      activemodel-serializers-xml (>= 1.0)
-      activesupport (>= 5.0)
-      request_store (>= 1.0)
-
 PATH
   remote: ..
   specs:
@@ -139,6 +128,12 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.3)
     docile (1.3.1)
+    draper (3.1.0)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
+      activemodel-serializers-xml (>= 1.0)
+      activesupport (>= 5.0)
+      request_store (>= 1.0)
     erubi (1.7.1)
     execjs (2.7.0)
     ffi (1.9.25)
@@ -344,7 +339,7 @@ DEPENDENCIES
   cucumber-rails (~> 1.5)
   database_cleaner
   devise (~> 4.6)
-  draper!
+  draper (~> 3.1)
   jasmine
   jasmine-core (= 2.9.1)
   jruby-openssl (~> 0.10.1)

--- a/gemfiles/rails_60.gemfile.lock
+++ b/gemfiles/rails_60.gemfile.lock
@@ -23,17 +23,6 @@ GIT
       responders
 
 GIT
-  remote: https://github.com/drapergem/draper
-  revision: 157eb955072a941e6455e0121fca09a989fcbc21
-  specs:
-    draper (3.0.1)
-      actionpack (>= 5.0)
-      activemodel (>= 5.0)
-      activemodel-serializers-xml (>= 1.0)
-      activesupport (>= 5.0)
-      request_store (>= 1.0)
-
-GIT
   remote: https://github.com/jruby/activerecord-jdbc-adapter
   revision: e49f1435167610e7801012da0d74d32234f8bc1d
   specs:
@@ -169,6 +158,12 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.3)
     docile (1.3.1)
+    draper (3.1.0)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
+      activemodel-serializers-xml (>= 1.0)
+      activesupport (>= 5.0)
+      request_store (>= 1.0)
     erubi (1.8.0)
     execjs (2.7.0)
     ffi (1.10.0)
@@ -358,7 +353,7 @@ DEPENDENCIES
   cucumber-rails (~> 1.5)
   database_cleaner
   devise (~> 4.6)
-  draper!
+  draper (~> 3.1)
   inherited_resources!
   jasmine
   jasmine-core (= 2.9.1)


### PR DESCRIPTION
Draper gem has introduced Rails 6 support in version 3.1.0 
https://github.com/drapergem/draper/blob/master/CHANGELOG.md#310