### PR TITLE
Re-use I18n translations of formtastic ~ Labels

### DIFF
--- a/lib/active_admin/filters/active_filter.rb
+++ b/lib/active_admin/filters/active_filter.rb
@@ -66,7 +66,8 @@ module ActiveAdmin
       def filter_label
         return unless filter
 
-        filter[:label]
+        filter[:label] ||
+          I18n.t(name, scope: ['formtastic', 'labels'], default: '').presence
       end
 
       #@return Ransack::Nodes::Attribute
@@ -75,7 +76,7 @@ module ActiveAdmin
       end
 
       def name
-        condition_attribute.attr_name
+        condition.attributes.map(&:name).join("_#{condition.combinator}_")
       end
 
       def ransack_predicate_name

--- a/lib/active_admin/filters/active_filter.rb
+++ b/lib/active_admin/filters/active_filter.rb
@@ -76,7 +76,7 @@ module ActiveAdmin
       end
 
       def name
-        condition.attributes.map(&:name).join("_#{condition.combinator}_")
+        condition_attribute.attr_name
       end
 
       def ransack_predicate_name

--- a/lib/active_admin/filters/active_filter.rb
+++ b/lib/active_admin/filters/active_filter.rb
@@ -66,8 +66,7 @@ module ActiveAdmin
       def filter_label
         return unless filter
 
-        filter[:label] ||
-          I18n.t(name, scope: ['formtastic', 'labels'], default: '').presence
+        filter[:label] || I18n.t(name, scope: ['formtastic', 'labels'], default: nil)
       end
 
       #@return Ransack::Nodes::Attribute

--- a/spec/unit/filters/active_filter_spec.rb
+++ b/spec/unit/filters/active_filter_spec.rb
@@ -29,8 +29,20 @@ RSpec.describe ActiveAdmin::Filters::ActiveFilter do
     expect(subject.values).to eq([post.title])
   end
 
-  it 'should have valid label' do
-    expect(subject.label).to eq("Title equals")
+  describe 'label' do
+    context 'by default' do
+      it 'should have valid label' do
+        expect(subject.label).to eq("Title equals")
+      end
+    end
+
+    context 'with formtastic translations' do
+      it 'should pick up formtastic label' do
+        with_translation formtastic: { labels: { title: 'Supertitle' } } do
+          expect(subject.label).to eq("Supertitle equals")
+        end
+      end
+    end
   end
 
   it 'should pick predicate name translation' do


### PR DESCRIPTION
# Todo

- [x] Implemente fix
- [x] Fix broken specs
- [x] Add specs

# Description

I have this code:

```ruby
# app/admin/user.rb
filter :username_or_email, as: :string
```

```yml
en:
  formtastic:
    labels:
      username_or_email: Username or E-mail
```

(:top: this is the right way to translate things in formtastic)

---

That code creates this filter:

![Screenshot from 2019-06-04 12-38-05](https://user-images.githubusercontent.com/3450257/58873025-a2d41c80-86c5-11e9-9416-61ba563f2ffa.png)

If i use it, in the Active Filters Widget I get (:bug:) :

![Screenshot from 2019-06-04 12-39-59](https://user-images.githubusercontent.com/3450257/58873141-e6c72180-86c5-11e9-8724-a5fe755e30d3.png)

---

My fix uses the `formtastic` translations if they exist:

![Screenshot from 2019-06-04 12-41-24](https://user-images.githubusercontent.com/3450257/58873205-16762980-86c6-11e9-8368-1745371cf68e.png)


