### PR TITLE
Fix es and es-MX sign_in and sign_up translation:

### DIFF
--- a/config/locales/es-MX.yml
+++ b/config/locales/es-MX.yml
@@ -86,7 +86,8 @@ es-MX:
         title: "Cambie su contraseña"
         submit: "Cambiar mi contraseña"
       links:
-        sign_in: "Registrarse"
+        sign_in: "Iniciar Sesión"
+        sign_up: "Registrarse"
         forgot_your_password: "¿Olvidó su contraseña?"
         sign_in_with_omniauth_provider: "Conéctate con %{provider}"
     index_list:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -144,7 +144,7 @@ es:
         submit: "Reenviar instrucciones de confirmación"
       links:
         sign_up: "Registrarse"
-        sign_in: "Ingresar"
+        sign_in: "Iniciar Sesión"
         forgot_your_password: "¿Olvidó su contraseña?"
         sign_in_with_omniauth_provider: "Conéctate con %{provider}"
         resend_unlock_instructions: "Reenviar instrucciones de desbloqueo"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -143,8 +143,8 @@ es:
         title: "Reenviar instrucciones de confirmación"
         submit: "Reenviar instrucciones de confirmación"
       links:
-        sign_up: "Ingresar"
-        sign_in: "Registrarse"
+        sign_up: "Registrarse"
+        sign_in: "Ingresar"
         forgot_your_password: "¿Olvidó su contraseña?"
         sign_in_with_omniauth_provider: "Conéctate con %{provider}"
         resend_unlock_instructions: "Reenviar instrucciones de desbloqueo"


### PR DESCRIPTION
This change fix the use the sign_up and sign_in meaning. In the last
version of these files it's was using the reverse meaning.


