### PR TITLE
It’s Sass not SASS

### DIFF
--- a/lib/generators/active_admin/assets/templates/active_admin.scss
+++ b/lib/generators/active_admin/assets/templates/active_admin.scss
@@ -1,4 +1,4 @@
-// SASS variable overrides must be declared before loading up Active Admin's styles.
+// Sass variable overrides must be declared before loading up Active Admin's styles.
 //
 // To view the variables that Active Admin provides, take a look at
 // `app/assets/stylesheets/active_admin/mixins/_variables.scss` in the
@@ -11,7 +11,7 @@
 @import "active_admin/mixins";
 @import "active_admin/base";
 
-// Overriding any non-variable SASS must be done after the fact.
+// Overriding any non-variable Sass must be done after the fact.
 // For example, to change the default status-tag color:
 //
 //   .status_tag { background: #6090DB; }

--- a/lib/generators/active_admin/webpacker/templates/active_admin.scss
+++ b/lib/generators/active_admin/webpacker/templates/active_admin.scss
@@ -1,4 +1,4 @@
-// SASS variable overrides must be declared before loading up Active Admin's styles.
+// Sass variable overrides must be declared before loading up Active Admin's styles.
 //
 // To view the variables that Active Admin provides, take a look at
 // `app/assets/stylesheets/active_admin/mixins/_variables.scss` in the
@@ -11,7 +11,7 @@
 @import "~@activeadmin/activeadmin/src/scss/mixins";
 @import "~@activeadmin/activeadmin/src/scss/base";
 
-// Overriding any non-variable SASS must be done after the fact.
+// Overriding any non-variable Sass must be done after the fact.
 // For example, to change the default status-tag color:
 //
 //   .status_tag { background: #6090DB; }


### PR DESCRIPTION
As this is the Sisyphean task I've assigned myself by naming it a backronym instead of an acronym or initialism, the language is officially Sass not SASS.

I've fixed two in these repeated files, but I'll forgive the middle usage as it does indeed seem to be yelling with joy and sass.

I would happily add this to the Changelog, but doesn't seem to warrant that – for this is my own private journey.