### PR TITLE
Make easy to find where the controller method is redefined

### DIFF
--- a/lib/active_admin/resource_dsl.rb
+++ b/lib/active_admin/resource_dsl.rb
@@ -133,7 +133,7 @@ module ActiveAdmin
     # action.
     #
     def action(set, name, options = {}, &block)
-      warn "Warning: method `#{name}` already defined" if controller.method_defined?(name)
+      warn "Warning: method `#{name}` already defined in #{controller.name}" if controller.method_defined?(name)
 
       set << ControllerAction.new(name, options)
       title = options.delete(:title)

--- a/spec/unit/action_builder_spec.rb
+++ b/spec/unit/action_builder_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe 'defining actions from registration blocks', type: :controller do
       end
 
       it 'writes warning to $stderr' do
-        expect($stderr.string).to include('Warning: method `process` already defined')
+        expect($stderr.string).to include('Warning: method `process` already defined in Admin::PostsController')
       end
     end
 
@@ -149,7 +149,7 @@ RSpec.describe 'defining actions from registration blocks', type: :controller do
       end
 
       it 'writes warning to $stderr' do
-        expect($stderr.string).to include('Warning: method `process` already defined')
+        expect($stderr.string).to include('Warning: method `process` already defined in Admin::PostsController')
       end
     end
   end


### PR DESCRIPTION
Why
---

I make many controllers which have same named actions by activeadmin.
It is too difficult to find where the method is redefined even if the warning message was shown.