### PR TITLE
Add ruby 2.7 to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,6 +305,39 @@ jobs:
     steps:
       *test_steps
 
+  ruby27rails52:
+    docker:
+      - image: circleci/ruby:2.7.0-node-browsers
+        user: root
+
+    environment:
+      BUNDLE_GEMFILE: gemfiles/rails_52/Gemfile
+
+    steps:
+      *test_steps
+
+  ruby27rails60:
+    docker:
+    - image: circleci/ruby:2.7.0-node-browsers
+      user: root
+
+    environment:
+      BUNDLE_GEMFILE: Gemfile
+
+    steps:
+      *test_steps
+
+  ruby27rails60turbolinks:
+    docker:
+    - image: circleci/ruby:2.7.0-node-browsers
+      user: root
+
+    environment:
+      BUNDLE_GEMFILE: gemfiles/rails_60_turbolinks/Gemfile
+
+    steps:
+      *test_steps
+
   jruby92rails52:
     docker:
       - image: circleci/jruby:9.2.8.0-node-browsers
@@ -385,6 +418,18 @@ workflows:
           requires:
             - testapp60turbolinks
 
+      - ruby27rails52:
+          requires:
+            - testapp52
+
+      - ruby27rails60:
+          requires:
+            - testapp60
+
+      - ruby27rails60turbolinks:
+          requires:
+            - testapp60turbolinks
+
       - jruby92rails52:
           requires:
             - testapp52
@@ -409,6 +454,10 @@ workflows:
             - ruby26rails52
             - ruby26rails60
             - ruby26rails60turbolinks
+
+            - ruby27rails52
+            - ruby27rails60
+            - ruby27rails60turbolinks
 
             - jruby92rails52
             - jruby92rails60

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ version: 2.1
 .format_coverage: &format_coverage
   run:
     name: Format coverage
-    command: bin/test-reporter format-coverage --input-type simplecov --output coverage/codeclimate.$CIRCLE_JOB.json
+    command: bin/test-reporter format-coverage --output coverage/codeclimate.$CIRCLE_JOB.json
 
 .save_coverage: &save_coverage
   persist_to_workspace:
@@ -66,9 +66,8 @@ version: 2.1
   run:
     name: Upload coverage results to Code Climate
     command: |
-      # The parts number should match the number of jobs under upload_coverage/requires
-      bin/test-reporter sum-coverage coverage/codeclimate.*.json --parts 12 --output coverage/codeclimate.total.json
-      bin/test-reporter upload-coverage --input coverage/codeclimate.total.json
+      bin/test-reporter sum-coverage coverage/codeclimate.*.json
+      bin/test-reporter upload-coverage
 
 .save_test_app: &save_test_app
   persist_to_workspace:


### PR DESCRIPTION
I'm starting to review #5855, but tests don't seem to pass locally.

I want to rule out that it's related to my ruby version, and start testing against ruby 2.7 in CI, since I'm at it.

<!--

Thanks for contributing to ActiveAdmin!

You can find all the instructions for contributing at the [CONTRIBUTING file].

Before submitting your PR make sure that:

* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are splitted apart.
* Your PR includes a regression test if it fixes a bug.
* You add an entry to the [Changelog] if the new code introduces user-observable changes. See [changelog entry format].

Before expecting a review for your PR make sure that all github checks are passing, but feel free to ask for early feedback if you need guidance.

[CONTRIBUTING file]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords
[Changelog]: https://github.com/activeadmin/activeadmin/blob/master/CHANGELOG.md
[changelog entry format]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md#add-a-changelog-entry

-->
