### PR TITLE
Lock tested rails version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :development, :test do
   gem 'draper', '~> 4.0'
   gem "devise", "~> 4.7"
 
-  gem "rails", "~> 6.0.0", github: "rails/rails", branch: "6-0-stable"
+  gem "rails", "~> 6.0.0", github: "rails/rails", branch: "6-0-stable", ref: "3ed7c5864ff4ac349848722fbf682a657eebddbf"
   gem "activerecord-jdbcsqlite3-adapter", "~> 60.0", platform: :jruby
 
   gem "formtastic", github: "justinfrench/formtastic"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ GIT
 GIT
   remote: https://github.com/rails/rails.git
   revision: 3ed7c5864ff4ac349848722fbf682a657eebddbf
+  ref: 3ed7c5864ff4ac349848722fbf682a657eebddbf
   branch: 6-0-stable
   specs:
     actioncable (6.0.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -382,7 +382,7 @@ GEM
     simplecov-html (0.10.2)
     spoon (0.0.6)
       ffi
-    sprockets (3.7.2)
+    sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)

--- a/gemfiles/rails_60_turbolinks/Gemfile
+++ b/gemfiles/rails_60_turbolinks/Gemfile
@@ -12,7 +12,7 @@ group :development, :test do
   gem 'draper', '~> 4.0'
   gem "devise", "~> 4.7"
 
-  gem "rails", "~> 6.0.0", github: "rails/rails", branch: "6-0-stable"
+  gem "rails", "~> 6.0.0", github: "rails/rails", branch: "6-0-stable", ref: "3ed7c5864ff4ac349848722fbf682a657eebddbf"
   gem "activerecord-jdbcsqlite3-adapter", "~> 60.0", platform: :jruby
 
   gem "turbolinks", "~> 5.2"

--- a/gemfiles/rails_60_turbolinks/Gemfile.lock
+++ b/gemfiles/rails_60_turbolinks/Gemfile.lock
@@ -325,7 +325,7 @@ GEM
     simplecov-html (0.10.2)
     spoon (0.0.6)
       ffi
-    sprockets (3.7.2)
+    sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)

--- a/gemfiles/rails_60_turbolinks/Gemfile.lock
+++ b/gemfiles/rails_60_turbolinks/Gemfile.lock
@@ -8,6 +8,7 @@ GIT
 GIT
   remote: https://github.com/rails/rails.git
   revision: 3ed7c5864ff4ac349848722fbf682a657eebddbf
+  ref: 3ed7c5864ff4ac349848722fbf682a657eebddbf
   branch: 6-0-stable
   specs:
     actioncable (6.0.2.1)


### PR DESCRIPTION
The idea of #6132 was only to fix the many ruby 2.7 warnings that are printed when running an activeadmin development of test application against 2.7.

Although we could consider it at some point, the idea was not to follow Rails 6-0-stable branch commit per commit.

By locking the reference, dependabot will no longer create a new PR for every commit to the Rails stable branch.

Also, this PR bumps back sprockets to 4.0.0. Dependabot downgraded it in #6134 and #6135 and I have no idea why.
 
<!--

Thanks for contributing to ActiveAdmin!

You can find all the instructions for contributing at the [CONTRIBUTING file].

Before submitting your PR make sure that:

* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are splitted apart.
* Your PR includes a regression test if it fixes a bug.
* You add an entry to the [Changelog] if the new code introduces user-observable changes. See [changelog entry format].

Before expecting a review for your PR make sure that all github checks are passing, but feel free to ask for early feedback if you need guidance.

[CONTRIBUTING file]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords
[Changelog]: https://github.com/activeadmin/activeadmin/blob/master/CHANGELOG.md
[changelog entry format]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md#add-a-changelog-entry

-->
