### PR TITLE
Include new i18n and documentation sections in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,24 @@
 
 ### Enhancements
 
-* Fix several Arabic translations. [#6368] by [@mshalaby]
 * Allow using PORO decorators. [#6249] by [@brunvez]
-* Add missing `scope/all` italian translation. [#6341] by [@fuzziness]
-* Improve Japanese translation. [#6315] by [@rn0rno]
 * Make sure `ActiveAdmin.routes` provides routes in a consistent order. [#6124] by [@jiikko]
 * Use proper closing tags for HTML in ModalDialog component. [#6221] by [@javierjulio]
-* Fix filter_columns_for_large_association and filter_method_for_large_association examples. [#6232] by [@ndbroadbent]
 
 ### Bug Fixes
 
 * Fix comment layout so regardless of size, each is aligned and spaced evenly. [#6393] by [@Ivanov-Anton]
-* Fix es and es-MX sign_in and sign_up translation:. [#6210] by [@roramirez]
+
+### Translation Improvements
+
+* Fix several Arabic translations. [#6368] by [@mshalaby]
+* Add missing `scope/all` italian translation. [#6341] by [@fuzziness]
+* Improve Japanese translation. [#6315] by [@rn0rno]
+* Fix es and es-MX sign_in and sign_up translation. [#6210] by [@roramirez]
+
+### Documentation
+
+* Fix filter_columns_for_large_association and filter_method_for_large_association examples. [#6232] by [@ndbroadbent]
 
 ### Dependency Changes
 

--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,7 @@ import 'tasks/test.rake'
 gemfile = ENV['BUNDLE_GEMFILE']
 
 if gemfile.nil? || File.expand_path(gemfile) == File.expand_path('Gemfile')
+  import 'tasks/changelog.rake'
   import 'tasks/docs.rake'
   import 'tasks/lint.rake'
   import 'tasks/release.rake'

--- a/spec/changelog_spec.lint.rb
+++ b/spec/changelog_spec.lint.rb
@@ -42,7 +42,7 @@ RSpec.describe "Changelog" do
 
   it 'has well defined third level entries' do
     third_level_entries = changelog.scan(/^### (.*)$/).flatten.uniq.sort
-    expect(third_level_entries).to eq(["Breaking Changes", "Bug Fixes", "Dependency Changes", "Deprecations", "Enhancements", "Security Fixes"])
+    expect(third_level_entries).to eq(["Breaking Changes", "Bug Fixes", "Dependency Changes", "Deprecations", "Documentation", "Enhancements", "Security Fixes", "Translation Improvements"])
   end
 
   describe 'entry' do

--- a/tasks/changelog.rake
+++ b/tasks/changelog.rake
@@ -1,0 +1,8 @@
+require_relative "changelog"
+
+namespace :changelog do
+  desc 'Syncronize latest release changelog with latest PR information'
+  task :resync do
+    Changelog.new.resync!
+  end
+end

--- a/tasks/changelog.rb
+++ b/tasks/changelog.rb
@@ -55,6 +55,8 @@ class Changelog
       "type: deprecation" => "Deprecations",
       "type: enhancement" => "Enhancements",
       "type: bug fix" => "Bug Fixes",
+      "type: i18n" => "Translation Improvements",
+      "type: documentation" => "Documentation",
       "type: dependency change" => "Dependency Changes",
     }
   end


### PR DESCRIPTION
* Create a new task to regenerate a (still unreleased) changelog after the release has already been cut inside the changelog file.

* Run it to regenerate the changelog with the new sections and with typo fix in a PR title.