### PR TITLE
Add a minimal git history to generated test apps

### DIFF
--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -142,3 +142,6 @@ if ENV['RAILS_ENV'] == 'test'
 
   rake "parallel:drop parallel:create parallel:load_schema", env: ENV['RAILS_ENV']
 end
+
+git add: "."
+git commit: "-m 'Bare application'"

--- a/spec/support/rails_template_with_data.rb
+++ b/spec/support/rails_template_with_data.rb
@@ -329,3 +329,6 @@ append_file "db/seeds.rb", "\n\n" + <<-RUBY.strip_heredoc
 RUBY
 
 rake 'db:seed'
+
+git add: '.'
+git commit: "-m 'Bare application with data'"


### PR DESCRIPTION
It's very common to make experimental modifications to test applications. This makes it very easy to go back to the freshly generated application without having to regenerate it, by running `git checkout .`, or to even keep track of the experimental changes being done using git.