### PR TITLE
Normalize test app paths

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,13 +72,13 @@ version: 2.1
 
 .save_test_app: &save_test_app
   persist_to_workspace:
-    root: tmp/rails
+    root: tmp/test_apps
     paths:
       - rails_*
 
 .restore_test_app_from_workspace: &restore_test_app_from_workspace
   attach_workspace:
-    at: tmp/rails
+    at: tmp/test_apps
 
 .restore_test_times: &restore_test_times
   restore_cache:

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ coverage
 .ruby-version
 pkg
 .bundle
-.test-rails-apps
 public
 .rspec_failures
 .rails-version

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,8 @@ AllCops:
   TargetRubyVersion: 2.4
 
   Exclude:
-    - tmp/rails/**/*
+    - tmp/development_apps/**/*
+    - tmp/test_apps/**/*
     - gemfiles/vendor/bundle/**/*
     - vendor/bundle/**/*
 

--- a/.simplecov
+++ b/.simplecov
@@ -1,5 +1,6 @@
 SimpleCov.start do
-  add_filter 'tmp/rails/'
+  add_filter 'tmp/development_apps/'
+  add_filter 'tmp/test_apps/'
 end
 
 if ENV['CI'] == 'true'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Now you should be able to run the entire suite using:
 bin/rake
 ```
 
-The test run will generate a sample Rails application in `tmp/rails` to run the
+The test run will generate a sample Rails application in `tmp/test_apps` to run the
 tests against.
 
 If your tests are passing locally but they're failing on CircleCI, it's probably
@@ -94,7 +94,7 @@ bin/rake local server
 ```
 
 This will automatically create a Rails app if none already exists, and store it
-in the `.test-rails-apps` folder.
+in the `tmp/development_apps` folder.
 
 You should now be able to open <http://localhost:3000/admin> in your browser.
 You can log in using:

--- a/tasks/test_application.rb
+++ b/tasks/test_application.rb
@@ -56,7 +56,7 @@ module ActiveAdmin
     private
 
     def base_dir
-      @base_dir ||= rails_env == 'test' ? 'tmp/rails' : '.test-rails-apps'
+      @base_dir ||= "tmp/#{rails_env}_apps"
     end
 
     def app_name


### PR DESCRIPTION
This is a little thing that always bothers me. We currently generate:

* Test applications for our specs at `tmp/rails`.
* Development applications for local development at `.test-rails-apps`.

I would like to use a more consistent structure where:

* Test applications live at `tmp/test_apps`.
* Development applications live at `tmp/development_apps`.