### PR TITLE
Fix missing Pundit policy causing extra queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Use filter label when condition has a predicate. [#5886] by [@ko-lem]
 * Fix error when routing with array containing symbol. [#5870] by [@jwesorick]
+* Fix additional loading with modified scoped_collection and missing Pundit policy. [#5199] by [@filipkis]
 
 ### Removals
 
@@ -528,6 +529,7 @@ Please check [0-6-stable] for previous changes.
 [#5877]: https://github.com/activeadmin/activeadmin/pull/5877
 [#5886]: https://github.com/activeadmin/activeadmin/pull/5886
 [#5870]: https://github.com/activeadmin/activeadmin/pull/5870
+[#5199]: https://github.com/activeadmin/activeadmin/pull/5199
 
 [@5t111111]: https://github.com/5t111111
 [@aarek]: https://github.com/aarek
@@ -554,6 +556,7 @@ Please check [0-6-stable] for previous changes.
 [@eikes]: https://github.com/eikes
 [@f1sherman]: https://github.com/f1sherman
 [@faucct]: https://github.com/faucct
+[@filipkis]: https://github.com/filipkis
 [@Fivell]: https://github.com/Fivell
 [@glebtv]: https://github.com/glebtv
 [@gonzedge]: https://github.com/gonzedge

--- a/spec/unit/pundit_adapter_spec.rb
+++ b/spec/unit/pundit_adapter_spec.rb
@@ -69,24 +69,24 @@ RSpec.describe ActiveAdmin::PunditAdapter do
       end
 
       it "looks for a namespaced policy" do
-        expect(Pundit).to receive(:policy!).with(anything, [:foobar, Post]).and_return(DefaultPolicy.new(double, double))
+        expect(Pundit).to receive(:policy).with(anything, [:foobar, Post]).and_return(DefaultPolicy.new(double, double))
         auth.authorized?(:read, Post)
       end
 
       it "looks for a namespaced policy scope" do
         collection = double
-        expect(Pundit).to receive(:policy_scope!).with(anything, [:foobar, collection]).and_return(DefaultPolicy::Scope.new(double, double))
+        expect(Pundit).to receive(:policy_scope).with(anything, [:foobar, collection]).and_return(DefaultPolicy::Scope.new(double, double))
         auth.scope_collection(collection, :read)
       end
 
       it "uses the resource when no subject given" do
-        expect(Pundit).to receive(:policy!).with(anything, [:foobar, resource]).and_return(DefaultPolicy::Scope.new(double, double))
+        expect(Pundit).to receive(:policy).with(anything, [:foobar, resource]).and_return(DefaultPolicy::Scope.new(double, double))
         auth.authorized?(:index)
       end
     end
 
     it "uses the resource when no subject given" do
-      expect(Pundit).to receive(:policy!).with(anything, resource).and_return(DefaultPolicy::Scope.new(double, double))
+      expect(Pundit).to receive(:policy).with(anything, resource).and_return(DefaultPolicy::Scope.new(double, double))
       auth.authorized?(:index)
     end
 
@@ -96,7 +96,7 @@ RSpec.describe ActiveAdmin::PunditAdapter do
 
       before do
         allow(ActiveAdmin.application).to receive(:pundit_default_policy).and_return default_policy_klass_name
-        allow(Pundit).to receive(:policy_scope!) { raise Pundit::NotDefinedError.new }
+        allow(Pundit).to receive(:policy_scope).and_return nil
       end
 
       it("should return default policy's scope if defined") { is_expected.to eq(collection) }
@@ -117,7 +117,7 @@ RSpec.describe ActiveAdmin::PunditAdapter do
 
       before do
         allow(ActiveAdmin.application).to receive(:pundit_default_policy).and_return default_policy_klass_name
-        allow(Pundit).to receive(:policy!) { raise Pundit::NotDefinedError.new }
+        allow(Pundit).to receive(:policy).and_return nil
       end
 
       it("should return default policy instance") { is_expected.to be_instance_of(default_policy_klass) }


### PR DESCRIPTION
`PunditAdapter` was checking for policy scope using `Pundit.policy_scope!` which throws an error that calls `.inspect` on the object it was called with. This is fine when `scoped_collection` is just a `ActiveRecord` class, however when users modify the `scoped_collection` (e.g. to use `includes` or `joins`) then the `.inspect` would cause unnecessary query execution.

This PR fixes it by calling `policy_scope` alternative that doesn't throw error, but returns nil instead.

Fixes  #5199