### PR TITLE
Fix input string filter no rendering dropdown input when its column name ends with a ransack predicate 

### DIFF
--- a/features/sti_resource.feature
+++ b/features/sti_resource.feature
@@ -7,10 +7,10 @@ Feature: STI Resource
     And a configuration of:
     """
       ActiveAdmin.register Publisher do
-        permit_params :first_name, :last_name, :username, :age
+        permit_params :first_name, :last_name, :username, :age, :reason_of_sign_in
       end
       ActiveAdmin.register User do
-        permit_params :first_name, :last_name, :username, :age
+        permit_params :first_name, :last_name, :username, :age, :reason_of_sign_in
       end
     """
 

--- a/lib/active_admin/filters/formtastic_addons.rb
+++ b/lib/active_admin/filters/formtastic_addons.rb
@@ -54,7 +54,7 @@ module ActiveAdmin
       end
 
       def seems_searchable?
-        has_predicate? || scope?
+        column_for(method).nil? && (has_predicate? || scope?)
       end
 
       # If the given method has a predicate (like _eq or _lteq), it's pretty

--- a/lib/active_admin/filters/formtastic_addons.rb
+++ b/lib/active_admin/filters/formtastic_addons.rb
@@ -63,11 +63,6 @@ module ActiveAdmin
         !!Ransack::Predicate.detect_from_string(method.to_s)
       end
 
-      # Ransack lets you define custom search methods, called ransackers.
-      def ransacker?
-        klass._ransackers.key? method.to_s
-      end
-
       # Ransack supports exposing selected scopes on your model for advanced searches.
       def scope?
         context = Ransack::Context.for klass

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -32,7 +32,7 @@ generate :migration, "create_profiles user_id:integer bio:text #{timestamps}"
 
 copy_file File.expand_path('templates/models/user.rb', __dir__), 'app/models/user.rb'
 
-generate :migration, "create_users type:string first_name:string last_name:string username:string age:integer encrypted_password:string #{timestamps}"
+generate :migration, "create_users type:string first_name:string last_name:string username:string age:integer encrypted_password:string reason_of_sign_in:string #{timestamps}"
 
 copy_file File.expand_path('templates/models/profile.rb', __dir__), 'app/models/profile.rb'
 

--- a/spec/unit/filters/filter_form_builder_spec.rb
+++ b/spec/unit/filters/filter_form_builder_spec.rb
@@ -131,6 +131,17 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
     end
   end
 
+  describe 'string attribute ended with ransack predicate' do
+    let(:scope) { User.ransack }
+    let(:body) { filter :reason_of_sign_in }
+
+    it "should generate a select options" do
+      expect(body).to have_selector("option[value=reason_of_sign_in_starts_with]")
+      expect(body).to have_selector("option[value=reason_of_sign_in_ends_with]")
+      expect(body).to have_selector("option[value=reason_of_sign_in_contains]")
+    end
+  end
+
   describe "text attribute" do
     let(:body) { filter :body }
 


### PR DESCRIPTION
fixes  #6413
<!--

Thanks for contributing to ActiveAdmin!

You can find all the instructions for contributing at the [CONTRIBUTING file].

Before submitting your PR make sure that:

* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are splitted apart.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all github checks are passing, but feel free to ask for early feedback if you need guidance.

[CONTRIBUTING file]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->
