### PR TITLE
Drop unnecessary stuff

### DIFF
--- a/lib/active_admin/filters/active_filter.rb
+++ b/lib/active_admin/filters/active_filter.rb
@@ -26,8 +26,7 @@ module ActiveAdmin
       end
 
       def label
-        # TODO: to remind us to go back to the simpler str.downcase once we support ruby >= 2.4 only.
-        translated_predicate = predicate_name.mb_chars.downcase.to_s
+        translated_predicate = predicate_name.downcase
         if filter_label && filter_label.is_a?(Proc)
           "#{filter_label.call} #{translated_predicate}"
         elsif filter_label

--- a/spec/unit/page_spec.rb
+++ b/spec/unit/page_spec.rb
@@ -31,8 +31,7 @@ module ActiveAdmin
       end
 
       it "returns the singular, lowercase name" do
-        expect(config.resource_name.singular)
-          .to eq "chocolate i l#{RUBY_VERSION >= '2.4.0' ? 'ø' : 'Ø'}ve you!"
+        expect(config.resource_name.singular).to eq "chocolate i løve you!"
       end
     end
 


### PR DESCRIPTION
We no longer need this, since we support rubies above or equal to 2.4.