### PR TITLE
Enhance release tasks to automatically generate our changelog

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,14 +12,11 @@ Before submitting your PR make sure that:
 * Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
 * Related commits are squashed together, and unrelated commits are splitted apart.
 * Your PR includes a regression test if it fixes a bug.
-* You add an entry to the [Changelog] if the new code introduces user-observable changes. See [changelog entry format].
 
 Before expecting a review for your PR make sure that all github checks are passing, but feel free to ask for early feedback if you need guidance.
 
 [CONTRIBUTING file]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
 [good commit messages]: https://chris.beams.io/posts/git-commit/
 [includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords
-[Changelog]: https://github.com/activeadmin/activeadmin/blob/master/CHANGELOG.md
-[changelog entry format]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md#add-a-changelog-entry
 
 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,12 +174,12 @@ met.
 
 Maintainers need to do the following to push out a release:
 
-* Make sure all pull requests are in and that changelog is current
 * Switch to the master branch and make sure it's up to date.
 * Make sure you have [chandler] properly configured. Chandler is used to
   automatically submit github release notes from the changelog right after
   pushing the gem to rubygems.
 * Run one of `bin/rake release:prepare_{prerelease,prepatch,patch,preminor,minor,premajor,major}`, push the result and create a PR.
+* Review and merge the PR. The generated changelog in the PR should include all user visible changes you intend to ship.
 * Run `bin/rake release` from the target branch once the PR is merged.
 
 [chandler]: https://github.com/mattbrictson/chandler#2-configure-credentials

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,22 +115,6 @@ checks as the rest of the project. `bin/rake lint` will give you feedback in
 this regard. You can check & fix style issues by running each linter
 individually. Run `bin/rake -T lint` to see the available linters.
 
-### Add a changelog entry
-
-If your PR includes user-observable changes, you'll be asked to add a changelog
-entry following the existing changelog format.
-
-The changelog format is the following:
-
-* One line per PR describing your fix or enhancement.
-* Entries end with a dot, followed by "[#pr-number] by [@github-username]".
-* Entries are added under the "Unreleased" section at the top of the file, under
-  the "Bug Fixes" or "Enhancements" subsection.
-* References to github usernames and pull requests use [shortcut reference
-  links].
-* Your github username reference definition is included in the correct
-  alphabetical position at the bottom of the file.
-
 ### Make a Pull Request
 
 At this point, you should switch back to your master branch and make sure it's

--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ end
 
 group :release do
   gem 'chandler', '0.9.0' # Github releases from changelog
+  gem 'octokit', '~> 4.18'
 end
 
 group :lint do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,7 +232,7 @@ GEM
       activesupport (>= 5.0)
       request_store (>= 1.0)
     erubi (1.9.0)
-    faraday (1.0.0)
+    faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.13.1)
     ffi (1.13.1-java)
@@ -326,7 +326,7 @@ GEM
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     nokogiri (1.10.9-java)
-    octokit (4.15.0)
+    octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     orm_adapter (0.5.0)
@@ -499,6 +499,7 @@ DEPENDENCIES
   kramdown
   launchy
   mdl (= 0.6.0)
+  octokit (~> 4.18)
   parallel_tests (~> 3.0)
   pry
   pry-byebug

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,6 @@ import 'tasks/test.rake'
 gemfile = ENV['BUNDLE_GEMFILE']
 
 if gemfile.nil? || File.expand_path(gemfile) == File.expand_path('Gemfile')
-  import 'tasks/changelog.rake'
   import 'tasks/docs.rake'
   import 'tasks/lint.rake'
   import 'tasks/release.rake'

--- a/tasks/changelog.rake
+++ b/tasks/changelog.rake
@@ -1,8 +1,0 @@
-require_relative "changelog"
-
-namespace :changelog do
-  desc "Sync changelog from latest PR information"
-  task :sync do
-    Changelog.new.sync!
-  end
-end

--- a/tasks/changelog.rake
+++ b/tasks/changelog.rake
@@ -1,8 +1,8 @@
 require_relative "changelog"
 
 namespace :changelog do
-  desc "Add missing changelog references to the unreleased section"
-  task :add_references do
-    Changelog.new.add_references
+  desc "Sync changelog from latest PR information"
+  task :sync do
+    Changelog.new.sync!
   end
 end

--- a/tasks/changelog.rb
+++ b/tasks/changelog.rb
@@ -1,6 +1,6 @@
 class Changelog
   def cut_version(header)
-    replace_with_lines([content[0..3], header, "", content[4..-1]])
+    replace_with_lines([header, "", content])
   end
 
   def add_references
@@ -38,7 +38,7 @@ class Changelog
   end
 
   def unreleased_section
-    content.drop_while { |line| !unreleased_section_header?(line) }.take_while { |line| !released_section_header?(line) }
+    content.take_while { |line| !released_section_header?(line) }
   end
 
   def pre_user_references
@@ -61,12 +61,8 @@ class Changelog
     content.drop_while { |line| !pull_request_reference?(line) }.take_while { |line| pull_request_reference?(line) }
   end
 
-  def unreleased_section_header?(line)
-    line == "## Unreleased"
-  end
-
   def released_section_header?(line)
-    line.start_with?("## ") && !unreleased_section_header?(line)
+    line.start_with?("## ")
   end
 
   def user_reference?(line)
@@ -78,11 +74,11 @@ class Changelog
   end
 
   def replace_with_lines(new_lines)
-    File.write(changelog_file, new_lines.join("\n") + "\n")
+    File.write(changelog_file, ["# Changelog", "", "## Unreleased", "", *new_lines].join("\n") + "\n")
   end
 
   def content
-    File.read(changelog_file).split("\n")
+    File.read(changelog_file).split("\n")[4..-1]
   end
 
   def changelog_file

--- a/tasks/changelog.rb
+++ b/tasks/changelog.rb
@@ -3,13 +3,117 @@ class Changelog
     replace_with_lines([header, "", content])
   end
 
+  def sync!
+    lines = []
+
+    group_by_labels(pull_requests_since_last_release).each do |label, pulls|
+      category = changelog_label_mapping[label]
+
+      lines << "### #{category}"
+      lines << ""
+
+      pulls.sort_by(&:merged_at).reverse_each do |pull|
+        lines << "* #{pull.title}. [##{pull.number}] by [@#{pull.user.login}]"
+      end
+
+      lines << ""
+    end
+
+    replace_unreleased_section(lines)
+
+    add_references
+  end
+
+  private
+
+  def group_by_labels(pulls)
+    grouped_pulls = pulls.group_by do |pull|
+      relevant_label_for(pull)
+    end
+
+    grouped_pulls.delete(nil) # exclude non categorized pulls
+
+    grouped_pulls.sort do |a, b|
+      changelog_labels.index(a[0]) <=> changelog_labels.index(b[0])
+    end.to_h
+  end
+
+  def pull_requests_since_last_release
+    last_release_date = gh_client.releases("activeadmin/activeadmin").sort_by(&:created_at).last.created_at
+
+    pr_ids = merged_pr_ids_since(last_release_date)
+
+    pull_requests_for(pr_ids)
+  end
+
+  def changelog_label_mapping
+    {
+      "type: security fix" => "Security Fixes",
+      "type: breaking change" => "Breaking Changes",
+      "type: deprecation" => "Deprecations",
+      "type: enhancement" => "Enhancements",
+      "type: bug fix" => "Bug Fixes",
+      "type: dependency change" => "Dependency Changes",
+    }
+  end
+
+  def replace_unreleased_section(new_content)
+    full_new_changelog = [new_content, released_section]
+
+    replace_with_lines(full_new_changelog)
+  end
+
   def add_references
     add_user_references
 
     add_pull_request_references
   end
 
-  private
+  def relevant_label_for(pull)
+    relevant_labels = pull.labels.map(&:name) & changelog_labels
+    return unless relevant_labels.any?
+
+    raise "#{pull.html_url} has multiple labels that map to changelog sections" unless relevant_labels.size == 1
+
+    relevant_labels.first
+  end
+
+  def changelog_labels
+    changelog_label_mapping.keys
+  end
+
+  def merged_pr_ids_since(date)
+    commits = `git log --oneline origin/master --since '#{date}'`.split("\n").map { |l| l.split(/\s/, 2) }
+    commits.map do |_sha, message|
+      match = /Merge pull request #(\d+)/.match(message)
+      match ||= /\(#(\d+)\)$/.match(message)
+      next unless match
+
+      match[1].to_i
+    end.compact
+  end
+
+  def pull_requests_for(ids)
+    pulls = gh_client.pull_requests("activeadmin/activeadmin", sort: :updated, state: :closed, direction: :desc)
+
+    loop do
+      pulls.select! { |pull| ids.include?(pull.number) }
+
+      return pulls if (pulls.map(&:number) & ids).to_set == ids.to_set
+
+      pulls.concat gh_client.get(gh_client.last_response.rels[:next].href)
+    end
+  end
+
+  def gh_client
+    @gh_client ||= begin
+      require "netrc"
+      _username, token = Netrc.read["api.github.com"]
+
+      require "octokit"
+      Octokit::Client.new(access_token: token)
+    end
+  end
 
   def add_user_references
     new_user_references = user_references
@@ -39,6 +143,10 @@ class Changelog
 
   def unreleased_section
     content.take_while { |line| !released_section_header?(line) }
+  end
+
+  def released_section
+    content.drop_while { |line| !released_section_header?(line) }
   end
 
   def pre_user_references

--- a/tasks/changelog.rb
+++ b/tasks/changelog.rb
@@ -1,5 +1,7 @@
 class Changelog
   def cut_version(header)
+    sync!
+
     replace_with_lines([header, "", content])
   end
 


### PR DESCRIPTION
Initially I was expecting to automatically update the changelog after every PR, so it's always up to date. I also planned to use [release-drafter](https://github.com/release-drafter/release-drafter) to publish release drafts after every PR to GitHub.

But in the end I realized that all that is a bit overkill, and hard to get right.

My intention was to ease the creation of the changelog for every release, avoiding having to manually triage every merged PR. So, what I did was to enhance our release tasks to including autogenerating the changelog too, using the criteria we defined in https://github.com/activeadmin/activeadmin/pull/6358 (i.e., include merged PRs with their titles, as long as they have a proper label).

After this PR, I'll use the new release tasks to release 2.8.0.