### PR TITLE
Empty lines after examples and example groups

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -82,6 +82,9 @@ Rails/FilePath:
 RSpec/EmptyLineAfterExample:
   Enabled: true
 
+RSpec/EmptyLineAfterExampleGroup:
+  Enabled: true
+
 RSpec/HookArgument:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -79,6 +79,9 @@ Rails/FilePath:
   Enabled: true
   EnforcedStyle: slashes
 
+RSpec/EmptyLineAfterExample:
+  Enabled: true
+
 RSpec/HookArgument:
   Enabled: true
 

--- a/spec/requests/stylesheets_spec.rb
+++ b/spec/requests/stylesheets_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "Stylesheets", type: :request, unless: ActiveAdmin.application.us
   it "should successfully render the scss stylesheets using sprockets" do
     expect(css).to_not eq nil
   end
+
   it "should not have any syntax errors" do
     expect(css.to_s).to_not include("Syntax error:")
   end

--- a/spec/unit/abstract_view_factory_spec.rb
+++ b/spec/unit/abstract_view_factory_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe ActiveAdmin::AbstractViewFactory do
     it "should generate a getter method" do
       expect(view_factory.my_default_view_class).to eq view
     end
+
     it "should be settable view a setter method and not change default" do
       view_factory.my_default_view_class = "Some Obj"
       expect(view_factory.my_default_view_class).to eq "Some Obj"

--- a/spec/unit/belongs_to_spec.rb
+++ b/spec/unit/belongs_to_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe ActiveAdmin::Resource::BelongsTo do
     it 'should be able to access the collection' do
       expect(controller.send :collection).to be_a ActiveRecord::Relation
     end
+
     it 'should be able to build a new resource' do
       expect(controller.send :build_resource).to be_a Post
     end

--- a/spec/unit/comments_spec.rb
+++ b/spec/unit/comments_spec.rb
@@ -193,6 +193,7 @@ RSpec.describe "Comments" do
       resource.comments = true
       expect(resource.comments).to eq true
     end
+
     it "should disable comments if set to false" do
       ns = ActiveAdmin::Namespace.new(application, :admin)
       resource = ActiveAdmin::Resource.new(ns, Post)

--- a/spec/unit/dependency_spec.rb
+++ b/spec/unit/dependency_spec.rb
@@ -20,28 +20,34 @@ RSpec.describe ActiveAdmin::Dependency do
         expect(k.foo?).to eq true
         expect(k.bar?).to eq false
       end
+
       it '=' do
         expect(k.foo? '= 1.2.3').to eq true
         expect(k.foo? '= 1').to eq false
       end
+
       it '>' do
         expect(k.foo? '> 1').to eq true
         expect(k.foo? '> 2').to eq false
       end
+
       it '<' do
         expect(k.foo? '< 2').to eq true
         expect(k.foo? '< 1').to eq false
       end
+
       it '>=' do
         expect(k.foo? '>= 1.2.3').to eq true
         expect(k.foo? '>= 1.2.2').to eq true
         expect(k.foo? '>= 1.2.4').to eq false
       end
+
       it '<=' do
         expect(k.foo? '<= 1.2.3').to eq true
         expect(k.foo? '<= 1.2.4').to eq true
         expect(k.foo? '<= 1.2.2').to eq false
       end
+
       it '~>' do
         expect(k.foo? '~> 1.2.0').to eq true
         expect(k.foo? '~> 1.1').to eq true
@@ -54,10 +60,12 @@ RSpec.describe ActiveAdmin::Dependency do
         expect { k.foo! '5' }.to raise_error ActiveAdmin::DependencyError,
           'You provided foo 1.2.3 but we need: 5.'
       end
+
       it 'accepts multiple arguments' do
         expect { k.foo! '> 1', '< 1.2' }.to raise_error ActiveAdmin::DependencyError,
           'You provided foo 1.2.3 but we need: > 1, < 1.2.'
       end
+
       it 'raises an error if not provided' do
         expect { k.bar! }.to raise_error ActiveAdmin::DependencyError,
           'To use bar you need to specify it in your Gemfile.'
@@ -104,19 +112,23 @@ RSpec.describe ActiveAdmin::Dependency do
         expect(k['a-b'] == '1.2').to eq false
         expect(k['a-b'] == 1).to eq false
       end
+
       it '>' do
         expect(k['a-b'] > 1).to eq true
         expect(k['a-b'] > 2).to eq false
       end
+
       it '<' do
         expect(k['a-b'] < 2).to eq true
         expect(k['a-b'] < 1).to eq false
       end
+
       it '>=' do
         expect(k['a-b'] >= '1.2.3').to eq true
         expect(k['a-b'] >= '1.2.2').to eq true
         expect(k['a-b'] >= '1.2.4').to eq false
       end
+
       it '<=' do
         expect(k['a-b'] <= '1.2.3').to eq true
         expect(k['a-b'] <= '1.2.4').to eq true

--- a/spec/unit/filters/filter_form_builder_spec.rb
+++ b/spec/unit/filters/filter_form_builder_spec.rb
@@ -170,13 +170,16 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
     it "should generate a date greater than" do
       expect(body).to have_selector("input.datepicker[name='q[published_date_gteq]']")
     end
+
     it "should generate a date less than" do
       expect(body).to have_selector("input.datepicker[name='q[published_date_lteq]']")
     end
+
     it "should generate two inputs with different ids" do
       ids = body.find_css("input.datepicker").to_a.map { |n| n[:id] }
       expect(ids).to contain_exactly("q_published_date_lteq", "q_published_date_gteq")
     end
+
     it "should generate one label without for attribute" do
       label = body.find_css("label")
       expect(label.length).to be(1)
@@ -208,6 +211,7 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
     it "should generate a date greater than" do
       expect(body).to have_selector("input.datepicker[name='q[created_at_gteq_datetime]']")
     end
+
     it "should generate a date less than" do
       expect(body).to have_selector("input.datepicker[name='q[created_at_lteq_datetime]']")
     end
@@ -238,15 +242,19 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
       it "should generate a select option for equal to" do
         expect(body).to have_selector("option[value=id_equals]", text: "Equals")
       end
+
       it "should generate a select option for greater than" do
         expect(body).to have_selector("option[value=id_greater_than]", text: "Greater than")
       end
+
       it "should generate a select option for less than" do
         expect(body).to have_selector("option[value=id_less_than]", text: "Less than")
       end
+
       it "should generate a text field for input" do
         expect(body).to have_selector("input[name='q[id_equals]']")
       end
+
       it "should select the option which is currently being filtered" do
         scope = Post.ransack id_greater_than: 1
         body = Capybara.string(render_filter scope, id: {})
@@ -275,9 +283,11 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
       it "should generate a select" do
         expect(body).to have_selector("select[name='q[starred_eq]']")
       end
+
       it "should set the default text to 'Any'" do
         expect(body).to have_selector("option[value='']", text: "Any")
       end
+
       it "should create an option for true and false" do
         expect(body).to have_selector("option[value=true]", text: "Yes")
         expect(body).to have_selector("option[value=false]", text: "No")
@@ -296,9 +306,11 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
       it "should generate a select" do
         expect(body).to have_selector("select[name='q[title_present]']")
       end
+
       it "should set the default text to 'Any'" do
         expect(body).to have_selector("option[value='']", text: "Any")
       end
+
       it "should create an option for true and false" do
         expect(body).to have_selector("option[value=true]", text: "Yes")
         expect(body).to have_selector("option[value=false]", text: "No")
@@ -328,9 +340,11 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
       it "should generate a select" do
         expect(body).to have_selector("select[name='q[author_id_eq]']")
       end
+
       it "should set the default text to 'Any'" do
         expect(body).to have_selector("option[value='']", text: "Any")
       end
+
       it "should create an option for each related object" do
         expect(body).to have_selector("option[value='#{@john.id}']", text: "John Doe")
         expect(body).to have_selector("option[value='#{@jane.id}']", text: "Jane Doe")
@@ -467,10 +481,12 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
           body = filter :body, verb => proc { true }
           expect(body).send if_true, have_selector("input[name='q[body_contains]']")
         end
+
         it "#{should} be displayed if false" do
           body = filter :body, verb => proc { false }
           expect(body).send if_false, have_selector("input[name='q[body_contains]']")
         end
+
         it "should still be hidden on the second render" do
           filters = { body: { verb => proc { verb == :unless } } }
           2.times do
@@ -478,6 +494,7 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
             expect(body).not_to have_selector("input[name='q[body_contains]']")
           end
         end
+
         it "should successfully keep rendering other filters after one is hidden" do
           filters = { body: { verb => proc { verb == :unless } }, author: {} }
           body = Capybara.string(render_filter scope, filters)
@@ -543,6 +560,7 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
         body = filter :author
         expect(body).to have_selector("option", text: "Any")
       end
+
       it "should be able to be disabled" do
         body = filter :author, include_blank: false
         expect(body).to_not have_selector("option", text: "Any")
@@ -554,6 +572,7 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
         body = filter :author, multiple: true
         expect(body).to_not have_selector("option", text: "Any")
       end
+
       it "should be able to be enabled" do
         body = filter :author, multiple: true, include_blank: true
         expect(body).to have_selector("option", text: "Any")

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -99,12 +99,15 @@ RSpec.describe ActiveAdmin::FormBuilder do
     it "should generate a text input" do
       expect(body).to have_selector("input[type=text][name='post[title]']")
     end
+
     it "should generate a textarea" do
       expect(body).to have_selector("textarea[name='post[body]']")
     end
+
     it "should only generate the form once" do
       expect(body).to have_selector("form", count: 1)
     end
+
     it "should generate actions" do
       expect(body).to have_selector("input[type=submit][value='Submit Me']")
       expect(body).to have_selector("input[type=submit][value='Another Button']")
@@ -221,6 +224,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
       expect(body).to have_selector(".inputs > ol > span")
       expect(body).to have_selector("span", count: 2)
     end
+
     it "should allow a simplified syntax" do
       body = build_form do |f|
         div do
@@ -251,6 +255,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
     it "should have a title input" do
       expect(body).to have_selector("input[type=text][name='post[title]']")
     end
+
     it "should have a body textarea" do
       expect(body).to have_selector("textarea[name='post[body]']")
     end
@@ -376,6 +381,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
       expect(body).to have_selector("[id=post_author_attributes_first_name_input]", count: 1)
       expect(body).to have_selector("[id=post_author_attributes_last_name_input]", count: 1)
     end
+
     it "should add author first and last name fields" do
       expect(body).to have_selector("input[name='post[author_attributes][first_name]']")
       expect(body).to have_selector("input[name='post[author_attributes][last_name]']")

--- a/spec/unit/namespace/register_resource_spec.rb
+++ b/spec/unit/namespace/register_resource_spec.rb
@@ -130,6 +130,7 @@ RSpec.describe ActiveAdmin::Namespace, "registering a resource" do
           expect(menu["Posts"]).to eq nil
         end
       end
+
       context "when optional" do
         before do
           namespace.register Post do
@@ -151,6 +152,7 @@ RSpec.describe ActiveAdmin::Namespace, "registering a resource" do
         expect(defined?(One::CategoriesController)).to eq 'constant'
       end
     end
+
     context "when not namespaced" do
       it "should not be namespaced" do
         namespace = ActiveAdmin::Namespace.new(application, :two)

--- a/spec/unit/namespace/register_resource_spec.rb
+++ b/spec/unit/namespace/register_resource_spec.rb
@@ -47,9 +47,11 @@ RSpec.describe ActiveAdmin::Namespace, "registering a resource" do
     it "should store the namespaced registered configuration" do
       expect(namespace.resources.keys).to include('Mock::Resource')
     end
+
     it "should create a new controller in the default namespace" do
       expect(defined?(SuperAdmin::MockResourcesController)).to eq 'constant'
     end
+
     it "should create a menu item" do
       expect(menu["Mock Resources"]).to be_an_instance_of(ActiveAdmin::MenuItem)
     end
@@ -100,6 +102,7 @@ RSpec.describe ActiveAdmin::Namespace, "registering a resource" do
       it "should generate the parent menu item" do
         expect(menu['Blog']).to_not eq nil
       end
+
       it "should generate its own child item" do
         expect(menu['Blog']['Categories']).to_not eq nil
       end

--- a/spec/unit/page_spec.rb
+++ b/spec/unit/page_spec.rb
@@ -17,6 +17,7 @@ module ActiveAdmin
       it "should return a namespaced controller name" do
         expect(config.controller_name).to eq "Admin::ChocolateILoveYouController"
       end
+
       context "when non namespaced controller" do
         let(:namespace) { ActiveAdmin::Namespace.new(application, :root) }
         it "should return a non namespaced controller name" do

--- a/spec/unit/resource/naming_spec.rb
+++ b/spec/unit/resource/naming_spec.rb
@@ -18,11 +18,13 @@ module ActiveAdmin
           expect(config.resource_name.singular).to eq "category"
         end
       end
+
       context "when a class in a module" do
         it "should underscore the module and the class" do
           expect(Resource.new(namespace, Mock::Resource).resource_name.singular).to eq "mock_resource"
         end
       end
+
       context "when you pass the 'as' option" do
         it "should underscore the passed through string" do
           expect(config(as: "Blog Category").resource_name.singular).to eq "blog_category"

--- a/spec/unit/resource_controller/data_access_spec.rb
+++ b/spec/unit/resource_controller/data_access_spec.rb
@@ -89,6 +89,7 @@ RSpec.describe ActiveAdmin::ResourceController::DataAccess do
           controller.send :apply_sorting, chain
         end
       end
+
       context "when params not applicable" do
         let(:http_params) { { order: "published_date_asc" } }
         it "reorders chain" do

--- a/spec/unit/resource_controller_spec.rb
+++ b/spec/unit/resource_controller_spec.rb
@@ -45,14 +45,17 @@ RSpec.describe ActiveAdmin::ResourceController do
         expect(controller).to receive(:call_before_create).with(resource)
         controller.send :create_resource, resource
       end
+
       it "should call the before save callback" do
         expect(controller).to receive(:call_before_save).with(resource)
         controller.send :create_resource, resource
       end
+
       it "should call the after save callback" do
         expect(controller).to receive(:call_after_save).with(resource)
         controller.send :create_resource, resource
       end
+
       it "should call the after create callback" do
         expect(controller).to receive(:call_after_create).with(resource)
         controller.send :create_resource, resource
@@ -72,14 +75,17 @@ RSpec.describe ActiveAdmin::ResourceController do
         expect(controller).to receive(:call_before_update).with(resource)
         controller.send :update_resource, resource, attributes
       end
+
       it "should call the before save callback" do
         expect(controller).to receive(:call_before_save).with(resource)
         controller.send :update_resource, resource, attributes
       end
+
       it "should call the after save callback" do
         expect(controller).to receive(:call_after_save).with(resource)
         controller.send :update_resource, resource, attributes
       end
+
       it "should call the after create callback" do
         expect(controller).to receive(:call_after_update).with(resource)
         controller.send :update_resource, resource, attributes

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -142,6 +142,7 @@ module ActiveAdmin
             expect(@resource.controller.new.send(:method_for_association_chain)).to eq :categories
           end
         end
+
         context "when passing in the method as an option" do
           before do
             @resource = application.register Category do

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -22,6 +22,7 @@ module ActiveAdmin
       it "should return the resource's table name" do
         expect(config.resource_table_name).to eq '"categories"'
       end
+
       context "when the :as option is given" do
         it "should return the resource's table name" do
           expect(config(as: "My Category").resource_table_name).to eq '"categories"'
@@ -39,6 +40,7 @@ module ActiveAdmin
       it 'returns nil by default' do
         expect(config.decorator_class).to eq nil
       end
+
       context 'when a decorator is defined' do
         around do |example|
           with_resources_during(example) { resource }
@@ -59,6 +61,7 @@ module ActiveAdmin
       it "should return a namespaced controller name" do
         expect(config.controller_name).to eq "Admin::CategoriesController"
       end
+
       context "when non namespaced controller" do
         let(:namespace) { ActiveAdmin::Namespace.new(application, :root) }
         it "should return a non namespaced controller name" do

--- a/spec/unit/view_helpers/breadcrumbs_spec.rb
+++ b/spec/unit/view_helpers/breadcrumbs_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe "Breadcrumbs" do
       it 'should have one item' do
         expect(trail.size).to eq 1
       end
+
       it 'should have a link to /admin' do
         expect(trail[0][:name]).to eq 'Admin'
         expect(trail[0][:path]).to eq '/admin'
@@ -48,6 +49,7 @@ RSpec.describe "Breadcrumbs" do
       it "should have one item" do
         expect(trail.size).to eq 1
       end
+
       it "should have a link to /admin" do
         expect(trail[0][:name]).to eq "Admin"
         expect(trail[0][:path]).to eq "/admin"
@@ -60,10 +62,12 @@ RSpec.describe "Breadcrumbs" do
       it "should have 2 items" do
         expect(trail.size).to eq 2
       end
+
       it "should have a link to /admin" do
         expect(trail[0][:name]).to eq "Admin"
         expect(trail[0][:path]).to eq "/admin"
       end
+
       it "should have a link to /admin/users" do
         expect(trail[1][:name]).to eq "Users"
         expect(trail[1][:path]).to eq "/admin/users"
@@ -76,10 +80,12 @@ RSpec.describe "Breadcrumbs" do
       it "should have 3 items" do
         expect(trail.size).to eq 3
       end
+
       it "should have a link to /admin" do
         expect(trail[0][:name]).to eq "Admin"
         expect(trail[0][:path]).to eq "/admin"
       end
+
       it "should have a link to /admin/users" do
         expect(trail[1][:name]).to eq "Users"
         expect(trail[1][:path]).to eq "/admin/users"
@@ -107,10 +113,12 @@ RSpec.describe "Breadcrumbs" do
       it "should have 3 items" do
         expect(trail.size).to eq 3
       end
+
       it "should have a link to /admin" do
         expect(trail[0][:name]).to eq "Admin"
         expect(trail[0][:path]).to eq "/admin"
       end
+
       it "should have a link to /admin/users" do
         expect(trail[1][:name]).to eq "Users"
         expect(trail[1][:path]).to eq "/admin/users"
@@ -142,10 +150,12 @@ RSpec.describe "Breadcrumbs" do
       it "should have 3 items" do
         expect(trail.size).to eq 3
       end
+
       it "should have a link to /admin" do
         expect(trail[0][:name]).to eq "Admin"
         expect(trail[0][:path]).to eq "/admin"
       end
+
       it "should have a link to /admin/users" do
         expect(trail[1][:name]).to eq "Users"
         expect(trail[1][:path]).to eq "/admin/users"
@@ -177,18 +187,22 @@ RSpec.describe "Breadcrumbs" do
       it "should have 4 items" do
         expect(trail.size).to eq 4
       end
+
       it "should have a link to /admin" do
         expect(trail[0][:name]).to eq "Admin"
         expect(trail[0][:path]).to eq "/admin"
       end
+
       it "should have a link to /admin/users" do
         expect(trail[1][:name]).to eq "Users"
         expect(trail[1][:path]).to eq "/admin/users"
       end
+
       it "should have a link to /admin/users/1" do
         expect(trail[2][:name]).to eq "Jane Doe"
         expect(trail[2][:path]).to eq "/admin/users/1"
       end
+
       it "should have a link to /admin/users/1/posts" do
         expect(trail[3][:name]).to eq "Posts"
         expect(trail[3][:path]).to eq "/admin/users/1/posts"
@@ -201,22 +215,27 @@ RSpec.describe "Breadcrumbs" do
       it "should have 5 items" do
         expect(trail.size).to eq 5
       end
+
       it "should have a link to /admin" do
         expect(trail[0][:name]).to eq "Admin"
         expect(trail[0][:path]).to eq "/admin"
       end
+
       it "should have a link to /admin/users" do
         expect(trail[1][:name]).to eq "Users"
         expect(trail[1][:path]).to eq "/admin/users"
       end
+
       it "should have a link to /admin/users/1" do
         expect(trail[2][:name]).to eq "Jane Doe"
         expect(trail[2][:path]).to eq "/admin/users/1"
       end
+
       it "should have a link to /admin/users/1/posts" do
         expect(trail[3][:name]).to eq "Posts"
         expect(trail[3][:path]).to eq "/admin/users/1/posts"
       end
+
       it "should have a link to /admin/users/1/posts/1" do
         expect(trail[4][:name]).to eq "Hello World"
         expect(trail[4][:path]).to eq "/admin/users/1/posts/1"
@@ -233,14 +252,17 @@ RSpec.describe "Breadcrumbs" do
       it "should have 3 items" do
         expect(trail.size).to eq 3
       end
+
       it "should have a link to /admin" do
         expect(trail[0][:name]).to eq "Admin"
         expect(trail[0][:path]).to eq "/admin"
       end
+
       it "should have a link to /admin/posts" do
         expect(trail[1][:name]).to eq "Posts"
         expect(trail[1][:path]).to eq "/admin/posts"
       end
+
       it "should not link to the show view for the post" do
         expect(trail[2]).to eq "Hello World"
       end

--- a/spec/unit/views/components/attributes_table_spec.rb
+++ b/spec/unit/views/components/attributes_table_spec.rb
@@ -142,6 +142,7 @@ RSpec.describe ActiveAdmin::Views::AttributesTable do
         expect(table.find_by_tag('th').first.content).to eq 'Author'
         expect(table.find_by_tag('td').first.content).to eq 'John Doe'
       end
+
       it 'should not attempt to call a nonexistant association' do
         table = render_arbre_component assigns do
           attributes_table_for post, :foo_id

--- a/spec/unit/views/components/index_table_for_spec.rb
+++ b/spec/unit/views/components/index_table_for_spec.rb
@@ -92,6 +92,7 @@ RSpec.describe ActiveAdmin::Views::IndexAsTable::IndexTableFor do
             expect(index_values).to eq(['1', '2'])
           end
         end
+
         context 'viewing the second page' do
           let(:collection) do
             base_collection.page(2)

--- a/spec/unit/views/components/status_tag_spec.rb
+++ b/spec/unit/views/components/status_tag_spec.rb
@@ -128,6 +128,7 @@ RSpec.describe ActiveAdmin::Views::StatusTag do
       describe '#content' do
         subject { super().content }
         it { is_expected.to eq('No') }
+
         it 'uses the unset locale key to customize the label for the `nil` case' do
           with_translation active_admin: { status_tag: { unset: 'Unknown' } } do
             expect(subject).to eq('Unknown')


### PR DESCRIPTION
Enforcing some style changes I noticed while reviewing #6115.
