### PR TITLE
Add flashes wrapper to logged_out view

### DIFF
--- a/app/views/layouts/active_admin_logged_out.html.erb
+++ b/app/views/layouts/active_admin_logged_out.html.erb
@@ -24,9 +24,11 @@
 <div id="wrapper">
 
   <div id="content_wrapper">
-    <% flash_messages.each do |type, message| %>
-      <%= content_tag :div, message, class: "flash flash_#{type}" %>
-    <% end %>
+    <div class="flashes">
+      <% flash_messages.each do |type, message| %>
+        <%= content_tag :div, message, class: "flash flash_#{type}" %>
+      <% end %>
+    </div>
     <div id="active_admin_content">
       <%= yield %>
     </div>


### PR DESCRIPTION
When logged in we have flash notifications wrapped inside a `<div class="flashes">` wrapper. When logged out there is no wrapper so the styling applied to `.flashes` does not get applied. This PR add the wrapper to `active_admin_logged_out.html.erb`.