### PR TITLE
Configure and enforce eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,6 @@
+app/assets/**/*.js
+vendor/**/*.js
+lib/generators/**/*.js
+tmp/**/*.js
+spec/**/*.js
+src/**/*.js

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,289 @@
+env:
+  browser: true
+  es6: true
+extends:
+  - 'eslint:recommended'
+  - 'plugin:import/errors'
+  - 'plugin:import/warnings'
+globals:
+  $: false
+  Atomics: readonly
+  jQuery: false
+  SharedArrayBuffer: readonly
+  Turbolinks: false
+parserOptions:
+  ecmaVersion: 2018
+  sourceType: module
+rules:
+  accessor-pairs: error
+  array-bracket-newline: error
+  array-bracket-spacing: 'off'
+  array-callback-return: error
+  array-element-newline: 'off'
+  arrow-body-style: 'off'
+  arrow-parens: 'off'
+  arrow-spacing:
+    - error
+    - after: true
+      before: true
+  block-scoped-var: error
+  block-spacing:
+    - error
+    - always
+  brace-style:
+    - error
+    - 1tbs
+    - allowSingleLine: true
+  callback-return: 'off'
+  camelcase: 'off'
+  capitalized-comments: 'off'
+  class-methods-use-this: 'off'
+  comma-dangle: error
+  comma-spacing:
+    - error
+    - after: true
+      before: false
+  comma-style:
+    - error
+    - last
+  complexity: error
+  computed-property-spacing:
+    - error
+    - never
+  consistent-return: 'off'
+  consistent-this: error
+  curly: error
+  default-case: error
+  default-param-last: error
+  dot-location: 'off'
+  dot-notation: 'off'
+  eol-last: error
+  eqeqeq: 'off'
+  func-call-spacing: error
+  func-name-matching: error
+  func-names: 'off'
+  func-style: 'off'
+  function-paren-newline: error
+  generator-star-spacing: error
+  global-require: error
+  grouped-accessor-pairs: error
+  guard-for-in: 'off'
+  handle-callback-err: error
+  id-blacklist: error
+  id-length: 'off'
+  id-match: error
+  implicit-arrow-linebreak: 'off'
+  indent: 'off'
+  indent-legacy: 'off'
+  init-declarations: 'off'
+  jsx-quotes: error
+  key-spacing: error
+  keyword-spacing:
+    - error
+    - after: true
+      before: true
+  line-comment-position: 'off'
+  linebreak-style:
+    - error
+    - unix
+  lines-around-comment: error
+  lines-around-directive: error
+  lines-between-class-members:
+    - error
+    - always
+  max-classes-per-file: error
+  max-depth: error
+  max-len: 'off'
+  max-lines: error
+  max-lines-per-function: 'off'
+  max-nested-callbacks: error
+  max-params: error
+  max-statements: 'off'
+  max-statements-per-line: 'off'
+  multiline-comment-style:
+    - error
+    - separate-lines
+  multiline-ternary:
+    - error
+    - never
+  new-parens: error
+  newline-after-var: 'off'
+  newline-before-return: 'off'
+  newline-per-chained-call: 'off'
+  no-alert: error
+  no-array-constructor: error
+  no-await-in-loop: error
+  no-bitwise: error
+  no-buffer-constructor: error
+  no-caller: error
+  no-catch-shadow: error
+  no-cond-assign:
+    - error
+    - except-parens
+  no-confusing-arrow: error
+  no-console: 'off'
+  no-constructor-return: error
+  no-continue: error
+  no-div-regex: error
+  no-dupe-else-if: error
+  no-duplicate-imports: error
+  no-else-return: 'off'
+  no-empty-function: 'off'
+  no-eq-null: 'off'
+  no-eval: error
+  no-extend-native: error
+  no-extra-bind: error
+  no-extra-label: error
+  no-extra-parens: 'off'
+  no-floating-decimal: error
+  no-implicit-coercion: error
+  no-implicit-globals: error
+  no-implied-eval: error
+  no-import-assign: error
+  no-inline-comments: 'off'
+  no-inner-declarations:
+    - error
+    - functions
+  no-invalid-this: 'off'
+  no-iterator: error
+  no-label-var: error
+  no-labels: error
+  no-lone-blocks: error
+  no-lonely-if: error
+  no-loop-func: 'off'
+  no-magic-numbers: 'off'
+  no-mixed-operators: error
+  no-mixed-requires: error
+  no-multi-assign: error
+  no-multi-spaces: 'off'
+  no-multi-str: error
+  no-multiple-empty-lines: error
+  no-native-reassign: error
+  no-negated-condition: 'off'
+  no-negated-in-lhs: error
+  no-nested-ternary: error
+  no-new: error
+  no-new-func: error
+  no-new-object: error
+  no-new-require: error
+  no-new-wrappers: error
+  no-octal-escape: error
+  no-param-reassign: 'off'
+  no-path-concat: error
+  no-plusplus: 'off'
+  no-process-env: error
+  no-process-exit: error
+  no-proto: error
+  no-restricted-globals: error
+  no-restricted-imports: error
+  no-restricted-modules: error
+  no-restricted-properties: error
+  no-restricted-syntax: error
+  no-return-assign: 'off'
+  no-return-await: error
+  no-script-url: error
+  no-self-compare: error
+  no-sequences: error
+  no-setter-return: error
+  no-shadow: error
+  no-spaced-func: error
+  no-sync: error
+  no-tabs: error
+  no-template-curly-in-string: error
+  no-ternary: 'off'
+  no-throw-literal: error
+  no-trailing-spaces: error
+  no-undef-init: error
+  no-undefined: error
+  no-underscore-dangle: 'off'
+  no-unmodified-loop-condition: error
+  no-unneeded-ternary: error
+  no-unused-expressions: error
+  no-unused-vars:
+    - error
+    - argsIgnorePattern: "^_"
+  no-use-before-define: 'off'
+  no-useless-call: error
+  no-useless-computed-key: error
+  no-useless-concat: error
+  no-useless-constructor: error
+  no-useless-rename: error
+  no-useless-return: error
+  no-var: 'off'
+  no-void: error
+  no-warning-comments: error
+  no-whitespace-before-property: error
+  nonblock-statement-body-position: error
+  object-curly-newline: error
+  object-curly-spacing: 'off'
+  object-shorthand: 'off'
+  one-var: 'off'
+  one-var-declaration-per-line:
+    - error
+    - initializations
+  operator-assignment:
+    - error
+    - always
+  operator-linebreak: error
+  padded-blocks: 'off'
+  padding-line-between-statements: error
+  prefer-arrow-callback: 'off'
+  prefer-const: 'off'
+  prefer-destructuring: error
+  prefer-exponentiation-operator: error
+  prefer-named-capture-group: 'off'
+  prefer-numeric-literals: error
+  prefer-object-spread: error
+  prefer-promise-reject-errors: error
+  prefer-reflect: 'off'
+  prefer-regex-literals: error
+  prefer-rest-params: 'off'
+  prefer-spread: error
+  prefer-template: 'off'
+  quote-props: 'off'
+  quotes: 'off'
+  radix:
+    - error
+    - always
+  require-atomic-updates: error
+  require-await: error
+  require-jsdoc: 'off'
+  require-unicode-regexp: 'off'
+  rest-spread-spacing:
+    - error
+    - never
+  semi: 'off'
+  semi-spacing: error
+  semi-style:
+    - error
+    - last
+  sort-keys: 'off'
+  sort-vars: error
+  space-before-blocks: 'off'
+  space-before-function-paren: 'off'
+  space-in-parens:
+    - error
+    - never
+  space-infix-ops: error
+  space-unary-ops: error
+  spaced-comment:
+    - error
+    - always
+  strict: error
+  switch-colon-spacing: error
+  symbol-description: error
+  template-curly-spacing:
+    - error
+    - never
+  template-tag-spacing: error
+  unicode-bom:
+    - error
+    - never
+  valid-jsdoc: error
+  vars-on-top: 'off'
+  wrap-iife: error
+  wrap-regex: 'off'
+  yield-star-spacing: error
+  yoda:
+    - error
+    - never

--- a/app/assets/javascripts/active_admin/base.js
+++ b/app/assets/javascripts/active_admin/base.js
@@ -66,7 +66,7 @@
     $("body").trigger("modal_dialog:before_open", [ form ]);
     form.dialog({
       modal: true,
-      open: function open(event, ui) {
+      open: function open(_event, _ui) {
         $("body").trigger("modal_dialog:after_open", [ form ]);
       },
       dialogClass: "active_admin_dialog",
@@ -134,7 +134,7 @@
       this._bind();
     }
     var _proto = CheckboxToggler.prototype;
-    _proto.option = function option(key, value) {};
+    _proto.option = function option(_key, _value) {};
     _proto._init = function _init() {
       if (!this.container) {
         throw new Error("Container element not found");
@@ -157,7 +157,7 @@
         return _this._didChangeToggleAllCheckbox();
       });
     };
-    _proto._didChangeCheckbox = function _didChangeCheckbox(checkbox) {
+    _proto._didChangeCheckbox = function _didChangeCheckbox(_checkbox) {
       var numChecked = this.checkboxes.filter(":checked").length;
       var allChecked = numChecked === this.checkboxes.length;
       var someChecked = numChecked > 0 && numChecked < this.checkboxes.length;
@@ -462,7 +462,7 @@
     return PerPage;
   }();
   (function($) {
-    $(document).on("change", ".pagination_per_page > select", function(event) {
+    $(document).on("change", ".pagination_per_page > select", function(_event) {
       PerPage._jQueryInterface.call($(this), "update");
     });
     $.fn["perPage"] = PerPage._jQueryInterface;

--- a/app/javascript/active_admin/initializers/per-page.js
+++ b/app/javascript/active_admin/initializers/per-page.js
@@ -3,7 +3,7 @@ import PerPage from "../lib/per-page";
 (($) => {
 
   $(document).
-    on('change', '.pagination_per_page > select', function(event) {
+    on('change', '.pagination_per_page > select', function(_event) {
       PerPage._jQueryInterface.call($(this), 'update')
     });
 

--- a/app/javascript/active_admin/lib/checkbox-toggler.js
+++ b/app/javascript/active_admin/lib/checkbox-toggler.js
@@ -6,7 +6,7 @@ class CheckboxToggler {
     this._bind();
   }
 
-  option(key, value) {
+  option(_key, _value) {
   }
 
   _init() {
@@ -30,7 +30,7 @@ class CheckboxToggler {
     this.toggle_all_checkbox.change(() => this._didChangeToggleAllCheckbox());
   }
 
-  _didChangeCheckbox(checkbox){
+  _didChangeCheckbox(_checkbox){
     const numChecked = this.checkboxes.filter(':checked').length;
 
     const allChecked = numChecked === this.checkboxes.length;
@@ -44,6 +44,6 @@ class CheckboxToggler {
     this.checkboxes.prop({ checked: setting });
     return setting;
   }
-};
+}
 
 export default CheckboxToggler;

--- a/app/javascript/active_admin/lib/dropdown-menu.js
+++ b/app/javascript/active_admin/lib/dropdown-menu.js
@@ -111,6 +111,6 @@ class DropdownMenu {
       this.$nipple.css('left', menu_center - nipple_center);
     }
   }
-};
+}
 
 export default DropdownMenu;

--- a/app/javascript/active_admin/lib/modal-dialog.js
+++ b/app/javascript/active_admin/lib/modal-dialog.js
@@ -44,7 +44,7 @@ function ModalDialog(message, inputs, callback){
 
   form.dialog({
     modal: true,
-    open(event, ui) {
+    open(_event, _ui) {
       $('body').trigger('modal_dialog:after_open', [form]);
     },
     dialogClass: 'active_admin_dialog',
@@ -58,6 +58,6 @@ function ModalDialog(message, inputs, callback){
       }
     }
   });
-};
+}
 
 export default ModalDialog;

--- a/app/javascript/active_admin/lib/per-page.js
+++ b/app/javascript/active_admin/lib/per-page.js
@@ -33,6 +33,6 @@ class PerPage {
       }
     })
   }
-};
+}
 
 export default PerPage;

--- a/app/javascript/active_admin/lib/table-checkbox-toggler.js
+++ b/app/javascript/active_admin/lib/table-checkbox-toggler.js
@@ -33,6 +33,6 @@ class TableCheckboxToggler extends CheckboxToggler {
       .find(':checkbox')
       .click();
   }
-};
+}
 
 export default TableCheckboxToggler;

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "scripts": {
     "gherkin-lint": "gherkin-lint",
     "build": "rollup --config rollup.config.js",
+    "eslint": "eslint .",
     "prepublishOnly": "rm -rf src && cp -R app/javascript/active_admin src && cp -R app/assets/stylesheets/active_admin src/scss"
   },
   "dependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -38,7 +38,7 @@ export default {
     resolve(),
     commonjs(),
     babel(),
-    terser(terserOptions),
+    terser(terserOptions)
   ],
   // Use client's yarn dependencies instead of bundling everything
   external: [

--- a/tasks/lint.rake
+++ b/tasks/lint.rake
@@ -106,7 +106,7 @@ class SassRailsLinter
 end
 
 desc "Lints ActiveAdmin code base"
-task lint: ["lint:rubocop", "lint:mdl", "lint:gherkin", "lint:trailing_blank_lines", "lint:missing_final_new_line", "lint:trailing_whitespace", "lint:fixme", "lint:sass_rails", "lint:rspec"]
+task lint: ["lint:rubocop", "lint:mdl", "lint:eslint", "lint:gherkin", "lint:trailing_blank_lines", "lint:missing_final_new_line", "lint:trailing_whitespace", "lint:fixme", "lint:sass_rails", "lint:rspec"]
 
 namespace :lint do
   require "rubocop/rake_task"
@@ -118,6 +118,14 @@ namespace :lint do
     puts "Running mdl..."
 
     sh("mdl", "--git-recurse", ".")
+  end
+
+  desc "Checks JS code style with eslint"
+  task :eslint do
+    puts "Linting JS code..."
+
+    sh("bin/yarn", "install")
+    sh("bin/yarn", "eslint")
   end
 
   desc "Checks gherkin code style"


### PR DESCRIPTION
When we first added our js bundle in order to migrate to webpack, `eslint` and `eslint-plugin-import` were added as development dependencies. However, they were never used or configured.

In this PR, I configure them to keep our current code style as much as possible.