### PR TITLE
Cast filter date value with respect of its class

### DIFF
--- a/lib/active_admin/inputs/filters/date_range_input.rb
+++ b/lib/active_admin/inputs/filters/date_range_input.rb
@@ -31,7 +31,15 @@ module ActiveAdmin
         def input_html_options_for(input_name, placeholder)
           current_value = begin
                             #cast value to date object before rendering input
-                            @object.public_send(input_name).to_s.to_date
+                            raw_value = @object.public_send(input_name)
+                            case raw_value
+                            when Time
+                              raw_value.to_date
+                            when Date
+                              raw_value
+                            else
+                              raw_value.to_s.to_date
+                            end
                           rescue
                             nil
                           end


### PR DESCRIPTION
This is proposal to fix an issue if filter dates.
Initially issue observed by parsing date incorrectly (swap month and date) after apply filter.
So when date filter was "2019-12-01" it returns after apply as "2019-01-12" and then exchange again.

Configuration  application.rb:
`Date::DATE_FORMATS[:default] = lambda { |date| I18n.l(date) }`
`Time::DATE_FORMATS[:default] = lambda { |time| I18n.l(time) }`

And config/locales/en.yml have:
<pre>en:
  date:
    formats:
      default: "%m/%d/%Y"

  time:
      formats:
        default: "%m/%d/%Y %I:%M %P"
</pre>


This configuration allows correctly select and submit date filter value.
Query have correct conditions and correctly processing and return result.
But parsing of query string into filter values become incorrect.

Original peace of code
`@object.public_send(input_name).to_s.to_date`
assumes the param is always String type.
But in Rails 6 it is really already a Time.
That is why "to_s" becomes here excess.

The debug details shown below:
<pre>
(byebug) @object.public_send(input_name).to_s.to_date
Sat, 12 Jan 2019

(byebug) @object.public_send(input_name).to_s("").to_date
Sun, 01 Dec 2019

(byebug) @object.public_send(input_name).to_s
"12/01/2019 12:00 am"

(byebug) @object.public_send(input_name).to_s("")
"2019-12-01 00:00:00 -0500"

(byebug) @object.public_send(input_name)
Sun, 01 Dec 2019 00:00:00 EST -05:00

(byebug) @object.public_send(input_name).class
ActiveSupport::TimeWithZone

> Rails.application.config.time_zone
 => "Eastern Time (US & Canada)" 
</pre>

I was going to write spec for this, but it is difficult for me.
Capibara or whatever emulation tool already passing dates converted to String.
That is why I can't add proper example.

The draft I used is:
<pre>
diff --git a/spec/unit/filters/filter_form_builder_spec.rb b/spec/unit/filters/filter_form_builder_spec.rb
index b1e0141e..ed2da41b 100644
--- a/spec/unit/filters/filter_form_builder_spec.rb
+++ b/spec/unit/filters/filter_form_builder_spec.rb
@@ -525,6 +525,18 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
           expect(body).to have_selector("input[name='q[custom_created_at_searcher_lteq_datetime]'][value='']")
         end
       end
+
+      context "filter value casts to date" do
+        let(:gteq) { DateTime.parse("2019-12-01") }
+        let(:lteq) { Time.parse("2019-12-01") }
+
+        it "from DateTime and Time" do
+          Time::DATE_FORMATS[:default] = "%m/%d/%Y %I:%M %P"
+          Date::DATE_FORMATS[:default] = "%m/%d/%Y"
+          expect(body).to have_selector("input[name='q[custom_created_at_searcher_gteq_datetime]'][value='2019-12-01']")
+          expect(body).to have_selector("input[name='q[custom_created_at_searcher_lteq_datetime]'][value='2019-12-01']")
+        end
+      end
     end
   end
</pre>


I believe the fix proposed by me is needed.
Please correct the spec draft or advise how to correct it to be passed into code.