### PR TITLE
Fix pundit policy retrieving on an edge case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+* Fix pundit policy retrieving for static pages when the pundit namespace is :active_admin. [#5777] by [@kwent]
+
 ## 2.1.0 [☰](https://github.com/activeadmin/activeadmin/compare/v2.0.0..v2.1.0)
 
 ### Bug Fixes
@@ -454,6 +458,7 @@ Please check [0-6-stable] for previous changes.
 [#5740]: https://github.com/activeadmin/activeadmin/pull/5740
 [#5751]: https://github.com/activeadmin/activeadmin/pull/5751
 [#5758]: https://github.com/activeadmin/activeadmin/pull/5758
+[#5777]: https://github.com/activeadmin/activeadmin/pull/5777
 
 [@5t111111]: https://github.com/5t111111
 [@aarek]: https://github.com/aarek
@@ -490,6 +495,7 @@ Please check [0-6-stable] for previous changes.
 [@johnnyshields]: https://github.com/johnnyshields
 [@kjeldahl]: https://github.com/kjeldahl
 [@kobeumut]: https://github.com/kobeumut
+[@kwent]: https://github.com/kwent
 [@leio10]: https://github.com/leio10
 [@markstory]: https://github.com/markstory
 [@mauriciopasquier]: https://github.com/mauriciopasquier

--- a/lib/active_admin/pundit_adapter.rb
+++ b/lib/active_admin/pundit_adapter.rb
@@ -57,8 +57,8 @@ module ActiveAdmin
     private
 
     def namespace(object)
-      if ActiveAdmin.application.pundit_policy_namespace
-        [ActiveAdmin.application.pundit_policy_namespace.to_sym, object]
+      if default_policy_namespace && !object.class.to_s.include?(default_policy_namespace.to_s.camelize)
+        [default_policy_namespace.to_sym, object]
       else
         object
       end
@@ -70,6 +70,10 @@ module ActiveAdmin
 
     def default_policy(user, subject)
       default_policy_class.new(user, subject)
+    end
+
+    def default_policy_namespace
+      ActiveAdmin.application.pundit_policy_namespace
     end
 
   end

--- a/spec/unit/pundit_adapter_spec.rb
+++ b/spec/unit/pundit_adapter_spec.rb
@@ -130,5 +130,17 @@ RSpec.describe ActiveAdmin::PunditAdapter do
         end
       end
     end
+
+    context "when retrieve_policy is given a page and namespace is :active_admin" do
+      let(:page) { namespace.register_page "Dashboard" }
+
+      subject(:policy) { auth.retrieve_policy(page) }
+
+      before do
+        allow(ActiveAdmin.application).to receive(:pundit_policy_namespace).and_return :active_admin
+      end
+
+      it("should return page policy instance") { is_expected.to be_instance_of(ActiveAdmin::PagePolicy) }
+    end
   end
 end


### PR DESCRIPTION
When retrieving the policy for an `ActiveAdmin::Page`, and the pundit namespace is `:active_admin`, we need an extra check so that the right policy is properly picked up.

This is a finished version of #5762.