### PR TITLE
Make jruby hangs appear earlier

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ version: 2.1
   run:
     name: Run Cucumber features
     command: |
-      COVERAGE=true PARALLEL_TEST_PROCESSORS=4 bin/parallel_cucumber features/
+      COVERAGE=true PARALLEL_TEST_PROCESSORS=4 PARALLEL_TEST_HEARTBEAT_INTERVAL=3600 bin/parallel_cucumber features/
       COVERAGE=true bin/cucumber --profile filesystem-changes
       COVERAGE=true bin/cucumber --profile class-reloading
 


### PR DESCRIPTION
The `parallel_tests` gem has this feature where it will output a dot every 60 seconds to avoid CIs that fail when no new output has not been displayed for a while.

Our jruby build is hanging randomly and when that happens, this feature makes it take hours for the job to fail.

In this commit, I'm essentially disabling this feature, by giving the heartbeat a high value, so that we actually get these failures earlier.