### PR TITLE
Fix `npm_push` task namespacing

### DIFF
--- a/tasks/release.rake
+++ b/tasks/release.rake
@@ -1,13 +1,13 @@
 require "chandler/tasks"
 require_relative "release_manager"
 
-desc 'Publish npm package'
-task :npm_push do
-  npm_tag = version.include?("-") ? "pre" : "latest"
-  sh "npm publish --tag #{npm_tag}"
-end
-
 namespace :release do
+  desc 'Publish npm package'
+  task :npm_push do
+    npm_tag = version.include?("-") ? "pre" : "latest"
+    sh "npm publish --tag #{npm_tag}"
+  end
+
   desc "Prepare a prerelease"
   task :prepare_prerelease do
     ReleaseManager.new.prepare_prerelease
@@ -47,4 +47,4 @@ end
 #
 # Add chandler as a prerequisite for `rake release`
 #
-task "release:rubygem_push" => ["chandler:push", "activeadmin:npm_push"]
+task "release:rubygem_push" => ["chandler:push", "release:npm_push"]


### PR DESCRIPTION
<!--

Thanks for contributing to ActiveAdmin!

You can find all the instructions for contributing at the [CONTRIBUTING file].

Before submitting your PR make sure that:

* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are splitted apart.
* Your PR includes a regression test if it fixes a bug.
* You add an entry to the [Changelog] if the new code introduces user-observable changes. See [changelog entry format].

Before expecting a review for your PR make sure that all github checks are passing, but feel free to ask for early feedback if you need guidance.

[CONTRIBUTING file]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords
[Changelog]: https://github.com/activeadmin/activeadmin/blob/master/CHANGELOG.md
[changelog entry format]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md#add-a-changelog-entry

-->

I tried to release, but the `npm_push` task failed due to a namespacing issue I introduced at https://github.com/activeadmin/activeadmin/pull/6048/commits/f81c7790ca9efc4ea88a0a486fce608611369004.
