### PR TITLE
Fix scopes renderer when resource has only optional scopes and their conditions are false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Extend menu to allow for nested submenus. [#5994] by [@taralbass]
 * Add Webpacker compatibility with opt-in config switch and installation generator. [#5855] by [@sgara]
 
+### Bug Fixes
+
+* Fix scopes renderer when resource has only optional scopes and their conditions are false. [#6149] by [@Looooong]
+
 ## 2.6.1 [☰](https://github.com/activeadmin/activeadmin/compare/v2.6.0..v2.6.1)
 
 ### Bug Fixes
@@ -561,6 +565,7 @@ Please check [0-6-stable] for previous changes.
 [#6002]: https://github.com/activeadmin/activeadmin/pull/6002
 [#6047]: https://github.com/activeadmin/activeadmin/pull/6047
 [#5994]: https://github.com/activeadmin/activeadmin/pull/5994
+[#6149]: https://github.com/activeadmin/activeadmin/pull/6149
 
 [@5t111111]: https://github.com/5t111111
 [@aarek]: https://github.com/aarek
@@ -613,6 +618,7 @@ Please check [0-6-stable] for previous changes.
 [@Kris-LIBIS]: https://github.com/Kris-LIBIS
 [@kwent]: https://github.com/kwent
 [@leio10]: https://github.com/leio10
+[@Looooong]: https://github.com/Looooong
 [@markstory]: https://github.com/markstory
 [@mauriciopasquier]: https://github.com/mauriciopasquier
 [@mconiglio]: https://github.com/mconiglio

--- a/features/index/index_scopes.feature
+++ b/features/index/index_scopes.feature
@@ -192,6 +192,18 @@ Feature: Index Scoping
     And I should see the scope "Shown with method name"
     And I should see the scope "Default" with the count 3
 
+  Scenario: Viewing resources with only optional scopes and their conditions are false
+    Given 3 posts exist
+    And an index configuration of:
+    """
+    ActiveAdmin.register Post do
+      scope :all, if: proc { false }
+      scope(:hidden, if: proc { false }) { |posts| posts }
+      scope(:hidden_as_well, if: proc { false }) { |posts| posts }
+    end
+    """
+    Then I should see empty scopes
+
   Scenario: Viewing resources with multiple scopes as blocks
     Given 3 posts exist
     And an index configuration of:

--- a/features/step_definitions/index_scope_steps.rb
+++ b/features/step_definitions/index_scope_steps.rb
@@ -40,3 +40,7 @@ Then "I should see an empty group with the scope {string}" do |name|
   name = name.tr(" ", "").underscore.downcase
   expect(page).to     have_css ".scopes .scope-default-group .#{name}"
 end
+
+Then "I should see empty scopes" do
+  expect(page.find(".scopes").text).to be_empty
+end

--- a/lib/active_admin/views/components/scopes.rb
+++ b/lib/active_admin/views/components/scopes.rb
@@ -26,6 +26,8 @@ module ActiveAdmin
             group_scopes.each do |scope|
               build_scope(scope, options) if call_method_or_exec_proc(scope.display_if_block)
             end
+
+            nil
           end
         end
       end


### PR DESCRIPTION
This PR resolves #5578 .

<!--

Thanks for contributing to ActiveAdmin!

You can find all the instructions for contributing at the [CONTRIBUTING file].

Before submitting your PR make sure that:

* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are splitted apart.
* Your PR includes a regression test if it fixes a bug.
* You add an entry to the [Changelog] if the new code introduces user-observable changes. See [changelog entry format].

Before expecting a review for your PR make sure that all github checks are passing, but feel free to ask for early feedback if you need guidance.

[CONTRIBUTING file]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords
[Changelog]: https://github.com/activeadmin/activeadmin/blob/master/CHANGELOG.md
[changelog entry format]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md#add-a-changelog-entry

-->
