### PR TITLE
Drop support for ruby 2.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ version: 2.1
     command: |
       # The parts number is the total jobs count plus the lint job,
       # This number should match the number of jobs under upload_coverage/requires
-      coverage/test-reporter sum-coverage coverage/codeclimate.*.json --parts 22 --output coverage/codeclimate.total.json
+      coverage/test-reporter sum-coverage coverage/codeclimate.*.json --parts 16 --output coverage/codeclimate.total.json
       coverage/test-reporter upload-coverage --input coverage/codeclimate.total.json
 
 .save_test_app_to_workspace: &save_test_app_to_workspace
@@ -244,39 +244,6 @@ jobs:
       - *format_coverage
       - *save_coverage
 
-  ruby23rails50:
-    docker:
-      - image: circleci/ruby:2.3.8-node-browsers
-        user: root
-
-    environment:
-      BUNDLE_GEMFILE: gemfiles/rails_50.gemfile
-
-    steps:
-      *test_steps
-
-  ruby23rails51:
-    docker:
-      - image: circleci/ruby:2.3.8-node-browsers
-        user: root
-
-    environment:
-      BUNDLE_GEMFILE: gemfiles/rails_51.gemfile
-
-    steps:
-      *test_steps
-
-  ruby23rails52:
-    docker:
-      - image: circleci/ruby:2.3.8-node-browsers
-        user: root
-
-    environment:
-      BUNDLE_GEMFILE: Gemfile
-
-    steps:
-      *test_steps
-
   ruby24rails50:
     docker:
       - image: circleci/ruby:2.4.6-node-browsers
@@ -398,42 +365,6 @@ jobs:
     steps:
       *test_steps
 
-  jruby91rails50:
-    docker:
-      - image: circleci/jruby:9.1.17.0-node-browsers
-        user: root
-
-    environment:
-      BUNDLE_GEMFILE: gemfiles/rails_50.gemfile
-      JRUBY_OPTS: -J-Xmx1024m --dev --debug
-
-    steps:
-      *test_steps
-
-  jruby91rails51:
-    docker:
-      - image: circleci/jruby:9.1.17.0-node-browsers
-        user: root
-
-    environment:
-      BUNDLE_GEMFILE: gemfiles/rails_51.gemfile
-      JRUBY_OPTS: -J-Xmx1024m --dev --debug
-
-    steps:
-      *test_steps
-
-  jruby91rails52:
-    docker:
-      - image: circleci/jruby:9.1.17.0-node-browsers
-        user: root
-
-    environment:
-      BUNDLE_GEMFILE: Gemfile
-      JRUBY_OPTS: -J-Xmx1024m --dev --debug
-
-    steps:
-      *test_steps
-
   jruby92rails50:
     docker:
       - image: circleci/jruby:9.2.7.0-node-browsers
@@ -518,18 +449,6 @@ workflows:
           requires:
             - setup_coverage
 
-      - ruby23rails50:
-          requires:
-            - testapp50
-
-      - ruby23rails51:
-          requires:
-            - testapp51
-
-      - ruby23rails52:
-          requires:
-            - testapp52
-
       - ruby24rails50:
           requires:
             - testapp50
@@ -574,18 +493,6 @@ workflows:
           requires:
             - testapp60
 
-      - jruby91rails50:
-          requires:
-            - testapp50
-
-      - jruby91rails51:
-          requires:
-            - testapp51
-
-      - jruby91rails52:
-          requires:
-            - testapp52
-
       - jruby92rails50:
           requires:
             - testapp50
@@ -606,10 +513,6 @@ workflows:
           requires:
             - lint_and_docs
 
-            - ruby23rails50
-            - ruby23rails51
-            - ruby23rails52
-
             - ruby24rails50
             - ruby24rails51
             - ruby24rails52
@@ -623,10 +526,6 @@ workflows:
             - ruby26rails51
             - ruby26rails52
             - ruby26rails60
-
-            - jruby91rails50
-            - jruby91rails51
-            - jruby91rails52
 
             - jruby92rails50
             - jruby92rails51

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ require: rubocop-rspec
 
 AllCops:
   DisabledByDefault: true
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
   Exclude:
     - tmp/rails/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Removals
+
+* Support for ruby 2.3 has been removed. [#5751] by [@deivid-rodriguez]
+
 ## 2.0.0 [☰](https://github.com/activeadmin/activeadmin/compare/v2.0.0.rc2..v2.0.0)
 
 _No changes_.
@@ -435,6 +439,7 @@ Please check [0-6-stable] for previous changes.
 [#5662]: https://github.com/activeadmin/activeadmin/pull/5662
 [#5726]: https://github.com/activeadmin/activeadmin/pull/5726
 [#5738]: https://github.com/activeadmin/activeadmin/pull/5738
+[#5751]: https://github.com/activeadmin/activeadmin/pull/5751
 
 [@5t111111]: https://github.com/5t111111
 [@aarek]: https://github.com/aarek

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.extra_rdoc_files = %w[CHANGELOG.md CODE_OF_CONDUCT.md CONTRIBUTING.md README.md]
 
-  s.required_ruby_version = '>= 2.3'
+  s.required_ruby_version = '>= 2.4'
 
   s.add_dependency 'arbre', '~> 1.2', '>= 1.2.1'
   s.add_dependency 'formtastic', '~> 3.1'


### PR DESCRIPTION
Support for it has ended: https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/