### PR TITLE
Docs site local improvements

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
 
 gem 'github-pages'
-gem 'jekyll-redirect-from'

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -243,7 +243,6 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
-  jekyll-redirect-from
 
 BUNDLED WITH
    1.16.5

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,3 +1,4 @@
 plugins:
   - jekyll-default-layout
   - jekyll-redirect-from
+  - jekyll-relative-links

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,2 +1,3 @@
 plugins:
+  - jekyll-default-layout
   - jekyll-redirect-from


### PR DESCRIPTION
I booted the documentation site locally and I was getting unstyled pages and a few broken links. This does not happen in production (I guess the plugins are applied by default), but this helps for developing locally.