### PR TITLE
Disable sprockets 4 concurrent asset export

### DIFF
--- a/gemfiles/rails_52/Gemfile.lock
+++ b/gemfiles/rails_52/Gemfile.lock
@@ -302,7 +302,7 @@ GEM
     simplecov-html (0.10.2)
     spoon (0.0.6)
       ffi
-    sprockets (3.7.2)
+    sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -49,6 +49,10 @@ gsub_file 'config/environments/test.rb', /  config.cache_classes = true/, <<-RUB
   config.action_mailer.default_url_options = {host: 'example.com'}
   config.assets.precompile += %w( some-random-css.css some-random-js.js a/favicon.ico )
 
+  config.assets.configure do |env|
+    env.export_concurrent = false
+  end
+
   config.active_record.maintain_test_schema = false
 
 RUBY


### PR DESCRIPTION
Our last CI run failed: https://circleci.com/gh/activeadmin/activeadmin/25520.

I investifatedI investigated the error message and related issues and a workaround is to disable concurrent export of assets, apparently. See https://github.com/rails/sprockets/issues/581 and related issues and PRs.