### PR TITLE
Try potential fix for jruby hangs

### DIFF
--- a/Gemfile.common
+++ b/Gemfile.common
@@ -16,7 +16,7 @@ group :test do
   gem 'capybara', '~> 3.14'
   gem 'db-query-matchers', '0.9.0'
 
-  gem 'simplecov', require: false # Test coverage generator. Go to /coverage/ after running tests
+  gem 'simplecov', '0.17.1', require: false # Test coverage generator. Go to /coverage/ after running tests
   gem 'cucumber-rails', '~> 1.5', require: false
   gem 'cucumber'
   gem 'database_cleaner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -369,7 +369,7 @@ GEM
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
-    simplecov (0.17.0)
+    simplecov (0.17.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
@@ -445,7 +445,7 @@ DEPENDENCIES
   rspec-rails
   rubocop (= 0.63.1)
   rubocop-rspec (~> 1.30)
-  simplecov
+  simplecov (= 0.17.1)
   sqlite3 (~> 1.4)
   yard
 

--- a/gemfiles/rails_50.gemfile.lock
+++ b/gemfiles/rails_50.gemfile.lock
@@ -293,7 +293,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    simplecov (0.17.0)
+    simplecov (0.17.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
@@ -356,7 +356,7 @@ DEPENDENCIES
   rails-i18n
   rake
   rspec-rails
-  simplecov
+  simplecov (= 0.17.1)
   sqlite3 (~> 1.3.6)
 
 BUNDLED WITH

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -293,7 +293,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    simplecov (0.17.0)
+    simplecov (0.17.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
@@ -356,7 +356,7 @@ DEPENDENCIES
   rails-i18n
   rake
   rspec-rails
-  simplecov
+  simplecov (= 0.17.1)
   sqlite3 (~> 1.4)
 
 BUNDLED WITH

--- a/gemfiles/rails_52.gemfile.lock
+++ b/gemfiles/rails_52.gemfile.lock
@@ -301,7 +301,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    simplecov (0.17.0)
+    simplecov (0.17.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
@@ -364,7 +364,7 @@ DEPENDENCIES
   rails-i18n
   rake
   rspec-rails
-  simplecov
+  simplecov (= 0.17.1)
   sqlite3 (~> 1.4)
 
 BUNDLED WITH

--- a/gemfiles/rails_60_turbolinks.gemfile.lock
+++ b/gemfiles/rails_60_turbolinks.gemfile.lock
@@ -316,7 +316,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    simplecov (0.17.0)
+    simplecov (0.17.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
@@ -383,7 +383,7 @@ DEPENDENCIES
   rails-i18n
   rake
   rspec-rails
-  simplecov
+  simplecov (= 0.17.1)
   sqlite3 (~> 1.4)
   turbolinks (~> 5.2)
 


### PR DESCRIPTION
I want to try out [this simplecov PR](https://github.com/colszowka/simplecov/pull/746) in case it helps with the jruby hangs.

The PR doesn't mention anything about jruby, but the sympthoms are very similar: it always hangs right before the last parallel process finishes, no matter whether it's the cucumber or the RSpec suite.

So, I guess we can try it.