### PR TITLE
Run `gherkin-lint` through `yarn`

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "rollup-plugin-uglify": "^6.0.3"
   },
   "scripts": {
-    "lint": "gherkin-lint features",
+    "gherkin-lint": "gherkin-lint",
     "build": "rollup --config rollup.config.js",
     "prepublishOnly": "rm -rf src && cp -R app/javascript/active_admin src && cp -R app/assets/stylesheets/active_admin src/scss"
   },

--- a/tasks/lint.rake
+++ b/tasks/lint.rake
@@ -106,7 +106,7 @@ class SassRailsLinter
 end
 
 desc "Lints ActiveAdmin code base"
-task lint: ["lint:rubocop", "lint:mdl", "lint:gherkin_lint", "lint:trailing_blank_lines", "lint:missing_final_new_line", "lint:trailing_whitespace", "lint:fixme", "lint:sass_rails", "lint:rspec"]
+task lint: ["lint:rubocop", "lint:mdl", "lint:gherkin", "lint:trailing_blank_lines", "lint:missing_final_new_line", "lint:trailing_whitespace", "lint:fixme", "lint:sass_rails", "lint:rspec"]
 
 namespace :lint do
   require "rubocop/rake_task"
@@ -120,9 +120,9 @@ namespace :lint do
     sh("mdl", "--git-recurse", ".")
   end
 
-  desc "Checks gherkin code style with gherkin-lint"
-  task :gherkin_lint do
-    puts "Running gherkin-lint..."
+  desc "Checks gherkin code style"
+  task :gherkin do
+    puts "Linting gherkin code..."
 
     sh("bin/yarn", "install")
     sh("bin/yarn", "gherkin-lint")

--- a/tasks/lint.rake
+++ b/tasks/lint.rake
@@ -124,7 +124,8 @@ namespace :lint do
   task :gherkin_lint do
     puts "Running gherkin-lint..."
 
-    sh("npx", "gherkin-lint")
+    sh("bin/yarn", "install")
+    sh("bin/yarn", "gherkin-lint")
   end
 
   desc "Check for unnecessary trailing blank lines across all repo files"

--- a/yarn.lock
+++ b/yarn.lock
@@ -843,6 +843,11 @@ core-js-compat@^3.1.1:
     browserslist "^4.6.6"
     semver "^6.3.0"
 
+core-js@3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.4.0.tgz#29ea478601789c72f2978e9bb98f43546f89d3aa"
+  integrity sha512-lQxb4HScV71YugF/X28LtePZj9AB7WqOpcB+YztYxusvhrgZiQXPmCYfPC5LHsw/+ScEtDbXU3xbqH3CjBRmYA==
+
 cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -1156,11 +1161,12 @@ functional-red-black-tree@^1.0.1:
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
 gherkin-lint@^3.3.6:
-  version "3.3.6"
-  resolved "https://registry.yarnpkg.com/gherkin-lint/-/gherkin-lint-3.3.6.tgz#175c3be5826e9bc03a4f9df9befaed8d7bf6dcf4"
-  integrity sha512-dWClHBtbSwRnrn9o1Vuccl6+4zN6QGGxCPAPQ+vPy/82LBez9CQI4nMLA6EL6CrLwjBI/KxuaxSlQXPBCX5hQg==
+  version "3.3.10"
+  resolved "https://registry.yarnpkg.com/gherkin-lint/-/gherkin-lint-3.3.10.tgz#967e718951dc3ccd6762a278b5fa5c71d405d6b0"
+  integrity sha512-1RdG9lT7Ka47G6xwoAKdQIcoR/TXeuc7FwCZWfyHaT2vR7uDnGs+r+BW31kUpSPStCCk3iLH95/tT7qIC1QVYQ==
   dependencies:
     commander "2.18.0"
+    core-js "3.4.0"
     gherkin "5.1.0"
     glob "7.1.3"
     lodash "4.17.14"


### PR DESCRIPTION
We switched from `npm` to `yarn` in #5868, but we didn't migrate the `rake lint` task to use yarn as well. Also took the chance to upgrade `gherkin-lint`.

@leio10 discovered that `gherkin-lint` is currently failing in CI in #5938. Surprisingly, it's not making the CI fail, but it seems to me that it's due to a bug in `npx` not transmitting the status code of the executable is running. Since we're migrating away from `npx`, it doesn't really matter.
