### PR TITLE
Another test app generation fix

### DIFF
--- a/tasks/local.rake
+++ b/tasks/local.rake
@@ -7,7 +7,7 @@ task :local do
     template: 'rails_template_with_data'
   )
 
-  test_application.generate
+  test_application.soft_generate
 
   # Discard the "local" argument (name of the task)
   argv = ARGV[1..-1]

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -24,15 +24,7 @@ namespace :setup do
 
   desc "Create a test rails app for the parallel specs to run against"
   task :run, [:rails_env, :template] do |_t, opts|
-    test_app = ActiveAdmin::TestApplication.new(opts)
-
-    app_dir = test_app.app_dir
-
-    if File.exist? app_dir
-      puts "test app #{app_dir} already exists; skipping test app generation"
-    else
-      test_app.generate
-    end
+    ActiveAdmin::TestApplication.new(opts).soft_generate
   end
 
   task :rm, [:rails_env, :template] do |_t, opts|

--- a/tasks/test_application.rb
+++ b/tasks/test_application.rb
@@ -9,6 +9,14 @@ module ActiveAdmin
       @template = opts[:template] || 'rails_template'
     end
 
+    def soft_generate
+      if File.exist? app_dir
+        puts "test app #{app_dir} already exists; skipping test app generation"
+      else
+        generate
+      end
+    end
+
     def generate
       FileUtils.mkdir_p base_dir
       args = %W(


### PR DESCRIPTION
Another regression from #5797... :grimacing:

When booting the sample development application with `bin/rake local server`, it would always try to regenerate the application.

This PR fixes that.