### PR TITLE
Move sassc to being a development dependency ONLY

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,6 @@ PATH
       kaminari (~> 1.0, >= 1.0.1)
       railties (>= 5.2, < 6.1)
       ransack (~> 2.1, >= 2.1.1)
-      sassc-rails (~> 2.1)
       sprockets (>= 3.0, < 4.1)
 
 GEM
@@ -355,7 +354,7 @@ GEM
     rubocop-rspec (1.39.0)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
-    sassc (2.2.1)
+    sassc (2.3.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
@@ -440,6 +439,7 @@ DEPENDENCIES
   rubocop (= 0.83.0)
   rubocop-rails (~> 2.3)
   rubocop-rspec (~> 1.30)
+  sassc-rails (~> 2.1)
   simplecov (= 0.17.1)
   sqlite3 (~> 1.4)
   yard

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'kaminari', '~> 1.0', '>= 1.0.1'
   s.add_dependency 'railties', '>= 5.2', '< 6.1'
   s.add_dependency 'ransack', '~> 2.1', '>= 2.1.1'
-  s.add_dependency 'sassc-rails', '~> 2.1'
   s.add_dependency 'sprockets', '>= 3.0', '< 4.1'
+  s.add_development_dependency 'sassc-rails', '~> 2.1'
 end

--- a/gemfiles/rails_52/Gemfile.lock
+++ b/gemfiles/rails_52/Gemfile.lock
@@ -17,7 +17,6 @@ PATH
       kaminari (~> 1.0, >= 1.0.1)
       railties (>= 5.2, < 6.1)
       ransack (~> 2.1, >= 2.1.1)
-      sassc-rails (~> 2.1)
       sprockets (>= 3.0, < 4.1)
 
 GEM
@@ -356,6 +355,7 @@ DEPENDENCIES
   rails-i18n
   rake
   rspec-rails
+  sassc-rails (~> 2.1)
   simplecov (= 0.17.1)
   sqlite3 (~> 1.4)
 

--- a/gemfiles/rails_60_turbolinks/Gemfile.lock
+++ b/gemfiles/rails_60_turbolinks/Gemfile.lock
@@ -17,7 +17,6 @@ PATH
       kaminari (~> 1.0, >= 1.0.1)
       railties (>= 5.2, < 6.1)
       ransack (~> 2.1, >= 2.1.1)
-      sassc-rails (~> 2.1)
       sprockets (>= 3.0, < 4.1)
 
 GEM
@@ -375,6 +374,7 @@ DEPENDENCIES
   rails-i18n
   rake
   rspec-rails
+  sassc-rails (~> 2.1)
   simplecov (= 0.17.1)
   sqlite3 (~> 1.4)
   turbolinks (~> 5.2)

--- a/gemfiles/rails_60_webpacker/Gemfile.lock
+++ b/gemfiles/rails_60_webpacker/Gemfile.lock
@@ -100,7 +100,6 @@ PATH
       kaminari (~> 1.0, >= 1.0.1)
       railties (>= 5.2, < 6.1)
       ransack (~> 2.1, >= 2.1.1)
-      sassc-rails (~> 2.1)
       sprockets (>= 3.0, < 4.1)
 
 GEM
@@ -385,6 +384,7 @@ DEPENDENCIES
   rails-i18n
   rake
   rspec-rails
+  sassc-rails (~> 2.1)
   simplecov (= 0.17.1)
   sqlite3 (~> 1.4)
   webpacker (~> 4.0)


### PR DESCRIPTION
Sassc has quite a [few](https://github.com/sass/sassc-ruby/issues/179) open issues about the subject of portability, 
And often times it’s recommended to just re-install the gem and rebuild
Native extensions. However, for build/CI processes, it’s unacceptable to wait 4+ minutes on a gem
that you've already built in a previous step or don't even rely on. 

This PR moves the sassc dependency to being a development ONLY dependency as it should not be required during runtime. 

<!--

Thanks for contributing to ActiveAdmin!

You can find all the instructions for contributing at the [CONTRIBUTING file].

Before submitting your PR make sure that:

* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are splitted apart.
* Your PR includes a regression test if it fixes a bug.
* You add an entry to the [Changelog] if the new code introduces user-observable changes. See [changelog entry format].

Before expecting a review for your PR make sure that all github checks are passing, but feel free to ask for early feedback if you need guidance.

[CONTRIBUTING file]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords
[Changelog]: https://github.com/activeadmin/activeadmin/blob/master/CHANGELOG.md
[changelog entry format]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md#add-a-changelog-entry

-->
