### PR TITLE
Invalid value shown in "to" entries count details.

### DIFF
--- a/lib/active_admin/views/components/paginated_collection.rb
+++ b/lib/active_admin/views/components/paginated_collection.rb
@@ -141,7 +141,7 @@ module ActiveAdmin
                    model: entries_name,
                    total: total,
                    from: offset + 1,
-                   to: offset + collection_size
+                   to: offset + collection.length
           end
         else
           # Do not display total count, in order to prevent a `SELECT count(*)`.
@@ -150,7 +150,7 @@ module ActiveAdmin
           I18n.t "active_admin.pagination.multiple_without_total",
                  model: entries_name,
                  from: offset + 1,
-                 to: offset + collection_size
+                 to: offset + collection.length
         end
       end
 


### PR DESCRIPTION
Fix for issue : https://github.com/activeadmin/activeadmin/issues/5549

Invalid value shown in `to` entries count when using `paginated_collection` method for showing collections with pagination.