### PR TITLE
Remove uneeded skips

### DIFF
--- a/spec/unit/csv_builder_spec.rb
+++ b/spec/unit/csv_builder_spec.rb
@@ -304,12 +304,4 @@ RSpec.describe ActiveAdmin::CSVBuilder do
       end
     end
   end
-
-  skip '#exec_columns'
-
-  describe '#build_row' do
-    xit 'renders non-strings'
-    xit 'encodes values correctly'
-    xit 'passes custom encoding options to String#encode!'
-  end
 end


### PR DESCRIPTION
I reviewed the rest of the csv builder specs, and I believe this stuff is already reasonably tested, so I don't think we need this.