### PR TITLE
Correct Getting Started instructions

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -54,7 +54,6 @@ If you want to use the devise gem for (admin) authentification, add it to
 your Gemfile
 
 ```ruby
-# Gemfile
 gem 'activeadmin'
 gem 'devise'
 ```

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -9,18 +9,19 @@ to implement beautiful and elegant interfaces with very little effort.
 # Getting Started
 
 Active Admin is released as a Ruby Gem. The gem is to be installed within a Ruby
-on Rails application. To install, simply add the following to your Gemfile:
+on Rails application. Active Admin does not provide authentification; this is done 
+by other gems (e.g. devise). To install without any authentification, simply 
+add the following to your Gemfile:
 
 ```ruby
 # Gemfile
 gem 'activeadmin'
-gem 'devise'
 ```
 
 After updating your bundle, run the installer
 
 ```bash
-rails generate active_admin:install
+rails generate active_admin:install --skip-users
 ```
 
 The installer creates an initializer used for configuring defaults used by
@@ -31,26 +32,67 @@ Migrate your db and start the server:
 
 ```bash
 $> rake db:migrate
-$> rake db:seed
 $> rails server
 ```
 
-Visit `http://localhost:3000/admin` and log in using:
+Visit `http://localhost:3000/admin` and voila: You&#8217;re on your brand 
+new Active Admin dashboard.
+
+To register an already existing model, run:
+
+```bash
+$> rails generate active_admin:resource [MyModelName]
+```
+
+This creates a file at `app/admin/my_model_names.rb` for configuring the
+resource. Refresh your web browser to see the interface. In order to CRUD
+items, tweak the parameter `permit_params` in `app/admin/MyModel.rb`.
+
+## Usage with devise
+
+If you want to use the devise gem for (admin) authentification, add it to
+your Gemfile
+
+```ruby
+# Gemfile
+gem 'activeadmin'
+gem 'devise'
+```
+
+Update the bundle and run the installer
+
+```bash
+rails generate active_admin:install
+```
+
+Migrate your db
+
+```bash
+$> rake db:migrate
+```
+
+If you are adding devise with Active Admin, you need to seed the database
+with an admin user for Active Admin (otherwise you probably will already
+have an admin user)
+
+```bash
+$> rake db:seed
+```
+
+and start the server
+
+```bash
+$> rails server
+```
+
+Visit `http://localhost:3000/admin` and log in using (this user has been generated
+by the database seed):
 
 * __User__: admin@example.com
 * __Password__: password
 
-Voila! You&#8217;re on your brand new Active Admin dashboard.
+Adding existing models to Active Admin works as described above.
 
-To register your first model, run:
-
-```bash
-$> rails generate active_admin:resource
-        [MyModelName]
-```
-
-This creates a file at `app/admin/my_model_names.rb` for configuring the
-resource. Refresh your web browser to see the interface.
 
 # Next Steps
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -50,7 +50,7 @@ items, tweak `permit_params` in `app/admin/my_model_names.rb`.
 
 ## Usage with devise
 
-If you want to use the devise gem for (admin) authentification, add it to
+If you want to use the devise gem for (admin) authentication, add it to
 your Gemfile
 
 ```ruby

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -14,6 +14,7 @@ on Rails application. To install, simply add the following to your Gemfile:
 ```ruby
 # Gemfile
 gem 'activeadmin'
+gem 'devise'
 ```
 
 After updating your bundle, run the installer
@@ -30,6 +31,7 @@ Migrate your db and start the server:
 
 ```bash
 $> rake db:migrate
+$> rake db:seed
 $> rails server
 ```
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -9,8 +9,8 @@ to implement beautiful and elegant interfaces with very little effort.
 # Getting Started
 
 Active Admin is released as a Ruby Gem. The gem is to be installed within a Ruby
-on Rails application. Active Admin does not provide authentification; this is done 
-by other gems (e.g. devise). To install without any authentification, simply 
+on Rails application. Active Admin does not provide authentification; this is done
+by other gems (e.g. devise). To install without any authentification, simply
 add the following to your Gemfile:
 
 ```ruby
@@ -35,7 +35,7 @@ $> rake db:migrate
 $> rails server
 ```
 
-Visit `http://localhost:3000/admin` and voila: You&#8217;re on your brand 
+Visit `http://localhost:3000/admin` and voila: You&#8217;re on your brand
 new Active Admin dashboard.
 
 To register an already existing model, run:
@@ -92,7 +92,6 @@ by the database seed):
 * __Password__: password
 
 Adding existing models to Active Admin works as described above.
-
 
 # Next Steps
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -62,7 +62,7 @@ gem 'devise'
 Update the bundle and run the installer
 
 ```bash
-rails generate active_admin:install
+$> rails generate active_admin:install
 ```
 
 Migrate your db

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -10,7 +10,7 @@ to implement beautiful and elegant interfaces with very little effort.
 
 Active Admin is released as a Ruby Gem. The gem is to be installed within a Ruby
 on Rails application. Active Admin does not provide authentication; this is done
-by other gems (e.g. devise). To install without any authentification, simply
+by other gems (e.g. devise). To install without any authentication,
 add the following to your Gemfile:
 
 ```ruby

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -46,7 +46,7 @@ $> rails generate active_admin:resource [MyModelName]
 
 This creates a file at `app/admin/my_model_names.rb` for configuring the
 resource. Refresh your web browser to see the interface. In order to CRUD
-items, tweak the parameter `permit_params` in `app/admin/MyModel.rb`.
+items, tweak `permit_params` in `app/admin/my_model_names.rb`.
 
 ## Usage with devise
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -9,7 +9,7 @@ to implement beautiful and elegant interfaces with very little effort.
 # Getting Started
 
 Active Admin is released as a Ruby Gem. The gem is to be installed within a Ruby
-on Rails application. Active Admin does not provide authentification; this is done
+on Rails application. Active Admin does not provide authentication; this is done
 by other gems (e.g. devise). To install without any authentification, simply
 add the following to your Gemfile:
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -35,7 +35,7 @@ $> rake db:migrate
 $> rails server
 ```
 
-Visit `http://localhost:3000/admin` and voila: You&#8217;re on your brand
+Visit `http://localhost:3000/admin` and you'll be on your brand
 new Active Admin dashboard.
 
 To register an already existing model, run:

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -59,7 +59,7 @@ gem 'activeadmin'
 gem 'devise'
 ```
 
-Update the bundle and run the installer
+Run `bundle install`, and then run the installer
 
 ```bash
 $> rails generate active_admin:install


### PR DESCRIPTION
The current getting started section does not work for the following two reasons:
- Either you issue a `rails g active_admin:install --skip-users` to make it work without devise (I did not test this), or you include `devise` in your Gemfile. I choose the second option.
- You need to seed the db, otherwise there is no admin user and you cannot login as described below.