### PR TITLE
Use arbre 1.3.0 in CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,6 @@ group :development, :test do
   gem 'pry' # Easily debug from your console with `binding.pry`
   gem 'pry-byebug', platform: :mri # Step-by-step debugging
 
-  gem 'arbre', github: 'activeadmin/arbre', ref: 'b546d7a10b95001cb7bd1273bbaa55172de77e98'
-
   gem 'cancancan'
   gem 'pundit'
   gem 'jruby-openssl', '~> 0.10.1', platform: :jruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: https://github.com/activeadmin/arbre.git
-  revision: b546d7a10b95001cb7bd1273bbaa55172de77e98
-  ref: b546d7a10b95001cb7bd1273bbaa55172de77e98
-  specs:
-    arbre (1.2.1)
-      activesupport (>= 3.0.0, < 6.1)
-      ruby2_keywords (>= 0.0.2)
-
-GIT
   remote: https://github.com/rails/sprockets-rails.git
   revision: c269f5e01fdffa5c41350e855183d94ff33d318a
   ref: c269f5e01fdffa5c41350e855183d94ff33d318a
@@ -156,6 +147,9 @@ GEM
     apparition (0.6.0)
       capybara (~> 3.13, < 4)
       websocket-driver (>= 0.6.5)
+    arbre (1.3.0)
+      activesupport (>= 3.0.0, < 6.1)
+      ruby2_keywords (>= 0.0.2, < 1.0)
     ast (2.4.1)
     bcrypt (3.1.13)
     bcrypt (3.1.13-java)
@@ -485,7 +479,6 @@ DEPENDENCIES
   activeadmin!
   activerecord-jdbcsqlite3-adapter (~> 60.0)
   apparition
-  arbre!
   cancancan
   capybara (~> 3.14)
   chandler (= 0.9.0)

--- a/gemfiles/rails_52/Gemfile
+++ b/gemfiles/rails_52/Gemfile
@@ -5,8 +5,6 @@ group :development, :test do
   gem 'pry' # Easily debug from your console with `binding.pry`
   gem 'pry-byebug', platform: :mri # Step-by-step debugging
 
-  gem 'arbre', github: 'activeadmin/arbre', ref: 'b546d7a10b95001cb7bd1273bbaa55172de77e98'
-
   gem 'cancancan'
   gem 'pundit'
   gem 'jruby-openssl', '~> 0.10.1', platform: :jruby

--- a/gemfiles/rails_52/Gemfile.lock
+++ b/gemfiles/rails_52/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: https://github.com/activeadmin/arbre.git
-  revision: b546d7a10b95001cb7bd1273bbaa55172de77e98
-  ref: b546d7a10b95001cb7bd1273bbaa55172de77e98
-  specs:
-    arbre (1.2.1)
-      activesupport (>= 3.0.0, < 6.1)
-      ruby2_keywords (>= 0.0.2)
-
-GIT
   remote: https://github.com/rails/sprockets-rails.git
   revision: c269f5e01fdffa5c41350e855183d94ff33d318a
   ref: c269f5e01fdffa5c41350e855183d94ff33d318a
@@ -142,6 +133,9 @@ GEM
     apparition (0.6.0)
       capybara (~> 3.13, < 4)
       websocket-driver (>= 0.6.5)
+    arbre (1.3.0)
+      activesupport (>= 3.0.0, < 6.1)
+      ruby2_keywords (>= 0.0.2, < 1.0)
     arel (9.0.0)
     bcrypt (3.1.13)
     bcrypt (3.1.13-java)
@@ -157,7 +151,7 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     coderay (1.1.2)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.7)
     crass (1.0.6)
     cucumber (4.1.0)
       builder (~> 3.2, >= 3.2.3)
@@ -225,7 +219,7 @@ GEM
     has_scope (0.7.2)
       actionpack (>= 4.1)
       activesupport (>= 4.1)
-    i18n (1.8.3)
+    i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     inherited_resources (1.11.0)
       actionpack (>= 5.0, < 6.1)
@@ -273,7 +267,7 @@ GEM
     mimemagic (0.3.5)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    minitest (5.14.1)
+    minitest (5.14.2)
     multi_test (0.1.2)
     nio4r (2.5.2)
     nio4r (2.5.2-java)
@@ -397,7 +391,6 @@ DEPENDENCIES
   activeadmin!
   activerecord-jdbcsqlite3-adapter (~> 52.0)
   apparition
-  arbre!
   cancancan
   capybara (~> 3.14)
   cucumber

--- a/gemfiles/rails_60_turbolinks/Gemfile
+++ b/gemfiles/rails_60_turbolinks/Gemfile
@@ -5,8 +5,6 @@ group :development, :test do
   gem 'pry' # Easily debug from your console with `binding.pry`
   gem 'pry-byebug', platform: :mri # Step-by-step debugging
 
-  gem 'arbre', github: 'activeadmin/arbre', ref: 'b546d7a10b95001cb7bd1273bbaa55172de77e98'
-
   gem 'cancancan'
   gem 'pundit'
   gem 'jruby-openssl', '~> 0.10.1', platform: :jruby

--- a/gemfiles/rails_60_turbolinks/Gemfile.lock
+++ b/gemfiles/rails_60_turbolinks/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: https://github.com/activeadmin/arbre.git
-  revision: b546d7a10b95001cb7bd1273bbaa55172de77e98
-  ref: b546d7a10b95001cb7bd1273bbaa55172de77e98
-  specs:
-    arbre (1.2.1)
-      activesupport (>= 3.0.0, < 6.1)
-      ruby2_keywords (>= 0.0.2)
-
-GIT
   remote: https://github.com/rails/sprockets-rails.git
   revision: c269f5e01fdffa5c41350e855183d94ff33d318a
   ref: c269f5e01fdffa5c41350e855183d94ff33d318a
@@ -156,6 +147,9 @@ GEM
     apparition (0.6.0)
       capybara (~> 3.13, < 4)
       websocket-driver (>= 0.6.5)
+    arbre (1.3.0)
+      activesupport (>= 3.0.0, < 6.1)
+      ruby2_keywords (>= 0.0.2, < 1.0)
     bcrypt (3.1.13)
     bcrypt (3.1.13-java)
     builder (3.2.4)
@@ -170,7 +164,7 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     coderay (1.1.2)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.7)
     crass (1.0.6)
     cucumber (4.1.0)
       builder (~> 3.2, >= 3.2.3)
@@ -238,7 +232,7 @@ GEM
     has_scope (0.7.2)
       actionpack (>= 4.1)
       activesupport (>= 4.1)
-    i18n (1.8.3)
+    i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     inherited_resources (1.11.0)
       actionpack (>= 5.0, < 6.1)
@@ -286,7 +280,7 @@ GEM
     mimemagic (0.3.5)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    minitest (5.14.1)
+    minitest (5.14.2)
     multi_test (0.1.2)
     nio4r (2.5.2)
     nio4r (2.5.2-java)
@@ -406,7 +400,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.3.1)
+    zeitwerk (2.4.0)
 
 PLATFORMS
   java
@@ -416,7 +410,6 @@ DEPENDENCIES
   activeadmin!
   activerecord-jdbcsqlite3-adapter (~> 60.0)
   apparition
-  arbre!
   cancancan
   capybara (~> 3.14)
   cucumber

--- a/gemfiles/rails_60_webpacker/Gemfile
+++ b/gemfiles/rails_60_webpacker/Gemfile
@@ -5,8 +5,6 @@ group :development, :test do
   gem 'pry' # Easily debug from your console with `binding.pry`
   gem 'pry-byebug', platform: :mri # Step-by-step debugging
 
-  gem 'arbre', github: 'activeadmin/arbre', ref: 'b546d7a10b95001cb7bd1273bbaa55172de77e98'
-
   gem 'cancancan'
   gem 'pundit'
   gem 'jruby-openssl', '~> 0.10.1', platform: :jruby

--- a/gemfiles/rails_60_webpacker/Gemfile.lock
+++ b/gemfiles/rails_60_webpacker/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: https://github.com/activeadmin/arbre.git
-  revision: b546d7a10b95001cb7bd1273bbaa55172de77e98
-  ref: b546d7a10b95001cb7bd1273bbaa55172de77e98
-  specs:
-    arbre (1.2.1)
-      activesupport (>= 3.0.0, < 6.1)
-      ruby2_keywords (>= 0.0.2)
-
-GIT
   remote: https://github.com/rails/sprockets-rails.git
   revision: c269f5e01fdffa5c41350e855183d94ff33d318a
   ref: c269f5e01fdffa5c41350e855183d94ff33d318a
@@ -156,6 +147,9 @@ GEM
     apparition (0.6.0)
       capybara (~> 3.13, < 4)
       websocket-driver (>= 0.6.5)
+    arbre (1.3.0)
+      activesupport (>= 3.0.0, < 6.1)
+      ruby2_keywords (>= 0.0.2, < 1.0)
     bcrypt (3.1.13)
     bcrypt (3.1.13-java)
     builder (3.2.4)
@@ -286,7 +280,7 @@ GEM
     mimemagic (0.3.5)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    minitest (5.14.1)
+    minitest (5.14.2)
     multi_test (0.1.2)
     nio4r (2.5.2)
     nio4r (2.5.2-java)
@@ -421,7 +415,6 @@ DEPENDENCIES
   activeadmin!
   activerecord-jdbcsqlite3-adapter (~> 60.0)
   apparition
-  arbre!
   cancancan
   capybara (~> 3.14)
   cucumber


### PR DESCRIPTION
I just released arbre 1.3.0 to rubygems.org. Let' try it.
