### PR TITLE
Fix bug report template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /tmp
+/tasks/tmp
 /coverage
 /.yardoc
 /.ruby-version

--- a/tasks/bug_report_template.rb
+++ b/tasks/bug_report_template.rb
@@ -88,16 +88,16 @@ class BugTest < ActionDispatch::IntegrationTest
 
   def test_admin_root_success?
     get admin_root_url
-    assert_response :success
     assert_match 'Test Me', response.body # has content
     assert_match 'Users', response.body # has 'Your Models' in menu
+    assert_response :success
   end
 
   def test_admin_users
     User.create! full_name: 'John Doe'
     get admin_users_url
-    assert_response :success
     assert_match 'John Doe', response.body # has created row
+    assert_response :success
   end
 
   private

--- a/tasks/bug_report_template.rb
+++ b/tasks/bug_report_template.rb
@@ -13,6 +13,7 @@ gemfile(true) do
   # Change Rails version if necessary.
   gem 'rails', '5.2.1.1'
 
+  gem 'sprockets', '3.7.2'
   gem 'sassc-rails', '2.1.1'
   gem 'sqlite3', '1.3.13', platform: :mri
   gem 'activerecord-jdbcsqlite3-adapter', "52.0", platform: :jruby

--- a/tasks/bug_report_template.rb
+++ b/tasks/bug_report_template.rb
@@ -46,7 +46,6 @@ class TestApp < Rails::Application
 
   config.eager_load = false
   config.logger = Logger.new($stdout)
-  Rails.logger  = config.logger
 
   config.hosts = "www.example.com"
 end

--- a/tasks/bug_report_template.rb
+++ b/tasks/bug_report_template.rb
@@ -14,7 +14,7 @@ gemfile(true) do
   gem 'rails', '5.2.1.1'
 
   gem 'sprockets', '3.7.2'
-  gem 'sassc-rails', '2.1.1'
+  gem 'sassc-rails', '2.1.2'
   gem 'sqlite3', '1.3.13', platform: :mri
   gem 'activerecord-jdbcsqlite3-adapter', "52.0", platform: :jruby
   gem 'jruby-openssl', '0.10.1', platform: :jruby

--- a/tasks/bug_report_template.rb
+++ b/tasks/bug_report_template.rb
@@ -11,11 +11,11 @@ gemfile(true) do
   end
 
   # Change Rails version if necessary.
-  gem 'rails', '5.2.1.1'
+  gem 'rails', '6.0.0'
 
   gem 'sprockets', '3.7.2'
   gem 'sassc-rails', '2.1.2'
-  gem 'sqlite3', '1.3.13', platform: :mri
+  gem 'sqlite3', '1.4.1', platform: :mri
   gem 'activerecord-jdbcsqlite3-adapter', "52.0", platform: :jruby
   gem 'jruby-openssl', '0.10.1', platform: :jruby
 end
@@ -47,6 +47,8 @@ class TestApp < Rails::Application
   config.eager_load = false
   config.logger = Logger.new($stdout)
   Rails.logger  = config.logger
+
+  config.hosts = "www.example.com"
 end
 
 class ApplicationController < ActionController::Base


### PR DESCRIPTION
Since the sprockets 4.0 release, our bug report template is failing to run.

This PR fixes that by locking sprockets to the latest 3.x release, and adds some other minor improvements to the template.