### PR TITLE
Update filters disabled error to include specific action

### DIFF
--- a/lib/active_admin/filters/resource_extension.rb
+++ b/lib/active_admin/filters/resource_extension.rb
@@ -4,7 +4,7 @@ module ActiveAdmin
 
     class Disabled < RuntimeError
       def initialize
-        super "Can't remove a filter when filters are disabled. Enable filters with 'config.filters = true'"
+        super "Can't add or remove a filter when filters are disabled. Enable filters with 'config.filters = true'"
       end
     end
 

--- a/lib/active_admin/filters/resource_extension.rb
+++ b/lib/active_admin/filters/resource_extension.rb
@@ -3,8 +3,8 @@ module ActiveAdmin
   module Filters
 
     class Disabled < RuntimeError
-      def initialize
-        super "Can't add or remove a filter when filters are disabled. Enable filters with 'config.filters = true'"
+      def initialize(action)
+        super "Cannot #{action} a filter when filters are disabled. Enable filters with 'config.filters = true'"
       end
     end
 
@@ -61,7 +61,7 @@ module ActiveAdmin
       #
       # @param [Symbol] attributes The attributes to not filter on
       def remove_filter(*attributes)
-        raise Disabled unless filters_enabled?
+        raise Disabled, "remove" unless filters_enabled?
 
         attributes.each { |attribute| (@filters_to_remove ||= []) << attribute.to_sym }
       end
@@ -73,7 +73,7 @@ module ActiveAdmin
       # @param [Hash] options The set of options that are passed through to
       #                       ransack for the field definition.
       def add_filter(attribute, options = {})
-        raise Disabled unless filters_enabled?
+        raise Disabled, "add" unless filters_enabled?
 
         (@filters ||= {})[attribute.to_sym] = options
       end

--- a/spec/unit/filters/resource_spec.rb
+++ b/spec/unit/filters/resource_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe ActiveAdmin::Filters::ResourceExtension do
 
     it "should raise an exception when filters are disabled" do
       resource.filters = false
-      expect { resource.remove_filter :author }.to raise_error ActiveAdmin::Filters::Disabled
+      expect { resource.remove_filter :author }.to raise_error(ActiveAdmin::Filters::Disabled, /Cannot remove a filter/)
     end
   end
 
@@ -116,7 +116,7 @@ RSpec.describe ActiveAdmin::Filters::ResourceExtension do
 
     it "should raise an exception when filters are disabled" do
       resource.filters = false
-      expect { resource.add_filter :title }.to raise_error ActiveAdmin::Filters::Disabled
+      expect { resource.add_filter :title }.to raise_error(ActiveAdmin::Filters::Disabled, /Cannot add a filter/)
     end
   end
 


### PR DESCRIPTION
`ActiveAdmin::Filters::Disabled` is raised both when attempting add a filter and when attempting to remove a filter when filters are disabled. Change the message to suit both use cases.