### PR TITLE
Disallow extra spacing even for alignment

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,6 +55,7 @@ Layout/EndOfLine:
   Enabled: true
 
 Layout/ExtraSpacing:
+  AllowForAlignment: false
   Enabled: true
 
 Rails/FilePath:

--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ group :lint do
 end
 
 group :docs do
-  gem 'yard'     # Documentation generator
+  gem 'yard' # Documentation generator
   gem 'kramdown' # Markdown implementation (for yard)
 end
 

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -1,19 +1,19 @@
 require File.join(__dir__, "lib", "active_admin", "version")
 
 Gem::Specification.new do |s|
-  s.name          = 'activeadmin'
-  s.license       = 'MIT'
-  s.version       = ActiveAdmin::VERSION
-  s.homepage      = 'https://activeadmin.info'
-  s.authors       = ['Charles Maresh', 'David Rodríguez', 'Greg Bell', 'Igor Fedoronchuk', 'Javier Julio', 'Piers C', 'Sean Linsley', 'Timo Schilling']
-  s.email         = ['deivid.rodriguez@riseup.net']
-  s.description   = 'The administration framework for Ruby on Rails.'
-  s.summary       = 'Active Admin is a Ruby on Rails plugin for generating ' \
+  s.name = 'activeadmin'
+  s.license = 'MIT'
+  s.version = ActiveAdmin::VERSION
+  s.homepage = 'https://activeadmin.info'
+  s.authors = ['Charles Maresh', 'David Rodríguez', 'Greg Bell', 'Igor Fedoronchuk', 'Javier Julio', 'Piers C', 'Sean Linsley', 'Timo Schilling']
+  s.email = ['deivid.rodriguez@riseup.net']
+  s.description = 'The administration framework for Ruby on Rails.'
+  s.summary = 'Active Admin is a Ruby on Rails plugin for generating ' \
     'administration style interfaces. It abstracts common business ' \
     'application patterns to make it simple for developers to implement ' \
     'beautiful and elegant interfaces with very little effort.'
 
-  s.files         = `git ls-files LICENSE app config/locales docs lib vendor -z`.split("\x0")
+  s.files = `git ls-files LICENSE app config/locales docs lib vendor -z`.split("\x0")
 
   s.extra_rdoc_files = %w[CHANGELOG.md CODE_OF_CONDUCT.md CONTRIBUTING.md README.md]
 

--- a/features/step_definitions/batch_action_steps.rb
+++ b/features/step_definitions/batch_action_steps.rb
@@ -33,7 +33,7 @@ end
 
 Given /^I submit the batch action form with "([^"]*)"$/ do |action|
   page.find("#batch_action", visible: false).set action
-  form   = page.find "#collection_selection"
+  form = page.find "#collection_selection"
   params = page.all("#main_content input", visible: false).each_with_object({}) do |input, obj|
     key = input['name']
     value = input['value']

--- a/features/step_definitions/factory_steps.rb
+++ b/features/step_definitions/factory_steps.rb
@@ -4,12 +4,12 @@ def create_user(name, type = 'User')
 end
 
 Given /^(a|\d+)( published)?( unstarred|starred)? posts?(?: with the title "([^"]*)")?(?: and body "([^"]*)")?(?: written by "([^"]*)")?(?: in category "([^"]*)")? exists?$/ do |count, published, starred, title, body, user, category_name|
-  count     = count == 'a' ? 1 : count.to_i
-  published = Time.now              if published
-  starred   = starred == " starred" if starred
-  author    = create_user(user)     if user
-  category  = Category.where(name: category_name).first_or_create if category_name
-  title   ||= "Hello World %i"
+  count = count == 'a' ? 1 : count.to_i
+  published = Time.now if published
+  starred = starred == " starred" if starred
+  author = create_user(user) if user
+  category = Category.where(name: category_name).first_or_create if category_name
+  title ||= "Hello World %i"
   count.times do |i|
     Post.create! title: title % i, body: body, author: author, published_date: published, custom_category_id: category.try(:id), starred: starred
   end

--- a/features/step_definitions/filesystem_steps.rb
+++ b/features/step_definitions/filesystem_steps.rb
@@ -6,8 +6,8 @@ module ActiveAdminContentsRollback
   # Records the contents of a file the first time we are
   # about to change it
   def record(filename)
-    contents        = File.read(filename) rescue nil
-    files[filename] = contents            unless files.has_key? filename
+    contents = File.read(filename) rescue nil
+    files[filename] = contents unless files.has_key? filename
   end
 
   # Rolls the recorded files back to their original states
@@ -26,7 +26,7 @@ module ActiveAdminContentsRollback
       begin
         dir = File.dirname(file)
         until dir == Rails.root
-          Dir.rmdir(dir)                        # delete current folder
+          Dir.rmdir(dir) # delete current folder
           dir = dir.split('/')[0..-2].join('/') # select parent folder
         end
       rescue Errno::ENOTEMPTY # Directory not empty

--- a/features/step_definitions/index_scope_steps.rb
+++ b/features/step_definitions/index_scope_steps.rb
@@ -24,7 +24,7 @@ end
 
 Then /^I should see the scope "([^"]*)" with no count$/ do |name|
   name = name.tr(" ", "").underscore.downcase
-  expect(page).to     have_css ".scopes .#{name}"
+  expect(page).to have_css ".scopes .#{name}"
   expect(page).to_not have_css ".scopes .#{name} .count"
 end
 
@@ -32,13 +32,13 @@ Then "I should see a group {string} with the scopes {string} and {string}" do |g
   group = group.tr(" ", "").underscore.downcase
   name1 = name1.tr(" ", "").underscore.downcase
   name2 = name2.tr(" ", "").underscore.downcase
-  expect(page).to     have_css ".scopes .scope-group-#{group} .#{name1}"
-  expect(page).to     have_css ".scopes .scope-group-#{group} .#{name2}"
+  expect(page).to have_css ".scopes .scope-group-#{group} .#{name1}"
+  expect(page).to have_css ".scopes .scope-group-#{group} .#{name2}"
 end
 
 Then "I should see an empty group with the scope {string}" do |name|
   name = name.tr(" ", "").underscore.downcase
-  expect(page).to     have_css ".scopes .scope-default-group .#{name}"
+  expect(page).to have_css ".scopes .scope-default-group .#{name}"
 end
 
 Then "I should see empty scopes" do

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -16,7 +16,7 @@ Given /^I am logged in with capybara$/ do
   step 'log out'
 
   visit new_admin_user_session_path
-  fill_in 'Email',    with: 'admin@example.com'
+  fill_in 'Email', with: 'admin@example.com'
   fill_in 'Password', with: 'password'
   click_button 'Login'
 end
@@ -35,7 +35,7 @@ Given /^"([^"]*)" requests a password reset with token "([^"]*)"( but it expires
 end
 
 Given /^override locale "([^"]*)" with "([^"]*)"$/ do |path, value|
-  keys_value  = path.split('.') + [value]
+  keys_value = path.split('.') + [value]
   locale_hash = keys_value.reverse.inject { |a, n| { n => a } }
   I18n.available_locales
   I18n.backend.store_translations(I18n.locale, locale_hash)

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -78,8 +78,8 @@ When /^I (check|uncheck) "([^"]*)"$/ do |action, field|
 end
 
 Then /^I should( not)? see( the element)? "([^"]*)"$/ do |negate, is_css, text|
-  should = negate ? :not_to        : :to
-  have   = is_css ? have_css(text) : have_content(text)
+  should = negate ? :not_to : :to
+  have = is_css ? have_css(text) : have_content(text)
   expect(page).send should, have
 end
 

--- a/lib/active_admin.rb
+++ b/lib/active_admin.rb
@@ -15,44 +15,44 @@ require 'active_admin/helpers/i18n'
 
 module ActiveAdmin
 
-  autoload :VERSION,                  'active_admin/version'
-  autoload :Application,              'active_admin/application'
-  autoload :AssetRegistration,        'active_admin/asset_registration'
-  autoload :Authorization,            'active_admin/authorization_adapter'
-  autoload :AuthorizationAdapter,     'active_admin/authorization_adapter'
-  autoload :Callbacks,                'active_admin/callbacks'
-  autoload :Component,                'active_admin/component'
-  autoload :BaseController,           'active_admin/base_controller'
-  autoload :CanCanAdapter,            'active_admin/cancan_adapter'
-  autoload :ControllerAction,         'active_admin/controller_action'
-  autoload :CSVBuilder,               'active_admin/csv_builder'
-  autoload :Dependency,               'active_admin/dependency'
-  autoload :Deprecation,              'active_admin/deprecation'
-  autoload :Devise,                   'active_admin/devise'
-  autoload :DSL,                      'active_admin/dsl'
-  autoload :FormBuilder,              'active_admin/form_builder'
-  autoload :Inputs,                   'active_admin/inputs'
-  autoload :Localizers,               'active_admin/localizers'
-  autoload :Menu,                     'active_admin/menu'
-  autoload :MenuCollection,           'active_admin/menu_collection'
-  autoload :MenuItem,                 'active_admin/menu_item'
-  autoload :Namespace,                'active_admin/namespace'
-  autoload :OrderClause,              'active_admin/order_clause'
-  autoload :Page,                     'active_admin/page'
-  autoload :PagePresenter,            'active_admin/page_presenter'
-  autoload :PageController,           'active_admin/page_controller'
-  autoload :PageDSL,                  'active_admin/page_dsl'
-  autoload :PunditAdapter,            'active_admin/pundit_adapter'
-  autoload :Resource,                 'active_admin/resource'
-  autoload :ResourceController,       'active_admin/resource_controller'
-  autoload :ResourceDSL,              'active_admin/resource_dsl'
-  autoload :Scope,                    'active_admin/scope'
-  autoload :ScopeChain,               'active_admin/helpers/scope_chain'
-  autoload :SidebarSection,           'active_admin/sidebar_section'
-  autoload :TableBuilder,             'active_admin/table_builder'
-  autoload :ViewFactory,              'active_admin/view_factory'
-  autoload :ViewHelpers,              'active_admin/view_helpers'
-  autoload :Views,                    'active_admin/views'
+  autoload :VERSION, 'active_admin/version'
+  autoload :Application, 'active_admin/application'
+  autoload :AssetRegistration, 'active_admin/asset_registration'
+  autoload :Authorization, 'active_admin/authorization_adapter'
+  autoload :AuthorizationAdapter, 'active_admin/authorization_adapter'
+  autoload :Callbacks, 'active_admin/callbacks'
+  autoload :Component, 'active_admin/component'
+  autoload :BaseController, 'active_admin/base_controller'
+  autoload :CanCanAdapter, 'active_admin/cancan_adapter'
+  autoload :ControllerAction, 'active_admin/controller_action'
+  autoload :CSVBuilder, 'active_admin/csv_builder'
+  autoload :Dependency, 'active_admin/dependency'
+  autoload :Deprecation, 'active_admin/deprecation'
+  autoload :Devise, 'active_admin/devise'
+  autoload :DSL, 'active_admin/dsl'
+  autoload :FormBuilder, 'active_admin/form_builder'
+  autoload :Inputs, 'active_admin/inputs'
+  autoload :Localizers, 'active_admin/localizers'
+  autoload :Menu, 'active_admin/menu'
+  autoload :MenuCollection, 'active_admin/menu_collection'
+  autoload :MenuItem, 'active_admin/menu_item'
+  autoload :Namespace, 'active_admin/namespace'
+  autoload :OrderClause, 'active_admin/order_clause'
+  autoload :Page, 'active_admin/page'
+  autoload :PagePresenter, 'active_admin/page_presenter'
+  autoload :PageController, 'active_admin/page_controller'
+  autoload :PageDSL, 'active_admin/page_dsl'
+  autoload :PunditAdapter, 'active_admin/pundit_adapter'
+  autoload :Resource, 'active_admin/resource'
+  autoload :ResourceController, 'active_admin/resource_controller'
+  autoload :ResourceDSL, 'active_admin/resource_dsl'
+  autoload :Scope, 'active_admin/scope'
+  autoload :ScopeChain, 'active_admin/helpers/scope_chain'
+  autoload :SidebarSection, 'active_admin/sidebar_section'
+  autoload :TableBuilder, 'active_admin/table_builder'
+  autoload :ViewFactory, 'active_admin/view_factory'
+  autoload :ViewHelpers, 'active_admin/view_helpers'
+  autoload :Views, 'active_admin/views'
 
   class << self
 
@@ -69,11 +69,11 @@ module ActiveAdmin
       application.prepare!
     end
 
-    delegate :register,      to: :application
+    delegate :register, to: :application
     delegate :register_page, to: :application
-    delegate :unload!,       to: :application
-    delegate :load!,         to: :application
-    delegate :routes,        to: :application
+    delegate :unload!, to: :application
+    delegate :load!, to: :application
+    delegate :routes, to: :application
 
     # A callback is triggered each time (before) Active Admin loads the configuration files.
     # In development mode, this will happen whenever the user changes files. In production
@@ -130,4 +130,4 @@ require 'active_admin/filters'
 
 # Require ORM-specific plugins
 require 'active_admin/orm/active_record' if defined? ActiveRecord
-require 'active_admin/orm/mongoid'       if defined? Mongoid
+require 'active_admin/orm/mongoid' if defined? Mongoid

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -46,7 +46,7 @@ module ActiveAdmin
 
     # Event that gets triggered on load of Active Admin
     BeforeLoadEvent = 'active_admin.application.before_load'.freeze
-    AfterLoadEvent  = 'active_admin.application.after_load'.freeze
+    AfterLoadEvent = 'active_admin.application.after_load'.freeze
 
     # Runs before the app's AA initializer
     def setup!
@@ -112,9 +112,9 @@ module ActiveAdmin
     def load!
       unless loaded?
         ActiveSupport::Notifications.publish BeforeLoadEvent, self # before_load hook
-        files.each { |file| load file }                            # load files
-        namespace(default_namespace)                               # init AA resources
-        ActiveSupport::Notifications.publish AfterLoadEvent, self  # after_load hook
+        files.each { |file| load file } # load files
+        namespace(default_namespace) # init AA resources
+        ActiveSupport::Notifications.publish AfterLoadEvent, self # after_load hook
         @@loaded = true
       end
     end
@@ -176,7 +176,7 @@ module ActiveAdmin
     # files from being loaded twice in production.
     def remove_active_admin_load_paths_from_rails_autoload_and_eager_load
       ActiveSupport::Dependencies.autoload_paths -= load_paths
-      Rails.application.config.eager_load_paths  -= load_paths
+      Rails.application.config.eager_load_paths -= load_paths
     end
 
     # Hook into the Rails code reloading mechanism so that things are reloaded

--- a/lib/active_admin/authorization_adapter.rb
+++ b/lib/active_admin/authorization_adapter.rb
@@ -2,9 +2,9 @@ module ActiveAdmin
 
   # Default Authorization permissions for Active Admin
   module Authorization
-    READ    = :read
-    CREATE  = :create
-    UPDATE  = :update
+    READ = :read
+    CREATE = :create
+    UPDATE = :update
     DESTROY = :destroy
   end
 

--- a/lib/active_admin/base_controller/authorization.rb
+++ b/lib/active_admin/base_controller/authorization.rb
@@ -112,9 +112,9 @@ module ActiveAdmin
             redirect_backwards_or_to_root
           end
 
-          format.csv  { render body:          error,           status: :unauthorized }
-          format.json { render json: { error: error },         status: :unauthorized }
-          format.xml  { render xml: "<error>#{error}</error>", status: :unauthorized }
+          format.csv { render body: error, status: :unauthorized }
+          format.json { render json: { error: error }, status: :unauthorized }
+          format.xml { render xml: "<error>#{error}</error>", status: :unauthorized }
         end
       end
 

--- a/lib/active_admin/batch_actions/controller.rb
+++ b/lib/active_admin/batch_actions/controller.rb
@@ -5,10 +5,10 @@ module ActiveAdmin
       # Controller action that is called when submitting the batch action form
       def batch_action
         if action_present?
-          selection  =            params[:collection_selection] || []
-          inputs     = JSON.parse params[:batch_action_inputs]  || '{}'
+          selection = params[:collection_selection] || []
+          inputs = JSON.parse params[:batch_action_inputs] || '{}'
           valid_keys = MethodOrProcHelper.render_in_context(self, current_batch_action.inputs).try(:keys)
-          inputs     = inputs.with_indifferent_access.slice *valid_keys
+          inputs = inputs.with_indifferent_access.slice *valid_keys
           instance_exec selection, inputs, &current_batch_action.block
         else
           raise "Couldn't find batch action \"#{params[:batch_action]}\""

--- a/lib/active_admin/batch_actions/views/batch_action_form.rb
+++ b/lib/active_admin/batch_actions/views/batch_action_form.rb
@@ -16,7 +16,7 @@ module ActiveAdmin
         # batch_action        => name of the specific action called
         # batch_action_inputs => a JSON string of any requested confirmation values
         text_node form_tag active_admin_config.route_batch_action_path(params, url_options), id: options[:id]
-        input name: :batch_action,        id: :batch_action,        type: :hidden
+        input name: :batch_action, id: :batch_action, type: :hidden
         input name: :batch_action_inputs, id: :batch_action_inputs, type: :hidden
 
         super(options)

--- a/lib/active_admin/csv_builder.rb
+++ b/lib/active_admin/csv_builder.rb
@@ -42,11 +42,11 @@ module ActiveAdmin
     end
 
     def build(controller, csv)
-      @collection  = controller.send :find_collection, except: :pagination
-      columns      = exec_columns controller.view_context
-      bom          = options.delete :byte_order_mark
+      @collection = controller.send :find_collection, except: :pagination
+      columns = exec_columns controller.view_context
+      bom = options.delete :byte_order_mark
       column_names = options.delete(:column_names) { true }
-      csv_options  = options.except :encoding_options, :humanize_name
+      csv_options = options.except :encoding_options, :humanize_name
 
       csv << bom if bom
 

--- a/lib/active_admin/filters.rb
+++ b/lib/active_admin/filters.rb
@@ -7,5 +7,5 @@ require 'active_admin/filters/active_sidebar'
 
 # Add our Extensions
 ActiveAdmin::ResourceDSL.send :include, ActiveAdmin::Filters::DSL
-ActiveAdmin::Resource.send    :include, ActiveAdmin::Filters::ResourceExtension
+ActiveAdmin::Resource.send :include, ActiveAdmin::Filters::ResourceExtension
 ActiveAdmin::ViewHelpers.send :include, ActiveAdmin::Filters::ViewHelper

--- a/lib/active_admin/filters/forms.rb
+++ b/lib/active_admin/filters/forms.rb
@@ -51,12 +51,12 @@ module ActiveAdmin
                      html: { class: 'filter_form' } }
         required = { html: { method: :get },
                      as: :q }
-        options  = defaults.deep_merge(options).deep_merge(required)
+        options = defaults.deep_merge(options).deep_merge(required)
 
         form_for search, options do |f|
           filters.each do |attribute, opts|
-            next if opts.key?(:if)     && !call_method_or_proc_on(self, opts[:if])
-            next if opts.key?(:unless) &&  call_method_or_proc_on(self, opts[:unless])
+            next if opts.key?(:if) && !call_method_or_proc_on(self, opts[:if])
+            next if opts.key?(:unless) && call_method_or_proc_on(self, opts[:unless])
 
             filter_opts = opts.except(:if, :unless)
             filter_opts[:input_html] = instance_exec(&filter_opts[:input_html]) if filter_opts[:input_html].is_a?(Proc)

--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -69,7 +69,7 @@ module ActiveAdmin
     def extract_custom_settings!(options)
       @heading = options.key?(:heading) ? options.delete(:heading) : default_heading
       @sortable_column = options.delete(:sortable)
-      @sortable_start  = options.delete(:sortable_start) || 0
+      @sortable_start = options.delete(:sortable_start) || 0
       @new_record = options.key?(:new_record) ? options.delete(:new_record) : true
       @destroy_option = options.delete(:allow_destroy)
       options
@@ -156,8 +156,8 @@ module ActiveAdmin
 
     # Capture the ADD JS
     def js_for_has_many(class_string, &form_block)
-      assoc_name       = assoc_klass.model_name
-      placeholder      = "NEW_#{assoc_name.to_s.underscore.upcase.gsub(/\//, '_')}_RECORD"
+      assoc_name = assoc_klass.model_name
+      placeholder = "NEW_#{assoc_name.to_s.underscore.upcase.gsub(/\//, '_')}_RECORD"
       opts = {
         for: [assoc, assoc_klass.new],
         class: class_string,

--- a/lib/active_admin/helpers/optional_display.rb
+++ b/lib/active_admin/helpers/optional_display.rb
@@ -15,7 +15,7 @@ module ActiveAdmin
 
   module OptionalDisplay
     def display_on?(action, render_context = self)
-      return false if @options[:only]   && !@options[:only].include?(action.to_sym)
+      return false if @options[:only] && !@options[:only].include?(action.to_sym)
       return false if @options[:except] && @options[:except].include?(action.to_sym)
 
       case condition = @options[:if]
@@ -31,7 +31,7 @@ module ActiveAdmin
     private
 
     def normalize_display_options!
-      @options[:only]   = Array(@options[:only])   if @options[:only]
+      @options[:only] = Array(@options[:only]) if @options[:only]
       @options[:except] = Array(@options[:except]) if @options[:except]
     end
   end

--- a/lib/active_admin/inputs/filters/base/search_method_select.rb
+++ b/lib/active_admin/inputs/filters/base/search_method_select.rb
@@ -37,9 +37,9 @@ module ActiveAdmin
 
           def to_html
             input_wrapping do
-              label_html  << # your label
+              label_html << # your label
               select_html << # the dropdown that holds the available search methods
-              input_html     # your input field
+              input_html # your input field
             end
           end
 

--- a/lib/active_admin/menu_item.rb
+++ b/lib/active_admin/menu_item.rb
@@ -45,13 +45,13 @@ module ActiveAdmin
     #
     def initialize(options = {})
       super() # MenuNode
-      @label          = options[:label]
-      @dirty_id       = options[:id]           || options[:label]
-      @url            = options[:url]          || '#'
-      @priority       = options[:priority]     || 10
-      @html_options   = options[:html_options] || {}
-      @should_display = options[:if]           || proc { true }
-      @parent         = options[:parent]
+      @label = options[:label]
+      @dirty_id = options[:id] || options[:label]
+      @url = options[:url] || '#'
+      @priority = options[:priority] || 10
+      @html_options = options[:html_options] || {}
+      @should_display = options[:if] || proc { true }
+      @parent = options[:parent]
 
       yield(self) if block_given? # Builder style syntax
     end

--- a/lib/active_admin/namespace.rb
+++ b/lib/active_admin/namespace.rb
@@ -212,7 +212,7 @@ module ActiveAdmin
     def unload_resources!
       resources.each do |resource|
         parent = (module_name || 'Object').constantize
-        name   = resource.controller_name.split('::').last
+        name = resource.controller_name.split('::').last
         parent.send(:remove_const, name) if parent.const_defined?(name, false)
 
         # Remove circular references

--- a/lib/active_admin/orm/active_record/comments.rb
+++ b/lib/active_admin/orm/active_record/comments.rb
@@ -4,14 +4,14 @@ require 'active_admin/orm/active_record/comments/namespace_helper'
 require 'active_admin/orm/active_record/comments/resource_helper'
 
 # Add the comments configuration
-ActiveAdmin::Application.inheritable_setting :comments,                   true
+ActiveAdmin::Application.inheritable_setting :comments, true
 ActiveAdmin::Application.inheritable_setting :comments_registration_name, 'Comment'
-ActiveAdmin::Application.inheritable_setting :comments_order,             "created_at ASC"
-ActiveAdmin::Application.inheritable_setting :comments_menu,              {}
+ActiveAdmin::Application.inheritable_setting :comments_order, "created_at ASC"
+ActiveAdmin::Application.inheritable_setting :comments_menu, {}
 
 # Insert helper modules
 ActiveAdmin::Namespace.send :include, ActiveAdmin::Comments::NamespaceHelper
-ActiveAdmin::Resource.send  :include, ActiveAdmin::Comments::ResourceHelper
+ActiveAdmin::Resource.send :include, ActiveAdmin::Comments::ResourceHelper
 ActiveAdmin.application.view_factory.show_page.send :include, ActiveAdmin::Comments::ShowPageHelper
 
 # Load the model as soon as it's referenced. By that point, Rails & Kaminari will be ready
@@ -36,7 +36,7 @@ ActiveAdmin.after_load do |app|
 
       menu namespace.comments ? namespace.comments_menu : false
 
-      config.comments      = false # Don't allow comments on comments
+      config.comments = false # Don't allow comments on comments
       config.batch_actions = false # The default destroy batch action isn't showing up anyway...
 
       scope :all, show_count: false
@@ -51,7 +51,7 @@ ActiveAdmin.after_load do |app|
       # Store the author and namespace
       before_save do |comment|
         comment.namespace = active_admin_config.namespace.name
-        comment.author    = current_active_admin_user
+        comment.author = current_active_admin_user
       end
 
       controller do
@@ -89,11 +89,11 @@ ActiveAdmin.after_load do |app|
 
       index do
         column I18n.t('active_admin.comments.resource_type'), :resource_type
-        column I18n.t('active_admin.comments.author_type'),   :author_type
-        column I18n.t('active_admin.comments.resource'),      :resource
-        column I18n.t('active_admin.comments.author'),        :author
-        column I18n.t('active_admin.comments.body'),          :body
-        column I18n.t('active_admin.comments.created_at'),    :created_at
+        column I18n.t('active_admin.comments.author_type'), :author_type
+        column I18n.t('active_admin.comments.resource'), :resource
+        column I18n.t('active_admin.comments.author'), :author
+        column I18n.t('active_admin.comments.body'), :body
+        column I18n.t('active_admin.comments.created_at'), :created_at
         actions
       end
     end

--- a/lib/active_admin/orm/active_record/comments/comment.rb
+++ b/lib/active_admin/orm/active_record/comments/comment.rb
@@ -4,7 +4,7 @@ module ActiveAdmin
     self.table_name = "#{table_name_prefix}active_admin_comments#{table_name_suffix}"
 
     belongs_to :resource, polymorphic: true, optional: true
-    belongs_to :author,   polymorphic: true
+    belongs_to :author, polymorphic: true
 
     validates_presence_of :body, :namespace, :resource
 

--- a/lib/active_admin/orm/active_record/comments/views/active_admin_comments.rb
+++ b/lib/active_admin/orm/active_record/comments/views/active_admin_comments.rb
@@ -80,9 +80,9 @@ module ActiveAdmin
         def build_comment_form
           active_admin_form_for(ActiveAdmin::Comment.new, url: comment_form_url) do |f|
             f.inputs do
-              f.input :resource_type, as: :hidden,  input_html: { value: ActiveAdmin::Comment.resource_type(parent.resource) }
-              f.input :resource_id,   as: :hidden,  input_html: { value: parent.resource.id }
-              f.input :body,          label: false, input_html: { size: '80x8' }
+              f.input :resource_type, as: :hidden, input_html: { value: ActiveAdmin::Comment.resource_type(parent.resource) }
+              f.input :resource_id, as: :hidden, input_html: { value: parent.resource.id }
+              f.input :body, label: false, input_html: { size: '80x8' }
             end
             f.actions do
               f.action :submit, label: I18n.t('active_admin.comments.add')

--- a/lib/active_admin/pundit_adapter.rb
+++ b/lib/active_admin/pundit_adapter.rb
@@ -31,7 +31,7 @@ module ActiveAdmin
 
     def retrieve_policy(subject)
       case subject
-      when nil   then Pundit.policy!(user, namespace(resource))
+      when nil then Pundit.policy!(user, namespace(resource))
       when Class then Pundit.policy!(user, namespace(subject.new))
       else Pundit.policy!(user, namespace(subject))
       end
@@ -46,9 +46,9 @@ module ActiveAdmin
     def format_action(action, subject)
       # https://github.com/varvet/pundit/blob/master/lib/generators/pundit/install/templates/application_policy.rb
       case action
-      when Auth::CREATE  then :create?
-      when Auth::UPDATE  then :update?
-      when Auth::READ    then subject.is_a?(Class) ? :index? : :show?
+      when Auth::CREATE then :create?
+      when Auth::UPDATE then :update?
+      when Auth::READ then subject.is_a?(Class) ? :index? : :show?
       when Auth::DESTROY then subject.is_a?(Class) ? :destroy_all? : :destroy?
       else "#{action}?"
       end

--- a/lib/active_admin/resource/menu.rb
+++ b/lib/active_admin/resource/menu.rb
@@ -7,12 +7,12 @@ module ActiveAdmin
       # To disable this menu item, call `menu(false)` from the DSL
       def menu_item_options=(options)
         if options == false
-          @include_in_menu   = false
+          @include_in_menu = false
           @menu_item_options = {}
         else
           @include_in_menu = true
           @navigation_menu_name = options[:menu_name]
-          @menu_item_options    = default_menu_options.merge options
+          @menu_item_options = default_menu_options.merge options
         end
       end
 

--- a/lib/active_admin/resource/routes.rb
+++ b/lib/active_admin/resource/routes.rb
@@ -98,13 +98,13 @@ module ActiveAdmin
           suffix = options[:suffix] || "path"
           route = []
 
-          route << options[:action]           # "batch_action", "edit" or "new"
-          route << resource.route_prefix      # "admin"
+          route << options[:action] # "batch_action", "edit" or "new"
+          route << resource.route_prefix # "admin"
           route << belongs_to_name if nested? # "category"
-          route << resource_path_name         # "posts" or "post"
-          route << suffix                     # "path" or "index path"
+          route << resource_path_name # "posts" or "post"
+          route << suffix # "path" or "index path"
 
-          route.compact.join('_').to_sym      # :admin_category_posts_path
+          route.compact.join('_').to_sym # :admin_category_posts_path
         end
 
         # @return params to pass to instance path

--- a/lib/active_admin/resource/scope_to.rb
+++ b/lib/active_admin/resource/scope_to.rb
@@ -38,10 +38,10 @@ module ActiveAdmin
         options = args.extract_options!
         method = args.first
 
-        scope_to_config[:method]              = block || method
-        scope_to_config[:association_method]  = options[:association_method]
-        scope_to_config[:if]                  = options[:if]
-        scope_to_config[:unless]              = options[:unless]
+        scope_to_config[:method] = block || method
+        scope_to_config[:association_method] = options[:association_method]
+        scope_to_config[:if] = options[:if]
+        scope_to_config[:unless] = options[:unless]
 
       end
 

--- a/lib/active_admin/resource_controller.rb
+++ b/lib/active_admin/resource_controller.rb
@@ -24,7 +24,7 @@ module ActiveAdmin
     include Streaming
     include Sidebars
     include ViewHelpers::DownloadFormatLinksHelper
-    extend  ResourceClassMethods
+    extend ResourceClassMethods
 
     def self.active_admin_config=(config)
       if @active_admin_config = config

--- a/lib/active_admin/resource_controller/data_access.rb
+++ b/lib/active_admin/resource_controller/data_access.rb
@@ -258,7 +258,7 @@ module ActiveAdmin
       end
 
       def collection_applies(options = {})
-        only   = Array(options.fetch(:only, COLLECTION_APPLIES))
+        only = Array(options.fetch(:only, COLLECTION_APPLIES))
         except = Array(options.fetch(:except, []))
 
         COLLECTION_APPLIES & only - except

--- a/lib/active_admin/resource_controller/decorators.rb
+++ b/lib/active_admin/resource_controller/decorators.rb
@@ -77,7 +77,7 @@ module ActiveAdmin
         # Draper::CollectionDecorator was introduced in 1.0.0
         # Draper::Decorator#collection_decorator_class was introduced in 1.3.0
         def self.find_collection_decorator(decorator)
-          if Dependency.draper?    '>= 1.3.0'
+          if Dependency.draper? '>= 1.3.0'
             decorator.collection_decorator_class
           elsif Dependency.draper? '>= 1.0.0'
             draper_collection_decorator

--- a/lib/active_admin/resource_dsl.rb
+++ b/lib/active_admin/resource_dsl.rb
@@ -183,16 +183,16 @@ module ActiveAdmin
     # == Before / After Destroy
     # Called before and after the object is destroyed from the database.
     #
-    delegate :before_build,   :after_build,   to: :controller
-    delegate :before_create,  :after_create,  to: :controller
-    delegate :before_update,  :after_update,  to: :controller
-    delegate :before_save,    :after_save,    to: :controller
+    delegate :before_build, :after_build, to: :controller
+    delegate :before_create, :after_create, to: :controller
+    delegate :before_update, :after_update, to: :controller
+    delegate :before_save, :after_save, to: :controller
     delegate :before_destroy, :after_destroy, to: :controller
 
     # This code defines both *_filter and *_action for Rails 5.0 and  *_action for Rails >= 5.1
     phases = [
       :before, :skip_before,
-      :after,  :skip_after,
+      :after, :skip_after,
       :around, :skip
     ]
     keywords = if Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR >= 1

--- a/lib/active_admin/scope.rb
+++ b/lib/active_admin/scope.rb
@@ -45,11 +45,11 @@ module ActiveAdmin
         @scope_block = block
       end
 
-      @localizer        = options[:localizer]
-      @show_count       = options.fetch(:show_count, true)
-      @display_if_block = options[:if]      || proc { true }
-      @default_block    = options[:default] || proc { false }
-      @group            = options[:group].try(:to_sym)
+      @localizer = options[:localizer]
+      @show_count = options.fetch(:show_count, true)
+      @display_if_block = options[:if] || proc { true }
+      @default_block = options[:default] || proc { false }
+      @group = options[:group].try(:to_sym)
     end
 
     def name

--- a/lib/active_admin/view_factory.rb
+++ b/lib/active_admin/view_factory.rb
@@ -4,7 +4,7 @@ module ActiveAdmin
   class ViewFactory < AbstractViewFactory
 
     # Register Helper Renderers
-    register  global_navigation:   ActiveAdmin::Views::TabbedNavigation,
+    register global_navigation:   ActiveAdmin::Views::TabbedNavigation,
               utility_navigation:  ActiveAdmin::Views::TabbedNavigation,
               site_title:          ActiveAdmin::Views::SiteTitle,
               unsupported_browser: ActiveAdmin::Views::UnsupportedBrowser,
@@ -16,7 +16,7 @@ module ActiveAdmin
               blank_slate:         ActiveAdmin::Views::BlankSlate
 
     # Register All The Pages
-    register  index_page: ActiveAdmin::Views::Pages::Index,
+    register index_page: ActiveAdmin::Views::Pages::Index,
               show_page:  ActiveAdmin::Views::Pages::Show,
               new_page:   ActiveAdmin::Views::Pages::Form,
               edit_page:  ActiveAdmin::Views::Pages::Form,

--- a/lib/active_admin/view_helpers/breadcrumb_helper.rb
+++ b/lib/active_admin/view_helpers/breadcrumb_helper.rb
@@ -15,7 +15,7 @@ module ActiveAdmin
           if part =~ /\A(\d+|[a-f0-9]{24}|(?:[a-f0-9]{8}-(?:[a-f0-9]{4}-){3}[a-f0-9]{12}))\z/ && parts[index - 1]
             parent = active_admin_config.belongs_to_config.try :target
             config = parent && parent.resource_name.route_key == parts[index - 1] ? parent : active_admin_config
-            name   = display_name config.find_resource part
+            name = display_name config.find_resource part
           end
           name ||= I18n.t "activerecord.models.#{part.singularize}", count: ::ActiveAdmin::Helpers::I18n::PLURAL_MANY_COUNT, default: part.titlecase
 

--- a/lib/active_admin/view_helpers/display_helper.rb
+++ b/lib/active_admin/view_helpers/display_helper.rb
@@ -5,7 +5,7 @@ module ActiveAdmin
       DISPLAY_NAME_FALLBACK = -> {
         name = ""
         klass = self.class
-        name << klass.model_name.human         if klass.respond_to? :model_name
+        name << klass.model_name.human if klass.respond_to? :model_name
         name << " ##{send(klass.primary_key)}" if klass.respond_to? :primary_key
         name.present? ? name : to_s
       }
@@ -26,7 +26,7 @@ module ActiveAdmin
         @@display_name_methods_cache ||= {}
         @@display_name_methods_cache[resource.class] ||= begin
           methods = active_admin_application.display_name_methods - association_methods_for(resource)
-          method  = methods.detect { |method| resource.respond_to? method }
+          method = methods.detect { |method| resource.respond_to? method }
 
           if method != :to_s || resource.method(method).source_location
             method
@@ -74,7 +74,7 @@ module ActiveAdmin
           format_collection(object)
         else
           if defined?(::ActiveRecord) && object.is_a?(ActiveRecord::Base) ||
-             defined?(::Mongoid)      && object.class.include?(Mongoid::Document)
+             defined?(::Mongoid) && object.class.include?(Mongoid::Document)
             auto_link object
           elsif defined?(::ActiveRecord) && object.is_a?(ActiveRecord::Relation)
             format_collection(object)

--- a/lib/active_admin/view_helpers/fields_for.rb
+++ b/lib/active_admin/view_helpers/fields_for.rb
@@ -15,7 +15,7 @@ module ActiveAdmin
       #
       def fields_for_params(params, options = {})
         namespace = options[:namespace]
-        except    = Array.wrap(options[:except]).map &:to_s
+        except = Array.wrap(options[:except]).map &:to_s
 
         params.flat_map do |k, v|
           next if namespace.nil? && %w(controller action commit utf8).include?(k.to_s)

--- a/lib/active_admin/views/components/attributes_table.rb
+++ b/lib/active_admin/views/components/attributes_table.rb
@@ -5,7 +5,7 @@ module ActiveAdmin
       builder_method :attributes_table_for
 
       def build(obj, *attrs)
-        @collection     = Array.wrap(obj)
+        @collection = Array.wrap(obj)
         @resource_class = @collection.first.class
         options = {}
         options[:for] = @collection.first if single_record?
@@ -20,7 +20,7 @@ module ActiveAdmin
       end
 
       def row(*args, &block)
-        title   = args[0]
+        title = args[0]
         options = args.extract_options!
         classes = [:row]
         if options[:class]

--- a/lib/active_admin/views/components/paginated_collection.rb
+++ b/lib/active_admin/views/components/paginated_collection.rb
@@ -38,12 +38,12 @@ module ActiveAdmin
       #   download_links => Download links override (false or [:csv, :pdf])
       #
       def build(collection, options = {})
-        @collection     = collection
-        @params         = options.delete(:params)
-        @param_name     = options.delete(:param_name)
+        @collection = collection
+        @params = options.delete(:params)
+        @param_name = options.delete(:param_name)
         @download_links = options.delete(:download_links)
-        @display_total  = options.delete(:pagination_total) { true }
-        @per_page       = options.delete(:per_page)
+        @display_total = options.delete(:pagination_total) { true }
+        @per_page = options.delete(:per_page)
 
         unless collection.respond_to?(:total_pages)
           raise(StandardError, "Collection is not a paginated scope. Set collection.page(params[:page]).per(10) before calling :paginated_collection.")
@@ -93,7 +93,7 @@ module ActiveAdmin
 
       def build_pagination
         options = { theme: @display_total ? 'active_admin' : 'active_admin_countless' }
-        options[:params]     = @params     if @params
+        options[:params] = @params if @params
         options[:param_name] = @param_name if @param_name
 
         if !@display_total
@@ -116,28 +116,28 @@ module ActiveAdmin
       # modified from will_paginate
       def page_entries_info(options = {})
         if options[:entry_name]
-          entry_name   = options[:entry_name]
+          entry_name = options[:entry_name]
           entries_name = options[:entries_name] || entry_name.pluralize
         elsif collection_is_empty?
-          entry_name   = I18n.t "active_admin.pagination.entry", count: 1, default: 'entry'
+          entry_name = I18n.t "active_admin.pagination.entry", count: 1, default: 'entry'
           entries_name = I18n.t "active_admin.pagination.entry", count: 2, default: 'entries'
         else
           key = "activerecord.models." + collection.first.class.model_name.i18n_key.to_s
 
-          entry_name   = I18n.translate key, count: 1,               default: collection.first.class.name.underscore.sub('_', ' ')
+          entry_name = I18n.translate key, count: 1, default: collection.first.class.name.underscore.sub('_', ' ')
           entries_name = I18n.translate key, count: collection.size, default: entry_name.pluralize
         end
 
         if @display_total
           if collection.total_pages < 2
             case collection_size
-            when 0; I18n.t("active_admin.pagination.empty",    model: entries_name)
-            when 1; I18n.t("active_admin.pagination.one",      model: entry_name)
-            else;   I18n.t("active_admin.pagination.one_page", model: entries_name, n: collection.total_count)
+            when 0; I18n.t("active_admin.pagination.empty", model: entries_name)
+            when 1; I18n.t("active_admin.pagination.one", model: entry_name)
+            else; I18n.t("active_admin.pagination.one_page", model: entries_name, n: collection.total_count)
             end
           else
             offset = (collection.current_page - 1) * collection.limit_value
-            total  = collection.total_count
+            total = collection.total_count
             I18n.t "active_admin.pagination.multiple",
                    model: entries_name,
                    total: total,

--- a/lib/active_admin/views/components/table_for.rb
+++ b/lib/active_admin/views/components/table_for.rb
@@ -8,14 +8,14 @@ module ActiveAdmin
       end
 
       def build(obj, *attrs)
-        options         = attrs.extract_options!
-        @sortable       = options.delete(:sortable)
-        @collection     = obj.respond_to?(:each) && !obj.is_a?(Hash) ? obj : [obj]
+        options = attrs.extract_options!
+        @sortable = options.delete(:sortable)
+        @collection = obj.respond_to?(:each) && !obj.is_a?(Hash) ? obj : [obj]
         @resource_class = options.delete(:i18n)
         @resource_class ||= @collection.klass if @collection.respond_to? :klass
 
-        @columns        = []
-        @row_class      = options.delete(:row_class)
+        @columns = []
+        @row_class = options.delete(:row_class)
 
         build_table
         super(options)
@@ -29,7 +29,7 @@ module ActiveAdmin
       def column(*args, &block)
         options = default_options.merge(args.extract_options!)
         title = args[0]
-        data  = args[1] || args[0]
+        data = args[1] || args[0]
 
         col = Column.new(title, data, @resource_class, options, &block)
         @columns << col
@@ -65,12 +65,12 @@ module ActiveAdmin
       end
 
       def build_table_header(col)
-        classes  = Arbre::HTML::ClassList.new
+        classes = Arbre::HTML::ClassList.new
         sort_key = sortable? && col.sortable? && col.sort_key
-        params   = request.query_parameters.except :page, :order, :commit, :format
+        params = request.query_parameters.except :page, :order, :commit, :format
 
-        classes << 'sortable'                         if sort_key
-        classes << "sorted-#{current_sort[1]}"        if sort_key && current_sort[0] == sort_key
+        classes << 'sortable' if sort_key
+        classes << "sorted-#{current_sort[1]}" if sort_key && current_sort[0] == sort_key
         classes << col.html_class
 
         if sort_key

--- a/lib/active_admin/views/index_as_table.rb
+++ b/lib/active_admin/views/index_as_table.rb
@@ -344,9 +344,9 @@ module ActiveAdmin
         #
         # ```
         def actions(options = {}, &block)
-          name          = options.delete(:name)     { '' }
-          defaults      = options.delete(:defaults) { true }
-          dropdown      = options.delete(:dropdown) { false }
+          name = options.delete(:name) { '' }
+          defaults = options.delete(:defaults) { true }
+          dropdown = options.delete(:dropdown) { false }
           dropdown_name = options.delete(:dropdown_name) { I18n.t 'active_admin.dropdown_actions.button_label', default: 'Actions' }
 
           options[:class] ||= 'col-actions'

--- a/lib/active_admin/views/pages/index.rb
+++ b/lib/active_admin/views/pages/index.rb
@@ -125,10 +125,10 @@ module ActiveAdmin
         def render_index
           renderer_class = find_index_renderer_class(config[:as])
 
-          paginator        = config.fetch(:paginator, true)
-          download_links   = config.fetch(:download_links, active_admin_config.namespace.download_links)
+          paginator = config.fetch(:paginator, true)
+          download_links = config.fetch(:download_links, active_admin_config.namespace.download_links)
           pagination_total = config.fetch(:pagination_total, true)
-          per_page         = config.fetch(:per_page, active_admin_config.per_page)
+          per_page = config.fetch(:per_page, active_admin_config.per_page)
 
           paginated_collection(collection, entry_name:       active_admin_config.resource_label,
                                            entries_name:     active_admin_config.plural_resource_label(count: collection_size),

--- a/lib/generators/active_admin/devise/devise_generator.rb
+++ b/lib/generators/active_admin/devise/devise_generator.rb
@@ -7,12 +7,12 @@ module ActiveAdmin
       desc "Creates an admin user and uses Devise for authentication"
       argument :name, type: :string, default: "AdminUser"
 
-      class_option  :registerable, type: :boolean, default: false,
+      class_option :registerable, type: :boolean, default: false,
                     desc: "Should the generated resource be registerable?"
 
       RESERVED_NAMES = [:active_admin_user]
 
-      class_option  :default_user, type: :boolean, default: true,
+      class_option :default_user, type: :boolean, default: true,
                     desc: "Should a default user be created inside the migration?"
 
       def install_devise

--- a/spec/unit/csv_builder_spec.rb
+++ b/spec/unit/csv_builder_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe ActiveAdmin::CSVBuilder do
       end
 
       it 'gets name from I18n' do
-        title_index =  resource.content_columns.index(:title) + 1 # First col is always id
+        title_index = resource.content_columns.index(:title) + 1 # First col is always id
         expect(csv_builder.columns[title_index].name).to eq localized_name
       end
     end

--- a/spec/unit/dependency_spec.rb
+++ b/spec/unit/dependency_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe ActiveAdmin::Dependency do
 
     describe '`!`' do
       it 'raises an error if requirement not met' do
-        expect { k.foo! '5'            }.to raise_error ActiveAdmin::DependencyError,
+        expect { k.foo! '5' }.to raise_error ActiveAdmin::DependencyError,
           'You provided foo 1.2.3 but we need: 5.'
       end
       it 'accepts multiple arguments' do
@@ -59,7 +59,7 @@ RSpec.describe ActiveAdmin::Dependency do
           'You provided foo 1.2.3 but we need: > 1, < 1.2.'
       end
       it 'raises an error if not provided' do
-        expect { k.bar!                }.to raise_error ActiveAdmin::DependencyError,
+        expect { k.bar! }.to raise_error ActiveAdmin::DependencyError,
           'To use bar you need to specify it in your Gemfile.'
       end
     end
@@ -92,7 +92,7 @@ RSpec.describe ActiveAdmin::Dependency do
       expect { k['a-b'].match! '2.5' }.to raise_error ActiveAdmin::DependencyError,
         'You provided a-b 1.2.3 but we need: 2.5.'
 
-      expect { k['b-c'].match!       }.to raise_error ActiveAdmin::DependencyError,
+      expect { k['b-c'].match! }.to raise_error ActiveAdmin::DependencyError,
         'To use b-c you need to specify it in your Gemfile.'
     end
 

--- a/spec/unit/filters/filter_form_builder_spec.rb
+++ b/spec/unit/filters/filter_form_builder_spec.rb
@@ -392,7 +392,7 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
 
     context "when using a custom foreign key" do
       let(:scope) { Post.ransack }
-      let(:body)  { filter :category }
+      let(:body) { filter :category }
       it "should ignore that foreign key and let Ransack handle it" do
         expect(Post.reflect_on_association(:category).foreign_key).to eq :custom_category_id
         expect(body).to have_selector("select[name='q[category_id_eq]']")
@@ -457,9 +457,9 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
 
   describe "conditional display" do
     [:if, :unless].each do |verb|
-      should   = verb == :if ? "should" : "shouldn't"
-      if_true  = verb == :if ? :to      : :to_not
-      if_false = verb == :if ? :to_not  : :to
+      should = verb == :if ? "should" : "shouldn't"
+      if_true = verb == :if ? :to : :to_not
+      if_false = verb == :if ? :to_not : :to
       context "with #{verb.inspect} proc" do
         it "#{should} be displayed if true" do
           body = filter :body, verb => proc { true }
@@ -478,9 +478,9 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
         end
         it "should successfully keep rendering other filters after one is hidden" do
           filters = { body: { verb => proc { verb == :unless } }, author: {} }
-          body    = Capybara.string(render_filter scope, filters)
+          body = Capybara.string(render_filter scope, filters)
           expect(body).not_to have_selector("input[name='q[body_contains]']")
-          expect(body).to     have_selector("select[name='q[author_id_eq]']")
+          expect(body).to have_selector("select[name='q[author_id_eq]']")
         end
       end
     end

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -320,7 +320,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
         end
         f.inputs name: 'Author', for: :author do |author|
           author.has_many :profile, allow_destroy: true do |profile|
-            profile.inputs  "inputs for profile #{profile.object.bio}" do
+            profile.inputs "inputs for profile #{profile.object.bio}" do
               profile.input :bio
             end
           end

--- a/spec/unit/menu_item_spec.rb
+++ b/spec/unit/menu_item_spec.rb
@@ -37,7 +37,7 @@ module ActiveAdmin
 
       it "should accept new children" do
         item = MenuItem.new label: "Dashboard"
-        item.add            label: "My Child Dashboard"
+        item.add label: "My Child Dashboard"
         expect(item.items.first).to be_a MenuItem
         expect(item.items.first.label).to eq "My Child Dashboard"
       end

--- a/spec/unit/namespace/authorization_spec.rb
+++ b/spec/unit/namespace/authorization_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ActiveAdmin::Resource, "authorization" do
 
   describe "authorization_adapter" do
     it "should return AuthorizationAdapter by default" do
-      expect(app.authorization_adapter).to       eq ActiveAdmin::AuthorizationAdapter
+      expect(app.authorization_adapter).to eq ActiveAdmin::AuthorizationAdapter
       expect(namespace.authorization_adapter).to eq ActiveAdmin::AuthorizationAdapter
     end
 

--- a/spec/unit/pretty_format_spec.rb
+++ b/spec/unit/pretty_format_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe "#pretty_format" do
   end
 
   context "given an arbitrary object" do
-    let(:obj)  { Class.new.new }
+    let(:obj) { Class.new.new }
 
     it "should delegate to `display_name`" do
       expect(view).to receive(:display_name).with(obj) { "I'm not famous" }

--- a/spec/unit/resource_collection_spec.rb
+++ b/spec/unit/resource_collection_spec.rb
@@ -3,18 +3,18 @@ require 'active_admin/resource_collection'
 
 RSpec.describe ActiveAdmin::ResourceCollection do
   let(:application) { ActiveAdmin::Application.new }
-  let(:namespace)   { ActiveAdmin::Namespace.new application, :admin }
-  let(:collection)  { ActiveAdmin::ResourceCollection.new }
-  let(:resource)    { double resource_name: "MyResource" }
+  let(:namespace) { ActiveAdmin::Namespace.new application, :admin }
+  let(:collection) { ActiveAdmin::ResourceCollection.new }
+  let(:resource) { double resource_name: "MyResource" }
 
-  it { is_expected.to respond_to :[]       }
-  it { is_expected.to respond_to :add      }
-  it { is_expected.to respond_to :each     }
+  it { is_expected.to respond_to :[] }
+  it { is_expected.to respond_to :add }
+  it { is_expected.to respond_to :each }
   it { is_expected.to respond_to :has_key? }
-  it { is_expected.to respond_to :keys     }
-  it { is_expected.to respond_to :values   }
-  it { is_expected.to respond_to :size     }
-  it { is_expected.to respond_to :to_a     }
+  it { is_expected.to respond_to :keys }
+  it { is_expected.to respond_to :values }
+  it { is_expected.to respond_to :size }
+  it { is_expected.to respond_to :to_a }
 
   it "should have no resources when new" do
     expect(collection).to be_empty
@@ -66,7 +66,7 @@ RSpec.describe ActiveAdmin::ResourceCollection do
 
     describe "should store both renamed and non-renamed resources" do
       let(:resource) { ActiveAdmin::Resource.new namespace, Category }
-      let(:renamed)  { ActiveAdmin::Resource.new namespace, Category, as: "Subcategory" }
+      let(:renamed) { ActiveAdmin::Resource.new namespace, Category, as: "Subcategory" }
 
       it "when the renamed version is added first" do
         collection.add renamed
@@ -83,12 +83,12 @@ RSpec.describe ActiveAdmin::ResourceCollection do
   end
 
   describe "#[]" do
-    let(:resource)              { ActiveAdmin::Resource.new namespace, resource_class }
-    let(:inherited_resource)    { ActiveAdmin::Resource.new namespace, inherited_resource_class }
+    let(:resource) { ActiveAdmin::Resource.new namespace, resource_class }
+    let(:inherited_resource) { ActiveAdmin::Resource.new namespace, inherited_resource_class }
 
-    let(:resource_class)           { User }
+    let(:resource_class) { User }
     let(:inherited_resource_class) { Publisher }
-    let(:unregistered_class)       { Category }
+    let(:unregistered_class) { Category }
 
     context "with resources" do
       before do
@@ -133,7 +133,7 @@ RSpec.describe ActiveAdmin::ResourceCollection do
 
     context "with a renamed resource" do
       let(:renamed_resource) { ActiveAdmin::Resource.new namespace, resource_class, as: name }
-      let(:name)             { "Administrators" }
+      let(:name) { "Administrators" }
 
       before do
         collection.add renamed_resource

--- a/spec/unit/routing_spec.rb
+++ b/spec/unit/routing_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe "Routing", type: :routing do
         end
 
         it "should default to GET" do
-          expect({ get: "/admin/posts/1/do_something" }).to      be_routable
+          expect({ get: "/admin/posts/1/do_something" }).to be_routable
           expect({ post: "/admin/posts/1/do_something" }).to_not be_routable
         end
       end

--- a/spec/unit/scope_spec.rb
+++ b/spec/unit/scope_spec.rb
@@ -9,17 +9,17 @@ RSpec.describe ActiveAdmin::Scope do
 
       describe '#name' do
         subject { super().name }
-        it      { is_expected.to eq("Published") }
+        it { is_expected.to eq("Published") }
       end
 
       describe '#id' do
         subject { super().id }
-        it      { is_expected.to eq("published") }
+        it { is_expected.to eq("published") }
       end
 
       describe '#scope_method' do
         subject { super().scope_method }
-        it      { is_expected.to eq(:published) }
+        it { is_expected.to eq(:published) }
       end
     end
 
@@ -28,24 +28,24 @@ RSpec.describe ActiveAdmin::Scope do
 
       describe '#name' do
         subject { super().name }
-        it      { is_expected.to eq("All") }
+        it { is_expected.to eq("All") }
       end
 
       describe '#id' do
         subject { super().id }
-        it      { is_expected.to eq("all") }
+        it { is_expected.to eq("all") }
       end
       # :all does not return a chain but an array of active record
       # instances. We set the scope_method to nil then.
 
       describe '#scope_method' do
         subject { super().scope_method }
-        it      { is_expected.to eq(nil) }
+        it { is_expected.to eq(nil) }
       end
 
       describe '#scope_block' do
         subject { super().scope_block }
-        it      { is_expected.to eq(nil) }
+        it { is_expected.to eq(nil) }
       end
     end
 
@@ -54,17 +54,17 @@ RSpec.describe ActiveAdmin::Scope do
 
       describe '#name' do
         subject { super().name }
-        it      { is_expected.to eq 'Tous' }
+        it { is_expected.to eq 'Tous' }
       end
 
       describe '#scope_method' do
         subject { super().scope_method }
-        it      { is_expected.to eq nil }
+        it { is_expected.to eq nil }
       end
 
       describe '#scope_block' do
         subject { super().scope_block }
-        it      { is_expected.to eq nil }
+        it { is_expected.to eq nil }
       end
     end
 
@@ -73,17 +73,17 @@ RSpec.describe ActiveAdmin::Scope do
 
       describe '#name' do
         subject { super().name }
-        it      { is_expected.to eq("With API Access") }
+        it { is_expected.to eq("With API Access") }
       end
 
       describe '#id' do
         subject { super().id }
-        it      { is_expected.to eq("with_api_access") }
+        it { is_expected.to eq("with_api_access") }
       end
 
       describe '#scope_method' do
         subject { super().scope_method }
-        it      { is_expected.to eq(:with_api_access) }
+        it { is_expected.to eq(:with_api_access) }
       end
     end
 
@@ -92,22 +92,22 @@ RSpec.describe ActiveAdmin::Scope do
 
       describe '#name' do
         subject { super().name }
-        it      { is_expected.to eq("My Scope") }
+        it { is_expected.to eq("My Scope") }
       end
 
       describe '#id' do
         subject { super().id }
-        it      { is_expected.to eq("my_scope") }
+        it { is_expected.to eq("my_scope") }
       end
 
       describe '#scope_method' do
         subject { super().scope_method }
-        it      { is_expected.to eq(nil) }
+        it { is_expected.to eq(nil) }
       end
 
       describe '#scope_block' do
         subject { super().scope_block }
-        it      { is_expected.to be_a(Proc) }
+        it { is_expected.to be_a(Proc) }
       end
     end
 
@@ -116,12 +116,12 @@ RSpec.describe ActiveAdmin::Scope do
 
       describe '#name' do
         subject { super().name }
-        it      { is_expected.to eq("my scope") }
+        it { is_expected.to eq("my scope") }
       end
 
       describe '#id' do
         subject { super().id }
-        it      { is_expected.to eq("my_scope") }
+        it { is_expected.to eq("my_scope") }
       end
     end
 

--- a/spec/unit/view_factory_spec.rb
+++ b/spec/unit/view_factory_spec.rb
@@ -7,11 +7,11 @@ def it_should_have_view(key, value)
 end
 
 RSpec.describe ActiveAdmin::ViewFactory do
-  it_should_have_view :global_navigation,    ActiveAdmin::Views::TabbedNavigation
-  it_should_have_view :utility_navigation,   ActiveAdmin::Views::TabbedNavigation
-  it_should_have_view :site_title,           ActiveAdmin::Views::SiteTitle
-  it_should_have_view :action_items,         ActiveAdmin::Views::ActionItems
-  it_should_have_view :header,               ActiveAdmin::Views::Header
-  it_should_have_view :blank_slate,          ActiveAdmin::Views::BlankSlate
-  it_should_have_view :layout,               ActiveAdmin::Views::Pages::Layout
+  it_should_have_view :global_navigation, ActiveAdmin::Views::TabbedNavigation
+  it_should_have_view :utility_navigation, ActiveAdmin::Views::TabbedNavigation
+  it_should_have_view :site_title, ActiveAdmin::Views::SiteTitle
+  it_should_have_view :action_items, ActiveAdmin::Views::ActionItems
+  it_should_have_view :header, ActiveAdmin::Views::Header
+  it_should_have_view :blank_slate, ActiveAdmin::Views::BlankSlate
+  it_should_have_view :layout, ActiveAdmin::Views::Pages::Layout
 end

--- a/spec/unit/view_helpers/breadcrumbs_spec.rb
+++ b/spec/unit/view_helpers/breadcrumbs_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe "Breadcrumbs" do
 
     actions = ActiveAdmin::BaseController::ACTIVE_ADMIN_ACTIONS
 
-    let(:user)        { double display_name: 'Jane Doe' }
+    let(:user) { double display_name: 'Jane Doe' }
     let(:user_config) { double find_resource: user, resource_name: double(route_key: 'users'),
                                defined_actions: actions }
-    let(:post)        { double display_name: 'Hello World' }
+    let(:post) { double display_name: 'Hello World' }
     let(:post_config) { double find_resource: post, resource_name: double(route_key: 'posts'),
                                defined_actions: actions, belongs_to_config: double(target: user_config) }
 

--- a/spec/unit/views/components/attributes_table_spec.rb
+++ b/spec/unit/views/components/attributes_table_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe ActiveAdmin::Views::AttributesTable do
       "when you create each row with a custom block that returns nil" => proc {
         render_arbre_component(assigns) {
           attributes_table_for post do
-            row("Id")   { text_node post.id; nil }
+            row("Id") { text_node post.id; nil }
             row("Title") { text_node post.title; nil }
             row("Body") { text_node post.body; nil }
           end

--- a/spec/unit/views/components/blank_slate_spec.rb
+++ b/spec/unit/views/components/blank_slate_spec.rb
@@ -10,17 +10,17 @@ RSpec.describe ActiveAdmin::Views::BlankSlate do
 
     describe '#tag_name' do
       subject { super().tag_name }
-      it      { is_expected.to eql 'div' }
+      it { is_expected.to eql 'div' }
     end
 
     describe '#class_list' do
       subject { super().class_list }
-      it      { is_expected.to include('blank_slate_container') }
+      it { is_expected.to include('blank_slate_container') }
     end
 
     describe '#content' do
       subject { super().content }
-      it      { is_expected.to include '<span class="blank_slate">There are no Posts yet. <a href="/posts/new">Create one</a></span>' }
+      it { is_expected.to include '<span class="blank_slate">There are no Posts yet. <a href="/posts/new">Create one</a></span>' }
     end
   end
 end

--- a/spec/unit/views/components/paginated_collection_spec.rb
+++ b/spec/unit/views/components/paginated_collection_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ActiveAdmin::Views::PaginatedCollection do
     let(:view) do
       view = mock_action_view
       allow(view.request).to receive(:query_parameters).and_return page: '1'
-      allow(view.request).to receive(:path_parameters).and_return  controller: 'admin/posts', action: 'index'
+      allow(view.request).to receive(:path_parameters).and_return controller: 'admin/posts', action: 'index'
       view
     end
 
@@ -27,7 +27,7 @@ RSpec.describe ActiveAdmin::Views::PaginatedCollection do
 
     before do
       allow(collection).to receive(:except) { collection } unless collection.respond_to? :except
-      allow(collection).to receive(:group_values) { [] }   unless collection.respond_to? :group_values
+      allow(collection).to receive(:group_values) { [] } unless collection.respond_to? :group_values
     end
 
     let(:pagination) { paginated_collection collection }

--- a/spec/unit/views/components/status_tag_spec.rb
+++ b/spec/unit/views/components/status_tag_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe ActiveAdmin::Views::StatusTag do
 
     describe '#tag_name' do
       subject { super().tag_name }
-      it      { is_expected.to eq 'span' }
+      it { is_expected.to eq 'span' }
     end
 
     describe '#class_list' do
       subject { super().class_list }
-      it      { is_expected.to include('status_tag') }
+      it { is_expected.to include('status_tag') }
     end
 
     context "when status is 'completed'" do
@@ -26,22 +26,22 @@ RSpec.describe ActiveAdmin::Views::StatusTag do
 
       describe '#tag_name' do
         subject { super().tag_name }
-        it      { is_expected.to eq 'span' }
+        it { is_expected.to eq 'span' }
       end
 
       describe '#class_list' do
         subject { super().class_list }
-        it      { is_expected.to include('status_tag') }
+        it { is_expected.to include('status_tag') }
       end
 
       describe '#class_list' do
         subject { super().class_list }
-        it      { is_expected.to include('completed') }
+        it { is_expected.to include('completed') }
       end
 
       describe '#content' do
         subject { super().content }
-        it      { is_expected.to eq 'Completed' }
+        it { is_expected.to eq 'Completed' }
       end
     end
 
@@ -50,12 +50,12 @@ RSpec.describe ActiveAdmin::Views::StatusTag do
 
       describe '#class_list' do
         subject { super().class_list }
-        it      { is_expected.to include('in_progress') }
+        it { is_expected.to include('in_progress') }
       end
 
       describe '#content' do
         subject { super().content }
-        it      { is_expected.to eq 'In Progress' }
+        it { is_expected.to eq 'In Progress' }
       end
     end
 
@@ -64,12 +64,12 @@ RSpec.describe ActiveAdmin::Views::StatusTag do
 
       describe '#class_list' do
         subject { super().class_list }
-        it      { is_expected.to include('in_progress') }
+        it { is_expected.to include('in_progress') }
       end
 
       describe '#content' do
         subject { super().content }
-        it      { is_expected.to eq 'In Progress' }
+        it { is_expected.to eq 'In Progress' }
       end
     end
 
@@ -78,12 +78,12 @@ RSpec.describe ActiveAdmin::Views::StatusTag do
 
       describe '#class_list' do
         subject { super().class_list }
-        it      { is_expected.to include('status_tag') }
+        it { is_expected.to include('status_tag') }
       end
 
       describe '#content' do
         subject { super().content }
-        it      { is_expected.to eq '' }
+        it { is_expected.to eq '' }
       end
     end
 
@@ -92,12 +92,12 @@ RSpec.describe ActiveAdmin::Views::StatusTag do
 
       describe '#class_list' do
         subject { super().class_list }
-        it      { is_expected.to include('status_tag') }
+        it { is_expected.to include('status_tag') }
       end
 
       describe '#content' do
         subject { super().content }
-        it      { is_expected.to eq('No') }
+        it { is_expected.to eq('No') }
       end
     end
 
@@ -106,12 +106,12 @@ RSpec.describe ActiveAdmin::Views::StatusTag do
 
       describe '#class_list' do
         subject { super().class_list }
-        it      { is_expected.to include('status_tag') }
+        it { is_expected.to include('status_tag') }
       end
 
       describe '#content' do
         subject { super().content }
-        it      { is_expected.to eq('No') }
+        it { is_expected.to eq('No') }
       end
     end
 
@@ -120,14 +120,14 @@ RSpec.describe ActiveAdmin::Views::StatusTag do
 
       describe '#class_list' do
         subject { super().class_list }
-        it      { is_expected.to include('status_tag') }
-        it      { is_expected.to include('no') }
-        it      { is_expected.to include('unset') }
+        it { is_expected.to include('status_tag') }
+        it { is_expected.to include('no') }
+        it { is_expected.to include('unset') }
       end
 
       describe '#content' do
         subject { super().content }
-        it      { is_expected.to eq('No') }
+        it { is_expected.to eq('No') }
         it 'uses the unset locale key to customize the label for the `nil` case' do
           with_translation active_admin: { status_tag: { unset: 'Unknown' } } do
             expect(subject).to eq('Unknown')
@@ -141,17 +141,17 @@ RSpec.describe ActiveAdmin::Views::StatusTag do
 
       describe '#class_list' do
         subject { super().class_list }
-        it      { is_expected.to include('status_tag') }
+        it { is_expected.to include('status_tag') }
       end
 
       describe '#class_list' do
         subject { super().class_list }
-        it      { is_expected.to include('active') }
+        it { is_expected.to include('active') }
       end
 
       describe '#class_list' do
         subject { super().class_list }
-        it      { is_expected.to include('ok') }
+        it { is_expected.to include('ok') }
       end
     end
 
@@ -160,22 +160,22 @@ RSpec.describe ActiveAdmin::Views::StatusTag do
 
       describe '#content' do
         subject { super().content }
-        it      { is_expected.to eq 'on' }
+        it { is_expected.to eq 'on' }
       end
 
       describe '#class_list' do
         subject { super().class_list }
-        it      { is_expected.to include('status_tag') }
+        it { is_expected.to include('status_tag') }
       end
 
       describe '#class_list' do
         subject { super().class_list }
-        it      { is_expected.to include('active') }
+        it { is_expected.to include('active') }
       end
 
       describe '#class_list' do
         subject { super().class_list }
-        it      { is_expected.not_to include('on') }
+        it { is_expected.not_to include('on') }
       end
     end
 
@@ -184,32 +184,32 @@ RSpec.describe ActiveAdmin::Views::StatusTag do
 
       describe '#content' do
         subject { super().content }
-        it      { is_expected.to eq 'So Useless' }
+        it { is_expected.to eq 'So Useless' }
       end
 
       describe '#class_list' do
         subject { super().class_list }
-        it      { is_expected.to include('status_tag') }
+        it { is_expected.to include('status_tag') }
       end
 
       describe '#class_list' do
         subject { super().class_list }
-        it      { is_expected.to include('so_useless') }
+        it { is_expected.to include('so_useless') }
       end
 
       describe '#class_list' do
         subject { super().class_list }
-        it      { is_expected.to include('woot') }
+        it { is_expected.to include('woot') }
       end
 
       describe '#class_list' do
         subject { super().class_list }
-        it      { is_expected.to include('awesome') }
+        it { is_expected.to include('awesome') }
       end
 
       describe '#id' do
         subject { super().id }
-        it      { is_expected.to eq 'useless' }
+        it { is_expected.to eq 'useless' }
       end
     end
 
@@ -218,12 +218,12 @@ RSpec.describe ActiveAdmin::Views::StatusTag do
 
       describe '#content' do
         subject { super().content }
-        it      { is_expected.to eq '42' }
+        it { is_expected.to eq '42' }
       end
 
       describe '#class_list' do
         subject { super().class_list }
-        it      { is_expected.not_to include('42') }
+        it { is_expected.not_to include('42') }
       end
     end
   end


### PR DESCRIPTION
I'd like to enable the `AlllowForAlignment: false` setting for the `Style/ExtraSpacing` cop in our rubocop configuration.

The rationale is explained below but I understand this is a matter of taste so if other maintainers disagree I'll immediately close this without any bike-shedding :)

Some people like the following code because it's prettier. I don't, because it makes diffs harder to read. Sometimes it forces you to change a bunch of lines just to keep the prettiness when you just want to really fix a single line. In my opinion, this hides meaningful changes inside stylistic ones.

For example, say I want to fix a bug caused by a typo in one of the keys in a big hash.  I used `deployments` but the actual key is `deployment`.

```ruby
{
  :clean       => true,
  :deployments => true,
  :frozen      => true,
  :"no-cache"  => true,
  :"no-prune"  => true,
  :path        => "vendor/bundle",
  :shebang     => "ruby27",
  :system      => true,
  :without     => "development",
  :with        => "development",
}
```

If using the "pretty alignment" style, I need to edit all lines in the hash just to make the fix, in order to keep the style, so the diff would look like:

```diff
{
- :clean       => true,
- :deployments => true,
- :frozen      => true,
- :"no-cache"  => true,
- :"no-prune"  => true,
- :path        => "vendor/bundle",
- :shebang     => "ruby27",
- :system      => true,
- :without     => "development",
- :with        => "development",
+ :clean      => true,
+ :deployment => true,
+ :frozen     => true,
+ :"no-cache" => true,
+ :"no-prune" => true,
+ :path       => "vendor/bundle",
+ :shebang    => "ruby27",
+ :system     => true,
+ :without    => "development",
+ :with       => "development",
}
```

In my opinion this is both inconvenient, and also hides the fix. With a no spacing style, it's simpler:

```diff
{
  :clean => true,
- :deployments => true,
+ :deployment => true,
  :frozen  => true,
  :"no-cache" => true,
  :"no-prune" => true,
  :path => "vendor/bundle",
  :shebang => "ruby27",
  :system => true,
  :without => "development",
  :with => "development",
}
```