### PR TITLE
Drop Ruby 2.4 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,17 +250,6 @@ jobs:
       - *format_coverage
       - *save_coverage
 
-  ruby24rails52:
-    docker:
-      - image: circleci/ruby:2.4.8-node-browsers
-        user: root
-
-    environment:
-      BUNDLE_GEMFILE: gemfiles/rails_52/Gemfile
-
-    steps:
-      *test_steps
-
   ruby25rails52:
     docker:
       - image: circleci/ruby:2.5.7-node-browsers
@@ -431,10 +420,6 @@ workflows:
           requires:
             - setup_coverage
 
-      - ruby24rails52:
-          requires:
-            - testapp52
-
       - ruby25rails52:
           requires:
             - testapp52
@@ -491,8 +476,6 @@ workflows:
             - testapp60
             - testapp60turbolinks
             - testapp60webpacker
-
-            - ruby24rails52
 
             - ruby25rails52
             - ruby25rails60

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ require:
 
 AllCops:
   DisabledByDefault: true
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
 
   Exclude:
     - tmp/development_apps/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Dependency Changes
+
+* Support for ruby 2.4 has been removed. [#6198] by [@deivid-rodriguez]
+
 ## 2.7.0 [☰](https://github.com/activeadmin/activeadmin/compare/v2.6.1..v2.7.0)
 
 ### Enhancements
@@ -572,6 +576,7 @@ Please check [0-6-stable] for previous changes.
 [#6149]: https://github.com/activeadmin/activeadmin/pull/6149
 [#6086]: https://github.com/activeadmin/activeadmin/pull/6086
 [#6099]: https://github.com/activeadmin/activeadmin/pull/6099
+[#6198]: https://github.com/activeadmin/activeadmin/pull/6198
 
 [@5t111111]: https://github.com/5t111111
 [@aarek]: https://github.com/aarek

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.extra_rdoc_files = %w[CHANGELOG.md CODE_OF_CONDUCT.md CONTRIBUTING.md README.md]
 
-  s.required_ruby_version = '>= 2.4'
+  s.required_ruby_version = '>= 2.5'
 
   s.add_dependency 'arbre', '~> 1.2', '>= 1.2.1'
   s.add_dependency 'formtastic', '~> 3.1'


### PR DESCRIPTION
Support for ruby 2.4 has ended.

https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/

<!--

Thanks for contributing to ActiveAdmin!

You can find all the instructions for contributing at the [CONTRIBUTING file].

Before submitting your PR make sure that:

* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are splitted apart.
* Your PR includes a regression test if it fixes a bug.
* You add an entry to the [Changelog] if the new code introduces user-observable changes. See [changelog entry format].

Before expecting a review for your PR make sure that all github checks are passing, but feel free to ask for early feedback if you need guidance.

[CONTRIBUTING file]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords
[Changelog]: https://github.com/activeadmin/activeadmin/blob/master/CHANGELOG.md
[changelog entry format]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md#add-a-changelog-entry

-->
