### PR TITLE
Fix order of versions for diff of 2.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 2.1.0 [☰](https://github.com/activeadmin/activeadmin/compare/v2.1.0..v2.0.0)
+## 2.1.0 [☰](https://github.com/activeadmin/activeadmin/compare/v2.0.0..v2.1.0)
 
 ### Bug Fixes
 


### PR DESCRIPTION
Putting the newer version last ensures that we get the expected diff. Otherwise, we see additions and removals switched.