### PR TITLE
Export ModalDialog component to re-enable client side usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+* Export ModalDialog component to re-enable client side usage. [#5956] by [@sgara]
+
 ### Enhacements
 
 * Display multiple flash messages in separate elements. [#5929] by [@mirelon]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,13 @@
 
 ## Unreleased
 
-### Bug Fixes
-
-* Export ModalDialog component to re-enable client side usage. [#5956] by [@sgara]
-
 ### Enhacements
 
 * Display multiple flash messages in separate elements. [#5929] by [@mirelon]
 
 ### Bug Fixes
 
+* Export ModalDialog component to re-enable client side usage. [#5956] by [@sgara]
 * Use default ActionView options instead of default Formtastic options for DateRangeInput [#5957] by [@mirelon]
 
 ## 2.5.0 [☰](https://github.com/activeadmin/activeadmin/compare/v2.4.0..v2.5.0)
@@ -536,6 +533,7 @@ Please check [0-6-stable] for previous changes.
 [#5931]: https://github.com/activeadmin/activeadmin/pull/5931
 [#5938]: https://github.com/activeadmin/activeadmin/pull/5938
 [#5929]: https://github.com/activeadmin/activeadmin/pull/5929
+[#5956]: https://github.com/activeadmin/activeadmin/pull/5956
 [#5957]: https://github.com/activeadmin/activeadmin/pull/5957
 
 [@5t111111]: https://github.com/5t111111

--- a/app/assets/javascripts/active_admin/base.js
+++ b/app/assets/javascripts/active_admin/base.js
@@ -10,9 +10,10 @@
 //= require jquery_ujs
 //= require_self
 
-(function(factory) {
-  typeof define === "function" && define.amd ? define([ "jquery", "jquery-ui/ui/widgets/datepicker", "jquery-ui/ui/widgets/dialog", "jquery-ui/ui/widgets/sortable", "jquery-ui/ui/widgets/tabs", "jquery-ui/ui/widget", "jquery-ujs" ], factory) : factory();
-})(function() {
+(function(global, factory) {
+  typeof exports === "object" && typeof module !== "undefined" ? factory(exports, require("jquery"), require("jquery-ui/ui/widgets/datepicker"), require("jquery-ui/ui/widgets/dialog"), require("jquery-ui/ui/widgets/sortable"), require("jquery-ui/ui/widgets/tabs"), require("jquery-ui/ui/widget"), require("jquery-ujs")) : typeof define === "function" && define.amd ? define([ "exports", "jquery", "jquery-ui/ui/widgets/datepicker", "jquery-ui/ui/widgets/dialog", "jquery-ui/ui/widgets/sortable", "jquery-ui/ui/widgets/tabs", "jquery-ui/ui/widget", "jquery-ujs" ], factory) : (global = global || self, 
+  factory(global.ActiveAdmin = {}));
+})(this, function(exports) {
   "use strict";
   $.fn.serializeObject = function() {
     return this.serializeArray().reduce(function(obj, item) {
@@ -506,4 +507,18 @@
     return $("#active_admin_content .tabs").tabs();
   };
   $(document).ready(onDOMReady$2).on("page:load turbolinks:load", onDOMReady$2);
+  exports.CheckboxToggler = CheckboxToggler;
+  exports.DropdownMenu = DropdownMenu;
+  exports.Filters = Filters;
+  exports.ModalDialog = ModalDialog;
+  exports.PerPage = PerPage;
+  exports.TableCheckboxToggler = TableCheckboxToggler;
+  exports.hasTurbolinks = hasTurbolinks;
+  exports.queryString = queryString;
+  exports.queryStringToParams = queryStringToParams;
+  exports.toQueryString = toQueryString;
+  exports.turbolinksVisit = turbolinksVisit;
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
 });

--- a/app/assets/javascripts/active_admin/base.js
+++ b/app/assets/javascripts/active_admin/base.js
@@ -507,7 +507,12 @@
     return $("#active_admin_content .tabs").tabs();
   };
   $(document).ready(onDOMReady$2).on("page:load turbolinks:load", onDOMReady$2);
+  function modal_dialog(message, inputs, callback) {
+    console.warn("ActiveAdmin.modal_dialog is deprecated in favor of ActiveAdmin.ModalDialog, please update usage.");
+    return ModalDialog(message, inputs, callback);
+  }
   exports.ModalDialog = ModalDialog;
+  exports.modal_dialog = modal_dialog;
   Object.defineProperty(exports, "__esModule", {
     value: true
   });

--- a/app/assets/javascripts/active_admin/base.js
+++ b/app/assets/javascripts/active_admin/base.js
@@ -507,17 +507,7 @@
     return $("#active_admin_content .tabs").tabs();
   };
   $(document).ready(onDOMReady$2).on("page:load turbolinks:load", onDOMReady$2);
-  exports.CheckboxToggler = CheckboxToggler;
-  exports.DropdownMenu = DropdownMenu;
-  exports.Filters = Filters;
   exports.ModalDialog = ModalDialog;
-  exports.PerPage = PerPage;
-  exports.TableCheckboxToggler = TableCheckboxToggler;
-  exports.hasTurbolinks = hasTurbolinks;
-  exports.queryString = queryString;
-  exports.queryStringToParams = queryStringToParams;
-  exports.toQueryString = toQueryString;
-  exports.turbolinksVisit = turbolinksVisit;
   Object.defineProperty(exports, "__esModule", {
     value: true
   });

--- a/app/javascript/active_admin/base.js
+++ b/app/javascript/active_admin/base.js
@@ -18,10 +18,4 @@ import "./initializers/per-page"
 import "./initializers/table-checkbox-toggler"
 import "./initializers/tabs"
 
-export { default as CheckboxToggler } from "./lib/checkbox-toggler";
-export { default as DropdownMenu } from "./lib/dropdown-menu";
-export { default as Filters } from "./lib/filters";
 export { default as ModalDialog } from "./lib/modal-dialog";
-export { default as PerPage } from "./lib/per-page";
-export { default as TableCheckboxToggler } from "./lib/table-checkbox-toggler";
-export * from "./lib/utils";

--- a/app/javascript/active_admin/base.js
+++ b/app/javascript/active_admin/base.js
@@ -18,4 +18,11 @@ import "./initializers/per-page"
 import "./initializers/table-checkbox-toggler"
 import "./initializers/tabs"
 
-export { default as ModalDialog } from "./lib/modal-dialog";
+import ModalDialog from "./lib/modal-dialog";
+
+function modal_dialog(message, inputs, callback) {
+  console.warn("ActiveAdmin.modal_dialog is deprecated in favor of ActiveAdmin.ModalDialog, please update usage.");
+  return ModalDialog(message, inputs, callback);
+}
+
+export { ModalDialog, modal_dialog };

--- a/app/javascript/active_admin/base.js
+++ b/app/javascript/active_admin/base.js
@@ -17,3 +17,11 @@ import "./initializers/has-many"
 import "./initializers/per-page"
 import "./initializers/table-checkbox-toggler"
 import "./initializers/tabs"
+
+export { default as CheckboxToggler } from "./lib/checkbox-toggler";
+export { default as DropdownMenu } from "./lib/dropdown-menu";
+export { default as Filters } from "./lib/filters";
+export { default as ModalDialog } from "./lib/modal-dialog";
+export { default as PerPage } from "./lib/per-page";
+export { default as TableCheckboxToggler } from "./lib/table-checkbox-toggler";
+export * from "./lib/utils";

--- a/docs/9-batch-actions.md
+++ b/docs/9-batch-actions.md
@@ -154,13 +154,13 @@ batch_action :doit, form: -> { {user: User.pluck(:name, :id)} } do |ids, inputs|
 end
 ```
 
-Under the covers this is powered by the JS `ActiveAdmin.modal_dialog` which you
+Under the covers this is powered by the JS `ActiveAdmin.ModalDialog` which you
 can use yourself:
 
 ```coffee
 if $('body.admin_users').length
   $('a[data-prompt]').click ->
-    ActiveAdmin.modal_dialog $(@).data('prompt'), comment: 'textarea',
+    ActiveAdmin.ModalDialog $(@).data('prompt'), comment: 'textarea',
       (inputs)=>
         $.post "/admin/users/#{$(@).data 'id'}/change_state",
           comment: inputs.comment, state: $(@).data('state'),

--- a/tasks/lint.rake
+++ b/tasks/lint.rake
@@ -26,7 +26,7 @@ module LinterMixin
   private
 
   def applicable_files
-    Open3.capture2("git grep -Il ''")[0].split.reject { |file| file =~ %r{vendor/} }
+    Open3.capture2("git grep -Il ''")[0].split.reject { |file| file =~ %r{vendor/|app/assets/javascripts/active_admin/base.js} }
   end
 
   def failure_message_for(offenses)


### PR DESCRIPTION
This fixes #5953 and possible other components usage in client code.

NB. case has changed from `modal_dialog` to `ModalDialog`. We could export it with both names but I think that would be unnecessary legacy code.