### PR TITLE
Fix error when routing with array containing symbol.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 * Use filter label when condition has a predicate. [#5886] by [@ko-lem]
+* Fix error when routing with array containing symbol. [#5870] by [@jwesorick]
 
 ### Removals
 
@@ -526,6 +527,7 @@ Please check [0-6-stable] for previous changes.
 [#5874]: https://github.com/activeadmin/activeadmin/pull/5874
 [#5877]: https://github.com/activeadmin/activeadmin/pull/5877
 [#5886]: https://github.com/activeadmin/activeadmin/pull/5886
+[#5870]: https://github.com/activeadmin/activeadmin/pull/5870
 
 [@5t111111]: https://github.com/5t111111
 [@aarek]: https://github.com/aarek
@@ -566,6 +568,7 @@ Please check [0-6-stable] for previous changes.
 [@johnnyshields]: https://github.com/johnnyshields
 [@jscheid]: https://github.com/jscheid
 [@juril33t]: https://github.com/juril33t
+[@jwesorick]: https://github.com/jwesorick
 [@kjeldahl]: https://github.com/kjeldahl
 [@ko-lem]: https://github.com/ko-lem
 [@kobeumut]: https://github.com/kobeumut

--- a/lib/active_admin/resource_controller/polymorphic_routes.rb
+++ b/lib/active_admin/resource_controller/polymorphic_routes.rb
@@ -25,7 +25,7 @@ module ActiveAdmin
           return ActiveAdmin::Model.new(active_admin_config, record)
         end
 
-        if record.is_a?(parent.class)
+        if respond_to?(:parent, true) && record.is_a?(parent.class)
           return ActiveAdmin::Model.new(active_admin_config.belongs_to_config.resource, record)
         end
 

--- a/spec/unit/resource_controller/polymorphic_routes_spec.rb
+++ b/spec/unit/resource_controller/polymorphic_routes_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe ActiveAdmin::ResourceController::PolymorphicRoutes, type: :controller do
+  let(:klass) { Admin::PostsController }
+
+  shared_context 'with post config' do
+    before do
+      load_resources { post_config }
+
+      @controller = klass.new
+
+      get :index
+    end
+  end
+
+  context 'polymorphic routes' do
+    include_context 'with post config' do
+      let(:post_config) { ActiveAdmin.register Post }
+      let(:post) { Post.create! title: "Hello World" }
+    end
+
+    %w(polymorphic_url polymorphic_path).each do |method|
+      describe method do
+        it 'arrays wtih action names' do
+          expect(controller.send(method, [:admin, post])).to include("/admin/posts/#{post.id}")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
See spec to reproduce issue. 

Looks like this was introduced in https://github.com/activeadmin/activeadmin/commit/d12dc9ab9ee8dd497fd29511961604aadf9b5f68#diff-9fd0a96ab1d1ed0f5d9e1258260e1cef

Fixes #5869 