### PR TITLE
Fix date field label visibility on Safari

### DIFF
--- a/app/assets/stylesheets/active_admin/_forms.scss
+++ b/app/assets/stylesheets/active_admin/_forms.scss
@@ -13,6 +13,7 @@ form {
 
     legend {
       width: 100%;
+      overflow: auto;
       span { display: block; @include section-header; }
     }
 


### PR DESCRIPTION
It fixes the label visibility of date fields on Safari.

Issue:
https://github.com/activeadmin/activeadmin/issues/5969