### PR TITLE
Make count query optimisation work when using decorate_with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+* Make optimization to not use expensive COUNT queries also work for decorated actions. [#5811](https://github.com/activeadmin/activeadmin/pull/5811) by [@irmela]
+
 ## 2.3.1 [☰](https://github.com/activeadmin/activeadmin/compare/v2.3.0..v2.3.1)
 
 ### Bug Fixes
@@ -499,6 +503,7 @@ Please check [0-6-stable] for previous changes.
 [#5800]: https://github.com/activeadmin/activeadmin/pull/5800
 [#5801]: https://github.com/activeadmin/activeadmin/pull/5801
 [#5802]: https://github.com/activeadmin/activeadmin/pull/5802
+[#5811]: https://github.com/activeadmin/activeadmin/pull/5811
 [#5816]: https://github.com/activeadmin/activeadmin/pull/5816
 [#5822]: https://github.com/activeadmin/activeadmin/pull/5822
 [#5826]: https://github.com/activeadmin/activeadmin/pull/5826
@@ -577,3 +582,4 @@ Please check [0-6-stable] for previous changes.
 [@ndbroadbent]: https://github.com/ndbroadbent
 [@Kris-LIBIS]: https://github.com/Kris-LIBIS
 [@sgara]: https://github.com/sgara
+[@irmela]: https://github.com/irmela

--- a/Gemfile.common
+++ b/Gemfile.common
@@ -14,6 +14,7 @@ gem "devise", "~> 4.7"
 group :test do
   gem 'apparition'
   gem 'capybara', '~> 3.14'
+  gem 'db-query-matchers', '0.9.0'
 
   gem 'simplecov', require: false # Test coverage generator. Go to /coverage/ after running tests
   gem 'cucumber-rails', '~> 1.5', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,9 @@ GEM
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
     database_cleaner (1.7.0)
+    db-query-matchers (0.9.0)
+      activesupport (>= 4.0, <= 6.0)
+      rspec (~> 3.0)
     devise (4.7.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -323,6 +326,10 @@ GEM
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
     rspec-core (3.8.2)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.4)
@@ -417,6 +424,7 @@ DEPENDENCIES
   cucumber
   cucumber-rails (~> 1.5)
   database_cleaner
+  db-query-matchers (= 0.9.0)
   devise (~> 4.7)
   draper (~> 3.1)
   i18n-spec

--- a/gemfiles/rails_50.gemfile.lock
+++ b/gemfiles/rails_50.gemfile.lock
@@ -115,6 +115,9 @@ GEM
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
     database_cleaner (1.7.0)
+    db-query-matchers (0.9.0)
+      activesupport (>= 4.0, <= 6.0)
+      rspec (~> 3.0)
     devise (4.7.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -261,6 +264,10 @@ GEM
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
     rspec-core (3.8.2)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.4)
@@ -334,6 +341,7 @@ DEPENDENCIES
   cucumber
   cucumber-rails (~> 1.5)
   database_cleaner
+  db-query-matchers (= 0.9.0)
   devise (~> 4.7)
   draper (~> 3.1)
   jasmine

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -115,6 +115,9 @@ GEM
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
     database_cleaner (1.7.0)
+    db-query-matchers (0.9.0)
+      activesupport (>= 4.0, <= 6.0)
+      rspec (~> 3.0)
     devise (4.7.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -261,6 +264,10 @@ GEM
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
     rspec-core (3.8.2)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.4)
@@ -334,6 +341,7 @@ DEPENDENCIES
   cucumber
   cucumber-rails (~> 1.5)
   database_cleaner
+  db-query-matchers (= 0.9.0)
   devise (~> 4.7)
   draper (~> 3.1)
   jasmine

--- a/gemfiles/rails_52.gemfile.lock
+++ b/gemfiles/rails_52.gemfile.lock
@@ -119,6 +119,9 @@ GEM
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
     database_cleaner (1.7.0)
+    db-query-matchers (0.9.0)
+      activesupport (>= 4.0, <= 6.0)
+      rspec (~> 3.0)
     devise (4.7.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -269,6 +272,10 @@ GEM
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
     rspec-core (3.8.2)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.4)
@@ -342,6 +349,7 @@ DEPENDENCIES
   cucumber
   cucumber-rails (~> 1.5)
   database_cleaner
+  db-query-matchers (= 0.9.0)
   devise (~> 4.7)
   draper (~> 3.1)
   jasmine

--- a/gemfiles/rails_60_turbolinks.gemfile.lock
+++ b/gemfiles/rails_60_turbolinks.gemfile.lock
@@ -132,6 +132,9 @@ GEM
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
     database_cleaner (1.7.0)
+    db-query-matchers (0.9.0)
+      activesupport (>= 4.0, <= 6.0)
+      rspec (~> 3.0)
     devise (4.7.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -284,6 +287,10 @@ GEM
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
     rspec-core (3.8.2)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.4)
@@ -361,6 +368,7 @@ DEPENDENCIES
   cucumber
   cucumber-rails (~> 1.5)
   database_cleaner
+  db-query-matchers (= 0.9.0)
   devise (~> 4.7)
   draper (~> 3.1)
   jasmine

--- a/lib/active_admin/resource_controller/decorators.rb
+++ b/lib/active_admin/resource_controller/decorators.rb
@@ -67,8 +67,8 @@ module ActiveAdmin
         def self.wrap!(parent, name)
           ::Class.new parent do
             delegate :reorder, :page, :current_page, :total_pages, :limit_value,
-                     :total_count, :total_pages, :to_key, :group_values, :except,
-                     :find_each, :ransack
+                     :total_count, :total_pages, :offset, :to_key, :group_values,
+                     :except, :find_each, :ransack
 
             define_singleton_method(:name) { name }
           end

--- a/lib/active_admin/views/components/paginated_collection.rb
+++ b/lib/active_admin/views/components/paginated_collection.rb
@@ -96,7 +96,7 @@ module ActiveAdmin
         options[:params]     = @params     if @params
         options[:param_name] = @param_name if @param_name
 
-        if !@display_total && collection.respond_to?(:offset)
+        if !@display_total
           # The #paginate method in kaminari will query the resource with a
           # count(*) to determine how many pages there should be unless
           # you pass in the :total_pages option. We issue a query to determine

--- a/spec/support/active_admin_integration_spec_helper.rb
+++ b/spec/support/active_admin_integration_spec_helper.rb
@@ -55,6 +55,32 @@ module ActiveAdminIntegrationSpecHelper
     base.new(view_paths, {}, controller)
   end
 
+  # Instantiates a fake decorated controller ready to unit test for a specific action
+  def controller_with_decorator(action, decorator_class)
+    method = action == "index" ? :apply_collection_decorator : :apply_decorator
+
+    controller_class = Class.new do
+      include ActiveAdmin::ResourceController::Decorators
+
+      public method
+    end
+
+    active_admin_config = double(decorator_class: decorator_class)
+
+    if action != "index"
+      form_presenter = double(options: { decorate: !decorator_class.nil? })
+
+      allow(active_admin_config).to receive(:get_page_presenter).with(:form).and_return(form_presenter)
+    end
+
+    controller = controller_class.new
+
+    allow(controller).to receive(:active_admin_config).and_return(active_admin_config)
+    allow(controller).to receive(:action_name).and_return(action)
+
+    controller
+  end
+
   def view_paths
     paths = ActionController::Base.view_paths
     # the constructor for ActionView::Base changed from Rails 6

--- a/spec/unit/resource_controller/decorators_spec.rb
+++ b/spec/unit/resource_controller/decorators_spec.rb
@@ -1,58 +1,34 @@
 require 'rails_helper'
 
 RSpec.describe ActiveAdmin::ResourceController::Decorators do
-  let(:controller_class) do
-    Class.new do
-      include ActiveAdmin::ResourceController::Decorators
-
-      public :apply_decorator, :apply_collection_decorator
-    end
-  end
-
-  let(:controller) { controller_class.new }
-  let(:active_admin_config) { double(decorator_class: decorator_class) }
-  before do
-    allow(controller).to receive(:active_admin_config).and_return(active_admin_config)
-    allow(controller).to receive(:action_name).and_return(action)
-  end
-
   describe '#apply_decorator' do
-    let(:action) { 'show' }
     let(:resource) { Post.new }
+    let(:controller) { controller_with_decorator(action, decorator_class) }
     subject(:applied) { controller.apply_decorator(resource) }
 
-    context 'with a decorator configured' do
+    context "in show action" do
+      let(:action) { 'show' }
       let(:decorator_class) { PostDecorator }
+
       it { is_expected.to be_kind_of(PostDecorator) }
-
-      context 'with form' do
-        let(:action) { 'update' }
-
-        it "does not decorate when :decorate is set to false" do
-          form = double
-          allow(form).to receive(:options).and_return(decorate: false)
-          allow(active_admin_config).to receive(:get_page_presenter).and_return(form)
-          is_expected.not_to be_kind_of(PostDecorator)
-        end
-      end
     end
 
-    context 'with no decorator configured' do
+    context "in update action" do
+      let(:action) { 'update' }
       let(:decorator_class) { nil }
-      it { is_expected.to be_kind_of(Post) }
+
+      it { is_expected.not_to be_kind_of(PostDecorator) }
     end
   end
 
   describe '#apply_collection_decorator' do
     before { Post.create! }
-    let(:action) { 'index' }
     let(:collection) { Post.where nil }
+    let(:controller) { controller_with_decorator("index", PostDecorator) }
     subject(:applied) { controller.apply_collection_decorator(collection) }
 
     context 'when a decorator is configured' do
       context 'and it is using a recent version of draper' do
-        let(:decorator_class) { PostDecorator }
-
         it 'calling certain scope collections work' do
           # This is an example of one of the methods that was consistently
           # failing before this feature existed
@@ -67,21 +43,18 @@ RSpec.describe ActiveAdmin::ResourceController::Decorators do
   end
 
   describe 'form actions' do
-    let(:action) { 'edit' }
     let(:resource) { Post.new }
-    let(:form_presenter) { double options: { decorate: decorate_form } }
-    let(:decorator_class) { PostDecorator }
-    before { allow(active_admin_config).to receive(:get_page_presenter).with(:form).and_return form_presenter }
+    let(:controller) { controller_with_decorator("edit", decorator_class) }
 
     subject(:applied) { controller.apply_decorator(resource) }
 
     context 'when the form is not configured to decorate' do
-      let(:decorate_form) { false }
+      let(:decorator_class) { nil }
       it { is_expected.to be_kind_of(Post) }
     end
 
     context 'when the form is configured to decorate' do
-      let(:decorate_form) { true }
+      let(:decorator_class) { PostDecorator }
       it { is_expected.to be_kind_of(PostDecorator) }
     end
   end

--- a/spec/unit/views/components/paginated_collection_spec.rb
+++ b/spec/unit/views/components/paginated_collection_spec.rb
@@ -227,6 +227,20 @@ RSpec.describe ActiveAdmin::Views::PaginatedCollection do
       end
     end
 
+    it "makes no expensive COUNT queries when pagination_total is false" do
+      require 'db-query-matchers'
+
+      undecorated_collection = Post.all.page(1).per(30)
+
+      expect { paginated_collection(undecorated_collection, pagination_total: false) }
+        .not_to make_database_queries(matching: "SELECT COUNT(*) FROM \"posts\"")
+
+      decorated_collection = controller_with_decorator("index", PostDecorator).apply_collection_decorator(undecorated_collection)
+
+      expect { paginated_collection(decorated_collection, pagination_total: false) }
+        .not_to make_database_queries(matching: "SELECT COUNT(*) FROM \"posts\"")
+    end
+
     context "when specifying per_page: array option" do
       let(:collection) do
         posts = 10.times.map { Post.new }


### PR DESCRIPTION
#3848 introduced a great performance improvement for pagination total_count. After #4068 this optimization was not available when using `decorate_with`.

This is another approach of #5389 with minimal change. Please let me know in case I missed something.