### PR TITLE
Send `active_admin/print.scss` to the proper webpacker directory

### DIFF
--- a/lib/generators/active_admin/webpacker/webpacker_generator.rb
+++ b/lib/generators/active_admin/webpacker/webpacker_generator.rb
@@ -7,7 +7,7 @@ module ActiveAdmin
       def install_assets
         template 'active_admin.js', 'app/javascript/packs/active_admin.js'
         template "active_admin.scss", "app/javascript/stylesheets/active_admin.scss"
-        template 'print.scss', 'app/javascript/packs/active_admin/print.scss'
+        template 'print.scss', 'app/javascript/stylesheets/active_admin/print.scss'
 
         copy_file "#{__dir__}/plugins/jquery.js", Rails.root.join("config/webpack/plugins/jquery.js").to_s
 

--- a/spec/unit/generators/install_spec.rb
+++ b/spec/unit/generators/install_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe "AA installation" do
   context "should create" do
     let(:asset_pipeline_stylesheet_dir) { Rails.root + 'app/assets/stylesheets' }
     let(:asset_pipeline_javascript_dir) { Rails.root + 'app/assets/javascripts' }
-    
+
     let(:webpacker_stylesheet_dir) { Rails.root + 'app/javascript/stylesheets' }
     let(:webpacker_javascript_dir) { Rails.root + 'app/javascript/packs' }
 
     let(:stylesheet_dir) { ActiveAdmin.application.use_webpacker ? webpacker_stylesheet_dir : asset_pipeline_stylesheet_dir }
     let(:javascript_dir) { ActiveAdmin.application.use_webpacker ? webpacker_javascript_dir : asset_pipeline_javascript_dir }
-    
+
     it 'active_admin.scss' do
       path = stylesheet_dir + 'active_admin.scss'
 

--- a/spec/unit/generators/install_spec.rb
+++ b/spec/unit/generators/install_spec.rb
@@ -11,6 +11,15 @@ RSpec.describe "AA installation" do
       expect(File.exist?(path)).to eq true
     end
 
+    it "print.scss" do
+      path = if ActiveAdmin.application.use_webpacker
+               Rails.root + "app/javascript/stylesheets/active_admin/print.scss"
+             else
+               Rails.root + "app/assets/stylesheets/active_admin.scss"
+             end
+      expect(File.exist?(path)).to eq true
+    end
+
     it "active_admin.js" do
       path = if ActiveAdmin.application.use_webpacker
                Rails.root + "app/javascript/packs/active_admin.js"

--- a/spec/unit/generators/install_spec.rb
+++ b/spec/unit/generators/install_spec.rb
@@ -2,30 +2,29 @@ require 'rails_helper'
 
 RSpec.describe "AA installation" do
   context "should create" do
-    it "active_admin.scss" do
-      path = if ActiveAdmin.application.use_webpacker
-               Rails.root + "app/javascript/stylesheets/active_admin.scss"
-             else
-               Rails.root + "app/assets/stylesheets/active_admin.scss"
-             end
+    let(:asset_pipeline_stylesheet_dir) { Rails.root + 'app/assets/stylesheets' }
+    let(:webpacker_stylesheet_dir)      { Rails.root + 'app/javascript/stylesheets' }
+    let(:asset_pipeline_javascript_dir) { Rails.root + 'app/assets/javascripts' }
+    let(:webpacker_javascript_dir)      { Rails.root + 'app/javascript/packs' }
+
+    let(:stylesheet_dir) { ActiveAdmin.application.use_webpacker ? webpacker_stylesheet_dir : asset_pipeline_stylesheet_dir }
+    let(:javascript_dir) { ActiveAdmin.application.use_webpacker ? webpacker_javascript_dir : asset_pipeline_javascript_dir }
+    
+    it 'active_admin.scss' do
+      path = stylesheet_dir + 'active_admin.scss'
+
       expect(File.exist?(path)).to eq true
     end
 
-    it "print.scss" do
-      path = if ActiveAdmin.application.use_webpacker
-               Rails.root + "app/javascript/stylesheets/active_admin/print.scss"
-             else
-               Rails.root + "app/assets/stylesheets/active_admin.scss"
-             end
+    it 'active_admin/print.scss' do
+      path = stylesheet_dir + 'active_admin/print.scss'
+
       expect(File.exist?(path)).to eq true
     end
 
-    it "active_admin.js" do
-      path = if ActiveAdmin.application.use_webpacker
-               Rails.root + "app/javascript/packs/active_admin.js"
-             else
-               Rails.root + "app/assets/javascripts/active_admin.js"
-             end
+    it 'active_admin.js' do
+      path = javascript_dir + 'active_admin.js'
+
       expect(File.exist?(path)).to eq true
     end
 

--- a/spec/unit/generators/install_spec.rb
+++ b/spec/unit/generators/install_spec.rb
@@ -17,10 +17,12 @@ RSpec.describe "AA installation" do
       expect(File.exist?(path)).to eq true
     end
 
-    it 'active_admin/print.scss' do
-      path = stylesheet_dir + 'active_admin/print.scss'
+    if ActiveAdmin.application.use_webpacker
+      it 'active_admin/print.scss' do
+        path = stylesheet_dir + 'active_admin/print.scss'
 
-      expect(File.exist?(path)).to eq true
+        expect(File.exist?(path)).to eq true
+      end
     end
 
     it 'active_admin.js' do

--- a/spec/unit/generators/install_spec.rb
+++ b/spec/unit/generators/install_spec.rb
@@ -3,9 +3,10 @@ require 'rails_helper'
 RSpec.describe "AA installation" do
   context "should create" do
     let(:asset_pipeline_stylesheet_dir) { Rails.root + 'app/assets/stylesheets' }
-    let(:webpacker_stylesheet_dir)      { Rails.root + 'app/javascript/stylesheets' }
     let(:asset_pipeline_javascript_dir) { Rails.root + 'app/assets/javascripts' }
-    let(:webpacker_javascript_dir)      { Rails.root + 'app/javascript/packs' }
+    
+    let(:webpacker_stylesheet_dir) { Rails.root + 'app/javascript/stylesheets' }
+    let(:webpacker_javascript_dir) { Rails.root + 'app/javascript/packs' }
 
     let(:stylesheet_dir) { ActiveAdmin.application.use_webpacker ? webpacker_stylesheet_dir : asset_pipeline_stylesheet_dir }
     let(:javascript_dir) { ActiveAdmin.application.use_webpacker ? webpacker_javascript_dir : asset_pipeline_javascript_dir }


### PR DESCRIPTION
1. Slightly tweaks the webpacker generator.  It was sending `print.scss` into the wrong directory.
2. Adds a spec for this file where there was none.
3. Slightly DRY's up the spec, too.

<!--

Thanks for contributing to ActiveAdmin!

You can find all the instructions for contributing at the [CONTRIBUTING file].

Before submitting your PR make sure that:

* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are splitted apart.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all github checks are passing, but feel free to ask for early feedback if you need guidance.

[CONTRIBUTING file]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->
