### PR TITLE
Get ready for 2.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 2.3.1 [☰](https://github.com/activeadmin/activeadmin/compare/v2.3.0..v2.3.1)
+
 ### Bug Fixes
 
 * Revert ransack version pinning because 2.3 has an outstanding bug that affects quite a lot of users. See [this ransack issue](https://github.com/activerecord-hackery/ransack/issues/1039) for more information. [#5854] by [@deivid-rodriguez]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    activeadmin (2.3.0)
+    activeadmin (2.3.1)
       arbre (~> 1.2, >= 1.2.1)
       formtastic (~> 3.1)
       formtastic_i18n (~> 0.4)

--- a/gemfiles/rails_50.gemfile.lock
+++ b/gemfiles/rails_50.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    activeadmin (2.3.0)
+    activeadmin (2.3.1)
       arbre (~> 1.2, >= 1.2.1)
       formtastic (~> 3.1)
       formtastic_i18n (~> 0.4)

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    activeadmin (2.3.0)
+    activeadmin (2.3.1)
       arbre (~> 1.2, >= 1.2.1)
       formtastic (~> 3.1)
       formtastic_i18n (~> 0.4)

--- a/gemfiles/rails_52.gemfile.lock
+++ b/gemfiles/rails_52.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    activeadmin (2.3.0)
+    activeadmin (2.3.1)
       arbre (~> 1.2, >= 1.2.1)
       formtastic (~> 3.1)
       formtastic_i18n (~> 0.4)

--- a/gemfiles/rails_60_turbolinks.gemfile.lock
+++ b/gemfiles/rails_60_turbolinks.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    activeadmin (2.3.0)
+    activeadmin (2.3.1)
       arbre (~> 1.2, >= 1.2.1)
       formtastic (~> 3.1)
       formtastic_i18n (~> 0.4)

--- a/lib/active_admin/version.rb
+++ b/lib/active_admin/version.rb
@@ -1,3 +1,3 @@
 module ActiveAdmin
-  VERSION = '2.3.0'
+  VERSION = '2.3.1'
 end


### PR DESCRIPTION
Releasing 2.3.1 to unpin ransack so that users can skip https://github.com/activerecord-hackery/ransack/issues/1039.