### PR TITLE
Relax dependency on railties

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       inherited_resources (~> 1.7)
       jquery-rails (~> 4.2)
       kaminari (~> 1.0, >= 1.0.1)
-      railties (>= 5.0, < 6.0)
+      railties (>= 5.0, < 6.1)
       ransack (~> 2.1, >= 2.1.1)
       sassc-rails (~> 2.1)
       sprockets (>= 3.0, < 4.1)

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'inherited_resources', '~> 1.7'
   s.add_dependency 'jquery-rails', '~> 4.2'
   s.add_dependency 'kaminari', '~> 1.0', '>= 1.0.1'
-  s.add_dependency 'railties', '>= 5.0', '< 6.0'
+  s.add_dependency 'railties', '>= 5.0', '< 6.1'
   s.add_dependency 'ransack', '~> 2.1', '>= 2.1.1'
   s.add_dependency 'sassc-rails', '~> 2.1'
   s.add_dependency 'sprockets', '>= 3.0', '< 4.1'

--- a/gemfiles/rails_50.gemfile.lock
+++ b/gemfiles/rails_50.gemfile.lock
@@ -8,7 +8,7 @@ PATH
       inherited_resources (~> 1.7)
       jquery-rails (~> 4.2)
       kaminari (~> 1.0, >= 1.0.1)
-      railties (>= 5.0, < 6.0)
+      railties (>= 5.0, < 6.1)
       ransack (~> 2.1, >= 2.1.1)
       sassc-rails (~> 2.1)
       sprockets (>= 3.0, < 4.1)

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -8,7 +8,7 @@ PATH
       inherited_resources (~> 1.7)
       jquery-rails (~> 4.2)
       kaminari (~> 1.0, >= 1.0.1)
-      railties (>= 5.0, < 6.0)
+      railties (>= 5.0, < 6.1)
       ransack (~> 2.1, >= 2.1.1)
       sassc-rails (~> 2.1)
       sprockets (>= 3.0, < 4.1)

--- a/gemfiles/rails_60.gemfile.lock
+++ b/gemfiles/rails_60.gemfile.lock
@@ -8,7 +8,7 @@ PATH
       inherited_resources (~> 1.7)
       jquery-rails (~> 4.2)
       kaminari (~> 1.0, >= 1.0.1)
-      railties (>= 5.0, < 6.0)
+      railties (>= 5.0, < 6.1)
       ransack (~> 2.1, >= 2.1.1)
       sassc-rails (~> 2.1)
       sprockets (>= 3.0, < 4.1)


### PR DESCRIPTION
This gets us ready to support the final release of Rails 6.0, and also allows activeadmin to be tried against Rails master more easily.