### PR TITLE
Fix crash when rendering comments from custom controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 * Ensure application gets reloaded only once. [#5740] by [@jscheid]
+* Crash when rendering comments from a custom controller block. [#5758] by [@deivid-rodriguez]
 
 ### Removals
 
@@ -445,6 +446,7 @@ Please check [0-6-stable] for previous changes.
 [#5738]: https://github.com/activeadmin/activeadmin/pull/5738
 [#5740]: https://github.com/activeadmin/activeadmin/pull/5740
 [#5751]: https://github.com/activeadmin/activeadmin/pull/5751
+[#5758]: https://github.com/activeadmin/activeadmin/pull/5758
 
 [@5t111111]: https://github.com/5t111111
 [@aarek]: https://github.com/aarek

--- a/features/comments/commenting.feature
+++ b/features/comments/commenting.feature
@@ -177,6 +177,25 @@ Feature: Commenting
     And I should see "Displaying comments 51 - 70 of 70 in total"
     And I should not see the pagination "Next" link
 
+  Scenario: Commments through explicit helper from custom controller
+    Given a post with the title "Hello World" written by "Jane Doe" exists
+    And a show configuration of:
+      """
+        ActiveAdmin.register Post do
+          controller do
+            def show
+              @post = Post.find(params[:id])
+              show!
+            end
+          end
+
+          show do |post|
+            active_admin_comments
+          end
+        end
+      """
+    Then I should be able to add a comment
+
   @authorization
   Scenario: Not authorized to list comments
     Given 5 comments added by admin with an email "commenter@example.com"

--- a/lib/active_admin/base_controller/authorization.rb
+++ b/lib/active_admin/base_controller/authorization.rb
@@ -18,6 +18,7 @@ module ActiveAdmin
 
         helper_method :authorized?
         helper_method :authorize!
+        helper_method :active_admin_authorization
       end
 
       protected


### PR DESCRIPTION
When we have a custom controller block, the `active_admin_authorization` method wouldn't be available, and that method is called from the `active_admin_comments` helper.

We fix the issue by explicitly declaring it as a helper.

Fixes #5754.