### PR TITLE
Enable `Style/BlockDelimiters` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -82,6 +82,9 @@ Rails/FilePath:
 RSpec/HookArgument:
   Enabled: true
 
+Style/BlockDelimiters:
+  Enabled: true
+
 Style/Dir:
   Enabled: true
 

--- a/features/step_definitions/additional_web_steps.rb
+++ b/features/step_definitions/additional_web_steps.rb
@@ -37,9 +37,9 @@ Then /^I should see a link to "([^"]*)"$/ do |link|
 end
 
 Then /^an "([^"]*)" exception should be raised when I follow "([^"]*)"$/ do |error, link|
-  expect {
+  expect do
     step "I follow \"#{link}\""
-  }.to raise_error(error.constantize)
+  end.to raise_error(error.constantize)
 end
 
 Then /^I should be in the resource section for (.+)$/ do |resource_name|

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -158,21 +158,21 @@ RSpec.describe ActiveAdmin::Application do
     end
 
     it "should yield an existing namespace" do
-      expect {
+      expect do
         application.namespace :admin do |ns|
           expect(ns).to eq application.namespaces[:admin]
           raise "found"
         end
-      }.to raise_error("found")
+      end.to raise_error("found")
     end
 
     it "should admit both strings and symbols" do
-      expect {
+      expect do
         application.namespace "admin" do |ns|
           expect(ns).to eq application.namespaces[:admin]
           raise "found"
         end
-      }.to raise_error("found")
+      end.to raise_error("found")
     end
 
     it "should not pollute the global app" do

--- a/spec/unit/belongs_to_spec.rb
+++ b/spec/unit/belongs_to_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe ActiveAdmin::Resource::BelongsTo do
   before do
     load_resources do
       ActiveAdmin.register User
-      ActiveAdmin.register Post do belongs_to :user end
+      ActiveAdmin.register(Post) { belongs_to :user }
     end
   end
 
   let(:namespace) { ActiveAdmin.application.namespace(:admin) }
   let(:user_config) { ActiveAdmin.register User }
-  let(:post_config) { ActiveAdmin.register Post do belongs_to :user end }
+  let(:post_config) { ActiveAdmin.register(Post) { belongs_to :user } }
   let(:belongs_to) { post_config.belongs_to_config }
 
   it "should have an owner" do
@@ -28,20 +28,20 @@ RSpec.describe ActiveAdmin::Resource::BelongsTo do
       let(:belongs_to) { ActiveAdmin::Resource::BelongsTo.new post_config, :missing }
 
       it "should raise a ActiveAdmin::BelongsTo::TargetNotFound" do
-        expect {
+        expect do
           belongs_to.target
-        }.to raise_error(ActiveAdmin::Resource::BelongsTo::TargetNotFound)
+        end.to raise_error(ActiveAdmin::Resource::BelongsTo::TargetNotFound)
       end
     end
 
     context "when the resource is on a namespace" do
-      let(:blog_post_config) { ActiveAdmin.register Blog::Post do; end }
+      let(:blog_post_config) { ActiveAdmin.register Blog::Post }
       let(:belongs_to) { ActiveAdmin::Resource::BelongsTo.new blog_post_config, :blog_author, class_name: "Blog::Author" }
       before do
         class Blog::Author
           include ActiveModel::Naming
         end
-        @blog_author_config = ActiveAdmin.register Blog::Author do; end
+        @blog_author_config = ActiveAdmin.register Blog::Author
       end
       it "should return the target resource" do
         expect(belongs_to.target).to eq @blog_author_config

--- a/spec/unit/csv_builder_spec.rb
+++ b/spec/unit/csv_builder_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe ActiveAdmin::CSVBuilder do
       @post1 = Post.create!(title: "Hello1", published_date: Date.today - 2.day)
       @post2 = Post.create!(title: "Hello2", published_date: Date.today - 1.day)
     end
-    let(:dummy_controller) {
+    let(:dummy_controller) do
       class DummyController
         def find_collection(*)
           collection
@@ -218,7 +218,7 @@ RSpec.describe ActiveAdmin::CSVBuilder do
         end
       end
       DummyController.new
-    }
+    end
     let(:builder) do
       ActiveAdmin::CSVBuilder.new do
         column "id"

--- a/spec/unit/filters/active_filter_spec.rb
+++ b/spec/unit/filters/active_filter_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe ActiveAdmin::Filters::ActiveFilter do
   end
 
   context "the association uses a different primary_key than the related class' primary_key" do
-    let(:resource_klass) {
+    let(:resource_klass) do
       Class.new(Post) do
         belongs_to :kategory, class_name: "Category", primary_key: :name, foreign_key: :title
 
@@ -201,7 +201,7 @@ RSpec.describe ActiveAdmin::Filters::ActiveFilter do
           "SuperPost"
         end
       end
-    }
+    end
 
     let(:resource) do
       namespace.register(resource_klass)

--- a/spec/unit/filters/filter_form_builder_spec.rb
+++ b/spec/unit/filters/filter_form_builder_spec.rb
@@ -354,7 +354,7 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
     end
 
     context "when given the name of relationship with a primary key other than id" do
-      let(:resource_klass) {
+      let(:resource_klass) do
         Class.new(Post) do
           belongs_to :kategory, class_name: "Category", primary_key: :name, foreign_key: :title
 
@@ -362,7 +362,7 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
             "SuperPost"
           end
         end
-      }
+      end
 
       let(:scope) do
         resource_klass.ransack

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -113,12 +113,12 @@ RSpec.describe ActiveAdmin::FormBuilder do
 
   context "when polymorphic relationship" do
     it "should raise error" do
-      expect {
+      expect do
         comment = ActiveAdmin::Comment.new
         build_form({ url: "admins/comments" }, comment) do |f|
           f.inputs :resource
         end
-      }.to raise_error(Formtastic::PolymorphicInputWithoutCollectionError)
+      end.to raise_error(Formtastic::PolymorphicInputWithoutCollectionError)
     end
   end
 

--- a/spec/unit/menu_collection_spec.rb
+++ b/spec/unit/menu_collection_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe ActiveAdmin::MenuCollection do
 
       menus.clear!
 
-      expect {
+      expect do
         menus.fetch(:non_default_menu)
-      }.to raise_error(ActiveAdmin::NoMenuError)
+      end.to raise_error(ActiveAdmin::NoMenuError)
     end
   end
 

--- a/spec/unit/namespace/register_page_spec.rb
+++ b/spec/unit/namespace/register_page_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe ActiveAdmin::Namespace, "registering a page" do
 
   context "with a block configuration" do
     it "should be evaluated in the dsl" do
-      expect { |block|
+      expect do |block|
         namespace.register_page "Status", &block
-      }.to yield_control
+      end.to yield_control
     end
   end
 

--- a/spec/unit/namespace/register_resource_spec.rb
+++ b/spec/unit/namespace/register_resource_spec.rb
@@ -32,9 +32,9 @@ RSpec.describe ActiveAdmin::Namespace, "registering a resource" do
 
   context "with a block configuration" do
     it "should be evaluated in the dsl" do
-      expect { |block|
+      expect do |block|
         namespace.register Category, &block
-      }.to yield_control
+      end.to yield_control
     end
   end
 

--- a/spec/unit/namespace_spec.rb
+++ b/spec/unit/namespace_spec.rb
@@ -78,9 +78,9 @@ RSpec.describe ActiveAdmin::Namespace do
     end
 
     it "should raise an exception if the menu doesn't exist" do
-      expect {
+      expect do
         namespace.fetch_menu(:not_a_menu_that_exists)
-      }.to raise_error(KeyError)
+      end.to raise_error(KeyError)
     end
   end
 

--- a/spec/unit/page_spec.rb
+++ b/spec/unit/page_spec.rb
@@ -73,11 +73,11 @@ module ActiveAdmin
 
     context "with belongs to config" do
       let!(:post_config) { namespace.register Post }
-      let!(:page_config) {
+      let!(:page_config) do
         namespace.register_page page_name do
           belongs_to :post
         end
-      }
+      end
 
       it "configures page with belongs_to" do
         expect(page_config.belongs_to?).to be true
@@ -104,11 +104,11 @@ module ActiveAdmin
 
     context "with optional belongs to config" do
       let!(:post_config) { namespace.register Post }
-      let!(:page_config) {
+      let!(:page_config) do
         namespace.register_page page_name do
           belongs_to :post, optional: true
         end
-      }
+      end
 
       it "does not override default navigation menu" do
         expect(page_config.navigation_menu_name).to eq(:default)

--- a/spec/unit/resource/action_items_spec.rb
+++ b/spec/unit/resource/action_items_spec.rb
@@ -58,9 +58,9 @@ RSpec.describe ActiveAdmin::Resource::ActionItems do
 
     it "should return only relevant action items" do
       expect(resource.action_items_for(:index).size).to eq 1
-      expect {
+      expect do
         resource.action_items_for(:index).first.call
-      }.to raise_exception(StandardError)
+      end.to raise_exception(StandardError)
     end
   end
 

--- a/spec/unit/resource_collection_spec.rb
+++ b/spec/unit/resource_collection_spec.rb
@@ -51,17 +51,17 @@ RSpec.describe ActiveAdmin::ResourceCollection do
     end
 
     it "shouldn't allow a resource name mismatch to occur" do
-      expect {
+      expect do
         ActiveAdmin.register Category
         ActiveAdmin.register Post, as: "Category"
-      }.to raise_error ActiveAdmin::ResourceCollection::ConfigMismatch
+      end.to raise_error ActiveAdmin::ResourceCollection::ConfigMismatch
     end
 
     it "shouldn't allow a Page/Resource mismatch to occur" do
-      expect {
+      expect do
         ActiveAdmin.register User
         ActiveAdmin.register_page 'User'
-      }.to raise_error ActiveAdmin::ResourceCollection::IncorrectClass
+      end.to raise_error ActiveAdmin::ResourceCollection::IncorrectClass
     end
 
     describe "should store both renamed and non-renamed resources" do

--- a/spec/unit/resource_controller_spec.rb
+++ b/spec/unit/resource_controller_spec.rb
@@ -277,9 +277,9 @@ RSpec.describe "A specific resource controller", type: :controller do
       end
 
       it "should raise an error" do
-        expect {
+        expect do
           controller.batch_action
-        }.to raise_error("Couldn't find batch action \"derp\"")
+        end.to raise_error("Couldn't find batch action \"derp\"")
       end
     end
 
@@ -291,9 +291,9 @@ RSpec.describe "A specific resource controller", type: :controller do
       end
 
       it "should raise an error" do
-        expect {
+        expect do
           controller.batch_action
-        }.to raise_error("Couldn't find batch action \"\"")
+        end.to raise_error("Couldn't find batch action \"\"")
       end
     end
   end

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -306,13 +306,13 @@ module ActiveAdmin
     end
 
     describe "delegation" do
-      let(:controller) {
+      let(:controller) do
         Class.new do
           def method_missing(name, *args, &block)
             "called #{name}"
           end
         end.new
-      }
+      end
       let(:resource) { ActiveAdmin::ResourceDSL.new(double) }
 
       before do

--- a/spec/unit/scope_spec.rb
+++ b/spec/unit/scope_spec.rb
@@ -127,9 +127,9 @@ RSpec.describe ActiveAdmin::Scope do
 
     context "with a proc as the label" do
       it "should raise an exception if a second argument isn't provided" do
-        expect {
+        expect do
           ActiveAdmin::Scope.new proc { Date.today.strftime '%A' }
-        }.to raise_error 'A string/symbol is required as the second argument if your label is a proc.'
+        end.to raise_error 'A string/symbol is required as the second argument if your label is a proc.'
       end
 
       it "should properly render the proc" do

--- a/spec/unit/view_helpers/breadcrumbs_spec.rb
+++ b/spec/unit/view_helpers/breadcrumbs_spec.rb
@@ -10,11 +10,15 @@ RSpec.describe "Breadcrumbs" do
     actions = ActiveAdmin::BaseController::ACTIVE_ADMIN_ACTIONS
 
     let(:user) { double display_name: 'Jane Doe' }
-    let(:user_config) { double find_resource: user, resource_name: double(route_key: 'users'),
-                               defined_actions: actions }
+    let(:user_config) do
+      double find_resource: user, resource_name: double(route_key: 'users'),
+             defined_actions: actions
+    end
     let(:post) { double display_name: 'Hello World' }
-    let(:post_config) { double find_resource: post, resource_name: double(route_key: 'posts'),
-                               defined_actions: actions, belongs_to_config: double(target: user_config) }
+    let(:post_config) do
+      double find_resource: post, resource_name: double(route_key: 'posts'),
+             defined_actions: actions, belongs_to_config: double(target: user_config)
+    end
 
     let :active_admin_config do
       post_config
@@ -224,9 +228,11 @@ RSpec.describe "Breadcrumbs" do
     end
 
     context "when the 'show' action is disabled" do
-      let(:post_config) { double find_resource: post, resource_name: double(route_key: 'posts'),
-                                 defined_actions: actions - [:show], # this is the change
-                                 belongs_to_config: double(target: user_config) }
+      let(:post_config) do
+        double find_resource: post, resource_name: double(route_key: 'posts'),
+               defined_actions: actions - [:show], # this is the change
+               belongs_to_config: double(target: user_config)
+      end
 
       let(:path) { "/admin/posts/1/edit" }
 

--- a/spec/unit/view_helpers/method_or_proc_helper_spec.rb
+++ b/spec/unit/view_helpers/method_or_proc_helper_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe MethodOrProcHelper do
     it "should exec a proc in the context" do
       test_proc = Proc.new { raise "Success" if receiver_in_context }
 
-      expect {
+      expect do
         context.call_method_or_exec_proc(test_proc)
-      }.to raise_error("Success")
+      end.to raise_error("Success")
     end
   end
 
@@ -50,9 +50,9 @@ RSpec.describe MethodOrProcHelper do
           raise "Success!" if arg == receiver_in_context
         end
 
-        expect {
+        expect do
           context.call_method_or_proc_on(receiver, test_proc)
-        }.to raise_error("Success!")
+        end.to raise_error("Success!")
       end
 
       it "should receive additional arguments" do
@@ -60,9 +60,9 @@ RSpec.describe MethodOrProcHelper do
           raise "Success!" if arg1 == receiver_in_context && arg2 == "Hello"
         end
 
-        expect {
+        expect do
           context.call_method_or_proc_on(receiver, test_proc, "Hello")
-        }.to raise_error("Success!")
+        end.to raise_error("Success!")
       end
     end
 
@@ -74,9 +74,9 @@ RSpec.describe MethodOrProcHelper do
           raise "Success!" if arg == receiver && obj_not_in_context
         end
 
-        expect {
+        expect do
           context.call_method_or_proc_on(receiver, test_proc, exec: false)
-        }.to raise_error("Success!")
+        end.to raise_error("Success!")
       end
     end
   end

--- a/spec/unit/views/components/attributes_table_spec.rb
+++ b/spec/unit/views/components/attributes_table_spec.rb
@@ -17,43 +17,43 @@ RSpec.describe ActiveAdmin::Views::AttributesTable do
     # and ensure that they produce the same results
     {
       "when attributes are passed in to the builder methods" => proc {
-        render_arbre_component(assigns) {
+        render_arbre_component(assigns) do
           attributes_table_for post, :id, :title, :body
-        }
+        end
       },
       "when attributes are built using the block" => proc {
-        render_arbre_component(assigns) {
+        render_arbre_component(assigns) do
           attributes_table_for post do
             rows :id, :title, :body
           end
-        }
+        end
       },
       "when each attribute is passed in by itself" => proc {
-        render_arbre_component(assigns) {
+        render_arbre_component(assigns) do
           attributes_table_for post do
             row :id
             row :title
             row :body
           end
-        }
+        end
       },
       "when you create each row with a custom block" => proc {
-        render_arbre_component(assigns) {
+        render_arbre_component(assigns) do
           attributes_table_for post do
             row("Id") { post.id }
             row("Title") { post.title }
             row("Body") { post.body }
           end
-        }
+        end
       },
       "when you create each row with a custom block that returns nil" => proc {
-        render_arbre_component(assigns) {
+        render_arbre_component(assigns) do
           attributes_table_for post do
             row("Id") { text_node post.id; nil }
             row("Title") { text_node post.title; nil }
             row("Body") { text_node post.body; nil }
           end
-        }
+        end
       },
     }.each do |context_title, table_decleration|
       context context_title do
@@ -96,12 +96,12 @@ RSpec.describe ActiveAdmin::Views::AttributesTable do
     end # describe dsl styles
 
     it "should add a class for each row based on the col name" do
-      table = render_arbre_component(assigns) {
+      table = render_arbre_component(assigns) do
         attributes_table_for(post) do
           row :title
           row :created_at
         end
-      }
+      end
       expect(table.find_by_tag("tr").first.to_s.
         split("\n").first.lstrip).
           to eq '<tr class="row row-title">'
@@ -112,21 +112,21 @@ RSpec.describe ActiveAdmin::Views::AttributesTable do
     end
 
     it "should allow html options for the row itself" do
-      table = render_arbre_component(assigns) {
+      table = render_arbre_component(assigns) do
         attributes_table_for(post) do
           row("Wee", class: "custom_row", style: "custom_style") {}
         end
-      }
+      end
       expect(table.find_by_tag("tr").first.to_s.split("\n").first.lstrip).
         to eq '<tr class="row custom_row" style="custom_style">'
     end
 
     it "should allow html content inside the attributes table" do
-      table = render_arbre_component(assigns) {
+      table = render_arbre_component(assigns) do
         attributes_table_for(post) do
           row("ID") { span(post.id, class: 'id') }
         end
-      }
+      end
       expect(table.find_by_tag("td").first.content.chomp.strip).to eq "<span class=\"id\">1</span>"
     end
 

--- a/spec/unit/views/components/index_list_spec.rb
+++ b/spec/unit/views/components/index_list_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe ActiveAdmin::Views::IndexList do
   describe "#index_list_renderer" do
     let(:index_classes) { [ActiveAdmin::Views::IndexAsTable, ActiveAdmin::Views::IndexAsBlock] }
 
-    let(:collection) {
+    let(:collection) do
       Post.create(title: 'First Post', starred: true)
       Post.where(nil)
-    }
+    end
 
     let(:helpers) do
       helpers = mock_action_view

--- a/spec/unit/views/components/menu_spec.rb
+++ b/spec/unit/views/components/menu_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe ActiveAdmin::Views::Menu do
   let(:helpers) { mock_action_view }
 
   let(:menu_component) do
-    arbre(assigns, helpers) {
+    arbre(assigns, helpers) do
       insert_tag(ActiveAdmin::Views::Menu, active_admin_menu)
-    }.children.first
+    end.children.first
   end
 
   let(:html) { Capybara.string(menu_component.to_s) }

--- a/spec/unit/views/components/paginated_collection_spec.rb
+++ b/spec/unit/views/components/paginated_collection_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe ActiveAdmin::Views::PaginatedCollection do
     end
 
     it "should raise error if collection has no pagination scope" do
-      expect {
+      expect do
         paginated_collection([Post.new, Post.new])
-      }.to raise_error(StandardError, "Collection is not a paginated scope. Set collection.page(params[:page]).per(10) before calling :paginated_collection.")
+      end.to raise_error(StandardError, "Collection is not a paginated scope. Set collection.page(params[:page]).per(10) before calling :paginated_collection.")
     end
 
     it 'should preserve custom query params' do


### PR DESCRIPTION
While reviewing #6115 I noticed it was correcting the style of some admittedly weird code. This PR enforces avoiding such code.
