### PR TITLE
Make posts a nested resource in test application

### DIFF
--- a/spec/support/templates_with_data/admin/posts.rb
+++ b/spec/support/templates_with_data/admin/posts.rb
@@ -1,6 +1,8 @@
 ActiveAdmin.register Post do
   permit_params :custom_category_id, :author_id, :title, :body, :published_date, :position, :starred, taggings_attributes: [ :id, :tag_id, :name, :position, :_destroy ]
 
+  belongs_to :user
+
   includes :author, :category, :taggings
 
   scope :all, default: true
@@ -23,7 +25,7 @@ ActiveAdmin.register Post do
 
   batch_action :set_starred, form: { starred: :checkbox } do |ids, inputs|
     Post.where(id: ids).update_all(starred: inputs['starred'].present?)
-    redirect_to collection_path, notice: "The posts have been updated."
+    redirect_to collection_path(user_id: params["user_id"]), notice: "The posts have been updated."
   end
 
   index do
@@ -57,7 +59,7 @@ ActiveAdmin.register Post do
   end
 
   action_item :toggle_starred, only: :show do
-    link_to 'Toggle Starred', toggle_starred_admin_post_path(post), method: :put
+    link_to 'Toggle Starred', toggle_starred_admin_user_post_path(post.author, post), method: :put
   end
 
   show do |post|

--- a/spec/support/templates_with_data/admin/users.rb
+++ b/spec/support/templates_with_data/admin/users.rb
@@ -31,7 +31,7 @@ ActiveAdmin.register User do
       paginated_collection(user.posts.includes(:category).order(:updated_at).page(params[:page]).per(10), download_links: false) do
         table_for(collection) do
           column :id do |post|
-            link_to post.id, admin_post_path(post)
+            link_to post.id, admin_user_post_path(post.author, post)
           end
           column :title
           column :published_date
@@ -42,7 +42,7 @@ ActiveAdmin.register User do
       end
 
       para do
-        link_to "View all posts", admin_posts_path('q[author_id_eq]' => user.id)
+        link_to "View all posts", admin_user_posts_path(user)
       end
     end
   end


### PR DESCRIPTION
So we have an example of a nested resource in our test application.

It can be useful to showcase what ActiveAdmin can do, and also to investigate issues regarding nested resources on a toy environment.