### PR TITLE
update method name in documentation

### DIFF
--- a/docs/2-resource-customization.md
+++ b/docs/2-resource-customization.md
@@ -355,7 +355,7 @@ end
 ```
 
 If you need to completely replace the record retrieving code (e.g., you have a
-custom `to_param` implementation in your models), override the `resource` method
+custom `to_param` implementation in your models), override the `find_resource` method
 on the controller:
 
 ```ruby


### PR DESCRIPTION
This fixes outdated method reference in documentation in `Customizing resource retrieval` section.