### PR TITLE
Improve multiple belongs_to hack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix error when there is a model named `Tag` and `meta_tags` have been configured. [#5893] by [@micred], [@FabioRos] and [@deivid-rodriguez]
 * Allow specifying custom `input_html` for `DateRangeInput`. [#5867] by [@mirelon]
 * Adjust `#main_content` right margin to take into account possible custom values of `$sidebar-width` and `$section-padding`. [#5887] by [@guigs]
+* Improved polymorphic routes generation to avoid problems when multiple `belongs_to` are defined. [#5938] by [@leio10]
 
 ### Dependency Changes
 
@@ -512,6 +513,7 @@ Please check [0-6-stable] for previous changes.
 [#5893]: https://github.com/activeadmin/activeadmin/pull/5893
 [#5867]: https://github.com/activeadmin/activeadmin/pull/5867
 [#5887]: https://github.com/activeadmin/activeadmin/pull/5887
+[#5938]: https://github.com/activeadmin/activeadmin/pull/5938
 
 [@5t111111]: https://github.com/5t111111
 [@aarek]: https://github.com/aarek

--- a/lib/active_admin/resource_controller/polymorphic_routes.rb
+++ b/lib/active_admin/resource_controller/polymorphic_routes.rb
@@ -25,8 +25,9 @@ module ActiveAdmin
           return ActiveAdmin::Model.new(active_admin_config, record)
         end
 
-        if respond_to?(:parent, true) && record.is_a?(parent.class)
-          return ActiveAdmin::Model.new(active_admin_config.belongs_to_config.resource, record)
+        belongs_to_resource = active_admin_config.belongs_to_config.try(:resource)
+        if belongs_to_resource && record.is_a?(belongs_to_resource.resource_class)
+          return ActiveAdmin::Model.new(belongs_to_resource, record)
         end
 
         record

--- a/spec/unit/resource_controller/polymorphic_routes_spec.rb
+++ b/spec/unit/resource_controller/polymorphic_routes_spec.rb
@@ -3,26 +3,103 @@ require 'rails_helper'
 RSpec.describe ActiveAdmin::ResourceController::PolymorphicRoutes, type: :controller do
   let(:klass) { Admin::PostsController }
 
-  shared_context 'with post config' do
-    before do
-      load_resources { post_config }
+  %w(polymorphic_url polymorphic_path).each do |method|
+    describe method do
+      let(:add_extra_routes) {}
+      let(:params) { {} }
 
-      @controller = klass.new
+      before do
+        load_resources { post_config }
 
-      get :index
-    end
-  end
+        add_extra_routes
 
-  context 'polymorphic routes' do
-    include_context 'with post config' do
-      let(:post_config) { ActiveAdmin.register Post }
-      let(:post) { Post.create! title: "Hello World" }
-    end
+        @controller = klass.new
 
-    %w(polymorphic_url polymorphic_path).each do |method|
-      describe method do
-        it 'arrays wtih action names' do
+        get :index, params: params
+      end
+
+      context 'without belongs_to' do
+        let(:post_config) { ActiveAdmin.register Post }
+        let(:post) { Post.create! title: "Hello World" }
+
+        it 'works with no parent' do
           expect(controller.send(method, [:admin, post])).to include("/admin/posts/#{post.id}")
+        end
+      end
+
+      context 'with belongs_to' do
+        let(:user) { User.create! }
+        let(:post) { Post.create! title: "Hello World", author: user }
+
+        let(:post_config) do
+          ActiveAdmin.register User
+          ActiveAdmin.register Post do
+            belongs_to :user, optional: true
+          end
+        end
+
+        %w(posts user_posts).each do |current_page|
+          context "within the #{current_page} page" do
+            let(:filter_param) { current_page.sub(/_?posts/, "").presence }
+            let(:params) { filter_param ? { "#{filter_param}_id" => send(filter_param).id } : {} }
+
+            it 'works with no parent' do
+              expect(controller.send(method, [:admin, post])).to include("/admin/posts/#{post.id}")
+            end
+
+            it 'works with a user as parent' do
+              expect(controller.send(method, [:admin, user, post])).to include("/admin/users/#{user.id}/posts/#{post.id}")
+            end
+          end
+        end
+      end
+
+      context 'with multiple belongs_to (not fully supported yet)' do
+        let(:user) { User.create! }
+        let(:category) { Category.create! name: "Category" }
+        let(:post) { Post.create! title: "Hello World", author: user, category: category }
+
+        let(:post_config) do
+          ActiveAdmin.register User
+          ActiveAdmin.register Category
+          ActiveAdmin.register Post do
+            belongs_to :category, optional: true
+            belongs_to :user, optional: true
+          end
+        end
+
+        let(:add_extra_routes) do
+          routes.draw do
+            ActiveAdmin.routes(self)
+            namespace :admin do
+              resources :posts
+              resources :users do
+                resources :posts
+              end
+              resources :categories do
+                resources :posts
+              end
+            end
+          end
+        end
+
+        %w(posts category_posts user_posts).each do |current_page|
+          context "within the #{current_page} page" do
+            let(:filter_param) { current_page.sub(/_?posts/, "").presence }
+            let(:params) { filter_param ? { "#{filter_param}_id" => send(filter_param).id } : {} }
+
+            it 'works with no parent' do
+              expect(controller.send(method, [:admin, post])).to include("/admin/posts/#{post.id}")
+            end
+
+            it 'works with a user as parent' do
+              expect(controller.send(method, [:admin, user, post])).to include("/admin/users/#{user.id}/posts/#{post.id}")
+            end
+
+            it 'works with a category as parent' do
+              expect(controller.send(method, [:admin, category, post])).to include("/admin/categories/#{category.id}/posts/#{post.id}")
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
This PR slightly modifies polymorphic routes generation. When mapping the route parameters, instead of checking each class of the given parameters against the `parent` class, it does it against the configured `belongs_to` resource class. This has sense because if this check is successful it won't use the `parent` but the configured `belongs_to` resource.

As explained in #221, when you define several `belongs_to` for a resource:
```ruby
ActiveAdmin.register Movie do
  belongs_to :provider, optional: true
  belongs_to :actor, optional: true
end
```
And then add the missing routes:
```
namespace :admin do
    resources :movies
    resources :providers do
        resources :movies
    end
    resources :actors do
        resources :movies
    end
end
```
Everything seems to work well, but when browsing the movies for the provider 123, some links are generated as `/actors/123/movies` instead of `/providers/123/movies`.

This change fixes this issue and **keeps the same behavior when having only one `belongs_to` declaration**.

Also, I've added some tests to avoid regression, even when multiple `belongs_to` is still not supported, since it can be useful for many people, and could be a little step further toward supporting this :smiley: .