### PR TITLE
Bump simplecov to 0.19.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,7 @@ jobs:
           name: Download Code Climate test-reporter
           command: |
             mkdir bin
-            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-0.6.3-linux-amd64 > bin/test-reporter
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-0.8.0-linux-amd64 > bin/test-reporter
             chmod +x  bin/test-reporter
 
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,9 @@ version: 2.1
 .format_coverage: &format_coverage
   run:
     name: Format coverage
-    command: bin/test-reporter format-coverage --output coverage/codeclimate.$CIRCLE_JOB.json
+    command: |
+      bin/prepare_coverage
+      bin/test-reporter format-coverage --output coverage/codeclimate.$CIRCLE_JOB.json
 
 .save_coverage: &save_coverage
   persist_to_workspace:

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ group :test do
   gem 'capybara', '~> 3.14'
   gem 'db-query-matchers', '0.10.0'
 
-  gem 'simplecov', '0.17.1', require: false # Test coverage generator. Go to /coverage/ after running tests
+  gem 'simplecov', '0.19.0', require: false # Test coverage generator. Go to /coverage/ after running tests
   gem 'cucumber-rails', '~> 2.0', require: false
   gem 'cucumber'
   gem 'database_cleaner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,8 +279,6 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     jruby-openssl (0.10.2-java)
-    json (2.3.0)
-    json (2.3.0-java)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.1)
@@ -448,11 +446,10 @@ GEM
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
-    simplecov (0.17.1)
+    simplecov (0.19.0)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.2)
     spoon (0.0.6)
       ffi
     sqlite3 (1.4.2)
@@ -524,7 +521,7 @@ DEPENDENCIES
   rubocop (= 0.89.1)
   rubocop-rails (~> 2.3)
   rubocop-rspec (~> 1.30)
-  simplecov (= 0.17.1)
+  simplecov (= 0.19.0)
   sprockets!
   sprockets-rails!
   sqlite3 (~> 1.4)

--- a/bin/prepare_coverage
+++ b/bin/prepare_coverage
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+
+# Borrowed from https://gist.github.com/qortex/7e7c49f3731391a91ee898336183acef
+
+# Temporary hack to get CodeClimate to work with SimpleCov 0.18 JSON format until issue is fixed
+# upstream: https://github.com/codeclimate/test-reporter/issues/413
+
+require 'json'
+
+filename = 'coverage/.resultset.json'
+contents = JSON.parse(File.read(filename))
+
+def remove_lines_key(obj)
+  case obj
+  when Hash
+    obj.transform_values do |val|
+      val.is_a?(Hash) && val.key?('lines') ? val['lines'] : remove_lines_key(val)
+    end
+  else
+    obj
+  end
+end
+
+# overwrite
+File.write(filename, JSON.generate(remove_lines_key(contents)))

--- a/gemfiles/rails_52/Gemfile
+++ b/gemfiles/rails_52/Gemfile
@@ -28,7 +28,7 @@ group :test do
   gem 'capybara', '~> 3.14'
   gem 'db-query-matchers', '0.10.0'
 
-  gem 'simplecov', '0.17.1', require: false # Test coverage generator. Go to /coverage/ after running tests
+  gem 'simplecov', '0.19.0', require: false # Test coverage generator. Go to /coverage/ after running tests
   gem 'cucumber-rails', '~> 2.0', require: false
   gem 'cucumber'
   gem 'database_cleaner'

--- a/gemfiles/rails_52/Gemfile.lock
+++ b/gemfiles/rails_52/Gemfile.lock
@@ -244,8 +244,6 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     jruby-openssl (0.10.2-java)
-    json (2.3.0)
-    json (2.3.0-java)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.1)
@@ -366,11 +364,10 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    simplecov (0.17.1)
+    simplecov (0.19.0)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.2)
     spoon (0.0.6)
       ffi
     sqlite3 (1.4.2)
@@ -427,7 +424,7 @@ DEPENDENCIES
   rspec-mocks!
   rspec-rails
   rspec-support!
-  simplecov (= 0.17.1)
+  simplecov (= 0.19.0)
   sprockets!
   sprockets-rails!
   sqlite3 (~> 1.4)

--- a/gemfiles/rails_60_turbolinks/Gemfile
+++ b/gemfiles/rails_60_turbolinks/Gemfile
@@ -30,7 +30,7 @@ group :test do
   gem 'capybara', '~> 3.14'
   gem 'db-query-matchers', '0.10.0'
 
-  gem 'simplecov', '0.17.1', require: false # Test coverage generator. Go to /coverage/ after running tests
+  gem 'simplecov', '0.19.0', require: false # Test coverage generator. Go to /coverage/ after running tests
   gem 'cucumber-rails', '~> 2.0', require: false
   gem 'cucumber'
   gem 'database_cleaner'

--- a/gemfiles/rails_60_turbolinks/Gemfile.lock
+++ b/gemfiles/rails_60_turbolinks/Gemfile.lock
@@ -257,8 +257,6 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     jruby-openssl (0.10.2-java)
-    json (2.3.0)
-    json (2.3.0-java)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.1)
@@ -381,11 +379,10 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    simplecov (0.17.1)
+    simplecov (0.19.0)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.2)
     spoon (0.0.6)
       ffi
     sqlite3 (1.4.2)
@@ -446,7 +443,7 @@ DEPENDENCIES
   rspec-mocks!
   rspec-rails
   rspec-support!
-  simplecov (= 0.17.1)
+  simplecov (= 0.19.0)
   sprockets!
   sprockets-rails!
   sqlite3 (~> 1.4)

--- a/gemfiles/rails_60_webpacker/Gemfile
+++ b/gemfiles/rails_60_webpacker/Gemfile
@@ -30,7 +30,7 @@ group :test do
   gem 'capybara', '~> 3.14'
   gem 'db-query-matchers', '0.10.0'
 
-  gem 'simplecov', '0.17.1', require: false # Test coverage generator. Go to /coverage/ after running tests
+  gem 'simplecov', '0.19.0', require: false # Test coverage generator. Go to /coverage/ after running tests
   gem 'cucumber-rails', '~> 2.0', require: false
   gem 'cucumber'
   gem 'database_cleaner'

--- a/gemfiles/rails_60_webpacker/Gemfile.lock
+++ b/gemfiles/rails_60_webpacker/Gemfile.lock
@@ -257,8 +257,6 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     jruby-openssl (0.10.4-java)
-    json (2.3.0)
-    json (2.3.0-java)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.1)
@@ -384,11 +382,10 @@ GEM
       sprockets-rails
       tilt
     semantic_range (2.3.0)
-    simplecov (0.17.1)
+    simplecov (0.19.0)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.2)
     spoon (0.0.6)
       ffi
     sqlite3 (1.4.2)
@@ -451,7 +448,7 @@ DEPENDENCIES
   rspec-mocks!
   rspec-rails
   rspec-support!
-  simplecov (= 0.17.1)
+  simplecov (= 0.19.0)
   sprockets!
   sprockets-rails!
   sqlite3 (~> 1.4)


### PR DESCRIPTION
Supersedes #6396.

It also bumps code climate's test-reporter to the latest version.