### PR TITLE
fix: Streaming CSV export.

### DIFF
--- a/lib/active_admin/resource_controller/streaming.rb
+++ b/lib/active_admin/resource_controller/streaming.rb
@@ -20,6 +20,7 @@ module ActiveAdmin
       def stream_resource(&block)
         headers['X-Accel-Buffering'] = 'no'
         headers['Cache-Control'] = 'no-cache'
+        headers["Last-Modified"] = Time.current.httpdate
 
         if ActiveAdmin.application.disable_streaming_in.include? Rails.env
           self.response_body = block['']


### PR DESCRIPTION
Streaming CSV exports was not working either in development (with `config.disable_streaming_in = []`)
nor on production Heroku. Adding a Last-Modified header made it work as is [recommended elsewhere](https://medium.com/table-xi/stream-csv-files-in-rails-because-you-can-46c212159ab7).