### PR TITLE
Enable `Layout/SpaceBeforeFistArg` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -124,6 +124,9 @@ Layout/SpaceBeforeBlockBraces:
 Layout/SpaceBeforeComma:
   Enabled: true
 
+Layout/SpaceBeforeFirstArg:
+  Enabled: true
+
 Layout/SpaceInsideBlockBraces:
   Enabled: true
 

--- a/features/step_definitions/index_scope_steps.rb
+++ b/features/step_definitions/index_scope_steps.rb
@@ -36,7 +36,7 @@ Then "I should see a group {string} with the scopes {string} and {string}" do |g
   expect(page).to     have_css ".scopes .scope-group-#{group} .#{name2}"
 end
 
-Then"I should see an empty group with the scope {string}" do |name|
+Then "I should see an empty group with the scope {string}" do |name|
   name = name.tr(" ", "").underscore.downcase
   expect(page).to     have_css ".scopes .scope-default-group .#{name}"
 end


### PR DESCRIPTION
This PR enables the corresponding cop for a style issue detected by @Looooong at #6149. 

<!--

Thanks for contributing to ActiveAdmin!

You can find all the instructions for contributing at the [CONTRIBUTING file].

Before submitting your PR make sure that:

* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are splitted apart.
* Your PR includes a regression test if it fixes a bug.
* You add an entry to the [Changelog] if the new code introduces user-observable changes. See [changelog entry format].

Before expecting a review for your PR make sure that all github checks are passing, but feel free to ask for early feedback if you need guidance.

[CONTRIBUTING file]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords
[Changelog]: https://github.com/activeadmin/activeadmin/blob/master/CHANGELOG.md
[changelog entry format]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md#add-a-changelog-entry

-->
