### PR TITLE
Remove redundant \_

### DIFF
--- a/lib/active_admin/order_clause.rb
+++ b/lib/active_admin/order_clause.rb
@@ -3,7 +3,7 @@ module ActiveAdmin
     attr_reader :field, :order, :active_admin_config
 
     def initialize(active_admin_config, clause)
-      clause =~ /^([\w\_\.]+)(->'\w+')?_(desc|asc)$/
+      clause =~ /^([\w\.]+)(->'\w+')?_(desc|asc)$/
       @column = $1
       @op = $2
       @order = $3


### PR DESCRIPTION
Remove warning of regex character class.
`\w` have already included `_`.
cf. https://ruby-doc.org/core-2.6.3/Regexp.html

```
$ ruby -w lib/active_admin/order_clause.rb
lib/active_admin/order_clause.rb:6: warning: character class has duplicated range: /^([\w\_\.]+)(->'\w+')?_(desc|asc)$/
```