### PR TITLE
Use CGI.unescape for non-Latin characters

### DIFF
--- a/lib/active_admin/view_helpers/breadcrumb_helper.rb
+++ b/lib/active_admin/view_helpers/breadcrumb_helper.rb
@@ -17,7 +17,7 @@ module ActiveAdmin
             config = parent && parent.resource_name.route_key == parts[index - 1] ? parent : active_admin_config
             name   = display_name config.find_resource part
           end
-          name ||= I18n.t "activerecord.models.#{part.singularize}", count: ::ActiveAdmin::Helpers::I18n::PLURAL_MANY_COUNT, default: part.titlecase
+          name ||= CGI.unescape I18n.t "activerecord.models.#{part.singularize}", count: ::ActiveAdmin::Helpers::I18n::PLURAL_MANY_COUNT, default: part.titlecase
 
           # Don't create a link if the resource's show action is disabled
           if !config || config.defined_actions.include?(:show)


### PR DESCRIPTION
non-Latin characters are being shown decoded, so this fix to show them correctly.
![activeadmin_fix](https://user-images.githubusercontent.com/721987/60015712-29609600-9695-11e9-8e1d-0b77ff8d7bf8.png)