### PR TITLE
Hide "Last" link when `pagination_total` is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Fix CSVBuilder not respecting `ActiveAdmin.application.csv_options = { humanize_name: false }` setting. [#5800] by [@HappyKadaver]
 * Fix crash when displaying current filters after filtering by a nested resource. [#5816] by [@deivid-rodriguez]
+* Fix pagination when `pagination_total` is false to not show a "Last" link, since it's incorrect because we don't have the total pages information. [#5822] by [@deivid-rodriguez]
 
 ## 2.2.0 [☰](https://github.com/activeadmin/activeadmin/compare/v2.1.0..v2.2.0)
 
@@ -483,6 +484,7 @@ Please check [0-6-stable] for previous changes.
 [#5801]: https://github.com/activeadmin/activeadmin/pull/5801
 [#5802]: https://github.com/activeadmin/activeadmin/pull/5802
 [#5816]: https://github.com/activeadmin/activeadmin/pull/5816
+[#5822]: https://github.com/activeadmin/activeadmin/pull/5822
 
 [@5t111111]: https://github.com/5t111111
 [@aarek]: https://github.com/aarek

--- a/app/views/kaminari/active_admin_countless/_first_page.html.erb
+++ b/app/views/kaminari/active_admin_countless/_first_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="first">
+  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote %>
+</span>

--- a/app/views/kaminari/active_admin_countless/_gap.html.erb
+++ b/app/views/kaminari/active_admin_countless/_gap.html.erb
@@ -1,0 +1,8 @@
+<%# Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page gap"><%= t('views.pagination.truncate').html_safe %></span>

--- a/app/views/kaminari/active_admin_countless/_next_page.html.erb
+++ b/app/views/kaminari/active_admin_countless/_next_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="next">
+  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote %>
+</span>

--- a/app/views/kaminari/active_admin_countless/_page.html.erb
+++ b/app/views/kaminari/active_admin_countless/_page.html.erb
@@ -1,0 +1,12 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page<%= ' current' if page.current? %>">
+  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel} %>
+</span>

--- a/app/views/kaminari/active_admin_countless/_paginator.html.erb
+++ b/app/views/kaminari/active_admin_countless/_paginator.html.erb
@@ -1,0 +1,24 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<%= paginator.render do -%>
+  <nav class="pagination">
+    <%= first_page_tag unless current_page.first? %>
+    <%= prev_page_tag unless current_page.first? %>
+    <% each_page do |page| -%>
+      <% if page.display_tag? -%>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? -%>
+        <%= gap_tag %>
+      <% end -%>
+    <% end -%>
+    <% unless current_page.out_of_range? %>
+      <%= next_page_tag unless current_page.last? %>
+    <% end %>
+  </nav>
+<% end -%>

--- a/app/views/kaminari/active_admin_countless/_prev_page.html.erb
+++ b/app/views/kaminari/active_admin_countless/_prev_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="prev">
+  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote %>
+</span>

--- a/features/index/pagination.feature
+++ b/features/index/pagination.feature
@@ -56,7 +56,9 @@ Feature: Index Pagination
     Then I should see "Displaying Posts 1 - 10"
     And I should not see "11 in total"
     And I should see the pagination "Next" link
+    And I should not see the pagination "Last" link
 
     When I follow "Next"
     Then I should see "Displaying Posts 11 - 11"
     And I should not see the pagination "Next" link
+    And I should not see the pagination "Last" link

--- a/features/step_definitions/pagination_steps.rb
+++ b/features/step_definitions/pagination_steps.rb
@@ -13,3 +13,7 @@ end
 Then /^I should not see the pagination "Next" link/ do
   expect(page).to_not have_css "a", text: "Next"
 end
+
+Then /^I should not see the pagination "Last" link/ do
+  expect(page).to_not have_css "a", text: "Last"
+end

--- a/lib/active_admin/views/components/paginated_collection.rb
+++ b/lib/active_admin/views/components/paginated_collection.rb
@@ -92,7 +92,7 @@ module ActiveAdmin
       end
 
       def build_pagination
-        options = { theme: 'active_admin' }
+        options = { theme: @display_total ? 'active_admin' : 'active_admin_countless' }
         options[:params]     = @params     if @params
         options[:param_name] = @param_name if @param_name
 


### PR DESCRIPTION
I was having a look at #5811 and I noticed that when using `pagination_total: false`, a "Last" link is still displayed, and it has the same link as the "Next" link.

In this case, we don't have the total pages information so displaying an incorrect "Last" link is misleading.

The solution is a bit verbose, but I'm unsure how to do it otherwise. What I did was to copy the default activeadmin pagination theme, but skip the "Last" link and the the `_last_page.html.erb` partial. And when `pagination_total` is false, use the alternative "countless" theme.