### PR TITLE
correct i18n key for scopes

### DIFF
--- a/docs/3-index-pages.md
+++ b/docs/3-index-pages.md
@@ -212,7 +212,7 @@ end
 ```
 
 Scopes can be labelled with a translation, e.g.
-`activerecord.scopes.invoice.expired`.
+`active_admin.scopes.scope_method`.
 
 ### Scopes groups
 


### PR DESCRIPTION
docs have wrong key for translating scope names. updated docs to correspond with:
https://github.com/activeadmin/activeadmin/blob/b52e8cbb80ca977d7037de42e51e981a8cf7dc41/lib/active_admin/resource/scopes.rb#L28

<!--

Thanks for contributing to ActiveAdmin!

You can find all the instructions for contributing at the [CONTRIBUTING file].

Before submitting your PR make sure that:

* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
+ The PR descripion [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are splitted apart.
* Your PR includes a regression test if it fixes a bug.
* You add an entry to the [Changelog] if the new code introduces user-observable changes. See [changelog entry format].

Before expecting a review for your PR make sure that all github checks are passing, but feel free to ask for early feedback if you need guidance.

[CONTRIBUTING file]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords
[Changelog]: https://github.com/activeadmin/activeadmin/blob/master/CHANGELOG.md
[changelog entry format]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md#add-a-changelog-entry

-->
