### PR TITLE
Fix duplicate namespace when using config.pundit_policy_namespace

### DIFF
--- a/lib/active_admin/pundit_adapter.rb
+++ b/lib/active_admin/pundit_adapter.rb
@@ -57,7 +57,7 @@ module ActiveAdmin
     private
 
     def namespace(object)
-      if ActiveAdmin.application.pundit_policy_namespace
+      if ActiveAdmin.application.pundit_policy_namespace && !object.class.to_s.include?(ActiveAdmin.application.pundit_policy_namespace.to_s.camelize)
         [ActiveAdmin.application.pundit_policy_namespace.to_sym, object]
       else
         object


### PR DESCRIPTION
Hi,

When using `config.pundit_policy_namespace = :active_admin` when the object namespace is already `ActiveAdmin::PagePolicy` results of trying to find `ActiveAdmin::ActiveAdmin::PagePolicy`. Other models inside `ActiveAdmin` are fine. Only no models policy as `Page` are impacted.

This PR is fixing that.

