### PR TITLE
Automatically create a release branch from release scripts

### DIFF
--- a/tasks/release_manager.rb
+++ b/tasks/release_manager.rb
@@ -129,6 +129,8 @@ class ReleaseManager
   end
 
   def prepare_version(version)
+    create_release_branch(version)
+
     bump_gem(version)
     bump_npm(version)
 
@@ -145,6 +147,10 @@ class ReleaseManager
 
   def bump_npm(version)
     system "npm", "version", npmify(version), "--no-git-tag-version", exception: true
+  end
+
+  def create_release_branch(version)
+    system "git", "checkout", "-b", "release/#{version}", exception: true
   end
 
   def bump_gem(version)


### PR DESCRIPTION
Current scripts tell you to start off the default branch, and release scripts don't do any branch switching, so they would commit to the default branch and tell you to push after that. We don't want that, but push to a non default branch and create a PR from it.