### PR TITLE
fix CSVBuilder not respecting global ":humanize_name" setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+* Fix CSVBuilder not respecting `ActiveAdmin.application.csv_options = { humanize_name: false }` setting. [#5800] by [@HappyKadaver]
+
 ## 2.2.0 [☰](https://github.com/activeadmin/activeadmin/compare/v2.1.0..v2.2.0)
 
 ### Enhancements
@@ -474,6 +478,7 @@ Please check [0-6-stable] for previous changes.
 [#5758]: https://github.com/activeadmin/activeadmin/pull/5758
 [#5777]: https://github.com/activeadmin/activeadmin/pull/5777
 [#5794]: https://github.com/activeadmin/activeadmin/pull/5794
+[#5800]: https://github.com/activeadmin/activeadmin/pull/5800
 [#5801]: https://github.com/activeadmin/activeadmin/pull/5801
 [#5802]: https://github.com/activeadmin/activeadmin/pull/5802
 
@@ -503,6 +508,7 @@ Please check [0-6-stable] for previous changes.
 [@Fivell]: https://github.com/Fivell
 [@glebtv]: https://github.com/glebtv
 [@gonzedge]: https://github.com/gonzedge
+[@HappyKadaver]: https://github.com/HappyKadaver
 [@innparusu95]: https://github.com/innparusu95
 [@ionut998]: https://github.com/ionut998
 [@jasl]: https://github.com/jasl

--- a/features/index/format_as_csv.feature
+++ b/features/index/format_as_csv.feature
@@ -79,6 +79,38 @@ Feature: Format as CSV
       | title | body |
       | Hello, World | (.*) |
 
+  Scenario: With humanize_name option turned off globally
+    Given a configuration of:
+    """
+      ActiveAdmin.application.csv_options = { humanize_name: false }
+      ActiveAdmin.register Post do
+      end
+    """
+    And a post exists
+    When I am on the index page for posts
+    And I follow "CSV"
+    Then I should download a CSV file with "," separator for "posts" containing:
+      | id  | title | body | published_date | position | starred | foo  | created_at | updated_at |
+      | (.*)| (.*)  | (.*) | (.*)           | (.*)     | (.*)    | (.*) | (.*)       | (.*)       |
+
+  Scenario: With humanize_name option turned off globally and enabled locally
+    Given a configuration of:
+    """
+      ActiveAdmin.application.csv_options = { humanize_name: false }
+      ActiveAdmin.register Post do
+        csv humanize_name: true do
+          column :title
+          column :body
+        end
+      end
+    """
+    And a post exists
+    When I am on the index page for posts
+    And I follow "CSV"
+    Then I should download a CSV file with "," separator for "posts" containing:
+      | Title | Body |
+      | (.*)  | (.*) |
+
   Scenario: With CSV option customization
     Given a configuration of:
     """

--- a/lib/active_admin/csv_builder.rb
+++ b/lib/active_admin/csv_builder.rb
@@ -33,7 +33,7 @@ module ActiveAdmin
     def initialize(options = {}, &block)
       @resource = options.delete(:resource)
       @columns = []
-      @options = options
+      @options = ActiveAdmin.application.csv_options.merge options
       @block = block
     end
 
@@ -44,7 +44,6 @@ module ActiveAdmin
     def build(controller, csv)
       @collection  = controller.send :find_collection, except: :pagination
       columns      = exec_columns controller.view_context
-      options      = ActiveAdmin.application.csv_options.merge self.options
       bom          = options.delete :byte_order_mark
       column_names = options.delete(:column_names) { true }
       csv_options  = options.except :encoding_options, :humanize_name

--- a/spec/unit/csv_builder_spec.rb
+++ b/spec/unit/csv_builder_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe ActiveAdmin::CSVBuilder do
     end
 
     it "should have proper separator" do
-      expect(builder.options).to eq({ col_sep: ";" })
+      expect(builder.options).to include(col_sep: ";")
     end
   end
 
@@ -174,7 +174,7 @@ RSpec.describe ActiveAdmin::CSVBuilder do
     end
 
     it "should have proper separator" do
-      expect(builder.options).to eq({ force_quotes: true })
+      expect(builder.options).to include(force_quotes: true)
     end
   end
 


### PR DESCRIPTION
fix CSVBuilder not respecting default ":humanize_name" setting in "ActiveAdmin.application.csv_options"

change two test cases to allow for extra options in CSVBuilder as long as it assumes any options directly passed to the initializer
fixes #5799

If someone can tell me how I can set ActiveAdmin.application.csv_options for a single spec without affecting other specs I will add some tests for this.