### PR TITLE
Convert namespace to sym to prevent duplicate namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+* Convert namespace to sym to prevent duplicate namespaces such as :foo and 'foo'. [#5931] by [@westonganger]
 * Use filter label when condition has a predicate. [#5886] by [@ko-lem]
 * Fix error when routing with array containing symbol. [#5870] by [@jwesorick]
 * Fix error when there is a model named `Tag` and `meta_tags` have been configured. [#5893] by [@micred], [@FabioRos] and [@deivid-rodriguez]
@@ -512,6 +513,7 @@ Please check [0-6-stable] for previous changes.
 [#5893]: https://github.com/activeadmin/activeadmin/pull/5893
 [#5867]: https://github.com/activeadmin/activeadmin/pull/5867
 [#5887]: https://github.com/activeadmin/activeadmin/pull/5887
+[#5931]: https://github.com/activeadmin/activeadmin/pull/5931
 
 [@5t111111]: https://github.com/5t111111
 [@aarek]: https://github.com/aarek
@@ -589,6 +591,7 @@ Please check [0-6-stable] for previous changes.
 [@violeta-p]: https://github.com/violeta-p
 [@WaKeMaTTa]: https://github.com/WaKeMaTTa
 [@wasifhossain]: https://github.com/wasifhossain
+[@westonganger]: https://github.com/westonganger
 [@Wowu]: https://github.com/Wowu
 [@wspurgin]: https://github.com/wspurgin
 [@zorab47]: https://github.com/zorab47

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -73,7 +73,7 @@ module ActiveAdmin
     def namespace(name)
       name ||= :root
 
-      namespace = namespaces[name] ||= begin
+      namespace = namespaces[name.to_sym] ||= begin
         namespace = Namespace.new(self, name)
         ActiveSupport::Notifications.publish ActiveAdmin::Namespace::RegisterEvent, namespace
         namespace

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -162,6 +162,15 @@ RSpec.describe ActiveAdmin::Application do
       }.to raise_error("found")
     end
 
+    it "should admit both strings and symbols" do
+      expect {
+        application.namespace "admin" do |ns|
+          expect(ns).to eq application.namespaces[:admin]
+          raise "found"
+        end
+      }.to raise_error("found")
+    end
+
     it "should not pollute the global app" do
       expect(application.namespaces).to be_empty
       application.namespace(:brand_new_ns)


### PR DESCRIPTION
If namespace `:foo` is passed in one place and `"foo"` is passed in another it will try to register the namespace twice. This causes an error for duplicate root routes.

With this PR we convert the passed namespace to sym to prevent duplicate namespaces