### PR TITLE
Skip webpack install in test app generation

### DIFF
--- a/tasks/application_generator.rb
+++ b/tasks/application_generator.rb
@@ -23,6 +23,7 @@ module ActiveAdmin
           --skip-turbolinks
           --skip-test-unit
           --skip-coffee
+          --skip-webpack-install
         )
 
         command = ['bundle', 'exec', 'rails', 'new', app_dir, *args].join(' ')


### PR DESCRIPTION
The test application generation on Rails 6 is crashing because of this. But thor does not signal it as a failure, and since it's run at the end of the app generation does not seem to cause any problems. The crash can be seen by scrolling to the end of the log in the "Create test app" job [here](https://circleci.com/gh/activeadmin/activeadmin/13556), for example.

Hopefully [thor will let us know](https://github.com/erikhuda/thor/pull/651) about these crashes in the future.