### PR TITLE
Support multiple belongs_to optional parents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+* Allow `belongs_to` with multiple optional parents. [#6115] by [@Looooong]
+
 ## 2.7.0 [☰](https://github.com/activeadmin/activeadmin/compare/v2.6.1..v2.7.0)
 
 ### Enhancements
@@ -572,6 +576,7 @@ Please check [0-6-stable] for previous changes.
 [#6149]: https://github.com/activeadmin/activeadmin/pull/6149
 [#6086]: https://github.com/activeadmin/activeadmin/pull/6086
 [#6099]: https://github.com/activeadmin/activeadmin/pull/6099
+[#6115]: https://github.com/activeadmin/activeadmin/pull/6115
 
 [@5t111111]: https://github.com/5t111111
 [@aarek]: https://github.com/aarek

--- a/docs/2-resource-customization.md
+++ b/docs/2-resource-customization.md
@@ -473,3 +473,13 @@ ActiveAdmin.register Ticket do
   belongs_to :project, optional: true
 end
 ```
+
+You can also declare optional `belongs_to` with multiple parents:
+
+```ruby
+ActiveAdmin.register Project
+ActiveAdmin.register User
+ActiveAdmin.register Ticket do
+  belongs_to :project, :user, optional: true
+end
+```

--- a/lib/active_admin/base_controller/menu.rb
+++ b/lib/active_admin/base_controller/menu.rb
@@ -17,16 +17,14 @@ module ActiveAdmin
       # Set's @current_tab to be name of the tab to mark as current
       # Get's called through a before filter
       def set_current_tab
-        @current_tab = if current_menu && active_admin_config.belongs_to? && parent?
-                         parent_item = active_admin_config.belongs_to_config.target.menu_item
-                         if current_menu.include? parent_item
-                           parent_item
-                         else
-                           active_admin_config.menu_item
-                         end
-                       else
-                         active_admin_config.menu_item
-                       end
+        @current_tab =
+          if current_menu && active_admin_config.belongs_to? && parent?
+            active_admin_config.belongs_to_config.targets.find(-> { active_admin_config }) do |target|
+              parent.is_a?(target.resource_class) && current_menu.include?(target.menu_item)
+            end.menu_item
+          else
+            active_admin_config.menu_item
+          end
       end
 
     end

--- a/lib/active_admin/page.rb
+++ b/lib/active_admin/page.rb
@@ -84,10 +84,11 @@ module ActiveAdmin
       @page_actions = []
     end
 
-    def belongs_to(target, options = {})
-      @belongs_to = Resource::BelongsTo.new(self, target, options)
-      self.navigation_menu_name = target unless @belongs_to.optional?
-      controller.send :belongs_to, target, options.dup
+    def belongs_to(targets, options = {})
+      @belongs_to = Resource::BelongsTo.new(self, targets, options.dup)
+      # Required `belongs_to` "should" have only one target
+      self.navigation_menu_name = targets[0] if @belongs_to.required?
+      controller.send :belongs_to, *targets, options.dup
     end
 
     def belongs_to_config

--- a/lib/active_admin/page_dsl.rb
+++ b/lib/active_admin/page_dsl.rb
@@ -25,8 +25,9 @@ module ActiveAdmin
       end
     end
 
-    def belongs_to(target, options = {})
-      config.belongs_to(target, options)
+    def belongs_to(*targets)
+      options = targets.extract_options!
+      config.belongs_to(targets, options)
     end
   end
 end

--- a/lib/active_admin/resource/routes.rb
+++ b/lib/active_admin/resource/routes.rb
@@ -127,11 +127,19 @@ module ActiveAdmin
         end
 
         def belongs_to_target_name
-          belongs_to_config.target_name
+          # This method is called when `#nested?` return true.
+          # Since `#nested?` means if `belongs_to` is required,
+          #   it makes sense to get the first target name,
+          #   because the required `belongs_to` "should" have only one target name.
+          belongs_to_config.target_names[0]
         end
 
         def belongs_to_name
-          belongs_to_config.target.resource_name.singular
+          # This method is called when `#nested?` return true.
+          # Since `#nested?` means if `belongs_to` is required,
+          #   it makes sense to get the first target,
+          #   because the required `belongs_to` "should" have only one target.
+          belongs_to_config.targets[0].resource_name.singular
         end
 
         def belongs_to_config

--- a/lib/active_admin/resource_controller/polymorphic_routes.rb
+++ b/lib/active_admin/resource_controller/polymorphic_routes.rb
@@ -25,9 +25,12 @@ module ActiveAdmin
           return ActiveAdmin::Model.new(active_admin_config, record)
         end
 
-        belongs_to_resource = active_admin_config.belongs_to_config.try(:resource)
-        if belongs_to_resource && record.is_a?(belongs_to_resource.resource_class)
-          return ActiveAdmin::Model.new(belongs_to_resource, record)
+        if active_admin_config.belongs_to?
+          active_admin_config.belongs_to_config.targets.each do |target|
+            if record.is_a?(target.resource_class)
+              return ActiveAdmin::Model.new(target, record)
+            end
+          end
         end
 
         record

--- a/lib/active_admin/resource_dsl.rb
+++ b/lib/active_admin/resource_dsl.rb
@@ -23,8 +23,9 @@ module ActiveAdmin
       config.ordering[column] = block
     end
 
-    def belongs_to(target, options = {})
-      config.belongs_to(target, options)
+    def belongs_to(*targets)
+      options = targets.extract_options!
+      config.belongs_to(targets, options)
     end
 
     # Scope collection to a relation

--- a/lib/active_admin/router.rb
+++ b/lib/active_admin/router.rb
@@ -99,9 +99,11 @@ module ActiveAdmin
       page_or_resource_routes(config) if config.belongs_to_config.optional?
 
       # Make the nested belongs_to routes
-      # :only is set to nothing so that we don't clobber any existing routes on the resource
-      router.resources config.belongs_to_config.target.resource_name.plural, only: [] do
-        page_or_resource_routes(config)
+      config.belongs_to_config.targets.each do |target|
+        # :only is set to nothing so that we don't clobber any existing routes on the resource
+        router.resources target.resource_name.plural, only: [] do
+          page_or_resource_routes(config)
+        end
       end
     end
 

--- a/spec/unit/belongs_to_spec.rb
+++ b/spec/unit/belongs_to_spec.rb
@@ -3,14 +3,16 @@ require 'rails_helper'
 RSpec.describe ActiveAdmin::Resource::BelongsTo do
   before do
     load_resources do
-      ActiveAdmin.register User
-      ActiveAdmin.register Post do belongs_to :user end
+      category_config
+      user_config
+      post_config
     end
   end
 
   let(:namespace) { ActiveAdmin.application.namespace(:admin) }
+  let(:category_config) { ActiveAdmin.register Category }
   let(:user_config) { ActiveAdmin.register User }
-  let(:post_config) { ActiveAdmin.register Post do belongs_to :user end }
+  let(:post_config) { ActiveAdmin.register(Post) { belongs_to :user } }
   let(:belongs_to) { post_config.belongs_to_config }
 
   it "should have an owner" do
@@ -20,23 +22,23 @@ RSpec.describe ActiveAdmin::Resource::BelongsTo do
   describe "finding the target" do
     context "when the resource has been registered" do
       it "should return the target resource" do
-        expect(belongs_to.target).to eq user_config
+        expect(belongs_to.targets).to contain_exactly(user_config)
       end
     end
 
     context "when the resource has not been registered" do
-      let(:belongs_to) { ActiveAdmin::Resource::BelongsTo.new post_config, :missing }
+      let(:belongs_to) { ActiveAdmin::Resource::BelongsTo.new post_config, [:missing] }
 
-      it "should raise a ActiveAdmin::BelongsTo::TargetNotFound" do
+      it "should raise a ActiveAdmin::Resource::BelongsTo::TargetNotFound" do
         expect {
-          belongs_to.target
+          belongs_to.targets
         }.to raise_error(ActiveAdmin::Resource::BelongsTo::TargetNotFound)
       end
     end
 
     context "when the resource is on a namespace" do
       let(:blog_post_config) { ActiveAdmin.register Blog::Post do; end }
-      let(:belongs_to) { ActiveAdmin::Resource::BelongsTo.new blog_post_config, :blog_author, class_name: "Blog::Author" }
+      let(:belongs_to) { ActiveAdmin::Resource::BelongsTo.new blog_post_config, [:blog_author], class_name: "Blog::Author" }
       before do
         class Blog::Author
           include ActiveModel::Naming
@@ -44,14 +46,34 @@ RSpec.describe ActiveAdmin::Resource::BelongsTo do
         @blog_author_config = ActiveAdmin.register Blog::Author do; end
       end
       it "should return the target resource" do
-        expect(belongs_to.target).to eq @blog_author_config
+        expect(belongs_to.targets).to contain_exactly(@blog_author_config)
       end
     end
   end
 
   it "should be optional" do
-    belongs_to = ActiveAdmin::Resource::BelongsTo.new post_config, :user, optional: true
+    belongs_to = ActiveAdmin::Resource::BelongsTo.new post_config, [:user], optional: true
     expect(belongs_to).to be_optional
+  end
+
+  describe "with multiple optional targets" do
+    let(:post_config) { ActiveAdmin.register(Post) { belongs_to :category, :user, optional: true } }
+
+    it "should be optional" do
+      expect(belongs_to).to be_optional
+    end
+
+    it "should return the target resources" do
+      expect(belongs_to.targets).to contain_exactly(category_config, user_config)
+    end
+  end
+
+  describe "with multiple non-optional targets" do
+    it "should raise a ActiveAdmin::Resource::BelongsTo::NotSupported" do
+      expect {
+        ActiveAdmin.register(Post) { belongs_to :category, :user }
+      }.to raise_error(ActiveAdmin::Resource::BelongsTo::NotSupported)
+    end
   end
 
   describe "controller" do

--- a/spec/unit/namespace/register_page_spec.rb
+++ b/spec/unit/namespace/register_page_spec.rb
@@ -95,5 +95,17 @@ RSpec.describe ActiveAdmin::Namespace, "registering a page" do
         expect(menu["Reports"]).to_not be_nil
       end
     end
+
+    context "with multiple optional parents" do
+      before do
+        namespace.register_page "Reports" do
+          belongs_to :author, :user, optional: true
+        end
+      end
+
+      it "should be in the menu" do
+        expect(menu["Reports"]).to_not be_nil
+      end
+    end
   end # describe "adding as a belongs to"
 end

--- a/spec/unit/namespace/register_resource_spec.rb
+++ b/spec/unit/namespace/register_resource_spec.rb
@@ -127,10 +127,22 @@ RSpec.describe ActiveAdmin::Namespace, "registering a resource" do
           expect(menu["Posts"]).to eq nil
         end
       end
+
       context "when optional" do
         before do
           namespace.register Post do
             belongs_to :author, optional: true
+          end
+        end
+        it "should show up in the menu" do
+          expect(menu["Posts"]).to_not eq nil
+        end
+      end
+
+      context "with multiple optional parents" do
+        before do
+          namespace.register Post do
+            belongs_to :author, :user, optional: true
           end
         end
         it "should show up in the menu" do

--- a/spec/unit/page_spec.rb
+++ b/spec/unit/page_spec.rb
@@ -90,7 +90,7 @@ module ActiveAdmin
       it "builds a belongs_to relationship" do
         belongs_to = page_config.belongs_to_config
 
-        expect(belongs_to.target).to eq(post_config)
+        expect(belongs_to.targets).to contain_exactly(post_config)
         expect(belongs_to.owner).to eq(page_config)
         expect(belongs_to.optional?).to be_falsy
       end
@@ -114,6 +114,32 @@ module ActiveAdmin
         expect(page_config.navigation_menu_name).to eq(:default)
       end
     end # context "with optional belongs to config" do
+
+    context "with optional belongs to multiple targets config" do
+      let!(:user_config) { namespace.register User }
+      let!(:post_config) { namespace.register Post }
+      let!(:page_config) {
+        namespace.register_page page_name do
+          belongs_to :user, :post, optional: true
+        end
+      }
+
+      it "configures page with belongs_to" do
+        expect(page_config.belongs_to?).to be true
+      end
+
+      it "does not override default navigation menu" do
+        expect(page_config.navigation_menu_name).to eq(:default)
+      end
+
+      it "builds a belongs_to relationship" do
+        belongs_to = page_config.belongs_to_config
+
+        expect(belongs_to.targets).to contain_exactly(user_config, post_config)
+        expect(belongs_to.owner).to eq(page_config)
+        expect(belongs_to.optional?).to be_truthy
+      end
+    end
 
     it "has no belongs_to by default" do
       expect(config.belongs_to?).to be_falsy

--- a/spec/unit/resource_controller/polymorphic_routes_spec.rb
+++ b/spec/unit/resource_controller/polymorphic_routes_spec.rb
@@ -5,13 +5,10 @@ RSpec.describe ActiveAdmin::ResourceController::PolymorphicRoutes, type: :contro
 
   %w(polymorphic_url polymorphic_path).each do |method|
     describe method do
-      let(:add_extra_routes) {}
       let(:params) { {} }
 
       before do
         load_resources { post_config }
-
-        add_extra_routes
 
         @controller = klass.new
 
@@ -54,7 +51,7 @@ RSpec.describe ActiveAdmin::ResourceController::PolymorphicRoutes, type: :contro
         end
       end
 
-      context 'with multiple belongs_to (not fully supported yet)' do
+      context 'with belongs_to multiple optional parents' do
         let(:user) { User.create! }
         let(:category) { Category.create! name: "Category" }
         let(:post) { Post.create! title: "Hello World", author: user, category: category }
@@ -63,23 +60,7 @@ RSpec.describe ActiveAdmin::ResourceController::PolymorphicRoutes, type: :contro
           ActiveAdmin.register User
           ActiveAdmin.register Category
           ActiveAdmin.register Post do
-            belongs_to :category, optional: true
-            belongs_to :user, optional: true
-          end
-        end
-
-        let(:add_extra_routes) do
-          routes.draw do
-            ActiveAdmin.routes(self)
-            namespace :admin do
-              resources :posts
-              resources :users do
-                resources :posts
-              end
-              resources :categories do
-                resources :posts
-              end
-            end
+            belongs_to :category, :user, optional: true
           end
         end
 

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -88,13 +88,13 @@ module ActiveAdmin
     describe "#belongs_to" do
       it "should build a belongs to configuration" do
         expect(config.belongs_to_config).to eq nil
-        config.belongs_to :posts
+        config.belongs_to [:posts]
         expect(config.belongs_to_config).to_not eq nil
       end
 
       it "should not set the target menu to the belongs to target" do
         expect(config.navigation_menu_name).to eq ActiveAdmin::DEFAULT_MENU
-        config.belongs_to :posts
+        config.belongs_to [:posts]
         expect(config.navigation_menu_name).to eq ActiveAdmin::DEFAULT_MENU
       end
     end

--- a/spec/unit/routing_spec.rb
+++ b/spec/unit/routing_spec.rb
@@ -187,6 +187,48 @@ RSpec.describe "Routing", type: :routing do
     end
   end
 
+  describe "belongs to multiple optional parents" do
+    around do |example|
+      with_resources_during(example) do
+        ActiveAdmin.register(Category)
+        ActiveAdmin.register(User)
+        ActiveAdmin.register(Post) { belongs_to :category, :user, optional: true }
+      end
+    end
+
+    it "should route the nested index path belongs to Category" do
+      expect(admin_category_posts_path(1)).to eq "/admin/categories/1/posts"
+    end
+
+    it "should route the nested show path belongs to Category" do
+      expect(admin_category_post_path(1, 2)).to eq "/admin/categories/1/posts/2"
+    end
+
+    it "should route the nested new path belongs to Category" do
+      expect(new_admin_category_post_path(1)).to eq "/admin/categories/1/posts/new"
+    end
+
+    it "should route the nested edit path belongs to Category" do
+      expect(edit_admin_category_post_path(1, 2)).to eq "/admin/categories/1/posts/2/edit"
+    end
+
+    it "should route the nested index path belongs to User" do
+      expect(admin_user_posts_path(1)).to eq "/admin/users/1/posts"
+    end
+
+    it "should route the nested show path belongs to User" do
+      expect(admin_user_post_path(1, 2)).to eq "/admin/users/1/posts/2"
+    end
+
+    it "should route the nested new path belongs to User" do
+      expect(new_admin_user_post_path(1)).to eq "/admin/users/1/posts/new"
+    end
+
+    it "should route the nested edit path belongs to User" do
+      expect(edit_admin_user_post_path(1, 2)).to eq "/admin/users/1/posts/2/edit"
+    end
+  end
+
   describe "page" do
     context "when default namespace" do
       around do |example|


### PR DESCRIPTION
This PR resolves #221 by allowing multiple symbols to be passed to `belongs_to`, which `optional` must be `true`. Example:

```ruby
ActiveAdmin.register Project
ActiveAdmin.register User
ActiveAdmin.register Ticket do
  belongs_to :project, :user, optional: true
end
```

These changes include: resource DSL, page DSL, breadcrumb, router, routes and polymorphic routes. Tests are added or updated for the corresponding modifications.

<!--

Thanks for contributing to ActiveAdmin!

You can find all the instructions for contributing at the [CONTRIBUTING file].

Before submitting your PR make sure that:

* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are splitted apart.
* Your PR includes a regression test if it fixes a bug.
* You add an entry to the [Changelog] if the new code introduces user-observable changes. See [changelog entry format].

Before expecting a review for your PR make sure that all github checks are passing, but feel free to ask for early feedback if you need guidance.

[CONTRIBUTING file]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords
[Changelog]: https://github.com/activeadmin/activeadmin/blob/master/CHANGELOG.md
[changelog entry format]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md#add-a-changelog-entry

-->
