### PR TITLE
Sort files to be loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+* Make source `ActiveAdmin.routes` provides routes in a consistent order. [#6124] by [@jiikko]
+
 ### Dependency Changes
 
 * Support for ruby 2.4 has been removed. [#6198] by [@deivid-rodriguez]
@@ -576,6 +580,7 @@ Please check [0-6-stable] for previous changes.
 [#6149]: https://github.com/activeadmin/activeadmin/pull/6149
 [#6086]: https://github.com/activeadmin/activeadmin/pull/6086
 [#6099]: https://github.com/activeadmin/activeadmin/pull/6099
+[#6124]: https://github.com/activeadmin/activeadmin/pull/6124
 [#6198]: https://github.com/activeadmin/activeadmin/pull/6198
 
 [@5t111111]: https://github.com/5t111111
@@ -620,6 +625,7 @@ Please check [0-6-stable] for previous changes.
 [@javierjulio]: https://github.com/javierjulio
 [@jawa]: https://github.com/jawa
 [@JiiHu]: https://github.com/JiiHu
+[@jiikko]: https://github.com/jiikko
 [@johnnyshields]: https://github.com/johnnyshields
 [@jscheid]: https://github.com/jscheid
 [@juril33t]: https://github.com/juril33t

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -125,7 +125,7 @@ module ActiveAdmin
 
     # Returns ALL the files to be loaded
     def files
-      load_paths.flatten.compact.uniq.flat_map { |path| Dir["#{path}/**/*.rb"] }
+      load_paths.flatten.compact.uniq.flat_map { |path| Dir["#{path}/**/*.rb"] }.sort
     end
 
     # Creates all the necessary routes for the ActiveAdmin configurations

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -122,6 +122,10 @@ RSpec.describe ActiveAdmin::Application do
   end
 
   describe "files in load path" do
+    it 'it should load sorted files' do
+      expect(application.files.map { |f| File.basename(f) }).to eq(%w(admin_users.rb dashboard.rb stores.rb))
+    end
+
     it "should load files in the first level directory" do
       expect(application.files).to include(File.expand_path("app/admin/dashboard.rb", application.app_path))
     end


### PR DESCRIPTION
hi.

I'm trying to make sure on CI that missing comments of annotate.
https://rubygems.org/gems/annotate

```shell
# for example
bundle exec annotate --routes
git diff --exit-code config/routes.rb # CI fail if exit(1)
```

However, there was a difference in the output of rake routes between macOS and CircleCI.
As a result of investigation, it was caused by using `Dir.[]` In `ActiveAdmin.routes()`.
https://bugs.ruby-lang.org/issues/8709

With this fix, the output of rake routes will be the same in all environments to sort the result of `Dir.[]`.

Thanks.