### PR TITLE
Use proper closing tags for HTML in ModalDialog component

### DIFF
--- a/app/javascript/active_admin/lib/modal-dialog.js
+++ b/app/javascript/active_admin/lib/modal-dialog.js
@@ -21,13 +21,13 @@ function ModalDialog(message, inputs, callback){
           const result = [];
 
           opts.forEach(v => {
-            const $elem = $(`<${elem}/>`);
+            const $elem = $(`<${elem}></${elem}>`);
             if ($.isArray(v)) {
               $elem.text(v[0]).val(v[1]);
             } else {
               $elem.text(v);
             }
-            result.push($elem.wrap('<div>').parent().html());
+            result.push($elem.wrap('<div></div>').parent().html());
           });
 
           return result;


### PR DESCRIPTION
This updates our ModalDialog component to use proper closing tags after reviewing the jQuery 3.5.0 release update in #6188 and [the 3.5 upgrade guide](https://jquery.com/upgrade-guide/3.5/), which includes a security fix with possible breaking changes. Although it does appear to impact us, this is a safe change since this input has been documented and supported since jQuery v1. The elements changed here are not self-closing and need matching closing tags to be valid.