### PR TITLE
Partially revert "Revert "Ensure locked bundler is used""

### DIFF
--- a/bin/bundle
+++ b/bin/bundle
@@ -1,0 +1,49 @@
+#!/usr/bin/env ruby
+
+require "rubygems"
+
+m = Module.new do
+  extend self
+
+  def invoked_as_script?
+    File.expand_path($PROGRAM_NAME) == File.expand_path(__FILE__)
+  end
+
+  def gemfile
+    gemfile = ENV["BUNDLE_GEMFILE"]
+    return gemfile if gemfile && !gemfile.empty?
+
+    File.expand_path("../Gemfile", __dir__)
+  end
+
+  def lockfile
+    "#{gemfile}.lock"
+  end
+
+  def lockfile_version
+    return unless File.file?(lockfile)
+    lockfile_contents = File.read(lockfile)
+
+    regexp = /\n\nBUNDLED WITH\n\s{2,}(#{Gem::Version::VERSION_PATTERN})\n/
+
+    regexp.match(lockfile_contents)[1]
+  end
+
+  def bundler_version
+    @bundler_version ||= lockfile_version
+  end
+
+  def load_bundler!
+    ENV["BUNDLE_GEMFILE"] ||= gemfile
+
+    activate_bundler(bundler_version)
+  end
+
+  def activate_bundler(bundler_version)
+    gem "bundler", bundler_version
+  end
+end
+
+m.load_bundler!
+
+load Gem.bin_path("bundler", "bundle") if m.invoked_as_script?

--- a/bin/cucumber
+++ b/bin/cucumber
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+load File.expand_path("bundle", __dir__)
+
 require "bundler/setup"
 
 load Gem.bin_path("cucumber", "cucumber")

--- a/bin/parallel_cucumber
+++ b/bin/parallel_cucumber
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+load File.expand_path("bundle", __dir__)
+
 require "bundler/setup"
 
 ["--serialize-stdout", "--combine-stderr", "--verbose", "--test-options", "-p default"].each do |flag|

--- a/bin/parallel_rspec
+++ b/bin/parallel_rspec
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+load File.expand_path("bundle", __dir__)
+
 require "bundler/setup"
 
 %w[--serialize-stdout --combine-stderr --verbose].each do |flag|

--- a/bin/rake
+++ b/bin/rake
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+load File.expand_path("bundle", __dir__)
+
 require "bundler/setup"
 
 load Gem.bin_path("rake", "rake")

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+load File.expand_path("bundle", __dir__)
+
 require "bundler/setup"
 
 load Gem.bin_path("rspec-core", "rspec")


### PR DESCRIPTION
This partially reverts commit 170c3c2b08edbc05d9edea44a61405a8806324f7. It is true that rubygems includes code that properly select the version of bundler your application or library needs. However, if you use bundler binstubs, you still need to load a binstub for bundler so that `bundle exec <executable>` behaves consistently with `bin/<executable>`.