### PR TITLE
Fix kwargs warnings in logged out template

### DIFF
--- a/app/views/layouts/active_admin_logged_out.html.erb
+++ b/app/views/layouts/active_admin_logged_out.html.erb
@@ -7,9 +7,9 @@
 
   <% ActiveAdmin.application.stylesheets.each do |style, options| %>
     <% if ActiveAdmin.application.use_webpacker %>
-      <%= stylesheet_pack_tag style, options %>
+      <%= stylesheet_pack_tag style, **options %>
     <% else %>
-      <%= stylesheet_link_tag style, options %>
+      <%= stylesheet_link_tag style, **options %>
     <% end %>
   <% end %>
   <% ActiveAdmin.application.javascripts.each do |path| %>


### PR DESCRIPTION
One more instance of kwargs warnings on ruby 2.7 that went unnoticed.
