### PR TITLE
Use the standard cucumber formatter everywhere

### DIFF
--- a/cucumber.yml
+++ b/cucumber.yml
@@ -1,6 +1,5 @@
 <%
-  std_format = RUBY_ENGINE == "jruby" && Gem::Version.new(RUBY_ENGINE_VERSION) < Gem::Version.new("9.2") ? "progress" : "pretty"
-  std_opts = "--format #{std_format} --order random"
+  std_opts = "--format progress --order random"
   default_opts = std_opts + " --format ParallelTests::Gherkin::RuntimeLogger --out tmp/parallel_runtime_cucumber.log"
 %>
 


### PR DESCRIPTION
The "pretty" formatter could be helpful when debugging order dependent failures (maybe), but other than that, it's just too verbose (specially with parallel_tests), and it makes it hard to see the actual scenarios that failed and the error messages.