### PR TITLE
Revert "Bump minimum ransack requirement to 2.3"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+* Revert ransack version pinning because 2.3 has an outstanding bug that affects quite a lot of users. See [this ransack issue](https://github.com/activerecord-hackery/ransack/issues/1039) for more information. [#5854] by [@deivid-rodriguez]
+
 ## 2.3.0 [☰](https://github.com/activeadmin/activeadmin/compare/v2.2.0..v2.3.0)
 
 ### Enhancements
@@ -498,6 +502,7 @@ Please check [0-6-stable] for previous changes.
 [#5826]: https://github.com/activeadmin/activeadmin/pull/5826
 [#5831]: https://github.com/activeadmin/activeadmin/pull/5831
 [#5842]: https://github.com/activeadmin/activeadmin/pull/5842
+[#5854]: https://github.com/activeadmin/activeadmin/pull/5854
 
 [@5t111111]: https://github.com/5t111111
 [@aarek]: https://github.com/aarek

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       jquery-rails (~> 4.2)
       kaminari (~> 1.0, >= 1.0.1)
       railties (>= 5.0, < 6.1)
-      ransack (~> 2.3)
+      ransack (~> 2.1, >= 2.1.1)
       sassc-rails (~> 2.1)
       sprockets (>= 3.0, < 4.1)
       sprockets-es6 (~> 0.9, >= 0.9.2)

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'jquery-rails', '~> 4.2'
   s.add_dependency 'kaminari', '~> 1.0', '>= 1.0.1'
   s.add_dependency 'railties', '>= 5.0', '< 6.1'
-  s.add_dependency 'ransack', '~> 2.3'
+  s.add_dependency 'ransack', '~> 2.1', '>= 2.1.1'
   s.add_dependency 'sassc-rails', '~> 2.1'
   s.add_dependency 'sprockets', '>= 3.0', '< 4.1'
   s.add_dependency 'sprockets-es6', '~> 0.9', '>= 0.9.2'

--- a/gemfiles/rails_50.gemfile.lock
+++ b/gemfiles/rails_50.gemfile.lock
@@ -9,7 +9,7 @@ PATH
       jquery-rails (~> 4.2)
       kaminari (~> 1.0, >= 1.0.1)
       railties (>= 5.0, < 6.1)
-      ransack (~> 2.3)
+      ransack (~> 2.1, >= 2.1.1)
       sassc-rails (~> 2.1)
       sprockets (>= 3.0, < 4.1)
       sprockets-es6 (~> 0.9, >= 0.9.2)

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -9,7 +9,7 @@ PATH
       jquery-rails (~> 4.2)
       kaminari (~> 1.0, >= 1.0.1)
       railties (>= 5.0, < 6.1)
-      ransack (~> 2.3)
+      ransack (~> 2.1, >= 2.1.1)
       sassc-rails (~> 2.1)
       sprockets (>= 3.0, < 4.1)
       sprockets-es6 (~> 0.9, >= 0.9.2)

--- a/gemfiles/rails_52.gemfile.lock
+++ b/gemfiles/rails_52.gemfile.lock
@@ -9,7 +9,7 @@ PATH
       jquery-rails (~> 4.2)
       kaminari (~> 1.0, >= 1.0.1)
       railties (>= 5.0, < 6.1)
-      ransack (~> 2.3)
+      ransack (~> 2.1, >= 2.1.1)
       sassc-rails (~> 2.1)
       sprockets (>= 3.0, < 4.1)
       sprockets-es6 (~> 0.9, >= 0.9.2)

--- a/gemfiles/rails_60_turbolinks.gemfile.lock
+++ b/gemfiles/rails_60_turbolinks.gemfile.lock
@@ -9,7 +9,7 @@ PATH
       jquery-rails (~> 4.2)
       kaminari (~> 1.0, >= 1.0.1)
       railties (>= 5.0, < 6.1)
-      ransack (~> 2.3)
+      ransack (~> 2.1, >= 2.1.1)
       sassc-rails (~> 2.1)
       sprockets (>= 3.0, < 4.1)
       sprockets-es6 (~> 0.9, >= 0.9.2)


### PR DESCRIPTION
This reverts commit d9d70c4a92c79dbd4ef2d842ef0ef6618012a57b, because ransack 2.3 has an outstanding bug that affects our supported Rails, and quite a lot of users.

By not pinning the ransack version, we give users the chance to use the latest ActiveAdmin while staying on a working ransack.

See https://github.com/activerecord-hackery/ransack/issues/1039 for more information.