### PR TITLE
Disable parallel_tests CI dots for RSpec too

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ version: 2.1
   run:
     name: Run RSpec tests
     command: |
-      COVERAGE=true PARALLEL_TEST_PROCESSORS=4 bin/parallel_rspec spec/
+      COVERAGE=true PARALLEL_TEST_PROCESSORS=4 PARALLEL_TEST_HEARTBEAT_INTERVAL=3600 bin/parallel_rspec spec/
       COVERAGE=true RSPEC_FILESYSTEM_CHANGES=true bin/rspec
 
 .run_features: &run_features


### PR DESCRIPTION
 The jruby hang is happening there too.

This is a follow up to #5847.