### PR TITLE
Make sure show page title is escaped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bug Fixes
 
 * Fix pundit policy retrieving for static pages when the pundit namespace is :active_admin. [#5777] by [@kwent]
+* Fix show page title not being properly escaped if title's content included HTML. [#5802] by [@deivid-rodriguez]
 
 ## 2.1.0 [☰](https://github.com/activeadmin/activeadmin/compare/v2.0.0..v2.1.0)
 
@@ -468,6 +469,7 @@ Please check [0-6-stable] for previous changes.
 [#5758]: https://github.com/activeadmin/activeadmin/pull/5758
 [#5777]: https://github.com/activeadmin/activeadmin/pull/5777
 [#5794]: https://github.com/activeadmin/activeadmin/pull/5794
+[#5802]: https://github.com/activeadmin/activeadmin/pull/5802
 
 [@5t111111]: https://github.com/5t111111
 [@aarek]: https://github.com/aarek

--- a/features/show/page_title_with_html.feature
+++ b/features/show/page_title_with_html.feature
@@ -1,0 +1,11 @@
+Feature: Show - Page Title with HTML
+
+  Page Title is escaped
+
+  Scenario: Set an HTML string as the title
+    Given a post with the title "<a href='https://somewhere-nasty.com/'>John Doe</a>" written by "Jane Doe" exists
+    And a show configuration of:
+    """
+      ActiveAdmin.register Post
+    """
+    Then I should see the page title "<a href='https://somewhere-nasty.com/'>John Doe</a>"

--- a/lib/active_admin/view_helpers/display_helper.rb
+++ b/lib/active_admin/view_helpers/display_helper.rb
@@ -15,7 +15,7 @@ module ActiveAdmin
       # Attempts to call any known display name methods on the resource.
       # See the setting in `application.rb` for the list of methods and their priority.
       def display_name(resource)
-        sanitize(render_in_context(resource, display_name_method_for(resource)).to_s) unless resource.nil?
+        ERB::Util.html_escape(render_in_context(resource, display_name_method_for(resource))) unless resource.nil?
       end
 
       # Looks up and caches the first available display name method.

--- a/spec/unit/view_helpers/breadcrumbs_spec.rb
+++ b/spec/unit/view_helpers/breadcrumbs_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe "Breadcrumbs" do
   include ActiveAdmin::ViewHelpers
-  include ActionView::Helpers::SanitizeHelper
 
   describe "generating a trail from paths" do
     def params; {}; end

--- a/spec/unit/view_helpers/display_helper_spec.rb
+++ b/spec/unit/view_helpers/display_helper_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe ActiveAdmin::ViewHelpers::DisplayHelper do
       include MethodOrProcHelper
       include ActionView::Helpers::UrlHelper
       include ActionView::Helpers::TranslationHelper
-      include ActionView::Helpers::SanitizeHelper
     end
   end
 
@@ -58,7 +57,7 @@ RSpec.describe ActiveAdmin::ViewHelpers::DisplayHelper do
         end
 
         it "should sanitize the result of #{m}" do
-          expect(displayed_name).to eq 'alert(1)'
+          expect(displayed_name).to eq '&lt;script&gt;alert(1)&lt;/script&gt;'
         end
       end
     end
@@ -106,7 +105,7 @@ RSpec.describe ActiveAdmin::ViewHelpers::DisplayHelper do
       it "should default to `to_s`" do
         result = resource.to_s
 
-        expect(displayed_name).to eq view.sanitize(result)
+        expect(displayed_name).to eq ERB::Util.html_escape(result)
       end
     end
 


### PR DESCRIPTION
This PR changes the `display_name` method (used to render the show page title, for example) to automatically escape HTML.

Fixes #5693.

Note that this PR changes the way we fixed https://github.com/activeadmin/activeadmin/pull/5284 by escaping instead of sanitizing, just like we did in https://github.com/activeadmin/activeadmin/pull/5299.

Escaping fixes issues like #5693 better than `sanitize` because the default Rails sanitizer only removes certain tags, not all, and it leads to behavior more similar to Rails defaults.