### PR TITLE
Upgrade kaminari to 1.2.1 or greater to address CSS vulnerability.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ PATH
       formtastic_i18n (~> 0.4)
       inherited_resources (~> 1.7)
       jquery-rails (~> 4.2)
-      kaminari (~> 1.0, >= 1.0.1)
+      kaminari (~> 1.0, >= 1.2.1)
       railties (>= 5.2, < 6.1)
       ransack (~> 2.1, >= 2.1.1)
       sassc-rails (~> 2.1)

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'formtastic_i18n', '~> 0.4'
   s.add_dependency 'inherited_resources', '~> 1.7'
   s.add_dependency 'jquery-rails', '~> 4.2'
-  s.add_dependency 'kaminari', '~> 1.0', '>= 1.0.1'
+  s.add_dependency 'kaminari', '~> 1.0', '>= 1.2.1'
   s.add_dependency 'railties', '>= 5.2', '< 6.1'
   s.add_dependency 'ransack', '~> 2.1', '>= 2.1.1'
   s.add_dependency 'sassc-rails', '~> 2.1'

--- a/gemfiles/rails_52/Gemfile.lock
+++ b/gemfiles/rails_52/Gemfile.lock
@@ -54,7 +54,7 @@ PATH
       formtastic_i18n (~> 0.4)
       inherited_resources (~> 1.7)
       jquery-rails (~> 4.2)
-      kaminari (~> 1.0, >= 1.0.1)
+      kaminari (~> 1.0, >= 1.2.1)
       railties (>= 5.2, < 6.1)
       ransack (~> 2.1, >= 2.1.1)
       sassc-rails (~> 2.1)

--- a/gemfiles/rails_60_turbolinks/Gemfile.lock
+++ b/gemfiles/rails_60_turbolinks/Gemfile.lock
@@ -54,7 +54,7 @@ PATH
       formtastic_i18n (~> 0.4)
       inherited_resources (~> 1.7)
       jquery-rails (~> 4.2)
-      kaminari (~> 1.0, >= 1.0.1)
+      kaminari (~> 1.0, >= 1.2.1)
       railties (>= 5.2, < 6.1)
       ransack (~> 2.1, >= 2.1.1)
       sassc-rails (~> 2.1)

--- a/gemfiles/rails_60_webpacker/Gemfile.lock
+++ b/gemfiles/rails_60_webpacker/Gemfile.lock
@@ -137,7 +137,7 @@ PATH
       formtastic_i18n (~> 0.4)
       inherited_resources (~> 1.7)
       jquery-rails (~> 4.2)
-      kaminari (~> 1.0, >= 1.0.1)
+      kaminari (~> 1.0, >= 1.2.1)
       railties (>= 5.2, < 6.1)
       ransack (~> 2.1, >= 2.1.1)
       sassc-rails (~> 2.1)


### PR DESCRIPTION
This pull request increased the minimum kaminari version to 1.2.1. This removes a XSS vulnerability. References to the issue are included below.

 - https://github.com/kaminari/kaminari/security/advisories/GHSA-r5jw-62xg-j433
 - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-11082

closes #6263 