### PR TITLE
Fix migration generator against Rails master

### DIFF
--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -4,38 +4,42 @@ create_file 'app/assets/stylesheets/some-random-css.css'
 create_file 'app/assets/javascripts/some-random-js.js'
 create_file 'app/assets/images/a/favicon.ico'
 
+require 'active_admin/dependency'
+
+timestamps = ActiveAdmin::Dependency.rails?('>= 6.1.0.a') ? '--timestamps' : 'created_at:datetime updated_at:datetime'
+
 generate :migration, 'create_posts title:string body:text published_date:date author_id:integer ' +
-  'position:integer custom_category_id:integer starred:boolean foo_id:integer created_at:datetime updated_at:datetime'
+  "position:integer custom_category_id:integer starred:boolean foo_id:integer #{timestamps}"
 
 copy_file File.expand_path('templates/models/post.rb', __dir__), 'app/models/post.rb'
 copy_file File.expand_path('templates/post_decorator.rb', __dir__), 'app/models/post_decorator.rb'
 
 generate :migration, 'create_blog_posts title:string body:text published_date:date author_id:integer ' +
-  'position:integer custom_category_id:integer starred:boolean foo_id:integer created_at:datetime updated_at:datetime'
+  "position:integer custom_category_id:integer starred:boolean foo_id:integer #{timestamps}"
 
 copy_file File.expand_path('templates/models/blog/post.rb', __dir__), 'app/models/blog/post.rb'
 
-generate :migration, 'create_profiles user_id:integer bio:text created_at:datetime updated_at:datetime'
+generate :migration, "create_profiles user_id:integer bio:text #{timestamps}"
 
 copy_file File.expand_path('templates/models/user.rb', __dir__), 'app/models/user.rb'
 
-generate :migration, 'create_users type:string first_name:string last_name:string username:string age:integer encrypted_password:string created_at:datetime updated_at:datetime'
+generate :migration, "create_users type:string first_name:string last_name:string username:string age:integer encrypted_password:string #{timestamps}"
 
 copy_file File.expand_path('templates/models/profile.rb', __dir__), 'app/models/profile.rb'
 
 generate :model, 'publisher --migration=false --parent=User'
 
-generate :migration, 'create_categories name:string description:text created_at:datetime updated_at:datetime'
+generate :migration, "create_categories name:string description:text #{timestamps}"
 
 copy_file File.expand_path('templates/models/category.rb', __dir__), 'app/models/category.rb'
 
 generate :model, 'store name:string user_id:integer'
 
-generate :migration, 'create_tags name:string created_at:datetime updated_at:datetime'
+generate :migration, "create_tags name:string #{timestamps}"
 
 copy_file File.expand_path('templates/models/tag.rb', __dir__), 'app/models/tag.rb'
 
-generate :migration, 'create_taggings post_id:integer tag_id:integer position:integer created_at:datetime updated_at:datetime'
+generate :migration, "create_taggings post_id:integer tag_id:integer position:integer #{timestamps}"
 
 copy_file File.expand_path('templates/models/tagging.rb', __dir__), 'app/models/tagging.rb'
 


### PR DESCRIPTION
Current Rails master (6.1.0.alpha) [adds a new `--timestamps` option](https://github.com/rails/rails/commit/93d2090011b5ccab504b8aeabf6a95b23193a689) to the migration generator that it's true by default. So to get migrations running under Rails master, we need to make sure we don't generate duplicate timestamp columns by using both explicit columns and the new (default) option at the same time.