### PR TITLE
Persist the correct Gemfile to each test app

### DIFF
--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -49,6 +49,10 @@ gsub_file 'config/environments/test.rb', /  config.cache_classes = true/, <<-RUB
 
 RUBY
 
+gsub_file 'config/boot.rb', /^.*BUNDLE_GEMFILE.*$/, <<-RUBY
+  ENV['BUNDLE_GEMFILE'] = "#{File.expand_path(ENV['BUNDLE_GEMFILE'])}"
+RUBY
+
 # Setup Active Admin
 generate 'active_admin:install'
 


### PR DESCRIPTION
With this, we no longer need to mess with `BUNDLE_GEMFILE`'s when booting applications for different Rails versions, and each application will always use the right Gemfile. We can even boot applications from
the root folder like this: `tmp/rails/rails-6.0.0.rc1/bin/rails s` and it will just work.