### PR TITLE
Use display name fallback if blank display name result

### DIFF
--- a/lib/active_admin/view_helpers/display_helper.rb
+++ b/lib/active_admin/view_helpers/display_helper.rb
@@ -24,7 +24,14 @@ module ActiveAdmin
       # Attempts to call any known display name methods on the resource.
       # See the setting in `application.rb` for the list of methods and their priority.
       def display_name(resource)
-        ERB::Util.html_escape(render_in_context(resource, display_name_method_for(resource))) unless resource.nil?
+        unless resource.nil?
+          result = render_in_context(resource, display_name_method_for(resource))
+          if result.to_s&.strip&.present?
+            ERB::Util.html_escape(result)
+          else
+            ERB::Util.html_escape(render_in_context(resource, DISPLAY_NAME_FALLBACK))
+          end
+        end
       end
 
       # Looks up and caches the first available display name method.

--- a/lib/active_admin/views/pages/show.rb
+++ b/lib/active_admin/views/pages/show.rb
@@ -40,13 +40,7 @@ module ActiveAdmin
         protected
 
         def default_title
-          title = display_name(resource)
-
-          if title.blank?
-            title = "#{active_admin_config.resource_label} ##{resource.id}"
-          end
-
-          title
+          display_name(resource)
         end
 
         module DefaultMainContent

--- a/spec/unit/view_helpers/display_helper_spec.rb
+++ b/spec/unit/view_helpers/display_helper_spec.rb
@@ -192,12 +192,12 @@ RSpec.describe ActiveAdmin::ViewHelpers::DisplayHelper do
       expect(value).to eq "right"
     end
 
-    it "auto-links ActiveRecord records by association" do
-      post = Post.create! author: User.new
+    it "auto-links ActiveRecord records by association with display name fallback" do
+      post = Post.create! author: User.new(first_name: "", last_name: "")
 
       value = view.format_attribute post, :author
 
-      expect(value).to match /<a href="\/admin\/users\/\d+"> <\/a>/
+      expect(value).to match /<a href="\/admin\/users\/\d+">User \#\d+<\/a>/
     end
 
     it "auto-links ActiveRecord records & uses a display_name method" do


### PR DESCRIPTION
The `display_name` helper only uses the display name fallback if no matching method is defined on a model from the configured `display_name_methods` list. The output of the display name fallback is the model human name and the primary key. So with a given `User` model and a numeric primary key, you would get `User #1` as an example output.

If the model implements a method from that `display_name_methods` list but it returns a blank value, **this has a side effect where an association link is generated without text so it's not seen or clickable**. I think it would help to use our display name fallback in this specific case since it is a good default, rather than be all or nothing. The `display_name_methods` list is a global configuration that cannot be modified per resource.

When working on this change, the test case I modified demonstrated the exact behavior I ran into. The anchor (link) HTML is generated but without a value so a user wouldn't see anything in the browser. While the test shows this is expected behavior, I think this would be an improvement for this specific scenario.

This change would not have any effect on cases where there is a custom display name because as long as it returns a present value, it will always be used. This is a small improvement to rely on a good default, our display name fallback, when there is no present value.

Let me know your thoughts and any suggestions for changes here.