### PR TITLE
Update `status_tag` to support separate `nil` and `false` boolean cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Minor
 
+* The `status_tag` component now supports different labels for `false` and `nil` boolean cases through the locale. Both default to display "No" for backwards compatibility. [#5794] by [@javierjulio]
 * Add Macedonian locale. [#5710] by [@violeta-p]
 
 ### Bug Fixes
@@ -466,6 +467,7 @@ Please check [0-6-stable] for previous changes.
 [#5751]: https://github.com/activeadmin/activeadmin/pull/5751
 [#5758]: https://github.com/activeadmin/activeadmin/pull/5758
 [#5777]: https://github.com/activeadmin/activeadmin/pull/5777
+[#5794]: https://github.com/activeadmin/activeadmin/pull/5794
 
 [@5t111111]: https://github.com/5t111111
 [@aarek]: https://github.com/aarek

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -39,6 +39,7 @@ ar:
     status_tag:
       "yes": "نعم"
       "no": "لا"
+      "unset": "لا"
     main_content: "الرجاء تنفيذ %{model}#main_content لعرض المحتوى."
     logout: "تسجيل الخروج"
     powered_by: "تنفيذ %{active_admin} %{version}"

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -37,8 +37,8 @@ ar:
       current_filters: "المُرشحات الحاليّة:"
       no_current_filters: "بدون"
     status_tag:
-      'yes': "نعم"
-      'no': "لا"
+      "yes": "نعم"
+      "no": "لا"
     main_content: "الرجاء تنفيذ %{model}#main_content لعرض المحتوى."
     logout: "تسجيل الخروج"
     powered_by: "تنفيذ %{active_admin} %{version}"

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -34,6 +34,7 @@ bg:
     status_tag:
       "yes": "Да"
       "no": "не"
+      "unset": "не"
     main_content: "Добавете %{model}#main_content за да видите съдържание."
     logout: "Изход"
     powered_by: "Задвижва се от %{active_admin} %{version}"

--- a/config/locales/bs.yml
+++ b/config/locales/bs.yml
@@ -34,6 +34,7 @@ bs:
     status_tag:
       "yes": "Da"
       "no": "Nema"
+      "unset": "Nema"
     main_content: "Molim Vas, implementirajte %{model}#main_content da biste prikazali sadržaj."
     logout: "Odjavi se"
     powered_by: "Powered by %{active_admin} %{version}"

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -35,6 +35,7 @@ ca:
     status_tag:
       "yes": "Sí"
       "no": "No"
+      "unset": "No"
     main_content: "Implementa %{model}#main_content per mostrar contingut."
     logout: "Desconnecta't"
     powered_by: "Powered by %{active_admin} %{version}"

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -34,6 +34,7 @@ cs:
     status_tag:
       "yes": "Ano"
       "no": "Ne"
+      "unset": "Ne"
     main_content: "Implementujte prosím %{model}#main_content pro zobrazení obsahu."
     logout: "Odhlásit"
     powered_by: "%{active_admin} %{version}"

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -40,6 +40,7 @@ da:
     status_tag:
       "yes": "Ja"
       "no": "Nej"
+      "unset": "Nej"
     main_content: "Implementer venligst %{model}#main_content for at vise noget indhold."
     logout: "Log ud"
     powered_by: "Powered by %{active_admin} %{version}"

--- a/config/locales/de-CH.yml
+++ b/config/locales/de-CH.yml
@@ -34,6 +34,7 @@
     status_tag:
       "yes": "Ja"
       "no": "Nicht"
+      "unset": "Nicht"
     main_content: "Bitte implementieren Sie %{model}#main_content, um Inhalte anzuzeigen."
     logout: "Abmelden"
     powered_by: "Powered by %{active_admin} %{version}"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -45,6 +45,7 @@ de:
     status_tag:
       "yes": "Ja"
       "no": "Nein"
+      "unset": "Nein"
     main_content: "Bitte implementieren Sie %{model}#main_content, um Inhalte anzuzeigen."
     logout: "Abmelden"
     powered_by: "Powered by %{active_admin} %{version}"

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -34,6 +34,7 @@ el:
     status_tag:
       "yes": "Ναι"
       "no": "Όχι"
+      "unset": "Όχι"
     main_content: "Παρακαλώ υλοποιήστε την %{model}#main_content για να εμφανίσετε περιεχόμενο."
     logout: "Αποσύνδεση"
     powered_by: "Powered by %{active_admin} %{version}"

--- a/config/locales/en-CA.yml
+++ b/config/locales/en-CA.yml
@@ -40,6 +40,7 @@
     status_tag:
       "yes": "Yes"
       "no": "No"
+      "unset": "No"
     main_content: "Please implement %{model}#main_content to display content."
     logout: "Logout"
     powered_by: "Powered by %{active_admin} %{version}"

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -40,6 +40,7 @@
     status_tag:
       "yes": "Yes"
       "no": "No"
+      "unset": "No"
     main_content: "Please implement %{model}#main_content to display content."
     logout: "Logout"
     powered_by: "Powered by %{active_admin} %{version}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,6 +63,7 @@ en:
     status_tag:
       "yes": "Yes"
       "no": "No"
+      "unset": "No"
     main_content: "Please implement %{model}#main_content to display content."
     logout: "Logout"
     powered_by: "Powered by %{active_admin} %{version}"

--- a/config/locales/eo.yml
+++ b/config/locales/eo.yml
@@ -45,6 +45,7 @@ eo:
     status_tag:
       "yes": "Jes"
       "no": "Ne"
+      "unset": "Ne"
     main_content: "Aldonu %{model}#main_content por montri la enhavon."
     logout: "Elsaluti"
     powered_by: "Povigita de %{active_admin} %{version}"

--- a/config/locales/es-MX.yml
+++ b/config/locales/es-MX.yml
@@ -34,6 +34,7 @@ es-MX:
     status_tag:
       "yes": "Sí"
       "no": "No"
+      "unset": "No"
     main_content: "Por favor implemente %{model}#main_content para mostrar contenido."
     logout: "Salir"
     powered_by: "Powered by %{active_admin} %{version}"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -63,6 +63,7 @@ es:
     status_tag:
       "yes": "Sí"
       "no": "No"
+      "unset": "No"
     main_content: "Por favor implemente %{model}#main_content para mostrar contenido."
     logout: "Salir"
     powered_by: "Funciona con %{active_admin} %{version}"

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -34,6 +34,7 @@ fa:
     status_tag:
       "yes": "بله"
       "no": "بدون"
+      "unset": "بدون"
     main_content: "لطفا %{model}#main_content را پیاده سازی کنید تا محتوی نمایش داده شود."
     logout: "خروج"
     powered_by: "قدرت گرفته از %{active_admin} %{version}"

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -34,6 +34,7 @@ fi:
     status_tag:
       "yes": "Kyllä"
       "no": "Ei"
+      "unset": "Ei"
     main_content: "Ole hyvä, käytä %{model}#main_content:ia nähdäksesi jotain."
     logout: "Kirjaudu ulos"
     powered_by: "Käyttää %{active_admin} %{version}:ia"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -44,6 +44,7 @@ fr:
     status_tag:
       "yes": "Oui"
       "no": "Non"
+      "unset": "Non"
     main_content: "Veuillez implémenter %{model}#main_content pour afficher le contenu."
     logout: "Déconnexion"
     powered_by: "Propulsé par %{active_admin} %{version}"

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -42,6 +42,7 @@ he:
     status_tag:
       "yes": "כן"
       "no": "לא"
+      "unset": "לא"
     main_content: "אנא הטמע את %{model}#main_content בכדי להציג תוכן."
     logout: "התנתקות"
     powered_by: "ממונע בעזרת %{active_admin} %{version}"

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -34,6 +34,7 @@ hr:
     status_tag:
       "yes": "Da"
       "no": "Nema"
+      "unset": "Nema"
     main_content: "Molim Vas, implementirajte %{model}#main_content da biste prikazali sadržaj."
     logout: "Odjavi se"
     powered_by: "Powered by %{active_admin} %{version}"

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -38,6 +38,7 @@ hu:
     status_tag:
       "yes": "Igen"
       "no": "Nem"
+      "unset": "Nem"
     main_content: "Kérem, implementálja a %{model}#main_content metódust a tartalom megjelenítéséhez."
     logout: "Kilépés"
     powered_by: "Powered by %{active_admin} %{version}"

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -39,6 +39,7 @@ id:
     status_tag:
       "yes": "Ya"
       "no": "Tidak"
+      "unset": "Tidak"
     main_content: "Harap mengimplementasikan %{model}#main_content untuk menampilkan konten."
     logout: "Keluar"
     powered_by: "Dibuat dengan %{active_admin} %{version}"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -45,6 +45,7 @@ it:
     status_tag:
       "yes": "Sì"
       "no": "No"
+      "unset": "No"
     main_content: "Devi implemetare %{model}#main_content per mostrarne il contenuto."
     logout: "Esci"
     powered_by: "Powered by %{active_admin} %{version}"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -44,6 +44,7 @@ ja:
     status_tag:
       "yes": "はい"
       "no": "いいえ"
+      "unset": "いいえ"
     main_content: "内容を表示するために %{model}#main_content を実装してください。"
     logout: "ログアウト"
     powered_by: "Powered by %{active_admin} %{version}"

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -39,6 +39,7 @@ ko:
     status_tag:
       "yes": "있음"
       "no": "없음"
+      "unset": "없음"
     main_content: "내용을 보시려면 %{model}#main_content의 코드를 먼저 구현해 주시기 바랍니다."
     logout: "로그아웃"
     powered_by: "Powered by %{active_admin} %{version}"

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -43,6 +43,7 @@ lt:
     status_tag:
       "yes": "Taip"
       "no": "Nėra"
+      "unset": "Nėra"
     main_content: 'Prašome realizuoti %{model}#main_content turiniui vaizduoti.'
     logout: 'Išeiti'
     powered_by: "Powered by %{active_admin} %{version}"

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -34,6 +34,7 @@ lv:
     status_tag:
       "yes": "Jā"
       "no": "Nē"
+      "unset": "Nē"
     main_content: "Lūdzu implementēt %{model}#main_content, lai rādītos saturs."
     logout: "Iziet"
     powered_by: "Powered by %{active_admin} %{version}"

--- a/config/locales/mk.yml
+++ b/config/locales/mk.yml
@@ -52,6 +52,7 @@ mk:
     status_tag:
       "yes": "Да"
       "no": "Не"
+      "unset": "Не"
     main_content: "Ве замолуваме имплементирајте %{model}#main_content за да прикажете содржина."
     logout: "Одјави се"
     powered_by: "Овозможено од %{active_admin} %{version}"

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -43,6 +43,7 @@ nb:
     status_tag:
       "yes": "Ja"
       "no": "Nei"
+      "unset": "Nei"
     main_content: "Vennligst implementer %{model}#main_content for å vise innhold."
     logout: "Logg ut"
     powered_by: "Powered by %{active_admin} %{version}"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -45,6 +45,7 @@ nl:
     status_tag:
       "yes": "Ja"
       "no": "Geen"
+      "unset": "Geen"
     main_content: "Implementeer %{model}#main_content om de content weer te geven."
     logout: "Uitloggen"
     powered_by: "Mogelijk gemaakt door %{active_admin} %{version}"

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -67,6 +67,7 @@ pl:
     status_tag:
       "yes": "Tak"
       "no": "Nie"
+      "unset": "Nie"
     main_content: "Zaimplementuj %{model}#main_content aby wyświetlić treść."
     logout: "Wyloguj"
     powered_by: "Powered by %{active_admin} %{version}"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -44,6 +44,7 @@ pt-BR:
     status_tag:
       "yes": "Sim"
       "no": "Não"
+      "unset": "Não"
     main_content: "Por favor implemente %{model}#main_content para exibir conteúdo."
     logout: "Sair"
     powered_by: "Powered by %{active_admin} %{version}"

--- a/config/locales/pt-PT.yml
+++ b/config/locales/pt-PT.yml
@@ -34,6 +34,7 @@
     status_tag:
       "yes": "Sim"
       "no": "Não"
+      "unset": "Não"
     main_content: "Por favor implemente %{model}#main_content para mostrar o conteúdo."
     logout: "Sair"
     powered_by: "Powered by %{active_admin} %{version}"

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -34,6 +34,7 @@ ro:
     status_tag:
       "yes": "Da"
       "no": "Nu"
+      "unset": "Nu"
     main_content: "Va rugam sa implementati %{model}#main_content pentru a afisa continut."
     logout: "Iesire"
     powered_by: "Powered by %{active_admin} %{version}"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -41,6 +41,7 @@ ru:
     status_tag:
       "yes": "Да"
       "no": "Нет"
+      "unset": "Нет"
     main_content: "Создайте %{model}#main_content для отображения содержимого."
     logout: "Выйти"
     powered_by: "Работает на %{active_admin} %{version}"

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -34,6 +34,7 @@ sk:
     status_tag:
       "yes": "Áno"
       "no": "Nie"
+      "unset": "Nie"
     main_content: "Implementujte prosím %{model}#main_content pre zobrazenie obsahu."
     logout: "Odhlásiť"
     powered_by: "%{active_admin} %{version}"

--- a/config/locales/sv-SE.yml
+++ b/config/locales/sv-SE.yml
@@ -41,6 +41,7 @@
     status_tag:
       "yes": "Ja"
       "no": "Nej"
+      "unset": "Nej"
     main_content: "Implementera %{model}#main_content för att kunna visa något."
     logout: "Logga ut"
     powered_by: "Powered by %{active_admin} %{version}"

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -45,6 +45,7 @@ tr:
     status_tag:
       "yes": "Evet"
       "no": "Hayır"
+      "unset": "Hayır"
     main_content: "İçeriği görüntülemek için lütfen %{model}#main_content metodunu ekleyin."
     logout: "Çıkış Yap"
     powered_by: "%{active_admin} %{version} tarafından desteklenmektedir."

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -41,6 +41,7 @@ uk:
     status_tag:
       "yes": "Так"
       "no": "Ні"
+      "unset": "Ні"
     main_content: "Створіть %{model}#main_content для відображення вмісту."
     logout: "Вийти"
     powered_by: "Powered by %{active_admin} %{version}"

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -43,6 +43,7 @@ vi:
     status_tag:
       "yes": "Có"
       "no": "Không Có"
+      "unset": "Không Có"
     main_content: "Xin bổ sung %{model}#main_content để hiển thị nội dung."
     logout: "Đăng xuất"
     powered_by: "Powered by %{active_admin} %{version}"

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -44,6 +44,7 @@
     status_tag:
       "yes": "是"
       "no": "否"
+      "unset": "否"
     main_content: "请执行 %{model}#main_content 来显示内容."
     logout: "退出"
     powered_by: "Powered by %{active_admin} %{version}"

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -39,6 +39,7 @@
     status_tag:
       "yes": "是"
       "no": "否"
+      "unset": "否"
     main_content: "請實作 %{model}#main_content 以顯示內容。"
     logout: "登出"
     powered_by: "Powered by %{active_admin} %{version}"

--- a/docs/12-arbre-components.md
+++ b/docs/12-arbre-components.md
@@ -177,6 +177,19 @@ status_tag 'active', class: 'important', id: 'status_123', label: 'on'
 # => <span class='status_tag active important' id='status_123'>on</span>
 ```
 
+When providing a `true` or `false` value, the `status_tag` will display "Yes"
+or "No". This can be configured through the `"en.active_admin.status_tag"`
+locale.
+
+```ruby
+status_tag true
+# => <span class='status_tag yes'>Yes</span>
+```
+
+In the case that a boolean field is `nil`, it will display "No" as a default.
+But using the `"en.active_admin.status_tag.unset"` locale key, it can be
+configured to display something else.
+
 ## Tabs
 
 The Tabs component is helpful for saving page real estate. The first tab will be

--- a/lib/active_admin/views/components/status_tag.rb
+++ b/lib/active_admin/views/components/status_tag.rb
@@ -51,8 +51,10 @@ module ActiveAdmin
         case status
         when true, 'true'
           'Yes'
-        when false, 'false', nil
+        when false, 'false'
           'No'
+        when nil
+          'Unset'
         else
           status
         end
@@ -60,6 +62,8 @@ module ActiveAdmin
 
       def status_to_class(status)
         case status
+        when 'Unset'
+          'unset no'
         when String, Symbol
           status.to_s.titleize.gsub(/\s/, '').underscore
         else

--- a/spec/unit/views/components/status_tag_spec.rb
+++ b/spec/unit/views/components/status_tag_spec.rb
@@ -121,11 +121,18 @@ RSpec.describe ActiveAdmin::Views::StatusTag do
       describe '#class_list' do
         subject { super().class_list }
         it      { is_expected.to include('status_tag') }
+        it      { is_expected.to include('no') }
+        it      { is_expected.to include('unset') }
       end
 
       describe '#content' do
         subject { super().content }
         it      { is_expected.to eq('No') }
+        it 'uses the unset locale key to customize the label for the `nil` case' do
+          with_translation active_admin: { status_tag: { unset: 'Unknown' } } do
+            expect(subject).to eq('Unknown')
+          end
+        end
       end
     end
 


### PR DESCRIPTION
When using the `status_tag` component with boolean fields, both `nil` and `false` are treated the same and have the same output but without a way to modify that other than overriding the component.

My suggestion is to split those 2 conditions so for the `nil` case it would now return "Unset" but the locale will keep a display value of "No" for that locale key. That **will maintain backwards compatibility** so when `status_tag` is called with `nil` or `false` it will continue to display the same "No" label but provide the option to customize the label for the `nil` case only, leaving the `false` one as is.

## Todo List
- [x] Improve test case and description
- [x] Look into [updating the documentation](https://github.com/activeadmin/activeadmin/search?l=Markdown&q=status_tag&type=) to include a note on the "unset" case
 - [x] Add a note to the changelog?
- [x] Add “no” CSS class for unset case to preserve same output
- [x] Test CSS class output for unset case
- [x] Update all other locale files with new "unset" key