### PR TITLE
Extend menu to allow for nested submenus.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+* Extend menu to allow for nested submenus. [#5994] by [@taralbass]
+
 ## 2.6.1 [☰](https://github.com/activeadmin/activeadmin/compare/v2.6.0..v2.6.1)
 
 ### Bug Fixes
@@ -554,6 +558,7 @@ Please check [0-6-stable] for previous changes.
 [#6000]: https://github.com/activeadmin/activeadmin/pull/6000
 [#6002]: https://github.com/activeadmin/activeadmin/pull/6002
 [#6047]: https://github.com/activeadmin/activeadmin/pull/6047
+[#5994]: https://github.com/activeadmin/activeadmin/pull/5994
 
 [@5t111111]: https://github.com/5t111111
 [@aarek]: https://github.com/aarek
@@ -628,6 +633,7 @@ Please check [0-6-stable] for previous changes.
 [@shouya]: https://github.com/shouya
 [@stefsava]: https://github.com/stefsava
 [@stereoscott]: https://github.com/stereoscott
+[@taralbass]: https://github.com/taralbass
 [@tiagotex]: https://github.com/tiagotex
 [@timoschilling]: https://github.com/timoschilling
 [@TimPetricola]: https://github.com/TimPetricola

--- a/app/assets/stylesheets/active_admin/_header.scss
+++ b/app/assets/stylesheets/active_admin/_header.scss
@@ -52,6 +52,11 @@
     margin: 0;
     padding: 0;
 
+    li {
+      /* Hover on li, display the ul */
+      &:hover > ul { display: block;}
+    }
+
     & > li {
       display: inline-block;
       margin-right: 4px;
@@ -95,8 +100,6 @@
       }
 
 
-      /* Hover on li, display the ul */
-      &:hover ul { display: block;}
       /* Drop down menus */
       ul {
         background: $hover-menu-item-background;
@@ -114,6 +117,7 @@
         z-index: 1010;
 
         li {
+          position: relative;
           margin: 0px;
           a {
             background: none;
@@ -124,10 +128,40 @@
           &.current {
             a { @include rounded(0) }
           }
+
+          &.has_nested > a {
+            background: url($menu-arrow-right-light-icon-url) no-repeat calc(100% - 7px) 55%;
+            padding-right: 20px;
+          }
+
+          &.has_nested:hover > a {
+            background: url($menu-arrow-right-dark-icon-url) no-repeat calc(100% - 7px) 55%;
+            color: #fff;
+          }
+
+          ul {
+            @include rounded-all(10px,10px,10px,10px);
+            margin-top: 0;
+            top: -3px;
+            left: 100%;
+
+            /* Create an invisible backdrop that adds 8px margin around the dropdown menu or submenu
+               that maintains the hover. This makes it much easier to navigate to submenus in
+               particular without losing hover accientally, especially near rounded corners. */
+            &:after {
+              content: "";
+              display: block;
+              position: absolute;
+              top: -8px;
+              left: -8px;
+              height: calc(100% + 16px);
+              width: calc(100% + 16px);
+              z-index: -2;
+            }
+          }
         }
       }
     }
-
   }
 
   #tabs {

--- a/app/assets/stylesheets/active_admin/mixins/_variables.scss
+++ b/app/assets/stylesheets/active_admin/mixins/_variables.scss
@@ -5,6 +5,9 @@
 // Images
 $menu-arrow-light-icon-url: 'data:image/png;base64,R0lGODlhBwAEAKIAAL6+vry8vIiIiJWVlf///3t7ewAAAAAAACH5BAEAAAUALAAAAAAHAAQAAAMLWLol80MoF5mQKgEAOw==' !default;
 $menu-arrow-dark-icon-url: 'data:image/png;base64,R0lGODlhBwAEAKIAAG1tbWxsbElJSVBQUP///0JCQgAAAAAAACH5BAEAAAUALAAAAAAHAAQAAAMLWLol80MoF5mQKgEAOw==' !default;
+$menu-arrow-right-light-icon-url: 'data:image/gif;base64,R0lGODlhBAAHAKECAKqqqszMzPkVFfkVFSH+EUNyZWF0ZWQgd2l0aCBHSU1QACH5BAEKAAIALAAAAAAEAAcAAAIJlA0XKbH9nmAFADs=' !default;
+$menu-arrow-right-dark-icon-url: 'data:image/gif;base64,R0lGODlhBAAHAMIEAG1tbWxsbElJSVBQUPkVFfkVFfkVFfkVFSH+EUNyZWF0ZWQgd2l0aCBHSU1QACH5BAEKAAEALAAAAAAEAAcAAAMKGKqy02G8OGeACQA7' !default;
+
 $orderable-icon-url: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAcAAABGCAYAAAAAVo4aAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAH5JREFUeNpi3LhlOwMU1AExGxDXwARYoHQLEFdD2cxAXAliMKFJgEAFEHfBJEHGMKLhMpgkTsAEdch/NNwCk2xCdiEQtML4LEgCf6EubUX3Cgh0oNvJ+P//f7wOGpUclRwYSZb41CyidNbB8giNM+9oXhmVHHm5bJjUSAABBgDKKiwMMUxPwgAAAABJRU5ErkJggg==' !default;
 
 // Colors

--- a/docs/2-resource-customization.md
+++ b/docs/2-resource-customization.md
@@ -164,7 +164,8 @@ The menu method accepts a hash with the following options:
 
 * `:label` - The string or proc label to display in the menu. If it's a proc, it
   will be called each time the menu is rendered.
-* `:parent` - The string id (or label) of the parent used for this menu
+* `:parent` - The string id (or label) of the parent used for this menu, or an array
+  of string ids (or labels) for a nested menu
 * `:if` - A block or a symbol of a method to call to decide if the menu item
   should be displayed
 * `:priority` - The integer value of the priority, which defaults to `10`
@@ -226,6 +227,14 @@ end
 
 Note that the "Blog" parent menu item doesn't even have to exist yet; it can be
 dynamically generated for you.
+
+To further nest an item under a submenu, provide an array of parents.
+
+```ruby
+ActiveAdmin.register Post do
+  menu parent: ["Admin", "Blog"]
+end
+```
 
 ### Customizing Parent Menu Items
 

--- a/lib/active_admin/menu.rb
+++ b/lib/active_admin/menu.rb
@@ -47,7 +47,10 @@ module ActiveAdmin
       #   menu.add parent: 'Dashboard', label: 'My Child Dashboard'
       #
       def add(options)
-        item = if parent = options.delete(:parent)
+        parent_chain = Array.wrap(options.delete(:parent))
+
+        item = if parent = parent_chain.shift
+                 options[:parent] = parent_chain if parent_chain.any?
                  (self[parent] || add(label: parent)).add options
                else
                  _add options.merge parent: self
@@ -60,7 +63,7 @@ module ActiveAdmin
 
       # Whether any children match the given item.
       def include?(item)
-        @children.values.include? item
+        @children.values.include?(item) || @children.values.any? { |child| child.include?(item) }
       end
 
       # Used in the UI to visually distinguish which menu item is selected.

--- a/spec/unit/menu_spec.rb
+++ b/spec/unit/menu_spec.rb
@@ -47,6 +47,14 @@ RSpec.describe ActiveAdmin::Menu do
       expect(menu["Admin"]["Projects"]).to be_an_instance_of(ActiveAdmin::MenuItem)
     end
 
+    it "should add a child to a non-root parent if it exists" do
+      menu = Menu.new
+      menu.add parent: "Admin", label: "Users"
+      menu.add parent: ["Admin", "Users"], label: "Projects"
+
+      expect(menu["Admin"]["Users"]["Projects"]).to be_an_instance_of(ActiveAdmin::MenuItem)
+    end
+
     it "should assign children regardless of resource file load order" do
       menu = Menu.new
       menu.add parent: "Users", label: "Posts"
@@ -54,6 +62,27 @@ RSpec.describe ActiveAdmin::Menu do
 
       expect(menu["Users"].url).to eq "/some/url"
       expect(menu["Users"]["Posts"]).to be_a ActiveAdmin::MenuItem
+    end
+  end
+
+  describe "determining if node is current" do
+    let(:menu) { Menu.new }
+    let(:admin_item) { menu.add label: "Admin" }
+    let(:users_item) { menu.add parent: "Admin", label: "Users" }
+    let(:projects_item) { menu.add parent: ["Admin", "Users"], label: "Projects" }
+    let(:posts_item) { menu.add label: "Posts" }
+
+    it "should consider item current in relation to itself" do
+      expect(admin_item.current?(admin_item)).to be true
+    end
+
+    it "should consider item current in relation to a descendent" do
+      expect(admin_item.current?(users_item)).to be true
+      expect(admin_item.current?(projects_item)).to be true
+    end
+
+    it "should not consider item current in relation to a non-self/non-descendant" do
+      expect(admin_item.current?(posts_item)).to be false
     end
   end
 end


### PR DESCRIPTION
We have so many Active Admin resources that our menus were becoming overwhelming. I added the ability to created nested submenus by monkey-patching Active Admin. There is no issue for this feature, but I decided to make a pull request, as it seemed that this feature might be useful based on assorted old conversations that I came across. My implementation does not require (or support) that the parent is a resource. It just extends how parent menus work today to allow multiple levels of parent, and handles the associated styling.


![active_admin_nested_menu_demo](https://user-images.githubusercontent.com/941242/71590568-e36e0a00-2add-11ea-8a75-9582f5b9596d.gif)

