### PR TITLE
Update documentation for including associated objects

### DIFF
--- a/docs/3-index-pages/index-as-table.md
+++ b/docs/3-index-pages/index-as-table.md
@@ -193,6 +193,13 @@ controller do
 end
 ```
 
+You can also define associated objects to include outside of the
+`scoped_collection` method:
+
+```ruby
+includes :publisher
+```
+
 Then it's simple to sort by any Publisher attribute from within the index table:
 
 ```ruby

--- a/lib/active_admin/views/index_as_table.rb
+++ b/lib/active_admin/views/index_as_table.rb
@@ -192,6 +192,13 @@ module ActiveAdmin
     # end
     # ```
     #
+    # You can also define associated objects to include outside of the
+    # `scoped_collection` method:
+    #
+    # ```ruby
+    # includes :publisher
+    # ```
+    #
     # Then it's simple to sort by any Publisher attribute from within the index table:
     #
     # ```ruby


### PR DESCRIPTION
This PR updates the documentation around including associated objects

The documentation was a little out of date around including associated objects on the "Index as Table" page. You can now just [`includes :publisher`](https://github.com/activeadmin/activeadmin/blob/master/lib/active_admin/resource_dsl.rb#L41) rather than appending it to the `scoped_collection` method.