### PR TITLE
Use release candidate version of CanCanCan gem

### DIFF
--- a/Gemfile.common
+++ b/Gemfile.common
@@ -4,8 +4,8 @@ gem 'pry' # Easily debug from your console with `binding.pry`
 gem 'pry-byebug', platform: :mri # Step-by-step debugging
 
 # Optional dependencies used in both development & test environments
-# CanCanCan gem has introduce support for Rails 6 in feature/3.0.0 branch
-gem 'cancancan', git: 'https://github.com/CanCanCommunity/cancancan', branch: 'feature/3.0.0'
+# CanCanCan gem has introduce support for Rails 6 in version 3.0.0.rc1
+gem 'cancancan', '3.0.0.rc1'
 gem 'pundit'
 gem 'jruby-openssl', '~> 0.10.1', platform: :jruby
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/CanCanCommunity/cancancan
-  revision: 23ac88c2aa7db77f08744dd3f5492af02a29cd03
-  branch: feature/3.0.0
-  specs:
-    cancancan (2.3.0)
-
 PATH
   remote: .
   specs:
@@ -89,6 +82,7 @@ GEM
     bcrypt (3.1.12-java)
     builder (3.2.3)
     byebug (10.0.2)
+    cancancan (3.0.0.rc1)
     capybara (3.14.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -399,7 +393,7 @@ PLATFORMS
 DEPENDENCIES
   activeadmin!
   activerecord-jdbcsqlite3-adapter (~> 52.0)
-  cancancan!
+  cancancan (= 3.0.0.rc1)
   capybara (~> 3.14)
   chandler (= 0.9.0)
   cucumber

--- a/gemfiles/rails_50.gemfile.lock
+++ b/gemfiles/rails_50.gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/CanCanCommunity/cancancan
-  revision: 23ac88c2aa7db77f08744dd3f5492af02a29cd03
-  branch: feature/3.0.0
-  specs:
-    cancancan (2.3.0)
-
 PATH
   remote: ..
   specs:
@@ -84,6 +77,7 @@ GEM
     bcrypt (3.1.12-java)
     builder (3.2.3)
     byebug (10.0.2)
+    cancancan (3.0.0.rc1)
     capybara (3.14.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -333,7 +327,7 @@ PLATFORMS
 DEPENDENCIES
   activeadmin!
   activerecord-jdbcsqlite3-adapter (~> 50.0)
-  cancancan!
+  cancancan (= 3.0.0.rc1)
   capybara (~> 3.14)
   cucumber
   cucumber-rails (~> 1.5)

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/CanCanCommunity/cancancan
-  revision: 23ac88c2aa7db77f08744dd3f5492af02a29cd03
-  branch: feature/3.0.0
-  specs:
-    cancancan (2.3.0)
-
 PATH
   remote: ..
   specs:
@@ -84,6 +77,7 @@ GEM
     bcrypt (3.1.12-java)
     builder (3.2.3)
     byebug (10.0.2)
+    cancancan (3.0.0.rc1)
     capybara (3.14.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -333,7 +327,7 @@ PLATFORMS
 DEPENDENCIES
   activeadmin!
   activerecord-jdbcsqlite3-adapter (~> 51.0)
-  cancancan!
+  cancancan (= 3.0.0.rc1)
   capybara (~> 3.14)
   cucumber
   cucumber-rails (~> 1.5)

--- a/gemfiles/rails_60.gemfile.lock
+++ b/gemfiles/rails_60.gemfile.lock
@@ -1,11 +1,4 @@
 GIT
-  remote: https://github.com/CanCanCommunity/cancancan
-  revision: 23ac88c2aa7db77f08744dd3f5492af02a29cd03
-  branch: feature/3.0.0
-  specs:
-    cancancan (2.3.0)
-
-GIT
   remote: https://github.com/jruby/activerecord-jdbc-adapter
   revision: e49f1435167610e7801012da0d74d32234f8bc1d
   specs:
@@ -106,6 +99,7 @@ GEM
     bcrypt (3.1.12-java)
     builder (3.2.3)
     byebug (11.0.0)
+    cancancan (3.0.0.rc1)
     capybara (3.14.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -352,7 +346,7 @@ GEM
     websocket-extensions (0.1.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (1.4.2)
+    zeitwerk (1.4.3)
 
 PLATFORMS
   java
@@ -362,7 +356,7 @@ DEPENDENCIES
   activeadmin!
   activerecord-jdbcsqlite3-adapter!
   arbre (~> 1.2.a)
-  cancancan!
+  cancancan (= 3.0.0.rc1)
   capybara (~> 3.14)
   cucumber
   cucumber-rails (~> 1.5)


### PR DESCRIPTION
CanCanCan gem has introduced Rails 6 support in version 3.0.0.rc1
https://github.com/CanCanCommunity/cancancan/blob/feature/3.0.0/CHANGELOG.md#300