### PR TITLE
Skip error when running `bin/rake local`

### DIFF
--- a/tasks/local.rake
+++ b/tasks/local.rake
@@ -10,16 +10,18 @@ task :local do
   # Discard the "local" argument (name of the task)
   argv = ARGV[1..-1]
 
-  # If it's a rails command, auto add the rails script
-  if %w(generate console server dbconsole g c s runner).include?(argv[0]) || argv[0] =~ /db:/
-    argv.unshift('rails')
-  end
+  if argv.any?
+    # If it's a rails command, auto add the rails script
+    if %w(generate console server dbconsole g c s runner).include?(argv[0]) || argv[0] =~ /db:/
+      argv.unshift('rails')
+    end
 
-  command = ['bundle', 'exec', *argv].join(' ')
-  gemfile = ENV['BUNDLE_GEMFILE'] || File.expand_path("../Gemfile", __dir__)
-  env = { 'BUNDLE_GEMFILE' => gemfile }
+    command = ['bundle', 'exec', *argv].join(' ')
+    gemfile = ENV['BUNDLE_GEMFILE'] || File.expand_path("../Gemfile", __dir__)
+    env = { 'BUNDLE_GEMFILE' => gemfile }
 
-  Dir.chdir(app_folder) do
-    Bundler.with_original_env { Kernel.exec(env, command) }
+    Dir.chdir(app_folder) do
+      Bundler.with_original_env { Kernel.exec(env, command) }
+    end
   end
 end


### PR DESCRIPTION
Normally, you would run `bin/rake local server`, `bin/rake local console`, or any other Rails command as the second argument. That creates a test application with seed data if it doesn't already exist, and then runs the specified Rails command on it.

However, if you just run `bin/rake local`, it will generate the application but then fail with the error `bundler: exec needs a command to run`. Instead of doing that, only generate the test application and exit without error.