### PR TITLE
i18n: Rename 'destroy' => 'delete'; Fix grammar

### DIFF
--- a/config/locales/en-CA.yml
+++ b/config/locales/en-CA.yml
@@ -68,8 +68,8 @@
       default_confirmation: "Are you sure you want to do this?"
       delete_confirmation: "Are you sure you want to delete these %{plural_model}?"
       succesfully_destroyed:
-        one: "Successfully destroyed 1 %{model}"
-        other: "Successfully destroyed %{count} %{plural_model}"
+        one: "Successfully deleted 1 %{model}"
+        other: "Successfully deleted %{count} %{plural_model}"
       selection_toggle_explanation: "(Toggle Selection)"
       action_label: "%{title} Selected"
       labels:
@@ -82,7 +82,7 @@
       author: "Author"
       add: "Add Comment"
       delete: "Delete Comment"
-      delete_confirmation: "Are you sure you want to delete these comment?"
+      delete_confirmation: "Are you sure you want to delete these comments?"
       resource: "Resource"
       no_comments_yet: "No comments yet."
       author_missing: "Anonymous"

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -68,8 +68,8 @@
       default_confirmation: "Are you sure you want to do this?"
       delete_confirmation: "Are you sure you want to delete these %{plural_model}?"
       succesfully_destroyed:
-        one: "Successfully destroyed 1 %{model}"
-        other: "Successfully destroyed %{count} %{plural_model}"
+        one: "Successfully deleted 1 %{model}"
+        other: "Successfully deleted %{count} %{plural_model}"
       selection_toggle_explanation: "(Toggle Selection)"
       action_label: "%{title} Selected"
       labels:
@@ -82,7 +82,7 @@
       author: "Author"
       add: "Add Comment"
       delete: "Delete Comment"
-      delete_confirmation: "Are you sure you want to delete these comment?"
+      delete_confirmation: "Are you sure you want to delete these comments?"
       resource: "Resource"
       no_comments_yet: "No comments yet."
       author_missing: "Anonymous"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -91,8 +91,8 @@ en:
       default_confirmation: "Are you sure you want to do this?"
       delete_confirmation: "Are you sure you want to delete these %{plural_model}?"
       succesfully_destroyed:
-        one: "Successfully destroyed 1 %{model}"
-        other: "Successfully destroyed %{count} %{plural_model}"
+        one: "Successfully deleted 1 %{model}"
+        other: "Successfully deleted %{count} %{plural_model}"
       selection_toggle_explanation: "(Toggle Selection)"
       action_label: "%{title} Selected"
       labels:
@@ -105,7 +105,7 @@ en:
       author: "Author"
       add: "Add Comment"
       delete: "Delete Comment"
-      delete_confirmation: "Are you sure you want to delete these comment?"
+      delete_confirmation: "Are you sure you want to delete these comments?"
       resource: "Resource"
       no_comments_yet: "No comments yet."
       author_missing: "Anonymous"

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -60,8 +60,8 @@ lv:
       default_confirmation: "Vai tiešām vēlaties to darīt?"
       delete_confirmation: "Vai tiešām vēlaties dzēst šos %{plural_model}?"
       succesfully_destroyed:
-        one: "Successfully destroyed 1 %{model}"
-        other: "Successfully destroyed %{count} %{plural_model}"
+        one: "Successfully deleted 1 %{model}"
+        other: "Successfully deleted %{count} %{plural_model}"
       selection_toggle_explanation: "(Toggle Selection)"
       action_label: "%{title} Selected"
       labels:

--- a/features/index/batch_actions.feature
+++ b/features/index/batch_actions.feature
@@ -18,7 +18,7 @@ Feature: Batch Actions
     Then I should see the batch action :destroy "Delete Selected"
 
     When I click "Delete Selected" and accept confirmation
-    Then I should see a flash with "Successfully destroyed 2 posts"
+    Then I should see a flash with "Successfully deleted 2 posts"
     And I should see 8 posts in the table
 
   Scenario: Use default (destroy) batch action when default_url_options present
@@ -40,7 +40,7 @@ Feature: Batch Actions
     Then I should see the batch action :destroy "Delete Selected"
 
     Given I submit the batch action form with "destroy"
-    Then I should see a flash with "Successfully destroyed 1 post"
+    Then I should see a flash with "Successfully deleted 1 post"
     And I should see 2 posts in the table
 
   Scenario: Use default (destroy) batch action on a decorated resource
@@ -57,7 +57,7 @@ Feature: Batch Actions
     Then I should see the batch action :destroy "Delete Selected"
 
     Given I submit the batch action form with "destroy"
-    Then I should see a flash with "Successfully destroyed 2 posts"
+    Then I should see a flash with "Successfully deleted 2 posts"
     And I should see 3 posts in the table
 
   @javascript
@@ -83,7 +83,7 @@ Feature: Batch Actions
     Then I should see the batch action :destroy "Delete Selected"
 
     When I click "Delete Selected" and accept confirmation
-    Then I should see a flash with "Successfully destroyed 2 posts"
+    Then I should see a flash with "Successfully deleted 2 posts"
     And I should see 3 posts in the table
 
   Scenario: Disable display of batch action button if all nested buttons hide


### PR DESCRIPTION
I realized that in most places "destroy" has been renamed to "delete", which sounds more "human", "destroy" sounds "robotic". :)

I found one message, that my client noticed yesterday, and decided to translate it as well.

I also fixed one "typo" where singular was used instead of plural.

<!--

Thanks for contributing to ActiveAdmin!

You can find all the instructions for contributing at the [CONTRIBUTING file].

Before submitting your PR make sure that:

* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are splitted apart.
* Your PR includes a regression test if it fixes a bug.
* You add an entry to the [Changelog] if the new code introduces user-observable changes. See [changelog entry format].

Before expecting a review for your PR make sure that all github checks are passing, but feel free to ask for early feedback if you need guidance.

[CONTRIBUTING file]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords
[Changelog]: https://github.com/activeadmin/activeadmin/blob/master/CHANGELOG.md
[changelog entry format]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md#add-a-changelog-entry

-->