### PR TITLE
Fix broken link in active_admin.rb template

### DIFF
--- a/lib/generators/active_admin/install/templates/active_admin.rb.erb
+++ b/lib/generators/active_admin/install/templates/active_admin.rb.erb
@@ -163,7 +163,10 @@ ActiveAdmin.setup do |config|
   #
   # Set the localize format to display dates and times.
   # To understand how to localize your app with I18n, read more at
-  # https://github.com/svenfuchs/i18n/blob/master/lib%2Fi18n%2Fbackend%2Fbase.rb#L52
+  # https://guides.rubyonrails.org/i18n.html
+  #
+  # You can run `bin/rails runner 'puts I18n.t("date.formats")'` to see the
+  # available formats in your application.
   #
   config.localize_format = :long
 


### PR DESCRIPTION
Fixed broken link and improved the description by adding another link, to `active_admin.rb` template, section `Localize Date/Time Format`