### PR TITLE
Bump minimum ransack requirement to 2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Enhancements
+
+#### Minor
+
+* Bump minimum ransack requirement to make sure everyone gets a version that works ok with all supported versions of Rails. [#5831] by [@deivid-rodriguez]
+
 ### Bug Fixes
 
 * Fix CSVBuilder not respecting `ActiveAdmin.application.csv_options = { humanize_name: false }` setting. [#5800] by [@HappyKadaver]
@@ -487,6 +493,7 @@ Please check [0-6-stable] for previous changes.
 [#5816]: https://github.com/activeadmin/activeadmin/pull/5816
 [#5822]: https://github.com/activeadmin/activeadmin/pull/5822
 [#5826]: https://github.com/activeadmin/activeadmin/pull/5826
+[#5831]: https://github.com/activeadmin/activeadmin/pull/5831
 
 [@5t111111]: https://github.com/5t111111
 [@aarek]: https://github.com/aarek

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ PATH
       jquery-rails (~> 4.2)
       kaminari (~> 1.0, >= 1.0.1)
       railties (>= 5.0, < 6.1)
-      ransack (~> 2.1, >= 2.1.1)
+      ransack (~> 2.3)
       sassc-rails (~> 2.1)
       sprockets (>= 3.0, < 4.1)
       sprockets-es6 (~> 0.9, >= 0.9.2)

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'jquery-rails', '~> 4.2'
   s.add_dependency 'kaminari', '~> 1.0', '>= 1.0.1'
   s.add_dependency 'railties', '>= 5.0', '< 6.1'
-  s.add_dependency 'ransack', '~> 2.1', '>= 2.1.1'
+  s.add_dependency 'ransack', '~> 2.3'
   s.add_dependency 'sassc-rails', '~> 2.1'
   s.add_dependency 'sprockets', '>= 3.0', '< 4.1'
   s.add_dependency 'sprockets-es6', '~> 0.9', '>= 0.9.2'

--- a/gemfiles/rails_50.gemfile.lock
+++ b/gemfiles/rails_50.gemfile.lock
@@ -20,7 +20,7 @@ PATH
       jquery-rails (~> 4.2)
       kaminari (~> 1.0, >= 1.0.1)
       railties (>= 5.0, < 6.1)
-      ransack (~> 2.1, >= 2.1.1)
+      ransack (~> 2.3)
       sassc-rails (~> 2.1)
       sprockets (>= 3.0, < 4.1)
       sprockets-es6 (~> 0.9, >= 0.9.2)

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -20,7 +20,7 @@ PATH
       jquery-rails (~> 4.2)
       kaminari (~> 1.0, >= 1.0.1)
       railties (>= 5.0, < 6.1)
-      ransack (~> 2.1, >= 2.1.1)
+      ransack (~> 2.3)
       sassc-rails (~> 2.1)
       sprockets (>= 3.0, < 4.1)
       sprockets-es6 (~> 0.9, >= 0.9.2)

--- a/gemfiles/rails_60.gemfile.lock
+++ b/gemfiles/rails_60.gemfile.lock
@@ -20,7 +20,7 @@ PATH
       jquery-rails (~> 4.2)
       kaminari (~> 1.0, >= 1.0.1)
       railties (>= 5.0, < 6.1)
-      ransack (~> 2.1, >= 2.1.1)
+      ransack (~> 2.3)
       sassc-rails (~> 2.1)
       sprockets (>= 3.0, < 4.1)
       sprockets-es6 (~> 0.9, >= 0.9.2)


### PR DESCRIPTION
I was going to point at specific ransack issues / prs, but in reality they've been adding fixes for almost every rc version rails released, so I think it's fine without the link. Users shouldn't care much, they just want an aa-rails-ransack combination that works, and this PR will ensure that.