### PR TITLE
Test against Rails 6.0 stable branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development , :test do
   gem 'draper', '~> 4.0'
   gem "devise", "~> 4.7"
 
-  gem "rails", "~> 6.0.0"
+  gem "rails", "~> 6.0.0", github: "rails/rails", branch: "6-0-stable"
   gem "activerecord-jdbcsqlite3-adapter", "~> 60.0.rc1", platform: :jruby
 
   gem "formtastic", github: "justinfrench/formtastic"

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ group :development , :test do
   gem 'pry' # Easily debug from your console with `binding.pry`
   gem 'pry-byebug', platform: :mri # Step-by-step debugging
 
-  # Optional dependencies used in both development & test environments
   gem 'cancancan'
   gem 'pundit'
   gem 'jruby-openssl', '~> 0.10.1', platform: :jruby
@@ -14,7 +13,7 @@ group :development , :test do
   gem "devise", "~> 4.7"
 
   gem "rails", "~> 6.0.0", github: "rails/rails", branch: "6-0-stable"
-  gem "activerecord-jdbcsqlite3-adapter", "~> 60.0.rc1", platform: :jruby
+  gem "activerecord-jdbcsqlite3-adapter", "~> 60.0", platform: :jruby
 
   gem "formtastic", github: "justinfrench/formtastic"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -417,7 +417,7 @@ PLATFORMS
 
 DEPENDENCIES
   activeadmin!
-  activerecord-jdbcsqlite3-adapter (~> 60.0.rc1)
+  activerecord-jdbcsqlite3-adapter (~> 60.0)
   apparition
   cancancan
   capybara (~> 3.14)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,23 +5,10 @@ GIT
     formtastic (3.2.0.pre)
       actionpack (>= 5.2.0)
 
-PATH
-  remote: .
-  specs:
-    activeadmin (2.6.1)
-      arbre (~> 1.2, >= 1.2.1)
-      formtastic (~> 3.1)
-      formtastic_i18n (~> 0.4)
-      inherited_resources (~> 1.7)
-      jquery-rails (~> 4.2)
-      kaminari (~> 1.0, >= 1.0.1)
-      railties (>= 5.2, < 6.1)
-      ransack (~> 2.1, >= 2.1.1)
-      sassc-rails (~> 2.1)
-      sprockets (>= 3.0, < 4.1)
-
-GEM
-  remote: https://rubygems.org/
+GIT
+  remote: https://github.com/rails/rails.git
+  revision: 2fa37f9ac91e7fad5a8d8bb7e055430199d74837
+  branch: 6-0-stable
   specs:
     actioncable (6.0.2.1)
       actionpack (= 6.0.2.1)
@@ -64,18 +51,9 @@ GEM
       globalid (>= 0.3.6)
     activemodel (6.0.2.1)
       activesupport (= 6.0.2.1)
-    activemodel-serializers-xml (1.0.2)
-      activemodel (> 5.x)
-      activesupport (> 5.x)
-      builder (~> 3.1)
     activerecord (6.0.2.1)
       activemodel (= 6.0.2.1)
       activesupport (= 6.0.2.1)
-    activerecord-jdbc-adapter (60.0-java)
-      activerecord (~> 6.0.0)
-    activerecord-jdbcsqlite3-adapter (60.0-java)
-      activerecord-jdbc-adapter (= 60.0)
-      jdbc-sqlite3 (~> 3.8, < 3.30)
     activestorage (6.0.2.1)
       actionpack (= 6.0.2.1)
       activejob (= 6.0.2.1)
@@ -86,7 +64,56 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-      zeitwerk (~> 2.2)
+      zeitwerk (~> 2.2, >= 2.2.2)
+    rails (6.0.2.1)
+      actioncable (= 6.0.2.1)
+      actionmailbox (= 6.0.2.1)
+      actionmailer (= 6.0.2.1)
+      actionpack (= 6.0.2.1)
+      actiontext (= 6.0.2.1)
+      actionview (= 6.0.2.1)
+      activejob (= 6.0.2.1)
+      activemodel (= 6.0.2.1)
+      activerecord (= 6.0.2.1)
+      activestorage (= 6.0.2.1)
+      activesupport (= 6.0.2.1)
+      bundler (>= 1.3.0)
+      railties (= 6.0.2.1)
+      sprockets-rails (>= 2.0.0)
+    railties (6.0.2.1)
+      actionpack (= 6.0.2.1)
+      activesupport (= 6.0.2.1)
+      method_source
+      rake (>= 0.8.7)
+      thor (>= 0.20.3, < 2.0)
+
+PATH
+  remote: .
+  specs:
+    activeadmin (2.6.1)
+      arbre (~> 1.2, >= 1.2.1)
+      formtastic (~> 3.1)
+      formtastic_i18n (~> 0.4)
+      inherited_resources (~> 1.7)
+      jquery-rails (~> 4.2)
+      kaminari (~> 1.0, >= 1.0.1)
+      railties (>= 5.2, < 6.1)
+      ransack (~> 2.1, >= 2.1.1)
+      sassc-rails (~> 2.1)
+      sprockets (>= 3.0, < 4.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel-serializers-xml (1.0.2)
+      activemodel (> 5.x)
+      activesupport (> 5.x)
+      builder (~> 3.1)
+    activerecord-jdbc-adapter (60.0-java)
+      activerecord (~> 6.0.0)
+    activerecord-jdbcsqlite3-adapter (60.0-java)
+      activerecord-jdbc-adapter (= 60.0)
+      jdbc-sqlite3 (~> 3.8, < 3.30)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     apparition (0.5.0)
@@ -235,7 +262,7 @@ GEM
     mime-types (3.3)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)
-    mimemagic (0.3.3)
+    mimemagic (0.3.4)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)
@@ -279,21 +306,6 @@ GEM
     rack (2.2.2)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rails (6.0.2.1)
-      actioncable (= 6.0.2.1)
-      actionmailbox (= 6.0.2.1)
-      actionmailer (= 6.0.2.1)
-      actionpack (= 6.0.2.1)
-      actiontext (= 6.0.2.1)
-      actionview (= 6.0.2.1)
-      activejob (= 6.0.2.1)
-      activemodel (= 6.0.2.1)
-      activerecord (= 6.0.2.1)
-      activestorage (= 6.0.2.1)
-      activesupport (= 6.0.2.1)
-      bundler (>= 1.3.0)
-      railties (= 6.0.2.1)
-      sprockets-rails (>= 2.0.0)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -302,12 +314,6 @@ GEM
     rails-i18n (6.0.0)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 7)
-    railties (6.0.2.1)
-      actionpack (= 6.0.2.1)
-      activesupport (= 6.0.2.1)
-      method_source
-      rake (>= 0.8.7)
-      thor (>= 0.20.3, < 2.0)
     rainbow (3.0.0)
     rake (13.0.1)
     ransack (2.3.2)
@@ -435,7 +441,7 @@ DEPENDENCIES
   pry
   pry-byebug
   pundit
-  rails (~> 6.0.0)
+  rails (~> 6.0.0)!
   rails-i18n
   rake
   rspec-rails

--- a/gemfiles/rails_60_turbolinks/Gemfile
+++ b/gemfiles/rails_60_turbolinks/Gemfile
@@ -12,7 +12,7 @@ group :development, :test do
   gem 'draper', '~> 4.0'
   gem "devise", "~> 4.7"
 
-  gem "rails", "~> 6.0.0"
+  gem "rails", "~> 6.0.0", github: "rails/rails", branch: "6-0-stable"
   gem "activerecord-jdbcsqlite3-adapter", "~> 60.0", platform: :jruby
 
   gem "turbolinks", "~> 5.2"

--- a/gemfiles/rails_60_turbolinks/Gemfile.lock
+++ b/gemfiles/rails_60_turbolinks/Gemfile.lock
@@ -5,23 +5,10 @@ GIT
     formtastic (3.2.0.pre)
       actionpack (>= 5.2.0)
 
-PATH
-  remote: ../..
-  specs:
-    activeadmin (2.6.1)
-      arbre (~> 1.2, >= 1.2.1)
-      formtastic (~> 3.1)
-      formtastic_i18n (~> 0.4)
-      inherited_resources (~> 1.7)
-      jquery-rails (~> 4.2)
-      kaminari (~> 1.0, >= 1.0.1)
-      railties (>= 5.2, < 6.1)
-      ransack (~> 2.1, >= 2.1.1)
-      sassc-rails (~> 2.1)
-      sprockets (>= 3.0, < 4.1)
-
-GEM
-  remote: https://rubygems.org/
+GIT
+  remote: https://github.com/rails/rails.git
+  revision: 2fa37f9ac91e7fad5a8d8bb7e055430199d74837
+  branch: 6-0-stable
   specs:
     actioncable (6.0.2.1)
       actionpack (= 6.0.2.1)
@@ -64,18 +51,9 @@ GEM
       globalid (>= 0.3.6)
     activemodel (6.0.2.1)
       activesupport (= 6.0.2.1)
-    activemodel-serializers-xml (1.0.2)
-      activemodel (> 5.x)
-      activesupport (> 5.x)
-      builder (~> 3.1)
     activerecord (6.0.2.1)
       activemodel (= 6.0.2.1)
       activesupport (= 6.0.2.1)
-    activerecord-jdbc-adapter (60.0-java)
-      activerecord (~> 6.0.0)
-    activerecord-jdbcsqlite3-adapter (60.0-java)
-      activerecord-jdbc-adapter (= 60.0)
-      jdbc-sqlite3 (~> 3.8, < 3.30)
     activestorage (6.0.2.1)
       actionpack (= 6.0.2.1)
       activejob (= 6.0.2.1)
@@ -86,7 +64,56 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-      zeitwerk (~> 2.2)
+      zeitwerk (~> 2.2, >= 2.2.2)
+    rails (6.0.2.1)
+      actioncable (= 6.0.2.1)
+      actionmailbox (= 6.0.2.1)
+      actionmailer (= 6.0.2.1)
+      actionpack (= 6.0.2.1)
+      actiontext (= 6.0.2.1)
+      actionview (= 6.0.2.1)
+      activejob (= 6.0.2.1)
+      activemodel (= 6.0.2.1)
+      activerecord (= 6.0.2.1)
+      activestorage (= 6.0.2.1)
+      activesupport (= 6.0.2.1)
+      bundler (>= 1.3.0)
+      railties (= 6.0.2.1)
+      sprockets-rails (>= 2.0.0)
+    railties (6.0.2.1)
+      actionpack (= 6.0.2.1)
+      activesupport (= 6.0.2.1)
+      method_source
+      rake (>= 0.8.7)
+      thor (>= 0.20.3, < 2.0)
+
+PATH
+  remote: ../..
+  specs:
+    activeadmin (2.6.1)
+      arbre (~> 1.2, >= 1.2.1)
+      formtastic (~> 3.1)
+      formtastic_i18n (~> 0.4)
+      inherited_resources (~> 1.7)
+      jquery-rails (~> 4.2)
+      kaminari (~> 1.0, >= 1.0.1)
+      railties (>= 5.2, < 6.1)
+      ransack (~> 2.1, >= 2.1.1)
+      sassc-rails (~> 2.1)
+      sprockets (>= 3.0, < 4.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel-serializers-xml (1.0.2)
+      activemodel (> 5.x)
+      activesupport (> 5.x)
+      builder (~> 3.1)
+    activerecord-jdbc-adapter (60.0-java)
+      activerecord (~> 6.0.0)
+    activerecord-jdbcsqlite3-adapter (60.0-java)
+      activerecord-jdbc-adapter (= 60.0)
+      jdbc-sqlite3 (~> 3.8, < 3.30)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     apparition (0.5.0)
@@ -207,7 +234,7 @@ GEM
     mime-types (3.3)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)
-    mimemagic (0.3.3)
+    mimemagic (0.3.4)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)
@@ -241,21 +268,6 @@ GEM
     rack (2.2.2)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rails (6.0.2.1)
-      actioncable (= 6.0.2.1)
-      actionmailbox (= 6.0.2.1)
-      actionmailer (= 6.0.2.1)
-      actionpack (= 6.0.2.1)
-      actiontext (= 6.0.2.1)
-      actionview (= 6.0.2.1)
-      activejob (= 6.0.2.1)
-      activemodel (= 6.0.2.1)
-      activerecord (= 6.0.2.1)
-      activestorage (= 6.0.2.1)
-      activesupport (= 6.0.2.1)
-      bundler (>= 1.3.0)
-      railties (= 6.0.2.1)
-      sprockets-rails (>= 2.0.0)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -264,12 +276,6 @@ GEM
     rails-i18n (6.0.0)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 7)
-    railties (6.0.2.1)
-      actionpack (= 6.0.2.1)
-      activesupport (= 6.0.2.1)
-      method_source
-      rake (>= 0.8.7)
-      thor (>= 0.20.3, < 2.0)
     rake (13.0.1)
     ransack (2.3.2)
       activerecord (>= 5.2.1)
@@ -371,7 +377,7 @@ DEPENDENCIES
   pry
   pry-byebug
   pundit
-  rails (~> 6.0.0)
+  rails (~> 6.0.0)!
   rails-i18n
   rake
   rspec-rails


### PR DESCRIPTION
Ruby 2.7 comes with a bunch of keyword warnings, making test runs and app logs way too verbose.

Most gems have caught up with the change now but Rails has not yet released a version fixing all warnings.

For now, I'd like to point to Rails 6 stable branch in order to fix this warnings in our development and test applications.

<!--

Thanks for contributing to ActiveAdmin!

You can find all the instructions for contributing at the [CONTRIBUTING file].

Before submitting your PR make sure that:

* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are splitted apart.
* Your PR includes a regression test if it fixes a bug.
* You add an entry to the [Changelog] if the new code introduces user-observable changes. See [changelog entry format].

Before expecting a review for your PR make sure that all github checks are passing, but feel free to ask for early feedback if you need guidance.

[CONTRIBUTING file]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords
[Changelog]: https://github.com/activeadmin/activeadmin/blob/master/CHANGELOG.md
[changelog entry format]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md#add-a-changelog-entry

-->
