### PR TITLE
Fix `belongs_to` specification

### DIFF
--- a/spec/support/templates_with_data/admin/posts.rb
+++ b/spec/support/templates_with_data/admin/posts.rb
@@ -1,7 +1,7 @@
 ActiveAdmin.register Post do
   permit_params :custom_category_id, :author_id, :title, :body, :published_date, :position, :starred, taggings_attributes: [ :id, :tag_id, :name, :position, :_destroy ]
 
-  belongs_to :user
+  belongs_to :author, class_name: "User", param: "user_id", route_name: "user"
 
   includes :author, :category, :taggings
 


### PR DESCRIPTION
I had this change locally, but I forgot to push it. It was supposed to be part of #5587 

It's necessary to make filtering by post in the user's index page (using the fix in #5816), otherwise, the applied filter cannot be properly displayed.