### PR TITLE
Update gems to use the released version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Enhancements
+
+#### Minor
+
+* Update gemspec dependency on arbre to use version `~> 1.2` [#5726] by [@ionut998]
+
 ## 2.0.0.rc1 [☰](https://github.com/activeadmin/activeadmin/compare/v1.4.3..v2.0.0.rc1)
 
 ### Enhancements
@@ -416,6 +422,7 @@ Please check [0-6-stable] for previous changes.
 [#5650]: https://github.com/activeadmin/activeadmin/pull/5650
 [#5590]: https://github.com/activeadmin/activeadmin/pull/5590
 [#5662]: https://github.com/activeadmin/activeadmin/pull/5662
+[#5726]: https://github.com/activeadmin/activeadmin/pull/5726
 
 [@5t111111]: https://github.com/5t111111
 [@aarek]: https://github.com/aarek
@@ -442,6 +449,7 @@ Please check [0-6-stable] for previous changes.
 [@glebtv]: https://github.com/glebtv
 [@gonzedge]: https://github.com/gonzedge
 [@innparusu95]: https://github.com/innparusu95
+[@ionut998]: https://github.com/ionut998
 [@jasl]: https://github.com/jasl
 [@javierjulio]: https://github.com/javierjulio
 [@jawa]: https://github.com/jawa

--- a/Gemfile.common
+++ b/Gemfile.common
@@ -4,8 +4,7 @@ gem 'pry' # Easily debug from your console with `binding.pry`
 gem 'pry-byebug', platform: :mri # Step-by-step debugging
 
 # Optional dependencies used in both development & test environments
-# CanCanCan gem has introduce support for Rails 6 in version 3.0.0.rc1
-gem 'cancancan', '3.0.0.rc1'
+gem 'cancancan'
 gem 'pundit'
 gem 'jruby-openssl', '~> 0.10.1', platform: :jruby
 
@@ -25,6 +24,6 @@ group :test do
   gem 'parallel_tests', '~> 2.26'
   gem 'rails-i18n' # Provides default i18n for many languages
   gem 'rspec-rails'
-  gem 'sqlite3', '~> 1.3.6', platform: :mri
+  gem 'sqlite3', platform: :mri
   gem 'selenium-webdriver'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     activeadmin (2.0.0.rc1)
-      arbre (>= 1.2.0)
+      arbre (~> 1.2)
       formtastic (~> 3.1)
       formtastic_i18n (~> 0.4)
       inherited_resources (~> 1.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     activeadmin (2.0.0.rc1)
-      arbre (~> 1.1, >= 1.1.1)
+      arbre (>= 1.2.0)
       formtastic (~> 3.1)
       formtastic_i18n (~> 0.4)
       inherited_resources (~> 1.7)
@@ -69,7 +69,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    arbre (1.1.1)
+    arbre (1.2.0)
       activesupport (>= 3.0.0)
     arel (9.0.0)
     ast (2.4.0)
@@ -166,11 +166,11 @@ GEM
       rails-i18n
       rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
-    inherited_resources (1.9.0)
-      actionpack (>= 4.2, < 5.3)
+    inherited_resources (1.10.0)
+      actionpack (>= 5.0, < 6.0)
       has_scope (~> 0.6)
-      railties (>= 4.2, < 5.3)
-      responders
+      railties (>= 5.0, < 6.0)
+      responders (~> 2.0)
     iso (0.2.2)
       i18n
     jaro_winkler (1.5.2)
@@ -336,7 +336,7 @@ GEM
       rubocop (>= 0.60.0)
     ruby-progressbar (1.10.0)
     rubyzip (1.2.2)
-    sass (3.7.3)
+    sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -393,7 +393,7 @@ PLATFORMS
 DEPENDENCIES
   activeadmin!
   activerecord-jdbcsqlite3-adapter (~> 52.0)
-  cancancan (= 3.0.0.rc1)
+  cancancan
   capybara (~> 3.14)
   chandler (= 0.9.0)
   cucumber
@@ -421,7 +421,7 @@ DEPENDENCIES
   rubocop-rspec (~> 1.30)
   selenium-webdriver
   simplecov
-  sqlite3 (~> 1.3.6)
+  sqlite3
   yard
 
 BUNDLED WITH

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.3'
 
-  s.add_dependency 'arbre', '~> 1.1', '>= 1.1.1'
+  s.add_dependency 'arbre', '>= 1.2.0'
   s.add_dependency 'formtastic', '~> 3.1'
   s.add_dependency 'formtastic_i18n', '~> 0.4'
   s.add_dependency 'inherited_resources', '~> 1.7'

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.3'
 
-  s.add_dependency 'arbre', '>= 1.2.0'
+  s.add_dependency 'arbre', '~> 1.2'
   s.add_dependency 'formtastic', '~> 3.1'
   s.add_dependency 'formtastic_i18n', '~> 0.4'
   s.add_dependency 'inherited_resources', '~> 1.7'

--- a/gemfiles/rails_50.gemfile.lock
+++ b/gemfiles/rails_50.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     activeadmin (2.0.0.rc1)
-      arbre (>= 1.2.0)
+      arbre (~> 1.2)
       formtastic (~> 3.1)
       formtastic_i18n (~> 0.4)
       inherited_resources (~> 1.7)

--- a/gemfiles/rails_50.gemfile.lock
+++ b/gemfiles/rails_50.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     activeadmin (2.0.0.rc1)
-      arbre (~> 1.1, >= 1.1.1)
+      arbre (>= 1.2.0)
       formtastic (~> 3.1)
       formtastic_i18n (~> 0.4)
       inherited_resources (~> 1.7)
@@ -65,7 +65,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    arbre (1.1.1)
+    arbre (1.2.0)
       activesupport (>= 3.0.0)
     arel (7.1.4)
     babel-source (5.8.35)
@@ -143,11 +143,11 @@ GEM
       activesupport (>= 4.1)
     i18n (1.1.1)
       concurrent-ruby (~> 1.0)
-    inherited_resources (1.9.0)
-      actionpack (>= 4.2, < 5.3)
+    inherited_resources (1.10.0)
+      actionpack (>= 5.0, < 6.0)
       has_scope (~> 0.6)
-      railties (>= 4.2, < 5.3)
-      responders
+      railties (>= 5.0, < 6.0)
+      responders (~> 2.0)
     jasmine (2.9.0)
       jasmine-core (>= 2.9.0, < 3.0.0)
       phantomjs
@@ -278,7 +278,7 @@ GEM
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
     rubyzip (1.2.2)
-    sass (3.7.3)
+    sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -327,7 +327,7 @@ PLATFORMS
 DEPENDENCIES
   activeadmin!
   activerecord-jdbcsqlite3-adapter (~> 50.0)
-  cancancan (= 3.0.0.rc1)
+  cancancan
   capybara (~> 3.14)
   cucumber
   cucumber-rails (~> 1.5)
@@ -348,7 +348,7 @@ DEPENDENCIES
   rspec-rails
   selenium-webdriver
   simplecov
-  sqlite3 (~> 1.3.6)
+  sqlite3
 
 BUNDLED WITH
    2.0.1

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     activeadmin (2.0.0.rc1)
-      arbre (>= 1.2.0)
+      arbre (~> 1.2)
       formtastic (~> 3.1)
       formtastic_i18n (~> 0.4)
       inherited_resources (~> 1.7)

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     activeadmin (2.0.0.rc1)
-      arbre (~> 1.1, >= 1.1.1)
+      arbre (>= 1.2.0)
       formtastic (~> 3.1)
       formtastic_i18n (~> 0.4)
       inherited_resources (~> 1.7)
@@ -65,7 +65,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    arbre (1.1.1)
+    arbre (1.2.0)
       activesupport (>= 3.0.0)
     arel (8.0.0)
     babel-source (5.8.35)
@@ -143,11 +143,11 @@ GEM
       activesupport (>= 4.1)
     i18n (1.1.1)
       concurrent-ruby (~> 1.0)
-    inherited_resources (1.9.0)
-      actionpack (>= 4.2, < 5.3)
+    inherited_resources (1.10.0)
+      actionpack (>= 5.0, < 6.0)
       has_scope (~> 0.6)
-      railties (>= 4.2, < 5.3)
-      responders
+      railties (>= 5.0, < 6.0)
+      responders (~> 2.0)
     jasmine (2.9.0)
       jasmine-core (>= 2.9.0, < 3.0.0)
       phantomjs
@@ -278,7 +278,7 @@ GEM
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
     rubyzip (1.2.2)
-    sass (3.7.3)
+    sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -327,7 +327,7 @@ PLATFORMS
 DEPENDENCIES
   activeadmin!
   activerecord-jdbcsqlite3-adapter (~> 51.0)
-  cancancan (= 3.0.0.rc1)
+  cancancan
   capybara (~> 3.14)
   cucumber
   cucumber-rails (~> 1.5)
@@ -348,7 +348,7 @@ DEPENDENCIES
   rspec-rails
   selenium-webdriver
   simplecov
-  sqlite3 (~> 1.3.6)
+  sqlite3
 
 BUNDLED WITH
    2.0.1

--- a/gemfiles/rails_60.gemfile
+++ b/gemfiles/rails_60.gemfile
@@ -4,8 +4,6 @@ eval_gemfile(File.expand_path(File.join("..", "Gemfile.common"), __dir__))
 
 gem "rails", "6.0.0.beta3"
 
-# Use the unreleased version of gems because they are compatible with Rails 6
-gem "arbre", "~> 1.2.a"
 gem "activerecord-jdbcsqlite3-adapter", git: 'https://github.com/jruby/activerecord-jdbc-adapter', platform: :jruby
 
 gemspec path: "../"

--- a/gemfiles/rails_60.gemfile.lock
+++ b/gemfiles/rails_60.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   remote: ..
   specs:
     activeadmin (2.0.0.rc1)
-      arbre (>= 1.2.0)
+      arbre (~> 1.2)
       formtastic (~> 3.1)
       formtastic_i18n (~> 0.4)
       inherited_resources (~> 1.7)

--- a/gemfiles/rails_60.gemfile.lock
+++ b/gemfiles/rails_60.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   remote: ..
   specs:
     activeadmin (2.0.0.rc1)
-      arbre (~> 1.1, >= 1.1.1)
+      arbre (>= 1.2.0)
       formtastic (~> 3.1)
       formtastic_i18n (~> 0.4)
       inherited_resources (~> 1.7)
@@ -88,7 +88,7 @@ GEM
       zeitwerk (~> 1.3, >= 1.3.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    arbre (1.2.0.rc1)
+    arbre (1.2.0)
       activesupport (>= 3.0.0)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
@@ -165,7 +165,7 @@ GEM
       activesupport (>= 4.1)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
-    inherited_resources (1.10.0.rc1)
+    inherited_resources (1.10.0)
       actionpack (>= 5.0, < 6.0)
       has_scope (~> 0.6)
       railties (>= 5.0, < 6.0)
@@ -305,7 +305,7 @@ GEM
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
     rubyzip (1.2.2)
-    sass (3.7.3)
+    sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -355,8 +355,7 @@ PLATFORMS
 DEPENDENCIES
   activeadmin!
   activerecord-jdbcsqlite3-adapter!
-  arbre (~> 1.2.a)
-  cancancan (= 3.0.0.rc1)
+  cancancan
   capybara (~> 3.14)
   cucumber
   cucumber-rails (~> 1.5)
@@ -377,7 +376,7 @@ DEPENDENCIES
   rspec-rails
   selenium-webdriver
   simplecov
-  sqlite3 (~> 1.3.6)
+  sqlite3
 
 BUNDLED WITH
    2.0.1


### PR DESCRIPTION
The following gems have been updated: `arbre`, `cancancan` and `inherited_resources`.