### PR TITLE
Fix filter_columns_for_large_association and filter_method_for_large_association examples

### DIFF
--- a/lib/generators/active_admin/install/templates/active_admin.rb.erb
+++ b/lib/generators/active_admin/install/templates/active_admin.rb.erb
@@ -294,7 +294,7 @@ ActiveAdmin.setup do |config|
   # config.include_default_association_filters = true
 
   # config.maximum_association_filter_arity = 256 # default value of :unlimited will change to 256 in a future version
-  # config.filter_columns_for_large_association, [
+  # config.filter_columns_for_large_association = [
   #    :display_name,
   #    :full_name,
   #    :name,
@@ -303,7 +303,7 @@ ActiveAdmin.setup do |config|
   #    :title,
   #    :email,
   #  ]
-  # config.filter_method_for_large_association, '_starts_with'
+  # config.filter_method_for_large_association = '_starts_with'
 
   # == Head
   #


### PR DESCRIPTION
I was just checking out the new `maximum_association_filter_arity`, `filter_columns_for_large_association`, `filter_method_for_large_association` options from https://github.com/activeadmin/activeadmin/pull/5548, which look like they will be a huge help! I think `maximum_association_filter_arity` should definitely be set to a sane maximum by default.

I copied these lines into my `config/initializers/active_admin.rb` and uncommented them, and saw that there was a syntax error. (`,` should be `=`). So I just thought I would send a PR to fix that!