### PR TITLE
Issue 6206

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@
 
 * Fix filter_columns_for_large_association and filter_method_for_large_association examples. [#6232] by [@ndbroadbent]
 
+### Bug Fixes
+
+* Fix an error if you don't have an app/assets folder and don't use Sprockets. [#6370] by [@hcatlin]
+
 ### Dependency Changes
 
 * Allow formtastic 4. [#6318] by [@deivid-rodriguez]
@@ -622,6 +626,7 @@ Please check [0-6-stable] for previous changes.
 [#6422]: https://github.com/activeadmin/activeadmin/pull/6422
 [#6451]: https://github.com/activeadmin/activeadmin/pull/6451
 [#6460]: https://github.com/activeadmin/activeadmin/pull/6460
+[#6370]: https://github.com/activeadmin/activeadmin/pull/6370
 
 [@5t111111]: https://github.com/5t111111
 [@aarek]: https://github.com/aarek
@@ -659,6 +664,7 @@ Please check [0-6-stable] for previous changes.
 [@gonzedge]: https://github.com/gonzedge
 [@guigs]: https://github.com/guigs
 [@HappyKadaver]: https://github.com/HappyKadaver
+[@hcatlin]: https://github.com/hcatlin
 [@imcvampire]: https://github.com/imcvampire
 [@innparusu95]: https://github.com/innparusu95
 [@ionut998]: https://github.com/ionut998

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -622,11 +622,11 @@ Please check [0-6-stable] for previous changes.
 [#6318]: https://github.com/activeadmin/activeadmin/pull/6318
 [#6341]: https://github.com/activeadmin/activeadmin/pull/6341
 [#6368]: https://github.com/activeadmin/activeadmin/pull/6368
+[#6370]: https://github.com/activeadmin/activeadmin/pull/6370
 [#6393]: https://github.com/activeadmin/activeadmin/pull/6393
 [#6422]: https://github.com/activeadmin/activeadmin/pull/6422
 [#6451]: https://github.com/activeadmin/activeadmin/pull/6451
 [#6460]: https://github.com/activeadmin/activeadmin/pull/6460
-[#6370]: https://github.com/activeadmin/activeadmin/pull/6370
 
 [@5t111111]: https://github.com/5t111111
 [@aarek]: https://github.com/aarek

--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,7 @@ group :development, :test do
   gem "rails", "~> 6.0.0"
   gem "activerecord-jdbcsqlite3-adapter", "~> 60.0", platform: :jruby
 
-  gem "sprockets-rails"
-  gem "sprockets", github: "rails/sprockets", ref: "2d6b1a8bde0cf870c14a2d193fa9a9be09ef99fc"
+  gem "sassc-rails"
 
   gem "formtastic", "~> 4.0.rc1"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: https://github.com/rails/sprockets.git
-  revision: 2d6b1a8bde0cf870c14a2d193fa9a9be09ef99fc
-  ref: 2d6b1a8bde0cf870c14a2d193fa9a9be09ef99fc
-  specs:
-    sprockets (4.0.0)
-      concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
-
-GIT
   remote: https://github.com/rspec/rspec-core.git
   revision: 119282ec3dde5295b337322fc53301c32d0bf7ec
   ref: 119282ec3dde5295b337322fc53301c32d0bf7ec
@@ -63,7 +54,6 @@ PATH
       railties (>= 5.2, < 6.1)
       ransack (~> 2.1, >= 2.1.1)
       sassc-rails (~> 2.1)
-      sprockets (>= 3.0, < 4.1)
 
 GEM
   remote: https://rubygems.org/
@@ -444,6 +434,9 @@ GEM
     simplecov-html (0.12.2)
     spoon (0.0.6)
       ffi
+    sprockets (4.0.2)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
     sprockets-rails (3.2.2)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
@@ -517,9 +510,8 @@ DEPENDENCIES
   rubocop-packaging (= 0.5.0)
   rubocop-rails (~> 2.3)
   rubocop-rspec (~> 1.30)
+  sassc-rails
   simplecov (= 0.19.0)
-  sprockets!
-  sprockets-rails
   sqlite3 (~> 1.4)
   yard
 

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -28,5 +28,4 @@ Gem::Specification.new do |s|
   s.add_dependency "railties", ">= 5.2", "< 6.1"
   s.add_dependency "ransack", "~> 2.1", ">= 2.1.1"
   s.add_dependency "sassc-rails", "~> 2.1"
-  s.add_dependency "sprockets", ">= 3.0", "< 4.1"
 end

--- a/gemfiles/rails_52/Gemfile
+++ b/gemfiles/rails_52/Gemfile
@@ -15,8 +15,7 @@ group :development, :test do
   gem "rails", "~> 5.2.3"
   gem "activerecord-jdbcsqlite3-adapter", "~> 52.0", platform: :jruby
 
-  gem "sprockets-rails"
-  gem "sprockets", github: "rails/sprockets", ref: "2d6b1a8bde0cf870c14a2d193fa9a9be09ef99fc"
+  gem "sassc-rails"
 
   gem "formtastic", "~> 4.0.rc1"
 end

--- a/gemfiles/rails_52/Gemfile.lock
+++ b/gemfiles/rails_52/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: https://github.com/rails/sprockets.git
-  revision: 2d6b1a8bde0cf870c14a2d193fa9a9be09ef99fc
-  ref: 2d6b1a8bde0cf870c14a2d193fa9a9be09ef99fc
-  specs:
-    sprockets (4.0.0)
-      concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
-
-GIT
   remote: https://github.com/rspec/rspec-core.git
   revision: 119282ec3dde5295b337322fc53301c32d0bf7ec
   ref: 119282ec3dde5295b337322fc53301c32d0bf7ec
@@ -63,7 +54,6 @@ PATH
       railties (>= 5.2, < 6.1)
       ransack (~> 2.1, >= 2.1.1)
       sassc-rails (~> 2.1)
-      sprockets (>= 3.0, < 4.1)
 
 GEM
   remote: https://rubygems.org/
@@ -360,6 +350,9 @@ GEM
     simplecov-html (0.12.2)
     spoon (0.0.6)
       ffi
+    sprockets (4.0.2)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
     sprockets-rails (3.2.2)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
@@ -417,9 +410,8 @@ DEPENDENCIES
   rspec-mocks!
   rspec-rails
   rspec-support!
+  sassc-rails
   simplecov (= 0.19.0)
-  sprockets!
-  sprockets-rails
   sqlite3 (~> 1.4)
 
 BUNDLED WITH

--- a/gemfiles/rails_60_turbolinks/Gemfile
+++ b/gemfiles/rails_60_turbolinks/Gemfile
@@ -15,8 +15,7 @@ group :development, :test do
   gem "rails", "~> 6.0.0"
   gem "activerecord-jdbcsqlite3-adapter", "~> 60.0", platform: :jruby
 
-  gem "sprockets-rails"
-  gem "sprockets", github: "rails/sprockets", ref: "2d6b1a8bde0cf870c14a2d193fa9a9be09ef99fc"
+  gem "sassc-rails"
 
   gem "turbolinks", "~> 5.2"
 

--- a/gemfiles/rails_60_turbolinks/Gemfile.lock
+++ b/gemfiles/rails_60_turbolinks/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: https://github.com/rails/sprockets.git
-  revision: 2d6b1a8bde0cf870c14a2d193fa9a9be09ef99fc
-  ref: 2d6b1a8bde0cf870c14a2d193fa9a9be09ef99fc
-  specs:
-    sprockets (4.0.0)
-      concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
-
-GIT
   remote: https://github.com/rspec/rspec-core.git
   revision: 119282ec3dde5295b337322fc53301c32d0bf7ec
   ref: 119282ec3dde5295b337322fc53301c32d0bf7ec
@@ -63,7 +54,6 @@ PATH
       railties (>= 5.2, < 6.1)
       ransack (~> 2.1, >= 2.1.1)
       sassc-rails (~> 2.1)
-      sprockets (>= 3.0, < 4.1)
 
 GEM
   remote: https://rubygems.org/
@@ -375,6 +365,9 @@ GEM
     simplecov-html (0.12.2)
     spoon (0.0.6)
       ffi
+    sprockets (4.0.2)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
     sprockets-rails (3.2.2)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
@@ -436,9 +429,8 @@ DEPENDENCIES
   rspec-mocks!
   rspec-rails
   rspec-support!
+  sassc-rails
   simplecov (= 0.19.0)
-  sprockets!
-  sprockets-rails
   sqlite3 (~> 1.4)
   turbolinks (~> 5.2)
 

--- a/gemfiles/rails_60_webpacker/Gemfile
+++ b/gemfiles/rails_60_webpacker/Gemfile
@@ -15,9 +15,6 @@ group :development, :test do
   gem "rails", "~> 6.0.0"
   gem "activerecord-jdbcsqlite3-adapter", "~> 60.0", platform: :jruby
 
-  gem "sprockets-rails"
-  gem "sprockets", github: "rails/sprockets", ref: "2d6b1a8bde0cf870c14a2d193fa9a9be09ef99fc"
-
   gem "webpacker", "~> 5.1"
 
   gem "formtastic", "~> 4.0.rc1"

--- a/gemfiles/rails_60_webpacker/Gemfile.lock
+++ b/gemfiles/rails_60_webpacker/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: https://github.com/rails/sprockets.git
-  revision: 2d6b1a8bde0cf870c14a2d193fa9a9be09ef99fc
-  ref: 2d6b1a8bde0cf870c14a2d193fa9a9be09ef99fc
-  specs:
-    sprockets (4.0.0)
-      concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
-
-GIT
   remote: https://github.com/rspec/rspec-core.git
   revision: 119282ec3dde5295b337322fc53301c32d0bf7ec
   ref: 119282ec3dde5295b337322fc53301c32d0bf7ec
@@ -63,7 +54,6 @@ PATH
       railties (>= 5.2, < 6.1)
       ransack (~> 2.1, >= 2.1.1)
       sassc-rails (~> 2.1)
-      sprockets (>= 3.0, < 4.1)
 
 GEM
   remote: https://rubygems.org/
@@ -378,6 +368,9 @@ GEM
     simplecov-html (0.12.2)
     spoon (0.0.6)
       ffi
+    sprockets (4.0.2)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
     sprockets-rails (3.2.2)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
@@ -442,8 +435,6 @@ DEPENDENCIES
   rspec-rails
   rspec-support!
   simplecov (= 0.19.0)
-  sprockets!
-  sprockets-rails
   sqlite3 (~> 1.4)
   webpacker (~> 5.1)
 

--- a/lib/active_admin.rb
+++ b/lib/active_admin.rb
@@ -1,15 +1,14 @@
 require "active_support/core_ext"
 require "set"
 
-require "ransack"
-require "ransack_ext"
-require "kaminari"
-require "formtastic"
-require "formtastic_i18n"
-require "inherited_resources"
-require "jquery-rails"
-require "sassc-rails"
-require "arbre"
+require 'ransack'
+require 'ransack_ext'
+require 'kaminari'
+require 'formtastic'
+require 'formtastic_i18n'
+require 'inherited_resources'
+require 'jquery-rails'
+require 'arbre'
 
 require "active_admin/helpers/i18n"
 

--- a/lib/active_admin.rb
+++ b/lib/active_admin.rb
@@ -1,14 +1,14 @@
 require "active_support/core_ext"
 require "set"
 
-require 'ransack'
-require 'ransack_ext'
-require 'kaminari'
-require 'formtastic'
-require 'formtastic_i18n'
-require 'inherited_resources'
-require 'jquery-rails'
-require 'arbre'
+require "ransack"
+require "ransack_ext"
+require "kaminari"
+require "formtastic"
+require "formtastic_i18n"
+require "inherited_resources"
+require "jquery-rails"
+require "arbre"
 
 require "active_admin/helpers/i18n"
 

--- a/lib/active_admin/engine.rb
+++ b/lib/active_admin/engine.rb
@@ -6,11 +6,13 @@ module ActiveAdmin
     end
 
     initializer "active_admin.precompile", group: :all do |app|
-      ActiveAdmin.application.stylesheets.each do |path, _|
-        app.config.assets.precompile << path
-      end
-      ActiveAdmin.application.javascripts.each do |path|
-        app.config.assets.precompile << path
+      unless ActiveAdmin.application.use_webpacker
+        ActiveAdmin.application.stylesheets.each do |path, _|
+          app.config.assets.precompile << path
+        end
+        ActiveAdmin.application.javascripts.each do |path|
+          app.config.assets.precompile << path
+        end
       end
     end
 

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -53,17 +53,20 @@ generate :migration, "create_taggings post_id:integer tag_id:integer position:in
 
 copy_file File.expand_path("templates/models/tagging.rb", __dir__), "app/models/tagging.rb"
 
-gsub_file "config/environments/test.rb", /  config.cache_classes = true/, <<-RUBY
-
+test_env_config = <<-RUBY
   config.cache_classes = !ENV['CLASS_RELOADING']
   config.action_mailer.default_url_options = {host: 'example.com'}
-  config.assets.precompile += %w( some-random-css.css some-random-js.js a/favicon.ico )
-
   config.active_record.maintain_test_schema = false
 
 RUBY
 
-gsub_file "config/boot.rb", /^.*BUNDLE_GEMFILE.*$/, <<-RUBY
+unless webpacker_app
+  test_env_config += "config.assets.precompile += %w( some-random-css.css some-random-js.js a/favicon.ico )"
+end
+
+gsub_file 'config/environments/test.rb', /  config.cache_classes = true/, test_env_config
+
+gsub_file 'config/boot.rb', /^.*BUNDLE_GEMFILE.*$/, <<-RUBY
   ENV['BUNDLE_GEMFILE'] = "#{File.expand_path(ENV['BUNDLE_GEMFILE'])}"
 RUBY
 

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -3,8 +3,9 @@
 webpacker_app = ENV["BUNDLE_GEMFILE"] == File.expand_path("../../gemfiles/rails_60_webpacker/Gemfile", __dir__)
 
 if webpacker_app
-  create_file "app/javascript/packs/some-random-css.css"
-  create_file "app/javascript/packs/some-random-js.js"
+  create_file 'app/javascript/packs/some-random-css.css'
+  create_file 'app/javascript/packs/some-random-js.js'
+  remove_dir 'app/assets'
 else
   create_file "app/assets/stylesheets/some-random-css.css"
   create_file "app/assets/javascripts/some-random-js.js"

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -3,9 +3,9 @@
 webpacker_app = ENV["BUNDLE_GEMFILE"] == File.expand_path("../../gemfiles/rails_60_webpacker/Gemfile", __dir__)
 
 if webpacker_app
-  create_file 'app/javascript/packs/some-random-css.css'
-  create_file 'app/javascript/packs/some-random-js.js'
-  remove_dir 'app/assets'
+  create_file "app/javascript/packs/some-random-css.css"
+  create_file "app/javascript/packs/some-random-js.js"
+  remove_dir "app/assets"
 else
   create_file "app/assets/stylesheets/some-random-css.css"
   create_file "app/assets/javascripts/some-random-js.js"
@@ -64,9 +64,9 @@ unless webpacker_app
   test_env_config += "config.assets.precompile += %w( some-random-css.css some-random-js.js a/favicon.ico )"
 end
 
-gsub_file 'config/environments/test.rb', /  config.cache_classes = true/, test_env_config
+gsub_file "config/environments/test.rb", /  config.cache_classes = true/, test_env_config
 
-gsub_file 'config/boot.rb', /^.*BUNDLE_GEMFILE.*$/, <<-RUBY
+gsub_file "config/boot.rb", /^.*BUNDLE_GEMFILE.*$/, <<-RUBY
   ENV['BUNDLE_GEMFILE'] = "#{File.expand_path(ENV['BUNDLE_GEMFILE'])}"
 RUBY
 

--- a/tasks/bug_report_template.rb
+++ b/tasks/bug_report_template.rb
@@ -13,7 +13,6 @@ gemfile(true) do
   # Change Rails version if necessary.
   gem "rails", "6.0.0"
 
-  gem "sprockets", "3.7.2"
   gem "sassc-rails", "2.1.2"
   gem "sqlite3", "1.4.1", platform: :mri
   gem "activerecord-jdbcsqlite3-adapter", "60.0", platform: :jruby

--- a/tasks/test_application.rb
+++ b/tasks/test_application.rb
@@ -33,6 +33,7 @@ module ActiveAdmin
       )
 
       args << "--skip-turbolinks" unless turbolinks_app?
+      args << "--skip-sprockets" if webpacker_app?
 
       command = ["bundle", "exec", "rails", "new", app_dir, *args].join(" ")
 
@@ -73,6 +74,10 @@ module ActiveAdmin
 
     def turbolinks_app?
       expanded_gemfile == File.expand_path("gemfiles/rails_60_turbolinks/Gemfile")
+    end
+
+    def webpacker_app?
+      expanded_gemfile == File.expand_path('gemfiles/rails_60_webpacker/Gemfile')
     end
 
     def gemfile

--- a/tasks/test_application.rb
+++ b/tasks/test_application.rb
@@ -77,7 +77,7 @@ module ActiveAdmin
     end
 
     def webpacker_app?
-      expanded_gemfile == File.expand_path('gemfiles/rails_60_webpacker/Gemfile')
+      expanded_gemfile == File.expand_path("gemfiles/rails_60_webpacker/Gemfile")
     end
 
     def gemfile


### PR DESCRIPTION
As reported in #6206, a Rails application that doesn't have an "app/assets" folder and is using Webpacker entirely without Sprockets will report an error on server startup. 

The reason for the error is that ActiveAdmin was including Sprockets and sassc-rails into the runtime and causing Sprockets to get initialized without the user intending this.

Here, several changes were needed to stop the automatic loading and requirement for sassc as a Ruby Gem.

This is in two commits, the first showing the failing test changes, and the second addresses the issues.