### PR TITLE
Fix render_blank_slate for specific resources

### DIFF
--- a/lib/active_admin/views/pages/index.rb
+++ b/lib/active_admin/views/pages/index.rb
@@ -110,9 +110,10 @@ module ActiveAdmin
         end
 
         def render_blank_slate
-          blank_slate_content = I18n.t("active_admin.blank_slate.content", resource_name: active_admin_config.plural_resource_label)
+          localizer = ActiveAdmin::Localizers.resource(active_admin_config)
+          blank_slate_content = localizer.t('blank_slate.content', resource_name: active_admin_config.plural_resource_label)
           if controller.action_methods.include?('new') && authorized?(ActiveAdmin::Auth::CREATE, active_admin_config.resource_class)
-            blank_slate_content = [blank_slate_content, blank_slate_link].compact.join(" ")
+            blank_slate_content = [blank_slate_content, blank_slate_link].compact.join(' ')
           end
           insert_tag(view_factory.blank_slate, blank_slate_content)
         end


### PR DESCRIPTION
Override method render_blank_slate for specific resources as well as `new_model`, `edit_model` & `delete_model`