### PR TITLE
Fix open redirect security issue

### DIFF
--- a/lib/active_admin/base_controller/authorization.rb
+++ b/lib/active_admin/base_controller/authorization.rb
@@ -119,7 +119,7 @@ module ActiveAdmin
       end
 
       def redirect_backwards_or_to_root
-        redirect_back fallback_location: active_admin_root
+        redirect_back fallback_location: active_admin_root, allow_other_hosts: false
       end
 
     end

--- a/lib/active_admin/orm/active_record/comments.rb
+++ b/lib/active_admin/orm/active_record/comments.rb
@@ -64,21 +64,21 @@ ActiveAdmin.after_load do |app|
         def create
           create! do |success, failure|
             success.html do
-              redirect_back fallback_location: active_admin_root
+              redirect_back fallback_location: active_admin_root, allow_other_hosts: false
             end
             failure.html do
               flash[:error] = I18n.t 'active_admin.comments.errors.empty_text'
-              redirect_back fallback_location: active_admin_root
+              redirect_back fallback_location: active_admin_root, allow_other_hosts: false
             end
           end
 
           def destroy
             destroy! do |success, failure|
               success.html do
-                redirect_back fallback_location: active_admin_root
+                redirect_back fallback_location: active_admin_root, allow_other_hosts: false
               end
               failure.html do
-                redirect_back fallback_location: active_admin_root
+                redirect_back fallback_location: active_admin_root, allow_other_hosts: false
               end
             end
           end


### PR DESCRIPTION
This PR closes #6307 by disallowing backward redirects to other hosts (which are potentially malicious). This eliminates the [open redirect](https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html) attack vector as identified by OWASP in [CWE-601](https://cwe.mitre.org/data/definitions/601.html).