### PR TITLE
Add a display_timezone config option

### DIFF
--- a/lib/active_admin/application_settings.rb
+++ b/lib/active_admin/application_settings.rb
@@ -20,6 +20,9 @@ module ActiveAdmin
     # Set default localize format for Date/Time values
     register :localize_format, :long
 
+    # Set default timezone for Date/Time value display
+    register :display_timezone, "UTC"
+
     # Active Admin makes educated guesses when displaying objects, this is
     # the list of methods it tries calling in order
     # Note that Formtastic also has 'collection_label_methods' similar to this

--- a/lib/active_admin/view_helpers/display_helper.rb
+++ b/lib/active_admin/view_helpers/display_helper.rb
@@ -55,10 +55,19 @@ module ActiveAdmin
       def find_value(resource, attr)
         if attr.is_a? Proc
           attr.call resource
-        elsif resource.respond_to? attr
-          resource.public_send attr
-        elsif resource.respond_to? :[]
-          resource[attr]
+        else
+          value = if resource.respond_to? attr
+                    resource.public_send attr
+                  elsif resource.respond_to? :[]
+                    resource[attr]
+                  end
+          if value.is_a?(Date)
+            value.in_time_zone(active_admin_application.display_timezone).to_date
+          elsif value.is_a?(Time)
+            value.in_time_zone(active_admin_application.display_timezone)
+          else
+            value
+          end
         end
       end
 

--- a/lib/active_admin/view_helpers/display_helper.rb
+++ b/lib/active_admin/view_helpers/display_helper.rb
@@ -61,9 +61,7 @@ module ActiveAdmin
                   elsif resource.respond_to? :[]
                     resource[attr]
                   end
-          if value.is_a?(Date)
-            value.in_time_zone(active_admin_application.display_timezone).to_date
-          elsif value.is_a?(Time)
+          if value.is_a?(Time) || value.is_a?(DateTime)
             value.in_time_zone(active_admin_application.display_timezone)
           else
             value

--- a/lib/generators/active_admin/install/templates/active_admin.rb.erb
+++ b/lib/generators/active_admin/install/templates/active_admin.rb.erb
@@ -167,6 +167,17 @@ ActiveAdmin.setup do |config|
   #
   config.localize_format = :long
 
+  # == Display Date/Time in Timezone
+  #
+  # Sets the timezone to display dates and times in.
+  # For a list of all the valid values, see
+  # https://api.rubyonrails.org/classes/ActiveSupport/TimeZone.html
+  #
+  # This can still be overridden in specific pages with a block as shown here
+  # https://activeadmin.info/6-show-pages.html
+
+  config.display_timezone = "UTC"
+
   # == Setting a Favicon
   #
   # config.favicon = 'favicon.ico'

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -56,6 +56,15 @@ RSpec.describe ActiveAdmin::Application do
     expect(application.localize_format).to eq :default
   end
 
+  it "should return default display timezone" do
+    expect(application.display_timezone).to eq "UTC"
+  end
+
+  it "should set display timezone" do
+    application.display_timezone = "Eastern Time (US & Canada)"
+    expect(application.display_timezone).to eq "Eastern Time (US & Canada)"
+  end
+
   it "should set the site's favicon" do
     application.favicon = "/a/favicon.ico"
     expect(application.favicon).to eq "/a/favicon.ico"

--- a/spec/unit/find_value_spec.rb
+++ b/spec/unit/find_value_spec.rb
@@ -10,6 +10,16 @@ RSpec.describe "#find_value" do
   let(:view) { mock_action_view(view_klass) }
   let(:found_value) { view.find_value(resource, attr) }
 
+  context "when given a proc" do
+    let(:resource) { "bar" }
+    let(:attr) { ->(resource) { "foo#{resource}" } }
+
+    it "calls the proc" do
+      expect(attr).to receive(:call).with(resource).and_call_original
+      expect(found_value).to eq("foobar")
+    end
+  end
+
   shared_examples_for "an object that can have values found" do
     shared_examples_for "a time-ish attribute" do
       let(:attr) { "#{attr_base}_during_dst".to_sym }

--- a/spec/unit/find_value_spec.rb
+++ b/spec/unit/find_value_spec.rb
@@ -1,0 +1,106 @@
+require 'rails_helper'
+require 'active_admin/view_helpers/display_helper'
+
+RSpec.describe "#find_value" do
+  include ActiveSupport::Testing::TimeHelpers
+  let(:view_klass) do
+    Class.new(ActionView::Base) do
+      include ActiveAdmin::ViewHelpers
+    end
+  end
+  let(:view) { mock_action_view(view_klass) }
+  let(:attr) { :datetime }
+  subject { view.find_value(resource, attr) }
+
+  context "when given an object that responds to the attr" do
+    let(:resource_class) do
+      Class.new do
+        def time
+          Time.new(2019, 5, 1, 11, 30, 0, "-07:00")
+        end
+
+        def datetime
+          DateTime.new(2019, 5, 1, 11, 30, 0, "-07:00")
+        end
+      end
+    end
+    let(:resource) { resource_class.new }
+    let(:resource_value) { resource.send(attr) }
+
+    context "when the value is a Time" do
+      let(:attr) { :time }
+      let(:expected_value) { resource_value.utc }
+
+      it "converts it to the default display_timezone" do
+        is_expected.to eq(resource_value.utc)
+      end
+
+      context "with a custom display_timezone" do
+        around do |example|
+          previous_display_timezone = ActiveAdmin.application.display_timezone
+          ActiveAdmin.application.display_timezone = "America/New_York"
+          example.call
+          ActiveAdmin.application.display_timezone = previous_display_timezone
+        end
+
+        context "when the date is during Daylight Savings Time" do
+          let(:resource_class) do
+            Class.new do
+              def time
+                Time.new(2019, 5, 1, 11, 30, 0, "-07:00")
+              end
+
+              def datetime
+                DateTime.new(2019, 5, 1, 11, 30, 0, "-07:00")
+              end
+            end
+          end
+          let(:expected_value) { Time.new(2019, 5, 1, 14, 30, 0, "-04:00") }
+
+          it "converts it to the custom timezone" do
+            is_expected.to eq(expected_value)
+            expect(subject.zone).to eq("EDT")
+          end
+        end
+
+        context "when the date is not during Daylight Savings Time" do
+          let(:resource_class) do
+            Class.new do
+              def time
+                Time.new(2019, 12, 1, 11, 30, 0, "-08:00")
+              end
+
+              def datetime
+                DateTime.new(2019, 12, 1, 11, 30, 0, "-08:00")
+              end
+            end
+          end
+          let(:expected_value) { Time.new(2019, 12, 1, 14, 30, 0, "-05:00") }
+
+          it "converts it to the custom timezone" do
+            is_expected.to eq(expected_value)
+            expect(subject.zone).to eq("EST")
+          end
+        end
+      end
+    end
+
+    # context "when the value is a DateTime" do
+    #   let(:attr) { :datetime }
+
+    #   it_behaves_like "a time-ish object"
+    # end
+
+    # TODO: When the value is something else
+  end
+
+  # TODO:
+  # context "When given an object that responds to :[]" do
+  #   it "when the value is a Time" do
+  #     it_behaves_like "a time-ish object"
+  #   end
+  #   it "when the value is a DateTime" do
+  #     it_behaves_like "a time-ish object"
+  #   end
+  # end
+end

--- a/spec/unit/find_value_spec.rb
+++ b/spec/unit/find_value_spec.rb
@@ -8,35 +8,9 @@ RSpec.describe "#find_value" do
     end
   end
   let(:view) { mock_action_view(view_klass) }
-  let(:resource) { resource_class.new }
   let(:found_value) { view.find_value(resource, attr) }
 
-  context "when given an object that responds to the attr" do
-    let(:resource_class) do
-      Class.new do
-        def time_during_dst
-          Time.new(2019, 5, 1, 11, 30, 0, "-07:00")
-        end
-
-        def time_not_during_dst
-          Time.new(2019, 12, 1, 11, 30, 0, "-08:00")
-        end
-
-        def datetime_during_dst
-          DateTime.new(2019, 5, 1, 11, 30, 0, "-07:00")
-        end
-
-        def datetime_not_during_dst
-          DateTime.new(2019, 12, 1, 11, 30, 0, "-08:00")
-        end
-
-        def string
-          "foobar"
-        end
-      end
-    end
-    let(:resource_value) { resource.send(attr) }
-
+  shared_examples_for "an object that can have values found" do
     shared_examples_for "a time-ish attribute" do
       let(:attr) { "#{attr_base}_during_dst".to_sym }
       let(:expected_value) { resource_value.utc }
@@ -105,13 +79,48 @@ RSpec.describe "#find_value" do
     end
   end
 
-  # TODO:
-  # context "When given an object that responds to :[]" do
-  #   it "when the value is a Time" do
-  #     it_behaves_like "a time-ish object"
-  #   end
-  #   it "when the value is a DateTime" do
-  #     it_behaves_like "a time-ish object"
-  #   end
-  # end
+  context "when given an object that responds to the attribute" do
+    let(:resource_class) do
+      Class.new do
+        def time_during_dst
+          Time.new(2019, 5, 1, 11, 30, 0, "-07:00")
+        end
+
+        def time_not_during_dst
+          Time.new(2019, 12, 1, 11, 30, 0, "-08:00")
+        end
+
+        def datetime_during_dst
+          DateTime.new(2019, 5, 1, 11, 30, 0, "-07:00")
+        end
+
+        def datetime_not_during_dst
+          DateTime.new(2019, 12, 1, 11, 30, 0, "-08:00")
+        end
+
+        def string
+          "foobar"
+        end
+      end
+    end
+    let(:resource) { resource_class.new }
+    let(:resource_value) { resource.send(attr) }
+
+    it_behaves_like "an object that can have values found"
+  end
+
+  context "when given an object that responds to :[]" do
+    let(:resource) do
+      {
+        time_during_dst: Time.new(2019, 5, 1, 11, 30, 0, "-07:00"),
+        time_not_during_dst: Time.new(2019, 12, 1, 11, 30, 0, "-08:00"),
+        datetime_during_dst: DateTime.new(2019, 5, 1, 11, 30, 0, "-07:00"),
+        datetime_not_during_dst: DateTime.new(2019, 12, 1, 11, 30, 0, "-08:00"),
+        string: "foobar"
+      }
+    end
+    let(:resource_value) { resource[attr] }
+
+    it_behaves_like "an object that can have values found"
+  end
 end

--- a/spec/unit/find_value_spec.rb
+++ b/spec/unit/find_value_spec.rb
@@ -2,37 +2,48 @@ require 'rails_helper'
 require 'active_admin/view_helpers/display_helper'
 
 RSpec.describe "#find_value" do
-  include ActiveSupport::Testing::TimeHelpers
   let(:view_klass) do
     Class.new(ActionView::Base) do
       include ActiveAdmin::ViewHelpers
     end
   end
   let(:view) { mock_action_view(view_klass) }
-  let(:attr) { :datetime }
-  subject { view.find_value(resource, attr) }
+  let(:resource) { resource_class.new }
+  let(:found_value) { view.find_value(resource, attr) }
 
   context "when given an object that responds to the attr" do
     let(:resource_class) do
       Class.new do
-        def time
+        def time_during_dst
           Time.new(2019, 5, 1, 11, 30, 0, "-07:00")
         end
 
-        def datetime
+        def time_not_during_dst
+          Time.new(2019, 12, 1, 11, 30, 0, "-08:00")
+        end
+
+        def datetime_during_dst
           DateTime.new(2019, 5, 1, 11, 30, 0, "-07:00")
+        end
+
+        def datetime_not_during_dst
+          DateTime.new(2019, 12, 1, 11, 30, 0, "-08:00")
+        end
+
+        def string
+          "foobar"
         end
       end
     end
-    let(:resource) { resource_class.new }
     let(:resource_value) { resource.send(attr) }
 
-    context "when the value is a Time" do
-      let(:attr) { :time }
+    shared_examples_for "a time-ish attribute" do
+      let(:attr) { "#{attr_base}_during_dst".to_sym }
       let(:expected_value) { resource_value.utc }
 
       it "converts it to the default display_timezone" do
-        is_expected.to eq(resource_value.utc)
+        expect(found_value).to eq(resource_value.utc)
+        expect(found_value.zone).to eq("UTC")
       end
 
       context "with a custom display_timezone" do
@@ -44,54 +55,54 @@ RSpec.describe "#find_value" do
         end
 
         context "when the date is during Daylight Savings Time" do
-          let(:resource_class) do
-            Class.new do
-              def time
-                Time.new(2019, 5, 1, 11, 30, 0, "-07:00")
-              end
-
-              def datetime
-                DateTime.new(2019, 5, 1, 11, 30, 0, "-07:00")
-              end
-            end
-          end
-          let(:expected_value) { Time.new(2019, 5, 1, 14, 30, 0, "-04:00") }
+          let(:attr) { "#{attr_base}_during_dst".to_sym }
 
           it "converts it to the custom timezone" do
-            is_expected.to eq(expected_value)
-            expect(subject.zone).to eq("EDT")
+            expect(found_value.year).to eq(2019)
+            expect(found_value.month).to eq(5)
+            expect(found_value.mday).to eq(1)
+            expect(found_value.hour).to eq(14)
+            expect(found_value.min).to eq(30)
+            expect(found_value.sec).to eq(0)
+            expect(found_value.zone).to eq("EDT")
           end
         end
 
         context "when the date is not during Daylight Savings Time" do
-          let(:resource_class) do
-            Class.new do
-              def time
-                Time.new(2019, 12, 1, 11, 30, 0, "-08:00")
-              end
-
-              def datetime
-                DateTime.new(2019, 12, 1, 11, 30, 0, "-08:00")
-              end
-            end
-          end
-          let(:expected_value) { Time.new(2019, 12, 1, 14, 30, 0, "-05:00") }
+          let(:attr) { "#{attr_base}_not_during_dst".to_sym }
 
           it "converts it to the custom timezone" do
-            is_expected.to eq(expected_value)
-            expect(subject.zone).to eq("EST")
+            expect(found_value.year).to eq(2019)
+            expect(found_value.month).to eq(12)
+            expect(found_value.mday).to eq(1)
+            expect(found_value.hour).to eq(14)
+            expect(found_value.min).to eq(30)
+            expect(found_value.sec).to eq(0)
+            expect(found_value.zone).to eq("EST")
           end
         end
       end
     end
 
-    # context "when the value is a DateTime" do
-    #   let(:attr) { :datetime }
+    context "when the attribute's value is a Time" do
+      let(:attr_base) { :time }
 
-    #   it_behaves_like "a time-ish object"
-    # end
+      it_behaves_like "a time-ish attribute"
+    end
 
-    # TODO: When the value is something else
+    context "when the value is a DateTime" do
+      let(:attr_base) { :datetime }
+
+      it_behaves_like "a time-ish attribute"
+    end
+
+    context "when the value is a string" do
+      let(:attr) { :string }
+
+      it "returns that value, unmodified" do
+        expect(found_value).to eq("foobar")
+      end
+    end
   end
 
   # TODO:


### PR DESCRIPTION
### Why?

The use-case I'm trying to solve is that I have an admin in US Eastern timezone, who is managing users across the US. Having all times shown in UTC is a poor UX for these admins, so I'd like to display things in EST by default, and override in other places.

The closes solution I could find is documented in this StackOverflow answer: https://stackoverflow.com/a/22791139/1202488

```rb
ActiveAdmin.setup do |config|
  # ...
  config.before_action do
    Time.zone = 'Eastern Time (US & Canada)'
  end
  # ...
end
```

The problem with this solution is it's setting `Time.zone`, which gets used across all controllers.

## What changed?

I added a new config option called `display_timezone`, which defaults to UTC and gets used when displaying dates and times (in conjunction with the existing `localize_format` option.

I also added this option to the initializer generator and documented it.