### PR TITLE
Fix filtering by nested resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 * Fix CSVBuilder not respecting `ActiveAdmin.application.csv_options = { humanize_name: false }` setting. [#5800] by [@HappyKadaver]
+* Fix crash when displaying current filters after filtering by a nested resource. [#5816] by [@deivid-rodriguez]
 
 ## 2.2.0 [☰](https://github.com/activeadmin/activeadmin/compare/v2.1.0..v2.2.0)
 
@@ -481,6 +482,7 @@ Please check [0-6-stable] for previous changes.
 [#5800]: https://github.com/activeadmin/activeadmin/pull/5800
 [#5801]: https://github.com/activeadmin/activeadmin/pull/5801
 [#5802]: https://github.com/activeadmin/activeadmin/pull/5802
+[#5816]: https://github.com/activeadmin/activeadmin/pull/5816
 
 [@5t111111]: https://github.com/5t111111
 [@aarek]: https://github.com/aarek

--- a/features/index/filters.feature
+++ b/features/index/filters.feature
@@ -194,7 +194,6 @@ Feature: Index Filtering
     And the "Jane Doe" checkbox should be checked
 
   Scenario: Filtering posts without default scope
-
     Given a post with the title "Hello World" written by "Jane Doe" exists
     And an index configuration of:
     """

--- a/features/index/filters.feature
+++ b/features/index/filters.feature
@@ -248,3 +248,20 @@ Feature: Index Filtering
     """
     And I press "Filter"
     Then I should not see a sidebar titled "Search status:"
+
+  Scenario: Filters and nested resources
+    Given a post with the title "The arrogant president" written by "Jane Doe" exists
+    And a configuration of:
+    """
+      ActiveAdmin.register User
+      ActiveAdmin.register Post do
+        permit_params :user_id
+
+        belongs_to :author, class_name: "User"
+      end
+    """
+    And I am logged in
+    And I am on the index page for users
+    When I select "The arrogant president" from "Posts"
+    And I press "Filter"
+    And I should see 1 user in the table

--- a/lib/active_admin/resource/belongs_to.rb
+++ b/lib/active_admin/resource/belongs_to.rb
@@ -14,6 +14,9 @@ module ActiveAdmin
       # The resource which initiated this relationship
       attr_reader :owner
 
+      # The name of the relation
+      attr_reader :target_name
+
       def initialize(owner, target_name, options = {})
         @owner = owner
         @target_name = target_name

--- a/lib/active_admin/resource/routes.rb
+++ b/lib/active_admin/resource/routes.rb
@@ -110,7 +110,7 @@ module ActiveAdmin
         # @return params to pass to instance path
         def route_instance_params(instance)
           if nested?
-            [instance.public_send(belongs_to_name).to_param, instance.to_param]
+            [instance.public_send(belongs_to_target_name).to_param, instance.to_param]
           else
             instance.to_param
           end
@@ -124,6 +124,10 @@ module ActiveAdmin
 
         def nested?
           resource.belongs_to? && belongs_to_config.required?
+        end
+
+        def belongs_to_target_name
+          belongs_to_config.target_name
         end
 
         def belongs_to_name

--- a/lib/active_admin/resource/routes.rb
+++ b/lib/active_admin/resource/routes.rb
@@ -123,11 +123,15 @@ module ActiveAdmin
         end
 
         def nested?
-          resource.belongs_to? && resource.belongs_to_config.required?
+          resource.belongs_to? && belongs_to_config.required?
         end
 
         def belongs_to_name
-          resource.belongs_to_config.target.resource_name.singular
+          belongs_to_config.target.resource_name.singular
+        end
+
+        def belongs_to_config
+          resource.belongs_to_config
         end
 
         def routes

--- a/lib/active_admin/resource/routes.rb
+++ b/lib/active_admin/resource/routes.rb
@@ -127,7 +127,7 @@ module ActiveAdmin
         end
 
         def belongs_to_name
-          resource.belongs_to_config.target.resource_name.singular if nested?
+          resource.belongs_to_config.target.resource_name.singular
         end
 
         def routes


### PR DESCRIPTION
After enabling a sample nested resource in #5814, I found a crash in the users page, when filtering by post.

I guess this kind of filtering is pretty uncommon (it always results in a single record), maybe it shouldn't be included by default?

Anyways, this should fix the crash, which by the way looks like this:

```
    And I press "Filter"                                                              # features/step_definitions/web_steps.rb:24
      undefined method `user' for #<Post:0x000055a5adf3d8d0>
      Did you mean?  super (ActionView::Template::Error)
      ./lib/active_admin/resource/routes.rb:113:in `public_send'
      ./lib/active_admin/resource/routes.rb:113:in `route_instance_params'
      ./lib/active_admin/resource/routes.rb:79:in `instance_path'
      ./lib/active_admin/resource/routes.rb:19:in `route_instance_path'
      ./lib/active_admin/view_helpers/auto_link_helper.rb:29:in `auto_url_for'
      ./lib/active_admin/view_helpers/auto_link_helper.rb:15:in `auto_link'
      ./lib/active_admin/view_helpers/display_helper.rb:78:in `pretty_format'
      ./lib/active_admin/filters/active_sidebar.rb:31:in `block (8 levels) in block'
(...)
```