### PR TITLE
Bump npm dev deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ public
 .rspec_failures
 .rails-version
 .rbenv-version
+node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,15 +45,15 @@
       "dev": true
     },
     "gherkin-lint": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/gherkin-lint/-/gherkin-lint-3.0.0.tgz",
-      "integrity": "sha512-Snl6CpGD75O9s14FC/bmjHYa8XMSlvvoGT/FtxvZkahWeUZOF2MIAy4nkbxu0sgVm9yIx2xhCKVq0DDVY0hOhA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gherkin-lint/-/gherkin-lint-3.0.2.tgz",
+      "integrity": "sha512-tCmDwlhEzDHe3A35ccVJg4ve7Mb9YYd9DiROFfRkZkHy37riwuvsvUGH1ZzKfnNbEUc5YYSV4MEz8Jb+FwtKcw==",
       "dev": true,
       "requires": {
         "commander": "2.18.0",
         "gherkin": "5.1.0",
         "glob": "7.1.3",
-        "lodash": "4.17.10"
+        "lodash": "4.17.11"
       }
     },
     "glob": {
@@ -87,9 +87,9 @@
       "dev": true
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
     "minimatch": {
@@ -112,7 +112,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "htts://activeadmin.info",
   "devDependencies": {
-    "gherkin-lint": "^3.0.0"
+    "gherkin-lint": "^3.0.2"
   },
   "scripts": {
     "lint": "gherkin-lint features"


### PR DESCRIPTION
Just upgrading `gherkin-lint` to the latest 3.0.2.