### PR TITLE
Use double-splat where appropriate for Ruby 2.7.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+* Fix some ruby 2.7 warnings about keyword args. [#6000] by [@vcsjones]
+
 ## 2.6.0 [☰](https://github.com/activeadmin/activeadmin/compare/v2.5.0..v2.6.0)
 
 ### Enhacements
@@ -541,6 +545,7 @@ Please check [0-6-stable] for previous changes.
 [#5946]: https://github.com/activeadmin/activeadmin/pull/5946
 [#5956]: https://github.com/activeadmin/activeadmin/pull/5956
 [#5957]: https://github.com/activeadmin/activeadmin/pull/5957
+[#6000]: https://github.com/activeadmin/activeadmin/pull/6000
 
 [@5t111111]: https://github.com/5t111111
 [@aarek]: https://github.com/aarek
@@ -618,6 +623,7 @@ Please check [0-6-stable] for previous changes.
 [@timoschilling]: https://github.com/timoschilling
 [@TimPetricola]: https://github.com/TimPetricola
 [@varyonic]: https://github.com/varyonic
+[@vcsjones]: https://github.com/vcsjones
 [@violeta-p]: https://github.com/violeta-p
 [@WaKeMaTTa]: https://github.com/WaKeMaTTa
 [@wasifhossain]: https://github.com/wasifhossain

--- a/lib/active_admin/csv_builder.rb
+++ b/lib/active_admin/csv_builder.rb
@@ -51,14 +51,14 @@ module ActiveAdmin
       csv << bom if bom
 
       if column_names
-        csv << CSV.generate_line(columns.map { |c| encode c.name, options }, csv_options)
+        csv << CSV.generate_line(columns.map { |c| encode c.name, options }, **csv_options)
       end
 
       ActiveRecord::Base.uncached do
         (1..paginated_collection.total_pages).each do |page|
           paginated_collection(page).each do |resource|
             resource = controller.send :apply_decorator, resource
-            csv << CSV.generate_line(build_row(resource, columns, options), csv_options)
+            csv << CSV.generate_line(build_row(resource, columns, options), **csv_options)
           end
         end
       end
@@ -81,7 +81,11 @@ module ActiveAdmin
 
     def encode(content, options)
       if options[:encoding]
-        content.to_s.encode options[:encoding], options[:encoding_options]
+        if options[:encoding_options]
+          content.to_s.encode options[:encoding], **options[:encoding_options]
+        else
+          content.to_s.encode options[:encoding]
+        end
       else
         content
       end

--- a/lib/active_admin/localizers/resource_localizer.rb
+++ b/lib/active_admin/localizers/resource_localizer.rb
@@ -21,7 +21,7 @@ module ActiveAdmin
         scope = options.delete(:scope)
         specific_key = array_to_key('resources', @model_name, scope, key)
         defaults = [array_to_key(scope, key), key.to_s.titleize]
-        ::I18n.t specific_key, options.reverse_merge(model: @model, default: defaults, scope: 'active_admin')
+        ::I18n.t specific_key, **options.reverse_merge(model: @model, default: defaults, scope: 'active_admin')
       end
       alias_method :t, :translate
 

--- a/lib/active_admin/resource/naming.rb
+++ b/lib/active_admin/resource/naming.rb
@@ -46,7 +46,7 @@ module ActiveAdmin
       end
 
       def translate(options = {})
-        I18n.t i18n_key, { scope: [:activerecord, :models] }.merge(options)
+        I18n.t i18n_key, **{ scope: [:activerecord, :models] }.merge(options)
       end
 
       def route_key


### PR DESCRIPTION
Ruby 2.7 [suggests][1] the use of double-splat for hash arguments.

This contributes to, but does not fully resolve, issue #5999.

The double splat is supported back to Ruby 2.0, which is well below ActiveAdmin's minimum ruby version.

[1]: https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/