### PR TITLE
Use double quotes consistently

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -127,6 +127,10 @@ Naming/PredicateName:
     - has_many
     - has_many_actions
 
+Style/StringLiterals:
+  Enabled: true
+  EnforcedStyle: double_quotes
+
 Style/TrailingCommaInArguments:
   Enabled: true
 

--- a/.simplecov
+++ b/.simplecov
@@ -1,9 +1,9 @@
 SimpleCov.start do
-  add_filter 'tmp/development_apps/'
-  add_filter 'tmp/test_apps/'
+  add_filter "tmp/development_apps/"
+  add_filter "tmp/test_apps/"
 end
 
-if ENV['CI'] == 'true'
+if ENV["CI"] == "true"
   SimpleCov.formatters = [
     SimpleCov::Formatter::HTMLFormatter
   ]

--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,15 @@
 source "https://rubygems.org"
 
 group :development, :test do
-  gem 'rake'
-  gem 'pry' # Easily debug from your console with `binding.pry`
-  gem 'pry-byebug', platform: :mri # Step-by-step debugging
+  gem "rake"
+  gem "pry" # Easily debug from your console with `binding.pry`
+  gem "pry-byebug", platform: :mri # Step-by-step debugging
 
-  gem 'cancancan'
-  gem 'pundit'
-  gem 'jruby-openssl', '~> 0.10.1', platform: :jruby
+  gem "cancancan"
+  gem "pundit"
+  gem "jruby-openssl", "~> 0.10.1", platform: :jruby
 
-  gem 'draper', '~> 4.0'
+  gem "draper", "~> 4.0"
   gem "devise"
 
   gem "rails", "~> 6.0.0"
@@ -22,48 +22,48 @@ group :development, :test do
 end
 
 group :test do
-  gem 'apparition'
-  gem 'capybara', '~> 3.14'
-  gem 'db-query-matchers', '0.10.0'
+  gem "apparition"
+  gem "capybara", "~> 3.14"
+  gem "db-query-matchers", "0.10.0"
 
-  gem 'simplecov', '0.19.0', require: false # Test coverage generator. Go to /coverage/ after running tests
-  gem 'cucumber-rails', '~> 2.0', require: false
-  gem 'cucumber'
-  gem 'database_cleaner'
-  gem 'jasmine'
-  gem 'jasmine-core', '2.99.2' # last release with Ruby 2.2 support.
-  gem 'launchy'
-  gem 'parallel_tests', '~> 3.0'
-  gem 'rails-i18n' # Provides default i18n for many languages
-  gem 'rspec-rails'
-  gem 'rspec', github: 'rspec/rspec', ref: '3e6c0fb9c9ec68eddd409cfe7b3eb077b390b302'
-  gem 'rspec-core', github: 'rspec/rspec-core', ref: '119282ec3dde5295b337322fc53301c32d0bf7ec'
-  gem 'rspec-mocks', github: 'rspec/rspec-mocks', ref: '1728885f65b25a9676c5ce54133ef8a1283e2e0d'
-  gem 'rspec-support', github: 'rspec/rspec-support', ref: '6553911974ee93855008f8ff41c26cea6652d74d'
-  gem 'rspec-expectations', github: 'rspec/rspec-expectations', ref: 'eb1787f0e1a5ec2c2650048ee60a45d4c9738d78'
+  gem "simplecov", "0.19.0", require: false # Test coverage generator. Go to /coverage/ after running tests
+  gem "cucumber-rails", "~> 2.0", require: false
+  gem "cucumber"
+  gem "database_cleaner"
+  gem "jasmine"
+  gem "jasmine-core", "2.99.2" # last release with Ruby 2.2 support.
+  gem "launchy"
+  gem "parallel_tests", "~> 3.0"
+  gem "rails-i18n" # Provides default i18n for many languages
+  gem "rspec-rails"
+  gem "rspec", github: "rspec/rspec", ref: "3e6c0fb9c9ec68eddd409cfe7b3eb077b390b302"
+  gem "rspec-core", github: "rspec/rspec-core", ref: "119282ec3dde5295b337322fc53301c32d0bf7ec"
+  gem "rspec-mocks", github: "rspec/rspec-mocks", ref: "1728885f65b25a9676c5ce54133ef8a1283e2e0d"
+  gem "rspec-support", github: "rspec/rspec-support", ref: "6553911974ee93855008f8ff41c26cea6652d74d"
+  gem "rspec-expectations", github: "rspec/rspec-expectations", ref: "eb1787f0e1a5ec2c2650048ee60a45d4c9738d78"
   gem "sqlite3", "~> 1.4", platform: :mri
 end
 
 group :release do
-  gem 'chandler', '0.9.0' # Github releases from changelog
-  gem 'octokit', '~> 4.18'
+  gem "chandler", "0.9.0" # Github releases from changelog
+  gem "octokit", "~> 4.18"
 end
 
 group :lint do
   # Code style
-  gem 'rubocop', '0.90.0'
-  gem 'rubocop-rspec', '~> 1.30'
-  gem 'rubocop-rails', '~> 2.3'
-  gem 'mdl', '0.11.0'
+  gem "rubocop", "0.90.0"
+  gem "rubocop-rspec", "~> 1.30"
+  gem "rubocop-rails", "~> 2.3"
+  gem "mdl", "0.11.0"
 
   # Translations
-  gem 'i18n-tasks'
-  gem 'i18n-spec'
+  gem "i18n-tasks"
+  gem "i18n-spec"
 end
 
 group :docs do
-  gem 'yard' # Documentation generator
-  gem 'kramdown' # Markdown implementation (for yard)
+  gem "yard" # Documentation generator
+  gem "kramdown" # Markdown implementation (for yard)
 end
 
 gemspec path: "."

--- a/Rakefile
+++ b/Rakefile
@@ -1,26 +1,26 @@
-require 'bundler/gem_tasks'
+require "bundler/gem_tasks"
 
-import 'tasks/gemfiles.rake'
-import 'tasks/local.rake'
-import 'tasks/test.rake'
+import "tasks/gemfiles.rake"
+import "tasks/local.rake"
+import "tasks/test.rake"
 
-gemfile = ENV['BUNDLE_GEMFILE']
+gemfile = ENV["BUNDLE_GEMFILE"]
 
-if gemfile.nil? || File.expand_path(gemfile) == File.expand_path('Gemfile')
-  import 'tasks/changelog.rake'
-  import 'tasks/docs.rake'
-  import 'tasks/lint.rake'
-  import 'tasks/release.rake'
+if gemfile.nil? || File.expand_path(gemfile) == File.expand_path("Gemfile")
+  import "tasks/changelog.rake"
+  import "tasks/docs.rake"
+  import "tasks/lint.rake"
+  import "tasks/release.rake"
 end
 
 task default: :test
 
-require 'jasmine'
-load 'jasmine/tasks/jasmine.rake'
+require "jasmine"
+load "jasmine/tasks/jasmine.rake"
 
 task :console do
-  require 'irb'
-  require 'irb/completion'
+  require "irb"
+  require "irb/completion"
 
   ARGV.clear
   IRB.start

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -1,32 +1,32 @@
 require File.join(__dir__, "lib", "active_admin", "version")
 
 Gem::Specification.new do |s|
-  s.name = 'activeadmin'
-  s.license = 'MIT'
+  s.name = "activeadmin"
+  s.license = "MIT"
   s.version = ActiveAdmin::VERSION
-  s.homepage = 'https://activeadmin.info'
-  s.authors = ['Charles Maresh', 'David Rodríguez', 'Greg Bell', 'Igor Fedoronchuk', 'Javier Julio', 'Piers C', 'Sean Linsley', 'Timo Schilling']
-  s.email = ['deivid.rodriguez@riseup.net']
-  s.description = 'The administration framework for Ruby on Rails.'
-  s.summary = 'Active Admin is a Ruby on Rails plugin for generating ' \
-    'administration style interfaces. It abstracts common business ' \
-    'application patterns to make it simple for developers to implement ' \
-    'beautiful and elegant interfaces with very little effort.'
+  s.homepage = "https://activeadmin.info"
+  s.authors = ["Charles Maresh", "David Rodríguez", "Greg Bell", "Igor Fedoronchuk", "Javier Julio", "Piers C", "Sean Linsley", "Timo Schilling"]
+  s.email = ["deivid.rodriguez@riseup.net"]
+  s.description = "The administration framework for Ruby on Rails."
+  s.summary = "Active Admin is a Ruby on Rails plugin for generating " \
+    "administration style interfaces. It abstracts common business " \
+    "application patterns to make it simple for developers to implement " \
+    "beautiful and elegant interfaces with very little effort."
 
   s.files = `git ls-files LICENSE app config/locales docs lib vendor -z`.split("\x0")
 
   s.extra_rdoc_files = %w[CHANGELOG.md CODE_OF_CONDUCT.md CONTRIBUTING.md README.md]
 
-  s.required_ruby_version = '>= 2.5'
+  s.required_ruby_version = ">= 2.5"
 
-  s.add_dependency 'arbre', '~> 1.2', '>= 1.2.1'
-  s.add_dependency 'formtastic', '>= 3.1', '< 5.0'
-  s.add_dependency 'formtastic_i18n', '~> 0.4'
-  s.add_dependency 'inherited_resources', '~> 1.7'
-  s.add_dependency 'jquery-rails', '~> 4.2'
-  s.add_dependency 'kaminari', '~> 1.0', '>= 1.2.1'
-  s.add_dependency 'railties', '>= 5.2', '< 6.1'
-  s.add_dependency 'ransack', '~> 2.1', '>= 2.1.1'
-  s.add_dependency 'sassc-rails', '~> 2.1'
-  s.add_dependency 'sprockets', '>= 3.0', '< 4.1'
+  s.add_dependency "arbre", "~> 1.2", ">= 1.2.1"
+  s.add_dependency "formtastic", ">= 3.1", "< 5.0"
+  s.add_dependency "formtastic_i18n", "~> 0.4"
+  s.add_dependency "inherited_resources", "~> 1.7"
+  s.add_dependency "jquery-rails", "~> 4.2"
+  s.add_dependency "kaminari", "~> 1.0", ">= 1.2.1"
+  s.add_dependency "railties", ">= 5.2", "< 6.1"
+  s.add_dependency "ransack", "~> 2.1", ">= 2.1.1"
+  s.add_dependency "sassc-rails", "~> 2.1"
+  s.add_dependency "sprockets", ">= 3.0", "< 4.1"
 end

--- a/bin/prepare_coverage
+++ b/bin/prepare_coverage
@@ -5,16 +5,16 @@
 # Temporary hack to get CodeClimate to work with SimpleCov 0.18 JSON format until issue is fixed
 # upstream: https://github.com/codeclimate/test-reporter/issues/413
 
-require 'json'
+require "json"
 
-filename = 'coverage/.resultset.json'
+filename = "coverage/.resultset.json"
 contents = JSON.parse(File.read(filename))
 
 def remove_lines_key(obj)
   case obj
   when Hash
     obj.transform_values do |val|
-      val.is_a?(Hash) && val.key?('lines') ? val['lines'] : remove_lines_key(val)
+      val.is_a?(Hash) && val.key?("lines") ? val["lines"] : remove_lines_key(val)
     end
   else
     obj

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,3 +1,3 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'github-pages'
+gem "github-pages"

--- a/features/step_definitions/action_item_steps.rb
+++ b/features/step_definitions/action_item_steps.rb
@@ -1,7 +1,7 @@
 Then /^I should see an action item link to "([^"]*)"$/ do |link|
-  expect(page).to have_css('.action_item a', text: link)
+  expect(page).to have_css(".action_item a", text: link)
 end
 
 Then /^I should not see an action item link to "([^"]*)"$/ do |link|
-  expect(page).to_not have_css('.action_item a', text: link)
+  expect(page).to_not have_css(".action_item a", text: link)
 end

--- a/features/step_definitions/action_link_steps.rb
+++ b/features/step_definitions/action_link_steps.rb
@@ -1,5 +1,5 @@
 Then /^I should see a member link to "([^"]*)"$/ do |name|
-  expect(page).to have_css('a.member_link', text: name)
+  expect(page).to have_css("a.member_link", text: name)
 end
 
 Then /^I should not see a member link to "([^"]*)"$/ do |name|
@@ -11,7 +11,7 @@ Then /^I should see the actions column with the class "([^"]*)" and the title "(
 end
 
 Then /^I should see a dropdown menu item to "([^"]*)"$/ do |name|
-  expect(page).to have_css('ul.dropdown_menu_list li a', text: name)
+  expect(page).to have_css("ul.dropdown_menu_list li a", text: name)
 end
 
 Then /^I should not see a dropdown menu item to "([^"]*)"$/ do |name|

--- a/features/step_definitions/additional_web_steps.rb
+++ b/features/step_definitions/additional_web_steps.rb
@@ -1,17 +1,17 @@
 Then /^I should see a table header with "([^"]*)"$/ do |content|
-  expect(page).to have_xpath '//th', text: content
+  expect(page).to have_xpath "//th", text: content
 end
 
 Then /^I should not see a table header with "([^"]*)"$/ do |content|
-  expect(page).to_not have_xpath '//th', text: content
+  expect(page).to_not have_xpath "//th", text: content
 end
 
 Then /^I should see a sortable table header with "([^"]*)"$/ do |content|
-  expect(page).to have_css 'th.sortable', text: content
+  expect(page).to have_css "th.sortable", text: content
 end
 
 Then /^I should not see a sortable table header with "([^"]*)"$/ do |content|
-  expect(page).to_not have_css 'th.sortable', text: content
+  expect(page).to_not have_css "th.sortable", text: content
 end
 
 Then /^I should not see a sortable table header$/ do
@@ -19,12 +19,12 @@ Then /^I should not see a sortable table header$/ do
 end
 
 Then /^the table "([^"]*)" should have (\d+) rows/ do |selector, count|
-  trs = page.find(selector).all :css, 'tr'
+  trs = page.find(selector).all :css, "tr"
   expect(trs.size).to eq count.to_i
 end
 
 Then /^the table "([^"]*)" should have (\d+) columns/ do |selector, count|
-  tds = page.find(selector).find('tr:first').all :css, 'td'
+  tds = page.find(selector).find("tr:first").all :css, "td"
   expect(tds.size).to eq count.to_i
 end
 
@@ -33,7 +33,7 @@ Then /^there should be (\d+) "([^"]*)" tags$/ do |count, tag|
 end
 
 Then /^I should see a link to "([^"]*)"$/ do |link|
-  expect(page).to have_xpath '//a', text: link
+  expect(page).to have_xpath "//a", text: link
 end
 
 Then /^an "([^"]*)" exception should be raised when I follow "([^"]*)"$/ do |error, link|
@@ -43,30 +43,30 @@ Then /^an "([^"]*)" exception should be raised when I follow "([^"]*)"$/ do |err
 end
 
 Then /^I should be in the resource section for (.+)$/ do |resource_name|
-  expect(current_url).to include resource_name.tr(' ', '').underscore.pluralize
+  expect(current_url).to include resource_name.tr(" ", "").underscore.pluralize
 end
 
 Then /^I should see the page title "([^"]*)"$/ do |title|
-  within('h2#page_title') do
+  within("h2#page_title") do
     expect(page).to have_content title
   end
 end
 
 Then /^I should see a fieldset titled "([^"]*)"$/ do |title|
-  expect(page).to have_css 'fieldset legend', text: title
+  expect(page).to have_css "fieldset legend", text: title
 end
 
 Then /^the "([^"]*)" field should contain the option "([^"]*)"$/ do |field, option|
   field = find_field(field)
-  expect(field).to have_css 'option', text: option
+  expect(field).to have_css "option", text: option
 end
 
 Then /^I should see the content "([^"]*)"$/ do |content|
-  expect(page).to have_css '#active_admin_content', text: content
+  expect(page).to have_css "#active_admin_content", text: content
 end
 
 Then /^I should see a validation error "([^"]*)"$/ do |error_message|
-  expect(page).to have_css '.inline-errors', text: error_message
+  expect(page).to have_css ".inline-errors", text: error_message
 end
 
 Then /^I should see a table with id "([^"]*)"$/ do |dom_id|

--- a/features/step_definitions/attribute_steps.rb
+++ b/features/step_definitions/attribute_steps.rb
@@ -9,5 +9,5 @@ Then /^I should see the attribute "([^"]*)" with a nicely formatted datetime$/ d
 end
 
 Then /^I should not see the attribute "([^"]*)"$/ do |title|
-  expect(page).to_not have_css '.attributes_table th', text: title
+  expect(page).to_not have_css ".attributes_table th", text: title
 end

--- a/features/step_definitions/attributes_table_title_steps.rb
+++ b/features/step_definitions/attributes_table_title_steps.rb
@@ -1,11 +1,11 @@
 Then /^I should see the panel title "([^"]*)"$/ do |title|
-  expect(page).to have_css '.panel > h3', text: title
+  expect(page).to have_css ".panel > h3", text: title
 end
 
 Then /^I should not see the panel title "([^"]*)"$/ do |title|
-  expect(page).to_not have_css '.panel > h3', text: title
+  expect(page).to_not have_css ".panel > h3", text: title
 end
 
 Then /^I should see the attributes table$/ do
-  expect(page).to have_css '.panel .attributes_table'
+  expect(page).to have_css ".panel .attributes_table"
 end

--- a/features/step_definitions/batch_action_steps.rb
+++ b/features/step_definitions/batch_action_steps.rb
@@ -1,13 +1,13 @@
 Then /^I (should|should not) see the batch action :([^\s]*) "([^"]*)"$/ do |maybe, sym, title|
   selector = ".batch_actions_selector a.batch_action"
-  selector << "[href='#'][data-action='#{sym}']" if maybe == 'should'
+  selector << "[href='#'][data-action='#{sym}']" if maybe == "should"
 
-  verb = maybe == 'should' ? :to : :to_not
+  verb = maybe == "should" ? :to : :to_not
   expect(page).send verb, have_css(selector, text: title)
 end
 
 Then /^the (\d+)(?:st|nd|rd|th) batch action should be "([^"]*)"$/ do |index, title|
-  batch_action = page.all('.batch_actions_selector a.batch_action')[index.to_i - 1]
+  batch_action = page.all(".batch_actions_selector a.batch_action")[index.to_i - 1]
   expect(batch_action.text).to match title
 end
 
@@ -21,29 +21,29 @@ end
 
 Then /^I (should|should not) see the batch action (button|selector)$/ do |maybe, type|
   selector = "div.table_tools .batch_actions_selector"
-  selector << ' .dropdown_menu_button' if maybe == 'should' && type == 'button'
+  selector << " .dropdown_menu_button" if maybe == "should" && type == "button"
 
-  verb = maybe == 'should' ? :to : :to_not
+  verb = maybe == "should" ? :to : :to_not
   expect(page).send verb, have_css(selector)
 end
 
 Then /^I should see the batch action popover$/ do
-  expect(page).to have_css '.batch_actions_selector'
+  expect(page).to have_css ".batch_actions_selector"
 end
 
 Given /^I submit the batch action form with "([^"]*)"$/ do |action|
   page.find("#batch_action", visible: false).set action
   form = page.find "#collection_selection"
   params = page.all("#main_content input", visible: false).each_with_object({}) do |input, obj|
-    key = input['name']
-    value = input['value']
-    if key == 'collection_selection[]'
+    key = input["name"]
+    value = input["value"]
+    if key == "collection_selection[]"
       (obj[key] ||= []).push value if input.checked?
     else
       obj[key] = value
     end
   end
-  page.driver.submit form['method'], form['action'], params
+  page.driver.submit form["method"], form["action"], params
 end
 
 When /^I click "(.*?)" and accept confirmation$/ do |link|
@@ -53,5 +53,5 @@ When /^I click "(.*?)" and accept confirmation$/ do |link|
 end
 
 Then /^I should not see checkboxes in the table$/ do
-  expect(page).to_not have_css '.paginated_collection table input[type=checkbox]'
+  expect(page).to_not have_css ".paginated_collection table input[type=checkbox]"
 end

--- a/features/step_definitions/blog_steps.rb
+++ b/features/step_definitions/blog_steps.rb
@@ -1,3 +1,3 @@
 Then /^I should see a blog header "([^"]*)"$/ do |header_text|
-  expect(page).to have_css 'h3', text: header_text
+  expect(page).to have_css "h3", text: header_text
 end

--- a/features/step_definitions/breadcrumb_steps.rb
+++ b/features/step_definitions/breadcrumb_steps.rb
@@ -1,4 +1,4 @@
-Around '@breadcrumb' do |scenario, block|
+Around "@breadcrumb" do |scenario, block|
   previous_breadcrumb = ActiveAdmin.application.breadcrumb
 
   begin
@@ -9,5 +9,5 @@ Around '@breadcrumb' do |scenario, block|
 end
 
 Then /^I should see a link to "([^"]*)" in the breadcrumb$/ do |text|
-  expect(page).to have_css '.breadcrumb > a', text: text
+  expect(page).to have_css ".breadcrumb > a", text: text
 end

--- a/features/step_definitions/column_steps.rb
+++ b/features/step_definitions/column_steps.rb
@@ -1,8 +1,8 @@
 Then /^I should see a columns container$/ do
-  expect(page).to have_css '.columns'
+  expect(page).to have_css ".columns"
 end
 
 Then /^I should see (a|\d+) columns?$/ do |count|
-  count = count == 'a' ? 1 : count.to_i
-  expect(page).to have_css '.column', count: count
+  count = count == "a" ? 1 : count.to_i
+  expect(page).to have_css ".column", count: count
 end

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -13,13 +13,13 @@ When /^I add a comment "([^"]*)"$/ do |comment|
 end
 
 Given /^(a|\d+) comments added by admin with an email "([^"]+)"?$/ do |number, email|
-  number = number == 'a' ? 1 : number.to_i
+  number = number == "a" ? 1 : number.to_i
   admin_user = ensure_user_created(email)
 
-  comment_text = 'Comment %i'
+  comment_text = "Comment %i"
 
   number.times do |i|
-    ActiveAdmin::Comment.create!(namespace: 'admin',
+    ActiveAdmin::Comment.create!(namespace: "admin",
                                  body: comment_text % i,
                                  resource_type: Post.to_s,
                                  resource_id: Post.first.id,
@@ -29,5 +29,5 @@ Given /^(a|\d+) comments added by admin with an email "([^"]+)"?$/ do |number, e
 end
 
 Then /^I should see (\d+) comments?$/ do |number|
-  expect(page).to have_selector('div.active_admin_comment', count: number.to_i)
+  expect(page).to have_selector("div.active_admin_comment", count: number.to_i)
 end

--- a/features/step_definitions/configuration_steps.rb
+++ b/features/step_definitions/configuration_steps.rb
@@ -14,26 +14,26 @@ Given /^a(?:n? (index|show))? configuration of:$/ do |action, config_content|
   load_aa_config(config_content)
 
   case action
-  when 'index'
-    step 'I am logged in'
+  when "index"
+    step "I am logged in"
     case resource = config_content.match(/ActiveAdmin\.register (\w+)/)[1]
-    when 'Post'
-      step 'I am on the index page for posts'
-    when 'Category'
-      step 'I am on the index page for categories'
+    when "Post"
+      step "I am on the index page for posts"
+    when "Category"
+      step "I am on the index page for categories"
     else
       # :nocov:
       raise "#{resource} is not supported"
       # :nocov:
     end
-  when 'show'
+  when "show"
     case resource = config_content.match(/ActiveAdmin\.register (\w+)/)[1]
-    when 'Post'
-      step 'I am logged in'
-      step 'I am on the index page for posts'
+    when "Post"
+      step "I am logged in"
+      step "I am on the index page for posts"
       step 'I follow "View"'
-    when 'Tag'
-      step 'I am logged in'
+    when "Tag"
+      step "I am logged in"
       Tag.create!
       visit admin_tag_path Tag.last
     else

--- a/features/step_definitions/factory_steps.rb
+++ b/features/step_definitions/factory_steps.rb
@@ -1,10 +1,10 @@
-def create_user(name, type = 'User')
-  first_name, last_name = name.split(' ')
-  user = type.camelize.constantize.where(first_name: first_name, last_name: last_name).first_or_create(username: name.tr(' ', '').underscore)
+def create_user(name, type = "User")
+  first_name, last_name = name.split(" ")
+  user = type.camelize.constantize.where(first_name: first_name, last_name: last_name).first_or_create(username: name.tr(" ", "").underscore)
 end
 
 Given /^(a|\d+)( published)?( unstarred|starred)? posts?(?: with the title "([^"]*)")?(?: and body "([^"]*)")?(?: written by "([^"]*)")?(?: in category "([^"]*)")? exists?$/ do |count, published, starred, title, body, user, category_name|
-  count = count == 'a' ? 1 : count.to_i
+  count = count == "a" ? 1 : count.to_i
   published = Time.now if published
   starred = starred == " starred" if starred
   author = create_user(user) if user
@@ -28,8 +28,8 @@ Given /^a store named "([^"]*)" exists$/ do |name|
 end
 
 Given /^I create a new post with the title "([^"]*)"$/ do |title|
-  first(:link, 'Posts').click
+  first(:link, "Posts").click
   click_link "New Post"
-  fill_in 'post_title', with: title
+  fill_in "post_title", with: title
   click_button "Create Post"
 end

--- a/features/step_definitions/filesystem_steps.rb
+++ b/features/step_definitions/filesystem_steps.rb
@@ -20,14 +20,14 @@ module ActiveAdminContentsRollback
   # Else, remove the file and its parent folder structure until Rails.root OR other files exist.
   def rollback_file(file, contents)
     if contents.present?
-      File.open(file, 'w') { |f| f << contents }
+      File.open(file, "w") { |f| f << contents }
     else
       File.delete(file)
       begin
         dir = File.dirname(file)
         until dir == Rails.root
           Dir.rmdir(dir) # delete current folder
-          dir = dir.split('/')[0..-2].join('/') # select parent folder
+          dir = dir.split("/")[0..-2].join("/") # select parent folder
         end
       rescue Errno::ENOTEMPTY # Directory not empty
       end
@@ -37,7 +37,7 @@ end
 
 World(ActiveAdminContentsRollback)
 
-After '@changes-filesystem' do
+After "@changes-filesystem" do
   rollback!
 end
 
@@ -46,7 +46,7 @@ Given /^"([^"]*)" contains:$/ do |filename, contents|
   FileUtils.mkdir_p File.dirname path
   record path
 
-  File.open(path, 'w+') { |f| f << contents }
+  File.open(path, "w+") { |f| f << contents }
 end
 
 Given /^I add "([^"]*)" to the "([^"]*)" model$/ do |code, model_name|
@@ -54,6 +54,6 @@ Given /^I add "([^"]*)" to the "([^"]*)" model$/ do |code, model_name|
   record path
 
   str = File.read(path).gsub /^(class .+)$/, "\\1\n  #{code}\n"
-  File.open(path, 'w+') { |f| f << str }
+  File.open(path, "w+") { |f| f << str }
   ActiveSupport::Dependencies.clear
 end

--- a/features/step_definitions/filter_steps.rb
+++ b/features/step_definitions/filter_steps.rb
@@ -1,4 +1,4 @@
-Around '@filters' do |scenario, block|
+Around "@filters" do |scenario, block|
   previous_current_filters = ActiveAdmin.application.current_filters
 
   begin
@@ -9,15 +9,15 @@ Around '@filters' do |scenario, block|
 end
 
 Then /^I should see a select filter for "([^"]*)"$/ do |label|
-  expect(page).to have_css '.filter_select label', text: label
+  expect(page).to have_css ".filter_select label", text: label
 end
 
 Then /^I should see a string filter for "([^"]*)"$/ do |label|
-  expect(page).to have_css '.filter_string label', text: label
+  expect(page).to have_css ".filter_string label", text: label
 end
 
 Then /^I should see a date range filter for "([^"]*)"$/ do |label|
-  expect(page).to have_css '.filter_date_range label', text: label
+  expect(page).to have_css ".filter_date_range label", text: label
 end
 
 Then /^I should see the following filters:$/ do |table|
@@ -28,8 +28,8 @@ end
 
 Given(/^I add parameter "([^"]*)" with value "([^"]*)" to the URL$/) do |key, value|
   url = page.current_url
-  separator = url.include?('?') ? '&' : '?'
-  visit url + separator + key.to_s + '=' + value.to_s
+  separator = url.include?("?") ? "&" : "?"
+  visit url + separator + key.to_s + "=" + value.to_s
 end
 
 Then(/^I should have parameter "([^"]*)" with value "([^"]*)"$/) do |key, value|

--- a/features/step_definitions/flash_steps.rb
+++ b/features/step_definitions/flash_steps.rb
@@ -3,9 +3,9 @@ Then /^I should see a flash with "([^"]*)"$/ do |text|
 end
 
 Then /^I should see a successful create flash$/ do
-  expect(page).to have_css 'div.flash_notice', text: /was successfully created/
+  expect(page).to have_css "div.flash_notice", text: /was successfully created/
 end
 
 Then /^I should not see a successful create flash$/ do
-  expect(page).to_not have_css 'div.flash_notice', text: /was successfully created/
+  expect(page).to_not have_css "div.flash_notice", text: /was successfully created/
 end

--- a/features/step_definitions/footer_steps.rb
+++ b/features/step_definitions/footer_steps.rb
@@ -1,4 +1,4 @@
-Around '@footer' do |scenario, block|
+Around "@footer" do |scenario, block|
   previous_footer = ActiveAdmin.application.footer
 
   begin
@@ -9,9 +9,9 @@ Around '@footer' do |scenario, block|
 end
 
 Then /^I should see the default footer$/ do
-  expect(page).to have_css '#footer', text: "Powered by Active Admin #{ActiveAdmin::VERSION}"
+  expect(page).to have_css "#footer", text: "Powered by Active Admin #{ActiveAdmin::VERSION}"
 end
 
 Then /^I should see the footer "([^"]*)"$/ do |footer|
-  expect(page).to have_css '#footer', text: footer
+  expect(page).to have_css "#footer", text: footer
 end

--- a/features/step_definitions/format_steps.rb
+++ b/features/step_definitions/format_steps.rb
@@ -1,6 +1,6 @@
-require 'csv'
+require "csv"
 
-Around '@csv' do |scenario, block|
+Around "@csv" do |scenario, block|
   default_csv_options = ActiveAdmin.application.csv_options
 
   begin
@@ -25,7 +25,7 @@ Then /^I should download a CSV file with "([^"]*)" separator for "([^"]*)" conta
   content_type_header, content_disposition_header = %w[Content-Type Content-Disposition].map do |header_name|
     page.response_headers[header_name]
   end
-  expect(content_type_header).to eq 'text/csv; charset=utf-8'
+  expect(content_type_header).to eq "text/csv; charset=utf-8"
   expect(content_disposition_header).to match /\Aattachment; filename=".+?\.csv"\z/
 
   csv = CSV.parse(body, col_sep: sep)
@@ -35,7 +35,7 @@ Then /^I should download a CSV file with "([^"]*)" separator for "([^"]*)" conta
       if expected_cell.blank?
         expect(cell).to eq nil
       else
-        expect(cell || '').to match /#{expected_cell}/
+        expect(cell || "").to match /#{expected_cell}/
       end
     end
   end

--- a/features/step_definitions/head_steps.rb
+++ b/features/step_definitions/head_steps.rb
@@ -1,4 +1,4 @@
-Around '@head' do |scenario, block|
+Around "@head" do |scenario, block|
   previous_head = ActiveAdmin.application.head
 
   begin

--- a/features/step_definitions/i18n_steps.rb
+++ b/features/step_definitions/i18n_steps.rb
@@ -1,5 +1,5 @@
 Given /^String "([^"]*)" corresponds to "([^"]*)"$/ do |translation, key|
-  *seq, last_key = key.split('.')
+  *seq, last_key = key.split(".")
   result = seq.reverse.inject({ last_key.to_sym => translation }) do |temp_result, nested_key|
     { nested_key.to_sym => temp_result }
   end

--- a/features/step_definitions/index_scope_steps.rb
+++ b/features/step_definitions/index_scope_steps.rb
@@ -6,11 +6,11 @@ end
 
 Then /^I should see the scope "([^"]*)" not selected$/ do |name|
   step %{I should see the scope "#{name}"}
-  expect(page).to_not have_css '.scopes .selected', text: name
+  expect(page).to_not have_css ".scopes .selected", text: name
 end
 
 Then /^I should see the scope "([^"]*)" with the count (\d+)$/ do |name, count|
-  name = name.tr(' ', '').underscore.downcase
+  name = name.tr(" ", "").underscore.downcase
   step %{I should see "#{count}" within ".scopes .#{name} .count"}
 end
 
@@ -19,7 +19,7 @@ Then /^I should see the scope with label "([^"]*)"$/ do |label|
 end
 
 Then /^I should see the current scope with label "([^"]*)"$/ do |label|
-  expect(page).to have_css '.current_scope_name', text: label
+  expect(page).to have_css ".current_scope_name", text: label
 end
 
 Then /^I should see the scope "([^"]*)" with no count$/ do |name|

--- a/features/step_definitions/layout_steps.rb
+++ b/features/step_definitions/layout_steps.rb
@@ -1,3 +1,3 @@
 Then /^I should see the Active Admin layout$/ do
-  expect(page).to have_css '#active_admin_content #main_content_wrapper'
+  expect(page).to have_css "#active_admin_content #main_content_wrapper"
 end

--- a/features/step_definitions/member_link_steps.rb
+++ b/features/step_definitions/member_link_steps.rb
@@ -1,7 +1,7 @@
 Then /^I should see an action item button "([^"]*)"$/ do |content|
-  expect(page).to have_css '.action_items a', text: content
+  expect(page).to have_css ".action_items a", text: content
 end
 
 Then /^I should not see an action item button "([^"]*)"$/ do |content|
-  expect(page).to_not have_css '.action_items', text: content
+  expect(page).to_not have_css ".action_items", text: content
 end

--- a/features/step_definitions/menu_steps.rb
+++ b/features/step_definitions/menu_steps.rb
@@ -1,11 +1,11 @@
 Then /^I should see a menu item for "([^"]*)"$/ do |name|
-  expect(page).to have_css '#tabs > li > a', text: name
+  expect(page).to have_css "#tabs > li > a", text: name
 end
 
 Then /^I should not see a menu item for "([^"]*)"$/ do |name|
-  expect(page).to_not have_css '#tabs > li > a', text: name
+  expect(page).to_not have_css "#tabs > li > a", text: name
 end
 
 Then /^I should see a nested menu item for "([^"]*)"$/ do |name|
-  expect(page).to have_css '#tabs > li > ul > li > a', text: name
+  expect(page).to have_css "#tabs > li > ul > li > a", text: name
 end

--- a/features/step_definitions/pagination_steps.rb
+++ b/features/step_definitions/pagination_steps.rb
@@ -1,9 +1,9 @@
 Then /^I should not see pagination$/ do
-  expect(page).to_not have_css '.pagination'
+  expect(page).to_not have_css ".pagination"
 end
 
 Then /^I should see pagination with (\d+) pages$/ do |count|
-  expect(page).to have_css '.pagination span.page', count: count
+  expect(page).to have_css ".pagination span.page", count: count
 end
 
 Then /^I should see the pagination "Next" link/ do

--- a/features/step_definitions/root_steps.rb
+++ b/features/step_definitions/root_steps.rb
@@ -1,4 +1,4 @@
-Around '@root' do |scenario, block|
+Around "@root" do |scenario, block|
   previous_root = ActiveAdmin.application.root_to
 
   begin

--- a/features/step_definitions/sidebar_steps.rb
+++ b/features/step_definitions/sidebar_steps.rb
@@ -1,9 +1,9 @@
 Then /^I should see a sidebar titled "([^"]*)"$/ do |title|
-  expect(page).to have_css '.sidebar_section h3', text: title
+  expect(page).to have_css ".sidebar_section h3", text: title
 end
 
 Then /^I should not see a sidebar titled "([^"]*)"$/ do |title|
-  expect(page).not_to have_css '.sidebar_section h3', text: title
+  expect(page).not_to have_css ".sidebar_section h3", text: title
 end
 
 Then(/^I should see a sidebar titled "(.*?)" above sidebar titled "(.*?)"$/) do |top_title, bottom_title|

--- a/features/step_definitions/site_title_steps.rb
+++ b/features/step_definitions/site_title_steps.rb
@@ -1,4 +1,4 @@
-Around '@site_title' do |scenario, block|
+Around "@site_title" do |scenario, block|
   previous_site_title = ActiveAdmin.application.site_title
   previous_site_title_link = ActiveAdmin.application.site_title_link
   previous_site_title_image = ActiveAdmin.application.site_title_image
@@ -13,19 +13,19 @@ Around '@site_title' do |scenario, block|
 end
 
 Then /^I should see the site title "([^"]*)"$/ do |title|
-  expect(page).to have_css 'h1#site_title', text: title
+  expect(page).to have_css "h1#site_title", text: title
 end
 
 Then /^I should not see the site title "([^"]*)"$/ do |title|
-  expect(page).to_not have_css 'h1#site_title', text: title
+  expect(page).to_not have_css "h1#site_title", text: title
 end
 
 Then /^I should see the site title image "([^"]*)"$/ do |image|
-  img = page.find('h1#site_title img')
+  img = page.find("h1#site_title img")
   expect(img[:src]).to eq(image)
 end
 
 Then /^I should see the site title image linked to "([^"]*)"$/ do |url|
-  link = page.find('h1#site_title a')
+  link = page.find("h1#site_title a")
   expect(link[:href]).to eq(url)
 end

--- a/features/step_definitions/table_steps.rb
+++ b/features/step_definitions/table_steps.rb
@@ -13,7 +13,7 @@ class HtmlTableToTextHelper
   def to_array
     rows = Nokogiri::HTML(@html).css("#{@selector} tr")
     rows.map do |row|
-      row.css('th, td').map do |td|
+      row.css("th, td").map do |td|
         cell_to_string(td)
       end
     end
@@ -23,13 +23,13 @@ class HtmlTableToTextHelper
 
   def cell_to_string(td)
     str = ""
-    input = td.css('input').last
+    input = td.css("input").last
 
     if input
       str << input_to_string(input)
     end
 
-    str << td.content.strip.gsub("\n", ' ')
+    str << td.content.strip.gsub("\n", " ")
   end
 
   def input_to_string(input)

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -1,24 +1,24 @@
 def ensure_user_created(email)
-  AdminUser.create_with(password: 'password', password_confirmation: 'password').find_or_create_by!(email: email)
+  AdminUser.create_with(password: "password", password_confirmation: "password").find_or_create_by!(email: email)
 end
 
 Given /^(?:I am logged|log) out$/ do
-  click_link 'Logout' if page.all(:css, "a", text: 'Logout').any?
+  click_link "Logout" if page.all(:css, "a", text: "Logout").any?
 end
 
 Given /^I am logged in$/ do
-  step 'log out'
-  login_as ensure_user_created 'admin@example.com'
+  step "log out"
+  login_as ensure_user_created "admin@example.com"
 end
 
 Given /^I am logged in with capybara$/ do
-  ensure_user_created 'admin@example.com'
-  step 'log out'
+  ensure_user_created "admin@example.com"
+  step "log out"
 
   visit new_admin_user_session_path
-  fill_in 'Email', with: 'admin@example.com'
-  fill_in 'Password', with: 'password'
-  click_button 'Login'
+  fill_in "Email", with: "admin@example.com"
+  fill_in "Password", with: "password"
+  click_button "Login"
 end
 
 Given /^an admin user "([^"]*)" exists$/ do |email|
@@ -27,7 +27,7 @@ end
 
 Given /^"([^"]*)" requests a password reset with token "([^"]*)"( but it expires)?$/ do |email, token, expired|
   visit new_admin_user_password_path
-  fill_in 'Email', with: email
+  fill_in "Email", with: email
   allow(Devise).to receive(:friendly_token).and_return(token)
   click_button "Reset My Password"
 
@@ -35,12 +35,12 @@ Given /^"([^"]*)" requests a password reset with token "([^"]*)"( but it expires
 end
 
 Given /^override locale "([^"]*)" with "([^"]*)"$/ do |path, value|
-  keys_value = path.split('.') + [value]
+  keys_value = path.split(".") + [value]
   locale_hash = keys_value.reverse.inject { |a, n| { n => a } }
   I18n.available_locales
   I18n.backend.store_translations(I18n.locale, locale_hash)
 end
 
 When /^I fill in the password field with "([^"]*)"$/ do |password|
-  fill_in 'admin_user_password', with: password
+  fill_in "admin_user_password", with: password
 end

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -1,4 +1,4 @@
-require 'uri'
+require "uri"
 require File.expand_path(File.join(__dir__, "..", "support", "paths"))
 
 module WithinHelpers
@@ -84,7 +84,7 @@ Then /^I should( not)? see( the element)? "([^"]*)"$/ do |negate, is_css, text|
 end
 
 Then /^I should see the select "([^"]*)" with options "([^"]+)"?$/ do |label, with_options|
-  expect(page).to have_select(label, with_options: with_options.split(', '))
+  expect(page).to have_select(label, with_options: with_options.split(", "))
 end
 
 Then /^I should see the field "([^"]*)" of type "([^"]+)"?$/ do |label, of_type|
@@ -94,7 +94,7 @@ end
 Then /^the "([^"]*)" field(?: within (.*))? should contain "([^"]*)"$/ do |field, parent, value|
   with_scope(parent) do
     field = find_field(field)
-    value = field.tag_name == 'textarea' ? field.text : field.value
+    value = field.tag_name == "textarea" ? field.text : field.value
 
     expect(value).to match(/#{value}/)
   end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,6 +1,6 @@
-ENV['RAILS_ENV'] = 'test'
+ENV["RAILS_ENV"] = "test"
 
-require 'simplecov' if ENV["COVERAGE"] == "true"
+require "simplecov" if ENV["COVERAGE"] == "true"
 
 Dir["#{File.expand_path('../step_definitions', __dir__)}/*.rb"].each do |f|
   require f
@@ -10,12 +10,12 @@ require_relative "../../tasks/test_application"
 
 require "#{ActiveAdmin::TestApplication.new.full_app_dir}/config/environment.rb"
 
-require_relative 'rails'
+require_relative "rails"
 
-require 'rspec/mocks'
+require "rspec/mocks"
 World(RSpec::Mocks::ExampleMethods)
 
-Around '@mocks' do |scenario, block|
+Around "@mocks" do |scenario, block|
   RSpec::Mocks.setup
 
   block.call
@@ -27,13 +27,13 @@ Around '@mocks' do |scenario, block|
   end
 end
 
-After '@debug' do |scenario|
+After "@debug" do |scenario|
   # :nocov:
   save_and_open_page if scenario.failed?
   # :nocov:
 end
 
-require 'capybara/dsl'
+require "capybara/dsl"
 
 World(Capybara::DSL)
 
@@ -45,7 +45,7 @@ Before do
   Capybara.use_default_driver
 end
 
-Before '@javascript' do
+Before "@javascript" do
   Capybara.current_driver = Capybara.javascript_driver
 end
 
@@ -54,7 +54,7 @@ Capybara.javascript_driver = :apparition
 
 Capybara.server = :webrick
 
-Capybara.asset_host = 'http://localhost:3000'
+Capybara.asset_host = "http://localhost:3000"
 
 # Capybara defaults to XPath selectors rather than Webrat's default of CSS3. In
 # order to ease the transition to Capybara we set the default here. If you'd
@@ -87,13 +87,13 @@ end
 # Force deprecations to raise an exception.
 ActiveSupport::Deprecation.behavior = :raise
 
-After '@authorization' do |scenario, block|
+After "@authorization" do |scenario, block|
   # Reset back to the default auth adapter
   ActiveAdmin.application.namespace(:admin).
     authorization_adapter = ActiveAdmin::AuthorizationAdapter
 end
 
-Around '@silent_unpermitted_params_failure' do |scenario, block|
+Around "@silent_unpermitted_params_failure" do |scenario, block|
   original = ActionController::Parameters.action_on_unpermitted_parameters
 
   begin
@@ -104,6 +104,6 @@ Around '@silent_unpermitted_params_failure' do |scenario, block|
   end
 end
 
-Around '@locale_manipulation' do |scenario, block|
+Around "@locale_manipulation" do |scenario, block|
   I18n.with_locale(:en, &block)
 end

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -57,7 +57,7 @@ module NavigationHelpers
       begin
         page_name =~ /the (.*) page/
         path_components = $1.split(/\s+/)
-        self.send path_components.push('path').join('_')
+        self.send path_components.push("path").join("_")
         # :nocov:
       rescue Object => e
         raise "Can't find mapping from \"#{page_name}\" to a path.\n" +

--- a/features/support/rails.rb
+++ b/features/support/rails.rb
@@ -1,8 +1,8 @@
-require 'cucumber/rails/application'
-require 'cucumber/rails/action_dispatch'
-require 'cucumber/rails/world'
-require 'cucumber/rails/hooks'
-require 'cucumber/rails/capybara'
-require 'cucumber/rails/database'
+require "cucumber/rails/application"
+require "cucumber/rails/action_dispatch"
+require "cucumber/rails/world"
+require "cucumber/rails/hooks"
+require "cucumber/rails/capybara"
+require "cucumber/rails/database"
 
 MultiTest.disable_autorun

--- a/features/support/simplecov_changes_env.rb
+++ b/features/support/simplecov_changes_env.rb
@@ -1,7 +1,7 @@
 if ENV["COVERAGE"] == "true"
-  require 'simplecov'
+  require "simplecov"
 
   SimpleCov.command_name "filesystem changes features"
 end
 
-require_relative 'env'
+require_relative "env"

--- a/features/support/simplecov_regular_env.rb
+++ b/features/support/simplecov_regular_env.rb
@@ -1,7 +1,7 @@
 if ENV["COVERAGE"] == "true"
-  require 'simplecov'
+  require "simplecov"
 
-  SimpleCov.command_name ["regular features", ENV['TEST_ENV_NUMBER']].join(" ").rstrip
+  SimpleCov.command_name ["regular features", ENV["TEST_ENV_NUMBER"]].join(" ").rstrip
 end
 
-require_relative 'env'
+require_relative "env"

--- a/features/support/simplecov_reload_env.rb
+++ b/features/support/simplecov_reload_env.rb
@@ -1,7 +1,7 @@
 if ENV["COVERAGE"] == "true"
-  require 'simplecov'
+  require "simplecov"
 
   SimpleCov.command_name "reload features"
 end
 
-require_relative 'env'
+require_relative "env"

--- a/gemfiles/rails_52/Gemfile
+++ b/gemfiles/rails_52/Gemfile
@@ -1,15 +1,15 @@
 source "https://rubygems.org"
 
 group :development, :test do
-  gem 'rake'
-  gem 'pry' # Easily debug from your console with `binding.pry`
-  gem 'pry-byebug', platform: :mri # Step-by-step debugging
+  gem "rake"
+  gem "pry" # Easily debug from your console with `binding.pry`
+  gem "pry-byebug", platform: :mri # Step-by-step debugging
 
-  gem 'cancancan'
-  gem 'pundit'
-  gem 'jruby-openssl', '~> 0.10.1', platform: :jruby
+  gem "cancancan"
+  gem "pundit"
+  gem "jruby-openssl", "~> 0.10.1", platform: :jruby
 
-  gem 'draper', '~> 4.0'
+  gem "draper", "~> 4.0"
   gem "devise"
 
   gem "rails", "~> 5.2.3"
@@ -22,25 +22,25 @@ group :development, :test do
 end
 
 group :test do
-  gem 'apparition'
-  gem 'capybara', '~> 3.14'
-  gem 'db-query-matchers', '0.10.0'
+  gem "apparition"
+  gem "capybara", "~> 3.14"
+  gem "db-query-matchers", "0.10.0"
 
-  gem 'simplecov', '0.19.0', require: false # Test coverage generator. Go to /coverage/ after running tests
-  gem 'cucumber-rails', '~> 2.0', require: false
-  gem 'cucumber'
-  gem 'database_cleaner'
-  gem 'jasmine'
-  gem 'jasmine-core', '2.99.2' # last release with Ruby 2.2 support.
-  gem 'launchy'
-  gem 'parallel_tests', '~> 3.0'
-  gem 'rails-i18n' # Provides default i18n for many languages
-  gem 'rspec-rails'
-  gem 'rspec', github: 'rspec/rspec', ref: '3e6c0fb9c9ec68eddd409cfe7b3eb077b390b302'
-  gem 'rspec-core', github: 'rspec/rspec-core', ref: '119282ec3dde5295b337322fc53301c32d0bf7ec'
-  gem 'rspec-mocks', github: 'rspec/rspec-mocks', ref: '1728885f65b25a9676c5ce54133ef8a1283e2e0d'
-  gem 'rspec-support', github: 'rspec/rspec-support', ref: '6553911974ee93855008f8ff41c26cea6652d74d'
-  gem 'rspec-expectations', github: 'rspec/rspec-expectations', ref: 'eb1787f0e1a5ec2c2650048ee60a45d4c9738d78'
+  gem "simplecov", "0.19.0", require: false # Test coverage generator. Go to /coverage/ after running tests
+  gem "cucumber-rails", "~> 2.0", require: false
+  gem "cucumber"
+  gem "database_cleaner"
+  gem "jasmine"
+  gem "jasmine-core", "2.99.2" # last release with Ruby 2.2 support.
+  gem "launchy"
+  gem "parallel_tests", "~> 3.0"
+  gem "rails-i18n" # Provides default i18n for many languages
+  gem "rspec-rails"
+  gem "rspec", github: "rspec/rspec", ref: "3e6c0fb9c9ec68eddd409cfe7b3eb077b390b302"
+  gem "rspec-core", github: "rspec/rspec-core", ref: "119282ec3dde5295b337322fc53301c32d0bf7ec"
+  gem "rspec-mocks", github: "rspec/rspec-mocks", ref: "1728885f65b25a9676c5ce54133ef8a1283e2e0d"
+  gem "rspec-support", github: "rspec/rspec-support", ref: "6553911974ee93855008f8ff41c26cea6652d74d"
+  gem "rspec-expectations", github: "rspec/rspec-expectations", ref: "eb1787f0e1a5ec2c2650048ee60a45d4c9738d78"
   gem "sqlite3", "~> 1.4", platform: :mri
 end
 

--- a/gemfiles/rails_60_turbolinks/Gemfile
+++ b/gemfiles/rails_60_turbolinks/Gemfile
@@ -1,15 +1,15 @@
 source "https://rubygems.org"
 
 group :development, :test do
-  gem 'rake'
-  gem 'pry' # Easily debug from your console with `binding.pry`
-  gem 'pry-byebug', platform: :mri # Step-by-step debugging
+  gem "rake"
+  gem "pry" # Easily debug from your console with `binding.pry`
+  gem "pry-byebug", platform: :mri # Step-by-step debugging
 
-  gem 'cancancan'
-  gem 'pundit'
-  gem 'jruby-openssl', '~> 0.10.1', platform: :jruby
+  gem "cancancan"
+  gem "pundit"
+  gem "jruby-openssl", "~> 0.10.1", platform: :jruby
 
-  gem 'draper', '~> 4.0'
+  gem "draper", "~> 4.0"
   gem "devise"
 
   gem "rails", "~> 6.0.0"
@@ -24,25 +24,25 @@ group :development, :test do
 end
 
 group :test do
-  gem 'apparition'
-  gem 'capybara', '~> 3.14'
-  gem 'db-query-matchers', '0.10.0'
+  gem "apparition"
+  gem "capybara", "~> 3.14"
+  gem "db-query-matchers", "0.10.0"
 
-  gem 'simplecov', '0.19.0', require: false # Test coverage generator. Go to /coverage/ after running tests
-  gem 'cucumber-rails', '~> 2.0', require: false
-  gem 'cucumber'
-  gem 'database_cleaner'
-  gem 'jasmine'
-  gem 'jasmine-core', '2.99.2' # last release with Ruby 2.2 support.
-  gem 'launchy'
-  gem 'parallel_tests', '~> 3.0'
-  gem 'rails-i18n' # Provides default i18n for many languages
-  gem 'rspec-rails'
-  gem 'rspec', github: 'rspec/rspec', ref: '3e6c0fb9c9ec68eddd409cfe7b3eb077b390b302'
-  gem 'rspec-core', github: 'rspec/rspec-core', ref: '119282ec3dde5295b337322fc53301c32d0bf7ec'
-  gem 'rspec-mocks', github: 'rspec/rspec-mocks', ref: '1728885f65b25a9676c5ce54133ef8a1283e2e0d'
-  gem 'rspec-support', github: 'rspec/rspec-support', ref: '6553911974ee93855008f8ff41c26cea6652d74d'
-  gem 'rspec-expectations', github: 'rspec/rspec-expectations', ref: 'eb1787f0e1a5ec2c2650048ee60a45d4c9738d78'
+  gem "simplecov", "0.19.0", require: false # Test coverage generator. Go to /coverage/ after running tests
+  gem "cucumber-rails", "~> 2.0", require: false
+  gem "cucumber"
+  gem "database_cleaner"
+  gem "jasmine"
+  gem "jasmine-core", "2.99.2" # last release with Ruby 2.2 support.
+  gem "launchy"
+  gem "parallel_tests", "~> 3.0"
+  gem "rails-i18n" # Provides default i18n for many languages
+  gem "rspec-rails"
+  gem "rspec", github: "rspec/rspec", ref: "3e6c0fb9c9ec68eddd409cfe7b3eb077b390b302"
+  gem "rspec-core", github: "rspec/rspec-core", ref: "119282ec3dde5295b337322fc53301c32d0bf7ec"
+  gem "rspec-mocks", github: "rspec/rspec-mocks", ref: "1728885f65b25a9676c5ce54133ef8a1283e2e0d"
+  gem "rspec-support", github: "rspec/rspec-support", ref: "6553911974ee93855008f8ff41c26cea6652d74d"
+  gem "rspec-expectations", github: "rspec/rspec-expectations", ref: "eb1787f0e1a5ec2c2650048ee60a45d4c9738d78"
   gem "sqlite3", "~> 1.4", platform: :mri
 end
 

--- a/gemfiles/rails_60_webpacker/Gemfile
+++ b/gemfiles/rails_60_webpacker/Gemfile
@@ -1,15 +1,15 @@
 source "https://rubygems.org"
 
 group :development, :test do
-  gem 'rake'
-  gem 'pry' # Easily debug from your console with `binding.pry`
-  gem 'pry-byebug', platform: :mri # Step-by-step debugging
+  gem "rake"
+  gem "pry" # Easily debug from your console with `binding.pry`
+  gem "pry-byebug", platform: :mri # Step-by-step debugging
 
-  gem 'cancancan'
-  gem 'pundit'
-  gem 'jruby-openssl', '~> 0.10.1', platform: :jruby
+  gem "cancancan"
+  gem "pundit"
+  gem "jruby-openssl", "~> 0.10.1", platform: :jruby
 
-  gem 'draper', '~> 4.0'
+  gem "draper", "~> 4.0"
   gem "devise"
 
   gem "rails", "~> 6.0.0"
@@ -24,25 +24,25 @@ group :development, :test do
 end
 
 group :test do
-  gem 'apparition'
-  gem 'capybara', '~> 3.14'
-  gem 'db-query-matchers', '0.10.0'
+  gem "apparition"
+  gem "capybara", "~> 3.14"
+  gem "db-query-matchers", "0.10.0"
 
-  gem 'simplecov', '0.19.0', require: false # Test coverage generator. Go to /coverage/ after running tests
-  gem 'cucumber-rails', '~> 2.0', require: false
-  gem 'cucumber'
-  gem 'database_cleaner'
-  gem 'jasmine'
-  gem 'jasmine-core', '2.99.2' # last release with Ruby 2.2 support.
-  gem 'launchy'
-  gem 'parallel_tests', '~> 3.0'
-  gem 'rails-i18n' # Provides default i18n for many languages
-  gem 'rspec-rails'
-  gem 'rspec', github: 'rspec/rspec', ref: '3e6c0fb9c9ec68eddd409cfe7b3eb077b390b302'
-  gem 'rspec-core', github: 'rspec/rspec-core', ref: '119282ec3dde5295b337322fc53301c32d0bf7ec'
-  gem 'rspec-mocks', github: 'rspec/rspec-mocks', ref: '1728885f65b25a9676c5ce54133ef8a1283e2e0d'
-  gem 'rspec-support', github: 'rspec/rspec-support', ref: '6553911974ee93855008f8ff41c26cea6652d74d'
-  gem 'rspec-expectations', github: 'rspec/rspec-expectations', ref: 'eb1787f0e1a5ec2c2650048ee60a45d4c9738d78'
+  gem "simplecov", "0.19.0", require: false # Test coverage generator. Go to /coverage/ after running tests
+  gem "cucumber-rails", "~> 2.0", require: false
+  gem "cucumber"
+  gem "database_cleaner"
+  gem "jasmine"
+  gem "jasmine-core", "2.99.2" # last release with Ruby 2.2 support.
+  gem "launchy"
+  gem "parallel_tests", "~> 3.0"
+  gem "rails-i18n" # Provides default i18n for many languages
+  gem "rspec-rails"
+  gem "rspec", github: "rspec/rspec", ref: "3e6c0fb9c9ec68eddd409cfe7b3eb077b390b302"
+  gem "rspec-core", github: "rspec/rspec-core", ref: "119282ec3dde5295b337322fc53301c32d0bf7ec"
+  gem "rspec-mocks", github: "rspec/rspec-mocks", ref: "1728885f65b25a9676c5ce54133ef8a1283e2e0d"
+  gem "rspec-support", github: "rspec/rspec-support", ref: "6553911974ee93855008f8ff41c26cea6652d74d"
+  gem "rspec-expectations", github: "rspec/rspec-expectations", ref: "eb1787f0e1a5ec2c2650048ee60a45d4c9738d78"
   gem "sqlite3", "~> 1.4", platform: :mri
 end
 

--- a/lib/active_admin.rb
+++ b/lib/active_admin.rb
@@ -1,58 +1,58 @@
-require 'active_support/core_ext'
-require 'set'
+require "active_support/core_ext"
+require "set"
 
-require 'ransack'
-require 'ransack_ext'
-require 'kaminari'
-require 'formtastic'
-require 'formtastic_i18n'
-require 'inherited_resources'
-require 'jquery-rails'
-require 'sassc-rails'
-require 'arbre'
+require "ransack"
+require "ransack_ext"
+require "kaminari"
+require "formtastic"
+require "formtastic_i18n"
+require "inherited_resources"
+require "jquery-rails"
+require "sassc-rails"
+require "arbre"
 
-require 'active_admin/helpers/i18n'
+require "active_admin/helpers/i18n"
 
 module ActiveAdmin
 
-  autoload :VERSION, 'active_admin/version'
-  autoload :Application, 'active_admin/application'
-  autoload :AssetRegistration, 'active_admin/asset_registration'
-  autoload :Authorization, 'active_admin/authorization_adapter'
-  autoload :AuthorizationAdapter, 'active_admin/authorization_adapter'
-  autoload :Callbacks, 'active_admin/callbacks'
-  autoload :Component, 'active_admin/component'
-  autoload :BaseController, 'active_admin/base_controller'
-  autoload :CanCanAdapter, 'active_admin/cancan_adapter'
-  autoload :ControllerAction, 'active_admin/controller_action'
-  autoload :CSVBuilder, 'active_admin/csv_builder'
-  autoload :Dependency, 'active_admin/dependency'
-  autoload :Deprecation, 'active_admin/deprecation'
-  autoload :Devise, 'active_admin/devise'
-  autoload :DSL, 'active_admin/dsl'
-  autoload :FormBuilder, 'active_admin/form_builder'
-  autoload :Inputs, 'active_admin/inputs'
-  autoload :Localizers, 'active_admin/localizers'
-  autoload :Menu, 'active_admin/menu'
-  autoload :MenuCollection, 'active_admin/menu_collection'
-  autoload :MenuItem, 'active_admin/menu_item'
-  autoload :Namespace, 'active_admin/namespace'
-  autoload :OrderClause, 'active_admin/order_clause'
-  autoload :Page, 'active_admin/page'
-  autoload :PagePresenter, 'active_admin/page_presenter'
-  autoload :PageController, 'active_admin/page_controller'
-  autoload :PageDSL, 'active_admin/page_dsl'
-  autoload :PunditAdapter, 'active_admin/pundit_adapter'
-  autoload :Resource, 'active_admin/resource'
-  autoload :ResourceController, 'active_admin/resource_controller'
-  autoload :ResourceDSL, 'active_admin/resource_dsl'
-  autoload :Scope, 'active_admin/scope'
-  autoload :ScopeChain, 'active_admin/helpers/scope_chain'
-  autoload :SidebarSection, 'active_admin/sidebar_section'
-  autoload :TableBuilder, 'active_admin/table_builder'
-  autoload :ViewFactory, 'active_admin/view_factory'
-  autoload :ViewHelpers, 'active_admin/view_helpers'
-  autoload :Views, 'active_admin/views'
+  autoload :VERSION, "active_admin/version"
+  autoload :Application, "active_admin/application"
+  autoload :AssetRegistration, "active_admin/asset_registration"
+  autoload :Authorization, "active_admin/authorization_adapter"
+  autoload :AuthorizationAdapter, "active_admin/authorization_adapter"
+  autoload :Callbacks, "active_admin/callbacks"
+  autoload :Component, "active_admin/component"
+  autoload :BaseController, "active_admin/base_controller"
+  autoload :CanCanAdapter, "active_admin/cancan_adapter"
+  autoload :ControllerAction, "active_admin/controller_action"
+  autoload :CSVBuilder, "active_admin/csv_builder"
+  autoload :Dependency, "active_admin/dependency"
+  autoload :Deprecation, "active_admin/deprecation"
+  autoload :Devise, "active_admin/devise"
+  autoload :DSL, "active_admin/dsl"
+  autoload :FormBuilder, "active_admin/form_builder"
+  autoload :Inputs, "active_admin/inputs"
+  autoload :Localizers, "active_admin/localizers"
+  autoload :Menu, "active_admin/menu"
+  autoload :MenuCollection, "active_admin/menu_collection"
+  autoload :MenuItem, "active_admin/menu_item"
+  autoload :Namespace, "active_admin/namespace"
+  autoload :OrderClause, "active_admin/order_clause"
+  autoload :Page, "active_admin/page"
+  autoload :PagePresenter, "active_admin/page_presenter"
+  autoload :PageController, "active_admin/page_controller"
+  autoload :PageDSL, "active_admin/page_dsl"
+  autoload :PunditAdapter, "active_admin/pundit_adapter"
+  autoload :Resource, "active_admin/resource"
+  autoload :ResourceController, "active_admin/resource_controller"
+  autoload :ResourceDSL, "active_admin/resource_dsl"
+  autoload :Scope, "active_admin/scope"
+  autoload :ScopeChain, "active_admin/helpers/scope_chain"
+  autoload :SidebarSection, "active_admin/sidebar_section"
+  autoload :TableBuilder, "active_admin/table_builder"
+  autoload :ViewFactory, "active_admin/view_factory"
+  autoload :ViewHelpers, "active_admin/view_helpers"
+  autoload :Views, "active_admin/views"
 
   class << self
 
@@ -121,13 +121,13 @@ module ActiveAdmin
 end
 
 # Require things that don't support autoload
-require 'active_admin/engine'
-require 'active_admin/error'
+require "active_admin/engine"
+require "active_admin/error"
 
 # Require internal plugins
-require 'active_admin/batch_actions'
-require 'active_admin/filters'
+require "active_admin/batch_actions"
+require "active_admin/filters"
 
 # Require ORM-specific plugins
-require 'active_admin/orm/active_record' if defined? ActiveRecord
-require 'active_admin/orm/mongoid' if defined? Mongoid
+require "active_admin/orm/active_record" if defined? ActiveRecord
+require "active_admin/orm/mongoid" if defined? Mongoid

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -1,6 +1,6 @@
-require 'active_admin/router'
-require 'active_admin/application_settings'
-require 'active_admin/namespace_settings'
+require "active_admin/router"
+require "active_admin/application_settings"
+require "active_admin/namespace_settings"
 
 module ActiveAdmin
   class Application
@@ -45,8 +45,8 @@ module ActiveAdmin
     include AssetRegistration
 
     # Event that gets triggered on load of Active Admin
-    BeforeLoadEvent = 'active_admin.application.before_load'.freeze
-    AfterLoadEvent = 'active_admin.application.after_load'.freeze
+    BeforeLoadEvent = "active_admin.application.before_load".freeze
+    AfterLoadEvent = "active_admin.application.after_load".freeze
 
     # Runs before the app's AA initializer
     def setup!
@@ -164,9 +164,9 @@ module ActiveAdmin
     private
 
     def register_default_assets
-      register_stylesheet 'active_admin.css', media: 'screen'
-      register_stylesheet 'active_admin/print.css', media: 'print'
-      register_javascript 'active_admin.js'
+      register_stylesheet "active_admin.css", media: "screen"
+      register_stylesheet "active_admin/print.css", media: "print"
+      register_javascript "active_admin.js"
     end
 
     # Since app/admin is alphabetically before app/models, we have to remove it

--- a/lib/active_admin/application_settings.rb
+++ b/lib/active_admin/application_settings.rb
@@ -1,4 +1,4 @@
-require 'active_admin/settings_node'
+require "active_admin/settings_node"
 
 module ActiveAdmin
   class ApplicationSettings < SettingsNode
@@ -15,7 +15,7 @@ module ActiveAdmin
     # Load paths for admin configurations. Add folders to this load path
     # to load up other resources for administration. External gems can
     # include their paths in this load path to provide active_admin UIs
-    register :load_paths, [File.expand_path('app/admin', Rails.root)]
+    register :load_paths, [File.expand_path("app/admin", Rails.root)]
 
     # Set default localize format for Date/Time values
     register :localize_format, :long
@@ -34,7 +34,7 @@ module ActiveAdmin
                                       :to_s ]
 
     # To make debugging easier, by default don't stream in development
-    register :disable_streaming_in, ['development']
+    register :disable_streaming_in, ["development"]
 
     # Remove sensitive attributes from being displayed, made editable, or exported by default
     register :filter_attributes, [:encrypted_password, :password, :password_confirmation]

--- a/lib/active_admin/base_controller.rb
+++ b/lib/active_admin/base_controller.rb
@@ -1,5 +1,5 @@
-require 'active_admin/base_controller/authorization'
-require 'active_admin/base_controller/menu'
+require "active_admin/base_controller/authorization"
+require "active_admin/base_controller/menu"
 
 module ActiveAdmin
   # BaseController for ActiveAdmin.
@@ -69,11 +69,11 @@ module ActiveAdmin
     #   2.  If we're rendering a custom action, we'll use the active_admin layout so
     #       that users can render any template inside Active Admin.
     def determine_active_admin_layout
-      ACTIVE_ADMIN_ACTIONS.include?(params[:action].to_sym) ? false : 'active_admin'
+      ACTIVE_ADMIN_ACTIONS.include?(params[:action].to_sym) ? false : "active_admin"
     end
 
     def active_admin_root
-      controller, action = active_admin_namespace.root_to.split '#'
+      controller, action = active_admin_namespace.root_to.split "#"
       { controller: controller, action: action }
     end
 

--- a/lib/active_admin/batch_actions/controller.rb
+++ b/lib/active_admin/batch_actions/controller.rb
@@ -6,7 +6,7 @@ module ActiveAdmin
       def batch_action
         if action_present?
           selection = params[:collection_selection] || []
-          inputs = JSON.parse params[:batch_action_inputs] || '{}'
+          inputs = JSON.parse params[:batch_action_inputs] || "{}"
           valid_keys = MethodOrProcHelper.render_in_context(self, current_batch_action.inputs).try(:keys)
           inputs = inputs.with_indifferent_access.slice *valid_keys
           instance_exec selection, inputs, &current_batch_action.block

--- a/lib/active_admin/batch_actions/resource_extension.rb
+++ b/lib/active_admin/batch_actions/resource_extension.rb
@@ -57,11 +57,11 @@ module ActiveAdmin
       def add_default_batch_action
         destroy_options = {
           priority: 100,
-          confirm: proc { I18n.t('active_admin.batch_actions.delete_confirmation', plural_model: active_admin_config.plural_resource_label.downcase) },
-          if: proc { controller.action_methods.include?('destroy') && authorized?(ActiveAdmin::Auth::DESTROY, active_admin_config.resource_class) }
+          confirm: proc { I18n.t("active_admin.batch_actions.delete_confirmation", plural_model: active_admin_config.plural_resource_label.downcase) },
+          if: proc { controller.action_methods.include?("destroy") && authorized?(ActiveAdmin::Auth::DESTROY, active_admin_config.resource_class) }
         }
 
-        add_batch_action :destroy, proc { I18n.t('active_admin.delete') }, destroy_options do |selected_ids|
+        add_batch_action :destroy, proc { I18n.t("active_admin.delete") }, destroy_options do |selected_ids|
           batch_action_collection.find(selected_ids).each do |record|
             authorize! ActiveAdmin::Auth::DESTROY, record
             destroy_resource(record)
@@ -84,7 +84,7 @@ module ActiveAdmin
 
     attr_reader :block, :title, :sym
 
-    DEFAULT_CONFIRM_MESSAGE = proc { I18n.t 'active_admin.batch_actions.default_confirmation' }
+    DEFAULT_CONFIRM_MESSAGE = proc { I18n.t "active_admin.batch_actions.default_confirmation" }
 
     # Create a Batch Action
     #

--- a/lib/active_admin/batch_actions/views/batch_action_form.rb
+++ b/lib/active_admin/batch_actions/views/batch_action_form.rb
@@ -1,4 +1,4 @@
-require 'active_admin/component'
+require "active_admin/component"
 
 module ActiveAdmin
   module BatchActions
@@ -30,7 +30,7 @@ module ActiveAdmin
       private
 
       def closing_form_tag
-        '</form>'.html_safe
+        "</form>".html_safe
       end
 
     end

--- a/lib/active_admin/batch_actions/views/batch_action_selector.rb
+++ b/lib/active_admin/batch_actions/views/batch_action_selector.rb
@@ -1,4 +1,4 @@
-require 'active_admin/component'
+require "active_admin/component"
 
 module ActiveAdmin
   module BatchActions

--- a/lib/active_admin/batch_actions/views/selection_cells.rb
+++ b/lib/active_admin/batch_actions/views/selection_cells.rb
@@ -1,4 +1,4 @@
-require 'active_admin/component'
+require "active_admin/component"
 
 module ActiveAdmin
   module BatchActions
@@ -7,7 +7,7 @@ module ActiveAdmin
     class ResourceSelectionToggleCell < ActiveAdmin::Component
       builder_method :resource_selection_toggle_cell
 
-      def build(label_text = '')
+      def build(label_text = "")
         label do
           input type: "checkbox", id: "collection_selection_toggle_all", name: "collection_selection_toggle_all", class: "toggle_all"
           text_node label_text if label_text.present?
@@ -30,7 +30,7 @@ module ActiveAdmin
 
       def build
         super(id: "collection_selection_toggle_panel")
-        resource_selection_toggle_cell(I18n.t('active_admin.batch_actions.selection_toggle_explanation', default: "(Toggle Selection)"))
+        resource_selection_toggle_cell(I18n.t("active_admin.batch_actions.selection_toggle_explanation", default: "(Toggle Selection)"))
       end
     end
 

--- a/lib/active_admin/cancan_adapter.rb
+++ b/lib/active_admin/cancan_adapter.rb
@@ -2,7 +2,7 @@ unless ActiveAdmin::Dependency.cancan? || ActiveAdmin::Dependency.cancancan?
   ActiveAdmin::Dependency.cancan!
 end
 
-require 'cancan'
+require "cancan"
 
 # Add a setting to the application to configure the ability
 ActiveAdmin::Application.inheritable_setting :cancan_ability_class, "Ability"

--- a/lib/active_admin/dependency.rb
+++ b/lib/active_admin/dependency.rb
@@ -1,7 +1,7 @@
 module ActiveAdmin
   module Dependency
     module Requirements
-      DEVISE = '>= 4.0', '< 5'
+      DEVISE = ">= 4.0", "< 5"
     end
 
     # Provides a clean interface to check for gem dependencies at runtime.
@@ -42,9 +42,9 @@ module ActiveAdmin
     # => false
     #
     def self.method_missing(name, *args)
-      if name[-1] == '?'
+      if name[-1] == "?"
         Matcher.new(name[0..-2]).match? args
-      elsif name[-1] == '!'
+      elsif name[-1] == "!"
         Matcher.new(name[0..-2]).match! args
       else
         Matcher.new name.to_s
@@ -91,7 +91,7 @@ module ActiveAdmin
       end
 
       def inspect
-        info = spec ? "#{spec.name} #{spec.version}" : '(missing)'
+        info = spec ? "#{spec.name} #{spec.version}" : "(missing)"
         "<ActiveAdmin::Dependency::Matcher for #{info}>"
       end
     end

--- a/lib/active_admin/devise.rb
+++ b/lib/active_admin/devise.rb
@@ -1,6 +1,6 @@
 ActiveAdmin::Dependency.devise! ActiveAdmin::Dependency::Requirements::DEVISE
 
-require 'devise'
+require "devise"
 
 module ActiveAdmin
   module Devise
@@ -9,7 +9,7 @@ module ActiveAdmin
       {
         path: ActiveAdmin.application.default_namespace || "/",
         controllers: ActiveAdmin::Devise.controllers,
-        path_names: { sign_in: 'login', sign_out: "logout" },
+        path_names: { sign_in: "login", sign_out: "logout" },
         sign_out_via: [*::Devise.sign_out_via, ActiveAdmin.application.logout_link_method].uniq
       }
     end
@@ -27,14 +27,14 @@ module ActiveAdmin
     module Controller
       extend ::ActiveSupport::Concern
       included do
-        layout 'active_admin_logged_out'
+        layout "active_admin_logged_out"
         helper ::ActiveAdmin::ViewHelpers
       end
 
       # Redirect to the default namespace on logout
       def root_path
         namespace = ActiveAdmin.application.default_namespace.presence
-        root_path_method = [namespace, :root_path].compact.join('_')
+        root_path_method = [namespace, :root_path].compact.join("_")
 
         path = if Helpers::Routes.respond_to? root_path_method
                  Helpers::Routes.send root_path_method
@@ -45,7 +45,7 @@ module ActiveAdmin
 
         # NOTE: `relative_url_root` is deprecated by Rails.
         #       Remove prefix here if it is removed completely.
-        prefix = Rails.configuration.action_controller[:relative_url_root] || ''
+        prefix = Rails.configuration.action_controller[:relative_url_root] || ""
         prefix + path
       end
     end

--- a/lib/active_admin/dsl.rb
+++ b/lib/active_admin/dsl.rb
@@ -101,7 +101,7 @@ module ActiveAdmin
     def batch_action(title, options = {}, &block)
       # Create symbol & title information
       if title.is_a? String
-        sym = title.titleize.tr(' ', '').underscore.to_sym
+        sym = title.titleize.tr(" ", "").underscore.to_sym
       else
         sym = title
         title = sym.to_s.titleize

--- a/lib/active_admin/dynamic_settings_node.rb
+++ b/lib/active_admin/dynamic_settings_node.rb
@@ -1,5 +1,5 @@
-require 'active_admin/dynamic_setting'
-require 'active_admin/settings_node'
+require "active_admin/dynamic_setting"
+require "active_admin/settings_node"
 
 module ActiveAdmin
 

--- a/lib/active_admin/engine.rb
+++ b/lib/active_admin/engine.rb
@@ -2,7 +2,7 @@ module ActiveAdmin
   class Engine < ::Rails::Engine
     initializer "active_admin.load_app_path" do |app|
       ActiveAdmin::Application.setting :app_path, app.root
-      ActiveAdmin::Application.setting :load_paths, [File.expand_path('app/admin', app.root)]
+      ActiveAdmin::Application.setting :load_paths, [File.expand_path("app/admin", app.root)]
     end
 
     initializer "active_admin.precompile", group: :all do |app|
@@ -14,8 +14,8 @@ module ActiveAdmin
       end
     end
 
-    initializer 'active_admin.routes' do
-      require 'active_admin/helpers/routes/url_helpers'
+    initializer "active_admin.routes" do
+      require "active_admin/helpers/routes/url_helpers"
     end
   end
 end

--- a/lib/active_admin/filters.rb
+++ b/lib/active_admin/filters.rb
@@ -1,9 +1,9 @@
-require 'active_admin/filters/dsl'
-require 'active_admin/filters/resource_extension'
-require 'active_admin/filters/formtastic_addons'
-require 'active_admin/filters/forms'
-require 'active_admin/helpers/optional_display'
-require 'active_admin/filters/active_sidebar'
+require "active_admin/filters/dsl"
+require "active_admin/filters/resource_extension"
+require "active_admin/filters/formtastic_addons"
+require "active_admin/filters/forms"
+require "active_admin/helpers/optional_display"
+require "active_admin/filters/active_sidebar"
 
 # Add our Extensions
 ActiveAdmin::ResourceDSL.send :include, ActiveAdmin::Filters::DSL

--- a/lib/active_admin/filters/active.rb
+++ b/lib/active_admin/filters/active.rb
@@ -1,4 +1,4 @@
-require 'active_admin/filters/active_filter'
+require "active_admin/filters/active_filter"
 
 module ActiveAdmin
   module Filters

--- a/lib/active_admin/filters/active_filter.rb
+++ b/lib/active_admin/filters/active_filter.rb
@@ -66,7 +66,7 @@ module ActiveAdmin
       def filter_label
         return unless filter
 
-        filter[:label] || I18n.t(name, scope: ['formtastic', 'labels'], default: nil)
+        filter[:label] || I18n.t(name, scope: ["formtastic", "labels"], default: nil)
       end
 
       #@return Ransack::Nodes::Attribute
@@ -83,7 +83,7 @@ module ActiveAdmin
       end
 
       def find_class?
-        ['eq', 'in'].include? condition.predicate.arel_predicate
+        ["eq", "in"].include? condition.predicate.arel_predicate
       end
 
       # detect related class for Ransack::Nodes::Attribute

--- a/lib/active_admin/filters/active_sidebar.rb
+++ b/lib/active_admin/filters/active_sidebar.rb
@@ -1,11 +1,11 @@
-require 'active_admin/filters/active'
+require "active_admin/filters/active"
 
 module ActiveAdmin
   module Filters
     class ActiveSidebar < ActiveAdmin::SidebarSection
 
       def initialize
-        super 'search_status', sidebar_options
+        super "search_status", sidebar_options
       end
 
       def block
@@ -13,11 +13,11 @@ module ActiveAdmin
           active_filters = ActiveAdmin::Filters::Active.new(active_admin_config, assigns[:search])
           span do
             if current_scope
-              h4 I18n.t("active_admin.search_status.current_scope"), style: 'display: inline'
-              b scope_name(current_scope), class: 'current_scope_name', style: "display: inline"
+              h4 I18n.t("active_admin.search_status.current_scope"), style: "display: inline"
+              b scope_name(current_scope), class: "current_scope_name", style: "display: inline"
             end
             div style: "margin-top: 10px" do
-              h4 I18n.t("active_admin.search_status.current_filters"), style: 'margin-bottom: 10px'
+              h4 I18n.t("active_admin.search_status.current_filters"), style: "margin-bottom: 10px"
               ul do
                 if active_filters.filters.blank?
                   li I18n.t("active_admin.search_status.no_current_filters")

--- a/lib/active_admin/filters/forms.rb
+++ b/lib/active_admin/filters/forms.rb
@@ -48,7 +48,7 @@ module ActiveAdmin
       def active_admin_filters_form_for(search, filters, options = {})
         defaults = { builder: ActiveAdmin::Filters::FormBuilder,
                      url: collection_path,
-                     html: { class: 'filter_form' } }
+                     html: { class: "filter_form" } }
         required = { html: { method: :get },
                      as: :q }
         options = defaults.deep_merge(options).deep_merge(required)
@@ -65,8 +65,8 @@ module ActiveAdmin
           end
 
           buttons = content_tag :div, class: "buttons" do
-            f.submit(I18n.t('active_admin.filters.buttons.filter')) +
-              link_to(I18n.t('active_admin.filters.buttons.clear'), '#', class: 'clear_filters_btn') +
+            f.submit(I18n.t("active_admin.filters.buttons.filter")) +
+              link_to(I18n.t("active_admin.filters.buttons.clear"), "#", class: "clear_filters_btn") +
               hidden_field_tags_for(params, except: except_hidden_fields)
           end
 

--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -22,7 +22,7 @@ module ActiveAdmin
 
     def cancel_link(url = { action: "index" }, html_options = {}, li_attrs = {})
       li_attrs[:class] ||= "cancel"
-      li_content = template.link_to I18n.t('active_admin.cancel'), url, html_options
+      li_content = template.link_to I18n.t("active_admin.cancel"), url, html_options
       template.content_tag(:li, li_content, li_attrs)
     end
 
@@ -47,7 +47,7 @@ module ActiveAdmin
       @assoc = assoc
       @options = extract_custom_settings!(options.dup)
       @options.reverse_merge!(for: assoc)
-      @options[:class] = [options[:class], "inputs has_many_fields"].compact.join(' ')
+      @options[:class] = [options[:class], "inputs has_many_fields"].compact.join(" ")
 
       if sortable_column
         @options[:for] = [assoc, sorted_children(sortable_column)]
@@ -93,7 +93,7 @@ module ActiveAdmin
       contents = without_wrapper { inputs(options, &form_block) }
       contents ||= "".html_safe
 
-      js = new_record ? js_for_has_many(options[:class], &form_block) : ''
+      js = new_record ? js_for_has_many(options[:class], &form_block) : ""
       contents << js
     end
 
@@ -107,19 +107,19 @@ module ActiveAdmin
     def has_many_actions(form_builder, contents)
       if form_builder.object.new_record?
         contents << template.content_tag(:li) do
-          template.link_to I18n.t('active_admin.has_many_remove'), "#", class: 'button has_many_remove'
+          template.link_to I18n.t("active_admin.has_many_remove"), "#", class: "button has_many_remove"
         end
       elsif allow_destroy?(form_builder.object)
         form_builder.input(:_destroy, as: :boolean,
-                                      wrapper_html: { class: 'has_many_delete' },
-                                      label: I18n.t('active_admin.has_many_delete'))
+                                      wrapper_html: { class: "has_many_delete" },
+                                      label: I18n.t("active_admin.has_many_delete"))
       end
 
       if sortable_column
         form_builder.input sortable_column, as: :hidden
 
-        contents << template.content_tag(:li, class: 'handle') do
-          I18n.t('active_admin.move')
+        contents << template.content_tag(:li, class: "handle") do
+          I18n.t("active_admin.move")
         end
       end
 
@@ -164,9 +164,9 @@ module ActiveAdmin
         for_options: { child_index: placeholder }
       }
       html = template.capture { __getobj__.send(:inputs_for_nested_attributes, opts, &form_block) }
-      text = new_record.is_a?(String) ? new_record : I18n.t('active_admin.has_many_new', model: assoc_name.human)
+      text = new_record.is_a?(String) ? new_record : I18n.t("active_admin.has_many_new", model: assoc_name.human)
 
-      template.link_to text, '#', class: "button has_many_add", data: {
+      template.link_to text, "#", class: "button has_many_add", data: {
         html: CGI.escapeHTML(html).html_safe, placeholder: placeholder
       }
     end
@@ -175,8 +175,8 @@ module ActiveAdmin
       template.content_tag(already_in_an_inputs_block ? :li : :div,
                            html,
                            class: "has_many_container #{assoc}",
-                           'data-sortable' => sortable_column,
-                           'data-sortable-start' => sortable_start)
+                           "data-sortable" => sortable_column,
+                           "data-sortable-start" => sortable_start)
     end
   end
 end

--- a/lib/active_admin/generators/boilerplate.rb
+++ b/lib/active_admin/generators/boilerplate.rb
@@ -14,7 +14,7 @@ module ActiveAdmin
       end
 
       def permit_params
-        assignable_attributes.map { |a| a.to_sym.inspect }.join(', ')
+        assignable_attributes.map { |a| a.to_sym.inspect }.join(", ")
       end
 
       def rows

--- a/lib/active_admin/inputs/datepicker_input.rb
+++ b/lib/active_admin/inputs/datepicker_input.rb
@@ -3,7 +3,7 @@ module ActiveAdmin
     class DatepickerInput < ::Formtastic::Inputs::StringInput
       def input_html_options
         super.tap do |options|
-          options[:class] = [options[:class], "datepicker"].compact.join(' ')
+          options[:class] = [options[:class], "datepicker"].compact.join(" ")
           options[:data] ||= {}
           options[:data].merge! datepicker_options
         end

--- a/lib/active_admin/inputs/filters/base.rb
+++ b/lib/active_admin/inputs/filters/base.rb
@@ -25,7 +25,7 @@ module ActiveAdmin
 
         def wrapper_html_options
           opts = super
-          (opts[:class] ||= '') << " filter_form_field filter_#{as}"
+          (opts[:class] ||= "") << " filter_form_field filter_#{as}"
           opts
         end
 

--- a/lib/active_admin/inputs/filters/base/search_method_select.rb
+++ b/lib/active_admin/inputs/filters/base/search_method_select.rb
@@ -31,7 +31,7 @@ module ActiveAdmin
 
           def wrapper_html_options
             opts = super
-            (opts[:class] ||= '') << ' select_and_search' unless seems_searchable?
+            (opts[:class] ||= "") << " select_and_search" unless seems_searchable?
             opts
           end
 
@@ -48,7 +48,7 @@ module ActiveAdmin
           end
 
           def select_html
-            template.select_tag '', template.options_for_select(filter_options, current_filter)
+            template.select_tag "", template.options_for_select(filter_options, current_filter)
           end
 
           def filters

--- a/lib/active_admin/inputs/filters/boolean_input.rb
+++ b/lib/active_admin/inputs/filters/boolean_input.rb
@@ -16,7 +16,7 @@ module ActiveAdmin
 
         # Provide the AA translation to the blank input field.
         def include_blank
-          I18n.t 'active_admin.any' if super
+          I18n.t "active_admin.any" if super
         end
       end
     end

--- a/lib/active_admin/inputs/filters/check_boxes_input.rb
+++ b/lib/active_admin/inputs/filters/check_boxes_input.rb
@@ -22,7 +22,7 @@ module ActiveAdmin
 
         # Add whitespace before label
         def choice_label(choice)
-          ' ' + super
+          " " + super
         end
 
         # Don't wrap in UL tag

--- a/lib/active_admin/inputs/filters/select_input.rb
+++ b/lib/active_admin/inputs/filters/select_input.rb
@@ -7,7 +7,7 @@ module ActiveAdmin
         def input_name
           return method if seems_searchable?
 
-          searchable_method_name + (multiple? ? '_in' : '_eq')
+          searchable_method_name + (multiple? ? "_in" : "_eq")
         end
 
         def searchable_method_name
@@ -22,7 +22,7 @@ module ActiveAdmin
 
         # Provide the AA translation to the blank input field.
         def include_blank
-          I18n.t 'active_admin.any' if super
+          I18n.t "active_admin.any" if super
         end
 
         def input_html_options_name

--- a/lib/active_admin/localizers.rb
+++ b/lib/active_admin/localizers.rb
@@ -1,4 +1,4 @@
-require 'active_admin/localizers/resource_localizer'
+require "active_admin/localizers/resource_localizer"
 
 module ActiveAdmin
   module Localizers

--- a/lib/active_admin/localizers/resource_localizer.rb
+++ b/lib/active_admin/localizers/resource_localizer.rb
@@ -19,16 +19,16 @@ module ActiveAdmin
 
       def translate(key, options = {})
         scope = options.delete(:scope)
-        specific_key = array_to_key('resources', @model_name, scope, key)
+        specific_key = array_to_key("resources", @model_name, scope, key)
         defaults = [array_to_key(scope, key), key.to_s.titleize]
-        ::I18n.t specific_key, **options.reverse_merge(model: @model, default: defaults, scope: 'active_admin')
+        ::I18n.t specific_key, **options.reverse_merge(model: @model, default: defaults, scope: "active_admin")
       end
       alias_method :t, :translate
 
       protected
 
       def array_to_key(*arr)
-        arr.flatten.compact.join('.').to_sym
+        arr.flatten.compact.join(".").to_sym
       end
     end
   end

--- a/lib/active_admin/menu.rb
+++ b/lib/active_admin/menu.rb
@@ -90,7 +90,7 @@ module ActiveAdmin
       def normalize_id(id)
         case id
         when String, Symbol, ActiveModel::Name
-          id.to_s.downcase.tr ' ', '_'
+          id.to_s.downcase.tr " ", "_"
         when ActiveAdmin::Resource::Name
           id.param_key
         else

--- a/lib/active_admin/menu_item.rb
+++ b/lib/active_admin/menu_item.rb
@@ -47,7 +47,7 @@ module ActiveAdmin
       super() # MenuNode
       @label = options[:label]
       @dirty_id = options[:id] || options[:label]
-      @url = options[:url] || '#'
+      @url = options[:url] || "#"
       @priority = options[:priority] || 10
       @html_options = options[:html_options] || {}
       @should_display = options[:if] || proc { true }

--- a/lib/active_admin/namespace.rb
+++ b/lib/active_admin/namespace.rb
@@ -1,4 +1,4 @@
-require 'active_admin/resource_collection'
+require "active_admin/resource_collection"
 
 module ActiveAdmin
 
@@ -31,7 +31,7 @@ module ActiveAdmin
       end
     end
 
-    RegisterEvent = 'active_admin.namespace.register'.freeze
+    RegisterEvent = "active_admin.namespace.register".freeze
 
     attr_reader :application, :resources, :menus
 
@@ -149,8 +149,8 @@ module ActiveAdmin
     def add_logout_button_to_menu(menu, priority = 20, html_options = {})
       if logout_link_path
         html_options = html_options.reverse_merge(method: logout_link_method || :get)
-        menu.add id: 'logout', priority: priority, html_options: html_options,
-                 label: -> { I18n.t 'active_admin.logout' },
+        menu.add id: "logout", priority: priority, html_options: html_options,
+                 label: -> { I18n.t "active_admin.logout" },
                  url: -> { render_or_call_method_or_proc_on self, active_admin_namespace.logout_link_path },
                  if: :current_active_admin_user?
       end
@@ -164,7 +164,7 @@ module ActiveAdmin
     #
     def add_current_user_to_menu(menu, priority = 10, html_options = {})
       if current_user_method
-        menu.add id: 'current_user', priority: priority, html_options: html_options,
+        menu.add id: "current_user", priority: priority, html_options: html_options,
                  label: -> { display_name current_active_admin_user },
                  url: -> { auto_url_for(current_active_admin_user) },
                  if: :current_active_admin_user?
@@ -211,8 +211,8 @@ module ActiveAdmin
 
     def unload_resources!
       resources.each do |resource|
-        parent = (module_name || 'Object').constantize
-        name = resource.controller_name.split('::').last
+        parent = (module_name || "Object").constantize
+        name = resource.controller_name.split("::").last
         parent.send(:remove_const, name) if parent.const_defined?(name, false)
 
         # Remove circular references

--- a/lib/active_admin/namespace_settings.rb
+++ b/lib/active_admin/namespace_settings.rb
@@ -1,4 +1,4 @@
-require 'active_admin/dynamic_settings_node'
+require "active_admin/dynamic_settings_node"
 
 module ActiveAdmin
   class NamespaceSettings < DynamicSettingsNode
@@ -57,7 +57,7 @@ module ActiveAdmin
     register :filters, true
 
     # The namespace root
-    register :root_to, 'dashboard#index'
+    register :root_to, "dashboard#index"
 
     # Options that are passed to root_to
     register :root_to_options, {}
@@ -73,7 +73,7 @@ module ActiveAdmin
     register :create_another, false
 
     # Default CSV options
-    register :csv_options, { col_sep: ',', byte_order_mark: "\xEF\xBB\xBF" }
+    register :csv_options, { col_sep: ",", byte_order_mark: "\xEF\xBB\xBF" }
 
     # Default Download Links options
     register :download_links, true
@@ -102,7 +102,7 @@ module ActiveAdmin
     ]
 
     # Set flash message keys that shouldn't show in ActiveAdmin
-    register :flash_keys_to_except, ['timedout']
+    register :flash_keys_to_except, ["timedout"]
 
     # Include association filters by default
     register :include_default_association_filters, true
@@ -118,7 +118,7 @@ module ActiveAdmin
         :title,
         :email,
     ]
-    register :filter_method_for_large_association, '_starts_with'
+    register :filter_method_for_large_association, "_starts_with"
 
     # Switch between asset pipeline and webpacker assets
     register :use_webpacker, false

--- a/lib/active_admin/order_clause.rb
+++ b/lib/active_admin/order_clause.rb
@@ -20,7 +20,7 @@ module ActiveAdmin
     end
 
     def to_sql
-      [table_column, @op, ' ', @order].compact.join
+      [table_column, @op, " ", @order].compact.join
     end
 
     def table

--- a/lib/active_admin/orm/active_record.rb
+++ b/lib/active_admin/orm/active_record.rb
@@ -2,4 +2,4 @@
 
 ActiveAdmin::DatabaseHitDuringLoad.database_error_classes << ActiveRecord::StatementInvalid
 
-require 'active_admin/orm/active_record/comments'
+require "active_admin/orm/active_record/comments"

--- a/lib/active_admin/orm/active_record/comments.rb
+++ b/lib/active_admin/orm/active_record/comments.rb
@@ -1,11 +1,11 @@
-require 'active_admin/orm/active_record/comments/views'
-require 'active_admin/orm/active_record/comments/show_page_helper'
-require 'active_admin/orm/active_record/comments/namespace_helper'
-require 'active_admin/orm/active_record/comments/resource_helper'
+require "active_admin/orm/active_record/comments/views"
+require "active_admin/orm/active_record/comments/show_page_helper"
+require "active_admin/orm/active_record/comments/namespace_helper"
+require "active_admin/orm/active_record/comments/resource_helper"
 
 # Add the comments configuration
 ActiveAdmin::Application.inheritable_setting :comments, true
-ActiveAdmin::Application.inheritable_setting :comments_registration_name, 'Comment'
+ActiveAdmin::Application.inheritable_setting :comments_registration_name, "Comment"
 ActiveAdmin::Application.inheritable_setting :comments_order, "created_at ASC"
 ActiveAdmin::Application.inheritable_setting :comments_menu, {}
 
@@ -15,7 +15,7 @@ ActiveAdmin::Resource.send :include, ActiveAdmin::Comments::ResourceHelper
 ActiveAdmin.application.view_factory.show_page.send :include, ActiveAdmin::Comments::ShowPageHelper
 
 # Load the model as soon as it's referenced. By that point, Rails & Kaminari will be ready
-ActiveAdmin.autoload :Comment, 'active_admin/orm/active_record/comments/comment'
+ActiveAdmin.autoload :Comment, "active_admin/orm/active_record/comments/comment"
 
 # Hint i18n-tasks about model and attribute translations used by default install
 # i18n-tasks-use t('activerecord.models.comment')
@@ -67,7 +67,7 @@ ActiveAdmin.after_load do |app|
               redirect_back fallback_location: active_admin_root
             end
             failure.html do
-              flash[:error] = I18n.t 'active_admin.comments.errors.empty_text'
+              flash[:error] = I18n.t "active_admin.comments.errors.empty_text"
               redirect_back fallback_location: active_admin_root
             end
           end
@@ -88,12 +88,12 @@ ActiveAdmin.after_load do |app|
       permit_params :body, :namespace, :resource_id, :resource_type
 
       index do
-        column I18n.t('active_admin.comments.resource_type'), :resource_type
-        column I18n.t('active_admin.comments.author_type'), :author_type
-        column I18n.t('active_admin.comments.resource'), :resource
-        column I18n.t('active_admin.comments.author'), :author
-        column I18n.t('active_admin.comments.body'), :body
-        column I18n.t('active_admin.comments.created_at'), :created_at
+        column I18n.t("active_admin.comments.resource_type"), :resource_type
+        column I18n.t("active_admin.comments.author_type"), :author_type
+        column I18n.t("active_admin.comments.resource"), :resource
+        column I18n.t("active_admin.comments.author"), :author
+        column I18n.t("active_admin.comments.body"), :body
+        column I18n.t("active_admin.comments.created_at"), :created_at
         actions
       end
     end

--- a/lib/active_admin/orm/active_record/comments/views.rb
+++ b/lib/active_admin/orm/active_record/comments/views.rb
@@ -1,2 +1,2 @@
-require 'active_admin/views'
-require 'active_admin/orm/active_record/comments/views/active_admin_comments'
+require "active_admin/views"
+require "active_admin/orm/active_record/comments/views/active_admin_comments"

--- a/lib/active_admin/orm/active_record/comments/views/active_admin_comments.rb
+++ b/lib/active_admin/orm/active_record/comments/views/active_admin_comments.rb
@@ -1,5 +1,5 @@
-require 'active_admin/views'
-require 'active_admin/views/components/panel'
+require "active_admin/views"
+require "active_admin/views/components/panel"
 
 module ActiveAdmin
   module Comments
@@ -22,13 +22,13 @@ module ActiveAdmin
         protected
 
         def title
-          I18n.t 'active_admin.comments.title_content', count: @comments.total_count
+          I18n.t "active_admin.comments.title_content", count: @comments.total_count
         end
 
         def build_comments
           if @comments.any?
             @comments.each(&method(:build_comment))
-            div page_entries_info(@comments).html_safe, class: 'pagination_information'
+            div page_entries_info(@comments).html_safe, class: "pagination_information"
           else
             build_empty_message
           end
@@ -42,39 +42,39 @@ module ActiveAdmin
 
         def build_comment(comment)
           div for: comment do
-            div class: 'active_admin_comment_meta' do
-              h4 class: 'active_admin_comment_author' do
-                comment.author ? auto_link(comment.author) : I18n.t('active_admin.comments.author_missing')
+            div class: "active_admin_comment_meta" do
+              h4 class: "active_admin_comment_author" do
+                comment.author ? auto_link(comment.author) : I18n.t("active_admin.comments.author_missing")
               end
               span pretty_format comment.created_at
               if authorized?(ActiveAdmin::Auth::DESTROY, comment)
-                text_node link_to I18n.t('active_admin.comments.delete'), comments_url(comment.id), method: :delete, data: { confirm: I18n.t('active_admin.comments.delete_confirmation') }
+                text_node link_to I18n.t("active_admin.comments.delete"), comments_url(comment.id), method: :delete, data: { confirm: I18n.t("active_admin.comments.delete_confirmation") }
               end
             end
-            div class: 'active_admin_comment_body' do
+            div class: "active_admin_comment_body" do
               simple_format comment.body
             end
           end
         end
 
         def build_empty_message
-          span I18n.t('active_admin.comments.no_comments_yet'), class: 'empty'
+          span I18n.t("active_admin.comments.no_comments_yet"), class: "empty"
         end
 
         def comments_url(*args)
           parts = []
           parts << active_admin_namespace.name unless active_admin_namespace.root?
           parts << active_admin_namespace.comments_registration_name.underscore
-          parts << 'path'
-          send parts.join('_'), *args
+          parts << "path"
+          send parts.join("_"), *args
         end
 
         def comment_form_url
           parts = []
           parts << active_admin_namespace.name unless active_admin_namespace.root?
           parts << active_admin_namespace.comments_registration_name.underscore.pluralize
-          parts << 'path'
-          send parts.join '_'
+          parts << "path"
+          send parts.join "_"
         end
 
         def build_comment_form
@@ -82,16 +82,16 @@ module ActiveAdmin
             f.inputs do
               f.input :resource_type, as: :hidden, input_html: { value: ActiveAdmin::Comment.resource_type(parent.resource) }
               f.input :resource_id, as: :hidden, input_html: { value: parent.resource.id }
-              f.input :body, label: false, input_html: { size: '80x8' }
+              f.input :body, label: false, input_html: { size: "80x8" }
             end
             f.actions do
-              f.action :submit, label: I18n.t('active_admin.comments.add')
+              f.action :submit, label: I18n.t("active_admin.comments.add")
             end
           end
         end
 
         def default_id_for_prefix
-          'active_admin_comments_for'
+          "active_admin_comments_for"
         end
       end
 

--- a/lib/active_admin/page.rb
+++ b/lib/active_admin/page.rb
@@ -65,7 +65,7 @@ module ActiveAdmin
     end
 
     def controller_name
-      [namespace.module_name, camelized_resource_name + "Controller"].compact.join('::')
+      [namespace.module_name, camelized_resource_name + "Controller"].compact.join("::")
     end
 
     # Override from `ActiveAdmin::Resource::Controllers`

--- a/lib/active_admin/pundit_adapter.rb
+++ b/lib/active_admin/pundit_adapter.rb
@@ -1,6 +1,6 @@
 ActiveAdmin::Dependency.pundit!
 
-require 'pundit'
+require "pundit"
 
 # Add a setting to the application to configure the pundit default policy
 ActiveAdmin::Application.inheritable_setting :pundit_default_policy, nil

--- a/lib/active_admin/resource.rb
+++ b/lib/active_admin/resource.rb
@@ -1,18 +1,18 @@
-require 'active_admin/resource/action_items'
-require 'active_admin/resource/attributes'
-require 'active_admin/resource/controllers'
-require 'active_admin/resource/menu'
-require 'active_admin/resource/page_presenters'
-require 'active_admin/resource/pagination'
-require 'active_admin/resource/routes'
-require 'active_admin/resource/naming'
-require 'active_admin/resource/scopes'
-require 'active_admin/resource/includes'
-require 'active_admin/resource/scope_to'
-require 'active_admin/resource/sidebars'
-require 'active_admin/resource/belongs_to'
-require 'active_admin/resource/ordering'
-require 'active_admin/resource/model'
+require "active_admin/resource/action_items"
+require "active_admin/resource/attributes"
+require "active_admin/resource/controllers"
+require "active_admin/resource/menu"
+require "active_admin/resource/page_presenters"
+require "active_admin/resource/pagination"
+require "active_admin/resource/routes"
+require "active_admin/resource/naming"
+require "active_admin/resource/scopes"
+require "active_admin/resource/includes"
+require "active_admin/resource/scope_to"
+require "active_admin/resource/sidebars"
+require "active_admin/resource/belongs_to"
+require "active_admin/resource/ordering"
+require "active_admin/resource/model"
 
 module ActiveAdmin
 
@@ -27,7 +27,7 @@ module ActiveAdmin
   class Resource
 
     # Event dispatched when a new resource is registered
-    RegisterEvent = 'active_admin.resource.register'.freeze
+    RegisterEvent = "active_admin.resource.register".freeze
 
     # The namespace this config belongs to
     attr_reader :namespace
@@ -44,7 +44,7 @@ module ActiveAdmin
     # The default sort order to use in the controller
     attr_writer :sort_order
     def sort_order
-      @sort_order ||= (resource_class.respond_to?(:primary_key) ? resource_class.primary_key.to_s : 'id') + '_desc'
+      @sort_order ||= (resource_class.respond_to?(:primary_key) ? resource_class.primary_key.to_s : "id") + "_desc"
     end
 
     # Set the configuration for the CSV

--- a/lib/active_admin/resource/action_items.rb
+++ b/lib/active_admin/resource/action_items.rb
@@ -1,4 +1,4 @@
-require 'active_admin/helpers/optional_display'
+require "active_admin/helpers/optional_display"
 
 module ActiveAdmin
 
@@ -64,7 +64,7 @@ module ActiveAdmin
       # Adds the default New link on index
       def add_default_new_action_item
         add_action_item :new, only: :index do
-          if controller.action_methods.include?('new') && authorized?(ActiveAdmin::Auth::CREATE, active_admin_config.resource_class)
+          if controller.action_methods.include?("new") && authorized?(ActiveAdmin::Auth::CREATE, active_admin_config.resource_class)
             localizer = ActiveAdmin::Localizers.resource(active_admin_config)
             link_to localizer.t(:new_model), new_resource_path
           end
@@ -74,7 +74,7 @@ module ActiveAdmin
       # Adds the default Edit link on show
       def add_default_edit_action_item
         add_action_item :edit, only: :show do
-          if controller.action_methods.include?('edit') && authorized?(ActiveAdmin::Auth::UPDATE, resource)
+          if controller.action_methods.include?("edit") && authorized?(ActiveAdmin::Auth::UPDATE, resource)
             localizer = ActiveAdmin::Localizers.resource(active_admin_config)
             link_to localizer.t(:edit_model), edit_resource_path(resource)
           end
@@ -84,7 +84,7 @@ module ActiveAdmin
       # Adds the default Destroy link on show
       def add_default_show_action_item
         add_action_item :destroy, only: :show do
-          if controller.action_methods.include?('destroy') && authorized?(ActiveAdmin::Auth::DESTROY, resource)
+          if controller.action_methods.include?("destroy") && authorized?(ActiveAdmin::Auth::DESTROY, resource)
             localizer = ActiveAdmin::Localizers.resource(active_admin_config)
             link_to localizer.t(:delete_model), resource_path(resource), method: :delete,
                                                                          data: { confirm: localizer.t(:delete_confirmation) }

--- a/lib/active_admin/resource/attributes.rb
+++ b/lib/active_admin/resource/attributes.rb
@@ -36,7 +36,7 @@ module ActiveAdmin
       end
 
       def counter_cache_col?(c)
-        c.name.end_with?('_count')
+        c.name.end_with?("_count")
       end
 
       def filtered_col?(c)

--- a/lib/active_admin/resource/belongs_to.rb
+++ b/lib/active_admin/resource/belongs_to.rb
@@ -1,4 +1,4 @@
-require 'active_admin/resource'
+require "active_admin/resource"
 
 module ActiveAdmin
   class Resource

--- a/lib/active_admin/resource/controllers.rb
+++ b/lib/active_admin/resource/controllers.rb
@@ -6,7 +6,7 @@ module ActiveAdmin
       # Returns a properly formatted controller name for this
       # config within its namespace
       def controller_name
-        [namespace.module_name, resource_name.plural.camelize + "Controller"].compact.join('::')
+        [namespace.module_name, resource_name.plural.camelize + "Controller"].compact.join("::")
       end
 
       # Returns the controller for this config

--- a/lib/active_admin/resource/naming.rb
+++ b/lib/active_admin/resource/naming.rb
@@ -4,7 +4,7 @@ module ActiveAdmin
     module Naming
       def resource_name
         @resource_name ||= begin
-          as = @options[:as].gsub /\s/, '' if @options[:as]
+          as = @options[:as].gsub /\s/, "" if @options[:as]
 
           if as || !resource_class.respond_to?(:model_name)
             Name.new resource_class, as
@@ -17,7 +17,7 @@ module ActiveAdmin
       # Returns the name to call this resource such as "Bank Account"
       def resource_label
         resource_name.translate count: 1,
-                                default: resource_name.to_s.gsub('::', ' ').titleize
+                                default: resource_name.to_s.gsub("::", " ").titleize
       end
 
       # Returns the plural version of this resource such as "Bank Accounts"

--- a/lib/active_admin/resource/routes.rb
+++ b/lib/active_admin/resource/routes.rb
@@ -104,7 +104,7 @@ module ActiveAdmin
           route << resource_path_name # "posts" or "post"
           route << suffix # "path" or "index path"
 
-          route.compact.join('_').to_sym # :admin_category_posts_path
+          route.compact.join("_").to_sym # :admin_category_posts_path
         end
 
         # @return params to pass to instance path

--- a/lib/active_admin/resource/sidebars.rb
+++ b/lib/active_admin/resource/sidebars.rb
@@ -1,4 +1,4 @@
-require 'active_admin/helpers/optional_display'
+require "active_admin/helpers/optional_display"
 
 module ActiveAdmin
 

--- a/lib/active_admin/resource_controller.rb
+++ b/lib/active_admin/resource_controller.rb
@@ -1,12 +1,12 @@
-require 'active_admin/collection_decorator'
-require 'active_admin/resource_controller/action_builder'
-require 'active_admin/resource_controller/data_access'
-require 'active_admin/resource_controller/decorators'
-require 'active_admin/resource_controller/polymorphic_routes'
-require 'active_admin/resource_controller/scoping'
-require 'active_admin/resource_controller/streaming'
-require 'active_admin/resource_controller/sidebars'
-require 'active_admin/resource_controller/resource_class_methods'
+require "active_admin/collection_decorator"
+require "active_admin/resource_controller/action_builder"
+require "active_admin/resource_controller/data_access"
+require "active_admin/resource_controller/decorators"
+require "active_admin/resource_controller/polymorphic_routes"
+require "active_admin/resource_controller/scoping"
+require "active_admin/resource_controller/streaming"
+require "active_admin/resource_controller/sidebars"
+require "active_admin/resource_controller/resource_class_methods"
 
 module ActiveAdmin
   # All Resources Controller inherits from this controller.

--- a/lib/active_admin/resource_controller/decorators.rb
+++ b/lib/active_admin/resource_controller/decorators.rb
@@ -28,7 +28,7 @@ module ActiveAdmin
 
       def decorate?
         case action_name
-        when 'new', 'edit', 'create', 'update'
+        when "new", "edit", "create", "update"
           form = active_admin_config.get_page_presenter :form
           form && form.options[:decorate] && decorator_class.present?
         else

--- a/lib/active_admin/resource_controller/streaming.rb
+++ b/lib/active_admin/resource_controller/streaming.rb
@@ -1,4 +1,4 @@
-require 'csv'
+require "csv"
 
 module ActiveAdmin
   class ResourceController < BaseController
@@ -18,11 +18,11 @@ module ActiveAdmin
       protected
 
       def stream_resource(&block)
-        headers['X-Accel-Buffering'] = 'no'
-        headers['Cache-Control'] = 'no-cache'
+        headers["X-Accel-Buffering"] = "no"
+        headers["Cache-Control"] = "no-cache"
 
         if ActiveAdmin.application.disable_streaming_in.include? Rails.env
-          self.response_body = block['']
+          self.response_body = block[""]
         else
           self.response_body = Enumerator.new &block
         end
@@ -33,8 +33,8 @@ module ActiveAdmin
       end
 
       def stream_csv
-        headers['Content-Type'] = 'text/csv; charset=utf-8' # In Rails 5 it's set to HTML??
-        headers['Content-Disposition'] = %{attachment; filename="#{csv_filename}"}
+        headers["Content-Type"] = "text/csv; charset=utf-8" # In Rails 5 it's set to HTML??
+        headers["Content-Disposition"] = %{attachment; filename="#{csv_filename}"}
         stream_resource &active_admin_config.csv_builder.method(:build).to_proc.curry[self]
       end
 

--- a/lib/active_admin/scope.rb
+++ b/lib/active_admin/scope.rb
@@ -55,7 +55,7 @@ module ActiveAdmin
     def name
       case @name
       when String then @name
-      when Symbol then @localizer ? @localizer.t(@name, scope: 'scopes') : @name.to_s.titleize
+      when Symbol then @localizer ? @localizer.t(@name, scope: "scopes") : @name.to_s.titleize
       else @name
       end
     end

--- a/lib/active_admin/version.rb
+++ b/lib/active_admin/version.rb
@@ -1,3 +1,3 @@
 module ActiveAdmin
-  VERSION = '2.8.0'
+  VERSION = "2.8.0"
 end

--- a/lib/active_admin/view_factory.rb
+++ b/lib/active_admin/view_factory.rb
@@ -1,4 +1,4 @@
-require 'active_admin/abstract_view_factory'
+require "active_admin/abstract_view_factory"
 
 module ActiveAdmin
   class ViewFactory < AbstractViewFactory

--- a/lib/active_admin/view_helpers.rb
+++ b/lib/active_admin/view_helpers.rb
@@ -2,7 +2,7 @@ module ActiveAdmin
   module ViewHelpers
 
     # Require all ruby files in the view helpers dir
-    Dir[File.expand_path('view_helpers', __dir__) + "/*.rb"].each { |f| require f }
+    Dir[File.expand_path("view_helpers", __dir__) + "/*.rb"].each { |f| require f }
 
     include ActiveAdminApplicationHelper
     include AutoLinkHelper

--- a/lib/active_admin/view_helpers/breadcrumb_helper.rb
+++ b/lib/active_admin/view_helpers/breadcrumb_helper.rb
@@ -6,7 +6,7 @@ module ActiveAdmin
       def breadcrumb_links(path = request.path)
         # remove leading "/" and split up the URL
         # and remove last since it's used as the page title
-        parts = path.split('/').select(&:present?)[0..-2]
+        parts = path.split("/").select(&:present?)[0..-2]
 
         parts.each_with_index.map do |part, index|
           # 1. try using `display_name` if we can locate a DB object
@@ -21,7 +21,7 @@ module ActiveAdmin
 
           # Don't create a link if the resource's show action is disabled
           if !config || config.defined_actions.include?(:show)
-            link_to name, '/' + parts[0..index].join('/')
+            link_to name, "/" + parts[0..index].join("/")
           else
             name
           end

--- a/lib/active_admin/view_helpers/display_helper.rb
+++ b/lib/active_admin/view_helpers/display_helper.rb
@@ -10,7 +10,7 @@ module ActiveAdmin
         name.present? ? name : to_s
       }
       def DISPLAY_NAME_FALLBACK.inspect
-        'DISPLAY_NAME_FALLBACK'
+        "DISPLAY_NAME_FALLBACK"
       end
 
       # Attempts to call any known display name methods on the resource.
@@ -85,7 +85,7 @@ module ActiveAdmin
       end
 
       def format_collection(collection)
-        safe_join(collection.map { |item| pretty_format(item) }, ', ')
+        safe_join(collection.map { |item| pretty_format(item) }, ", ")
       end
 
       def boolean_attr?(resource, attr, value)

--- a/lib/active_admin/view_helpers/download_format_links_helper.rb
+++ b/lib/active_admin/view_helpers/download_format_links_helper.rb
@@ -18,7 +18,7 @@ module ActiveAdmin
       def build_download_format_links(formats = self.class.formats)
         params = request.query_parameters.except :format, :commit
         div class: "download_links" do
-          span I18n.t('active_admin.download')
+          span I18n.t("active_admin.download")
           formats.each do |format|
             a format.upcase, href: url_for(params: params, format: format)
           end

--- a/lib/active_admin/view_helpers/fields_for.rb
+++ b/lib/active_admin/view_helpers/fields_for.rb
@@ -37,7 +37,7 @@ module ActiveAdmin
               { "#{k}[]" => v }
             end
           when nil
-            { k => '' }
+            { k => "" }
           when TrueClass, FalseClass
             { k => v }
           else

--- a/lib/active_admin/views.rb
+++ b/lib/active_admin/views.rb
@@ -2,7 +2,7 @@ module ActiveAdmin
   module Views
 
     # Loads all the classes in views/*.rb
-    Dir[File.expand_path('views', __dir__) + "/**/*.rb"].sort.each { |f| require f }
+    Dir[File.expand_path("views", __dir__) + "/**/*.rb"].sort.each { |f| require f }
 
   end
 end

--- a/lib/active_admin/views/components/active_admin_form.rb
+++ b/lib/active_admin/views/components/active_admin_form.rb
@@ -111,14 +111,14 @@ module ActiveAdmin
         create_another = params[:create_another]
         label = @resource.class.model_name.human
         Arbre::Context.new do
-          li class: 'create_another' do
+          li class: "create_another" do
             input(
               checked: create_another,
-              id: 'create_another',
-              name: 'create_another',
-              type: 'checkbox'
+              id: "create_another",
+              name: "create_another",
+              type: "checkbox"
             )
-            label(I18n.t('active_admin.create_another', model: label), for: 'create_another')
+            label(I18n.t("active_admin.create_another", model: label), for: "create_another")
           end
         end
       end

--- a/lib/active_admin/views/components/attributes_table.rb
+++ b/lib/active_admin/views/components/attributes_table.rb
@@ -28,7 +28,7 @@ module ActiveAdmin
         elsif title.present?
           classes << "row-#{title.to_s.parameterize(separator: "_")}"
         end
-        options[:class] = classes.join(' ')
+        options[:class] = classes.join(" ")
 
         @table << tr(options) do
           th do
@@ -45,7 +45,7 @@ module ActiveAdmin
       protected
 
       def default_id_for_prefix
-        'attributes_table'
+        "attributes_table"
       end
 
       # Build Colgroups
@@ -75,7 +75,7 @@ module ActiveAdmin
       end
 
       def empty_value
-        span I18n.t('active_admin.empty'), class: "empty"
+        span I18n.t("active_admin.empty"), class: "empty"
       end
 
       def content_for(record, attr)

--- a/lib/active_admin/views/components/blank_slate.rb
+++ b/lib/active_admin/views/components/blank_slate.rb
@@ -5,7 +5,7 @@ module ActiveAdmin
       builder_method :blank_slate
 
       def default_class_name
-        'blank_slate_container'
+        "blank_slate_container"
       end
 
       def build(content)

--- a/lib/active_admin/views/components/dropdown_menu.rb
+++ b/lib/active_admin/views/components/dropdown_menu.rb
@@ -44,21 +44,21 @@ module ActiveAdmin
       private
 
       def build_button(name, button_options)
-        button_options[:class] ||= ''
-        button_options[:class] << ' dropdown_menu_button'
+        button_options[:class] ||= ""
+        button_options[:class] << " dropdown_menu_button"
 
-        button_options[:href] = '#'
+        button_options[:href] = "#"
 
         a name, button_options
       end
 
       def build_menu(options)
-        options[:class] ||= ''
-        options[:class] << ' dropdown_menu_list'
+        options[:class] ||= ""
+        options[:class] << " dropdown_menu_list"
 
         menu_list = nil
 
-        div class: 'dropdown_menu_list_wrapper' do
+        div class: "dropdown_menu_list_wrapper" do
           menu_list = ul(options)
         end
 

--- a/lib/active_admin/views/components/index_list.rb
+++ b/lib/active_admin/views/components/index_list.rb
@@ -1,4 +1,4 @@
-require 'active_admin/helpers/collection'
+require "active_admin/helpers/collection"
 
 module ActiveAdmin
   module Views
@@ -15,7 +15,7 @@ module ActiveAdmin
       end
 
       def tag_name
-        'ul'
+        "ul"
       end
 
       # Builds the links for presenting different index views to the user

--- a/lib/active_admin/views/components/menu.rb
+++ b/lib/active_admin/views/components/menu.rb
@@ -25,7 +25,7 @@ module ActiveAdmin
       end
 
       def tag_name
-        'ul'
+        "ul"
       end
     end
   end

--- a/lib/active_admin/views/components/menu_item.rb
+++ b/lib/active_admin/views/components/menu_item.rb
@@ -30,7 +30,7 @@ module ActiveAdmin
       end
 
       def tag_name
-        'li'
+        "li"
       end
 
       # Sorts by priority first, then alphabetically by label if needed.
@@ -44,14 +44,14 @@ module ActiveAdmin
       end
 
       def to_s
-        visible? ? super : ''
+        visible? ? super : ""
       end
 
       private
 
       # URL is not nil, empty, or '#'
       def real_url?
-        url && url.present? && url != '#'
+        url && url.present? && url != "#"
       end
     end
   end

--- a/lib/active_admin/views/components/paginated_collection.rb
+++ b/lib/active_admin/views/components/paginated_collection.rb
@@ -1,5 +1,5 @@
-require 'active_admin/helpers/collection'
-require 'active_admin/view_helpers/download_format_links_helper'
+require "active_admin/helpers/collection"
+require "active_admin/view_helpers/download_format_links_helper"
 
 module ActiveAdmin
   module Views
@@ -92,7 +92,7 @@ module ActiveAdmin
       end
 
       def build_pagination
-        options = { theme: @display_total ? 'active_admin' : 'active_admin_countless' }
+        options = { theme: @display_total ? "active_admin" : "active_admin_countless" }
         options[:params] = @params if @params
         options[:param_name] = @param_name if @param_name
 
@@ -119,12 +119,12 @@ module ActiveAdmin
           entry_name = options[:entry_name]
           entries_name = options[:entries_name] || entry_name.pluralize
         elsif collection_is_empty?
-          entry_name = I18n.t "active_admin.pagination.entry", count: 1, default: 'entry'
-          entries_name = I18n.t "active_admin.pagination.entry", count: 2, default: 'entries'
+          entry_name = I18n.t "active_admin.pagination.entry", count: 1, default: "entry"
+          entries_name = I18n.t "active_admin.pagination.entry", count: 2, default: "entries"
         else
           key = "activerecord.models." + collection.first.class.model_name.i18n_key.to_s
 
-          entry_name = I18n.translate key, count: 1, default: collection.first.class.name.underscore.sub('_', ' ')
+          entry_name = I18n.translate key, count: 1, default: collection.first.class.name.underscore.sub("_", " ")
           entries_name = I18n.translate key, count: collection.size, default: entry_name.pluralize
         end
 

--- a/lib/active_admin/views/components/panel.rb
+++ b/lib/active_admin/views/components/panel.rb
@@ -29,7 +29,7 @@ module ActiveAdmin
       def header_action(*args)
         action = args[0]
 
-        @title << div(class: 'header_action') do
+        @title << div(class: "header_action") do
           action
         end
       end

--- a/lib/active_admin/views/components/scopes.rb
+++ b/lib/active_admin/views/components/scopes.rb
@@ -1,5 +1,5 @@
-require 'active_admin/helpers/collection'
-require 'active_admin/view_helpers/method_or_proc_helper'
+require "active_admin/helpers/collection"
+require "active_admin/view_helpers/method_or_proc_helper"
 
 module ActiveAdmin
   module Views
@@ -17,7 +17,7 @@ module ActiveAdmin
       end
 
       def tag_name
-        'div'
+        "div"
       end
 
       def build(scopes, options = {})
@@ -38,9 +38,9 @@ module ActiveAdmin
         li class: classes_for_scope(scope) do
           params = request.query_parameters.except :page, :scope, :commit, :format
 
-          a href: url_for(scope: scope.id, params: params), class: 'table_tools_button' do
+          a href: url_for(scope: scope.id, params: params), class: "table_tools_button" do
             text_node scope_name(scope)
-            span class: 'count' do
+            span class: "count" do
               "(#{get_scope_count(scope)})"
             end if options[:scope_count] && scope.show_count
           end

--- a/lib/active_admin/views/components/site_title.rb
+++ b/lib/active_admin/views/components/site_title.rb
@@ -4,7 +4,7 @@ module ActiveAdmin
     class SiteTitle < Component
 
       def tag_name
-        'h1'
+        "h1"
       end
 
       def build(namespace)

--- a/lib/active_admin/views/components/status_tag.rb
+++ b/lib/active_admin/views/components/status_tag.rb
@@ -5,11 +5,11 @@ module ActiveAdmin
       builder_method :status_tag
 
       def tag_name
-        'span'
+        "span"
       end
 
       def default_class_name
-        'status_tag'
+        "status_tag"
       end
 
       # @overload status_tag(status, options = {})
@@ -49,12 +49,12 @@ module ActiveAdmin
 
       def convert_to_boolean_status(status)
         case status
-        when true, 'true'
-          'Yes'
-        when false, 'false'
-          'No'
+        when true, "true"
+          "Yes"
+        when false, "false"
+          "No"
         when nil
-          'Unset'
+          "Unset"
         else
           status
         end
@@ -62,12 +62,12 @@ module ActiveAdmin
 
       def status_to_class(status)
         case status
-        when 'Unset'
-          'unset no'
+        when "Unset"
+          "unset no"
         when String, Symbol
-          status.to_s.titleize.gsub(/\s/, '').underscore
+          status.to_s.titleize.gsub(/\s/, "").underscore
         else
-          ''
+          ""
         end
       end
     end

--- a/lib/active_admin/views/components/table_for.rb
+++ b/lib/active_admin/views/components/table_for.rb
@@ -4,7 +4,7 @@ module ActiveAdmin
       builder_method :table_for
 
       def tag_name
-        'table'
+        "table"
       end
 
       def build(obj, *attrs)
@@ -69,7 +69,7 @@ module ActiveAdmin
         sort_key = sortable? && col.sortable? && col.sort_key
         params = request.query_parameters.except :page, :order, :commit, :format
 
-        classes << 'sortable' if sort_key
+        classes << "sortable" if sort_key
         classes << "sorted-#{current_sort[1]}" if sort_key && current_sort[0] == sort_key
         classes << col.html_class
 
@@ -86,13 +86,13 @@ module ActiveAdmin
         @tbody = tbody do
           # Build enough rows for our collection
           @collection.each do |elem|
-            classes = [helpers.cycle('odd', 'even')]
+            classes = [helpers.cycle("odd", "even")]
 
             if @row_class
               classes << @row_class.call(elem)
             end
 
-            tr(class: classes.flatten.join(' '), id: dom_id_for(elem))
+            tr(class: classes.flatten.join(" "), id: dom_id_for(elem))
           end
         end
       end
@@ -126,8 +126,8 @@ module ActiveAdmin
       # 'desc' it will return 'asc'
       def order_for_sort_key(sort_key)
         current_key, current_order = current_sort
-        return 'desc' unless current_key == sort_key
-        current_order == 'desc' ? 'asc' : 'desc'
+        return "desc" unless current_key == sort_key
+        current_order == "desc" ? "asc" : "desc"
       end
 
       def default_options
@@ -150,7 +150,7 @@ module ActiveAdmin
           elsif @title.present?
             html_classes << "col-#{@title.to_s.parameterize(separator: "_")}"
           end
-          @html_class = html_classes.join(' ')
+          @html_class = html_classes.join(" ")
           @data = args[1] || args[0]
           @data = block if block
           @resource_class = args[2]

--- a/lib/active_admin/views/components/tabs.rb
+++ b/lib/active_admin/views/components/tabs.rb
@@ -10,8 +10,8 @@ module ActiveAdmin
       end
 
       def build(&block)
-        @menu = ul(class: 'nav nav-tabs', role: "tablist")
-        @tabs_content = div(class: 'tab-content')
+        @menu = ul(class: "nav nav-tabs", role: "tablist")
+        @tabs_content = div(class: "tab-content")
       end
 
       def build_menu_item(title, options, &block)

--- a/lib/active_admin/views/footer.rb
+++ b/lib/active_admin/views/footer.rb
@@ -20,7 +20,7 @@ module ActiveAdmin
       end
 
       def powered_by_message
-        I18n.t('active_admin.powered_by',
+        I18n.t("active_admin.powered_by",
           active_admin: link_to("Active Admin", "https://activeadmin.info"),
           version: ActiveAdmin::VERSION).html_safe
       end

--- a/lib/active_admin/views/header.rb
+++ b/lib/active_admin/views/header.rb
@@ -10,8 +10,8 @@ module ActiveAdmin
         @utility_menu = @namespace.fetch_menu(:utility_navigation)
 
         site_title @namespace
-        global_navigation @menu, class: 'header-item tabs'
-        utility_navigation @utility_menu, id: "utility_nav", class: 'header-item tabs'
+        global_navigation @menu, class: "header-item tabs"
+        utility_navigation @utility_menu, id: "utility_nav", class: "header-item tabs"
       end
 
     end

--- a/lib/active_admin/views/index_as_blog.rb
+++ b/lib/active_admin/views/index_as_blog.rb
@@ -135,7 +135,7 @@ module ActiveAdmin
 
       def build_body(post)
         if @body
-          div class: 'content' do
+          div class: "content" do
             render_method_on_post_or_call_proc post, @body
           end
         end

--- a/lib/active_admin/views/index_as_grid.rb
+++ b/lib/active_admin/views/index_as_grid.rb
@@ -68,7 +68,7 @@ module ActiveAdmin
       end
 
       def build_empty_cell
-        td '&nbsp;'.html_safe
+        td "&nbsp;".html_safe
       end
 
       def default_number_of_columns

--- a/lib/active_admin/views/index_as_table.rb
+++ b/lib/active_admin/views/index_as_table.rb
@@ -278,13 +278,13 @@ module ActiveAdmin
         # Display a column for checkbox
         def selectable_column
           return unless active_admin_config.batch_actions.any?
-          column resource_selection_toggle_cell, class: 'col-selectable', sortable: false do |resource|
+          column resource_selection_toggle_cell, class: "col-selectable", sortable: false do |resource|
             resource_selection_cell resource
           end
         end
 
         def index_column(start_value = 1)
-          column '#', class: 'col-index', sortable: false do |resource|
+          column "#", class: "col-index", sortable: false do |resource|
             @collection.offset_value + @collection.index(resource) + start_value
           end
         end
@@ -293,9 +293,9 @@ module ActiveAdmin
         def id_column
           raise "#{resource_class.name} has no primary_key!" unless resource_class.primary_key
           column(resource_class.human_attribute_name(resource_class.primary_key), sortable: resource_class.primary_key) do |resource|
-            if controller.action_methods.include?('show')
+            if controller.action_methods.include?("show")
               link_to resource.id, resource_path(resource), class: "resource_id_link"
-            elsif controller.action_methods.include?('edit')
+            elsif controller.action_methods.include?("edit")
               link_to resource.id, edit_resource_path(resource), class: "resource_id_link"
             else
               resource.id
@@ -304,7 +304,7 @@ module ActiveAdmin
         end
 
         def default_actions
-          raise '`default_actions` is no longer provided in ActiveAdmin 1.x. Use `actions` instead.'
+          raise "`default_actions` is no longer provided in ActiveAdmin 1.x. Use `actions` instead."
         end
 
         # Add links to perform actions.
@@ -344,12 +344,12 @@ module ActiveAdmin
         #
         # ```
         def actions(options = {}, &block)
-          name = options.delete(:name) { '' }
+          name = options.delete(:name) { "" }
           defaults = options.delete(:defaults) { true }
           dropdown = options.delete(:dropdown) { false }
-          dropdown_name = options.delete(:dropdown_name) { I18n.t 'active_admin.dropdown_actions.button_label', default: 'Actions' }
+          dropdown_name = options.delete(:dropdown_name) { I18n.t "active_admin.dropdown_actions.button_label", default: "Actions" }
 
-          options[:class] ||= 'col-actions'
+          options[:class] ||= "col-actions"
 
           column name, options do |resource|
             if dropdown
@@ -373,13 +373,13 @@ module ActiveAdmin
 
         def defaults(resource, options = {})
           localizer = ActiveAdmin::Localizers.resource(active_admin_config)
-          if controller.action_methods.include?('show') && authorized?(ActiveAdmin::Auth::READ, resource)
+          if controller.action_methods.include?("show") && authorized?(ActiveAdmin::Auth::READ, resource)
             item localizer.t(:view), resource_path(resource), class: "view_link #{options[:css_class]}", title: localizer.t(:view)
           end
-          if controller.action_methods.include?('edit') && authorized?(ActiveAdmin::Auth::UPDATE, resource)
+          if controller.action_methods.include?("edit") && authorized?(ActiveAdmin::Auth::UPDATE, resource)
             item localizer.t(:edit), edit_resource_path(resource), class: "edit_link #{options[:css_class]}", title: localizer.t(:edit)
           end
-          if controller.action_methods.include?('destroy') && authorized?(ActiveAdmin::Auth::DESTROY, resource)
+          if controller.action_methods.include?("destroy") && authorized?(ActiveAdmin::Auth::DESTROY, resource)
             item localizer.t(:delete), resource_path(resource), class: "delete_link #{options[:css_class]}", title: localizer.t(:delete),
                                                                 method: :delete, data: { confirm: localizer.t(:delete_confirmation) }
           end

--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -15,7 +15,7 @@ module ActiveAdmin
         end
 
         def main_content
-          I18n.t('active_admin.main_content', model: title).html_safe
+          I18n.t("active_admin.main_content", model: title).html_safe
         end
 
         private
@@ -65,9 +65,9 @@ module ActiveAdmin
         def body_classes
           Arbre::HTML::ClassList.new [
             params[:action],
-            params[:controller].tr('/', '_'),
-            'active_admin', 'logged_in',
-            active_admin_namespace.name.to_s + '_namespace'
+            params[:controller].tr("/", "_"),
+            "active_admin", "logged_in",
+            active_admin_namespace.name.to_s + "_namespace"
           ]
         end
 
@@ -81,12 +81,12 @@ module ActiveAdmin
           build_flash_messages
           div id: "active_admin_content", class: (skip_sidebar? ? "without_sidebar" : "with_sidebar") do
             build_main_content_wrapper
-            sidebar sidebar_sections_for_action, id: 'sidebar' unless skip_sidebar?
+            sidebar sidebar_sections_for_action, id: "sidebar" unless skip_sidebar?
           end
         end
 
         def build_flash_messages
-          div class: 'flashes' do
+          div class: "flashes" do
             flash_messages.each do |type, messages|
               [*messages].each do |message|
                 div message, class: "flash flash_#{type}"

--- a/lib/active_admin/views/pages/index.rb
+++ b/lib/active_admin/views/pages/index.rb
@@ -1,4 +1,4 @@
-require 'active_admin/helpers/collection'
+require "active_admin/helpers/collection"
 
 module ActiveAdmin
   module Views
@@ -111,7 +111,7 @@ module ActiveAdmin
 
         def render_blank_slate
           blank_slate_content = I18n.t("active_admin.blank_slate.content", resource_name: active_admin_config.plural_resource_label)
-          if controller.action_methods.include?('new') && authorized?(ActiveAdmin::Auth::CREATE, active_admin_config.resource_class)
+          if controller.action_methods.include?("new") && authorized?(ActiveAdmin::Auth::CREATE, active_admin_config.resource_class)
             blank_slate_content = [blank_slate_content, blank_slate_link].compact.join(" ")
           end
           insert_tag(view_factory.blank_slate, blank_slate_content)
@@ -136,7 +136,7 @@ module ActiveAdmin
                                            paginator: paginator,
                                            per_page: per_page,
                                            pagination_total: pagination_total) do
-            div class: 'index_content' do
+            div class: "index_content" do
               insert_tag(renderer_class, config, collection)
             end
           end

--- a/lib/active_admin/views/tabbed_navigation.rb
+++ b/lib/active_admin/views/tabbed_navigation.rb
@@ -1,10 +1,10 @@
-require_relative 'components/menu'
+require_relative "components/menu"
 
 module ActiveAdmin
   module Views
     class TabbedNavigation < Menu
       def build(menu, options = {})
-        super(menu, options.reverse_merge(id: 'tabs'))
+        super(menu, options.reverse_merge(id: "tabs"))
       end
     end
   end

--- a/lib/active_admin/views/title_bar.rb
+++ b/lib/active_admin/views/title_bar.rb
@@ -43,7 +43,7 @@ module ActiveAdmin
       end
 
       def build_title_tag
-        h2(@title, id: 'page_title')
+        h2(@title, id: "page_title")
       end
 
       def build_action_items

--- a/lib/activeadmin.rb
+++ b/lib/activeadmin.rb
@@ -1,1 +1,1 @@
-require 'active_admin'
+require "active_admin"

--- a/lib/generators/active_admin/assets/assets_generator.rb
+++ b/lib/generators/active_admin/assets/assets_generator.rb
@@ -2,10 +2,10 @@ module ActiveAdmin
   module Generators
     class AssetsGenerator < Rails::Generators::Base
 
-      source_root File.expand_path('templates', __dir__)
+      source_root File.expand_path("templates", __dir__)
 
       def install_assets
-        template 'active_admin.js', 'app/assets/javascripts/active_admin.js'
+        template "active_admin.js", "app/assets/javascripts/active_admin.js"
         template "active_admin.scss", "app/assets/stylesheets/active_admin.scss"
       end
 

--- a/lib/generators/active_admin/devise/devise_generator.rb
+++ b/lib/generators/active_admin/devise/devise_generator.rb
@@ -22,7 +22,7 @@ module ActiveAdmin
           raise ActiveAdmin::GeneratorError, "#{e.message} If you don't want to use devise, run the generator with --skip-users."
         end
 
-        require 'devise'
+        require "devise"
 
         initializer_file =
           File.join(destination_root, "config", "initializers", "devise.rb")

--- a/lib/generators/active_admin/install/install_generator.rb
+++ b/lib/generators/active_admin/install/install_generator.rb
@@ -1,4 +1,4 @@
-require 'rails/generators/active_record'
+require "rails/generators/active_record"
 
 module ActiveAdmin
   module Generators
@@ -10,22 +10,22 @@ module ActiveAdmin
       class_option :skip_comments, type: :boolean, default: false, desc: "Skip installation of comments"
       class_option :use_webpacker, type: :boolean, default: false, desc: "Use Webpacker assets instead of Sprockets"
 
-      source_root File.expand_path('templates', __dir__)
+      source_root File.expand_path("templates", __dir__)
 
       def copy_initializer
-        @underscored_user_name = name.underscore.gsub('/', '_')
+        @underscored_user_name = name.underscore.gsub("/", "_")
         @use_authentication_method = options[:users].present?
         @skip_comments = options[:skip_comments]
         @use_webpacker = options[:use_webpacker]
-        template 'active_admin.rb.erb', 'config/initializers/active_admin.rb'
+        template "active_admin.rb.erb", "config/initializers/active_admin.rb"
       end
 
       def setup_directory
         empty_directory "app/admin"
-        template 'dashboard.rb', 'app/admin/dashboard.rb'
+        template "dashboard.rb", "app/admin/dashboard.rb"
         if options[:users].present?
           @user_class = name
-          template 'admin_users.rb.erb', "app/admin/#{name.underscore.pluralize}.rb"
+          template "admin_users.rb.erb", "app/admin/#{name.underscore.pluralize}.rb"
         end
       end
 
@@ -47,7 +47,7 @@ module ActiveAdmin
 
       def create_migrations
         unless options[:skip_comments]
-          migration_template 'migrations/create_active_admin_comments.rb.erb', 'db/migrate/create_active_admin_comments.rb'
+          migration_template "migrations/create_active_admin_comments.rb.erb", "db/migrate/create_active_admin_comments.rb"
         end
       end
     end

--- a/lib/generators/active_admin/page/page_generator.rb
+++ b/lib/generators/active_admin/page/page_generator.rb
@@ -1,7 +1,7 @@
 module ActiveAdmin
   module Generators
     class PageGenerator < Rails::Generators::NamedBase
-      source_root File.expand_path('templates', __dir__)
+      source_root File.expand_path("templates", __dir__)
 
       def generate_config_file
         template "page.rb", "app/admin/#{file_path.tr('/', '_')}.rb"

--- a/lib/generators/active_admin/resource/resource_generator.rb
+++ b/lib/generators/active_admin/resource/resource_generator.rb
@@ -1,4 +1,4 @@
-require 'active_admin/generators/boilerplate'
+require "active_admin/generators/boilerplate"
 
 module ActiveAdmin
   module Generators
@@ -8,7 +8,7 @@ module ActiveAdmin
       class_option :include_boilerplate, type: :boolean, default: false,
                                          desc: "Generate boilerplate code for your resource."
 
-      source_root File.expand_path('templates', __dir__)
+      source_root File.expand_path("templates", __dir__)
 
       def generate_config_file
         @boilerplate = ActiveAdmin::Generators::Boilerplate.new(class_name)

--- a/lib/generators/active_admin/webpacker/webpacker_generator.rb
+++ b/lib/generators/active_admin/webpacker/webpacker_generator.rb
@@ -2,12 +2,12 @@ module ActiveAdmin
   module Generators
     class WebpackerGenerator < Rails::Generators::Base
 
-      source_root File.expand_path('templates', __dir__)
+      source_root File.expand_path("templates", __dir__)
 
       def install_assets
-        template 'active_admin.js', 'app/javascript/packs/active_admin.js'
+        template "active_admin.js", "app/javascript/packs/active_admin.js"
         template "active_admin.scss", "app/javascript/stylesheets/active_admin.scss"
-        template 'print.scss', 'app/javascript/packs/active_admin/print.scss'
+        template "print.scss", "app/javascript/packs/active_admin/print.scss"
 
         copy_file "#{__dir__}/plugins/jquery.js", Rails.root.join("config/webpack/plugins/jquery.js").to_s
 

--- a/lib/ransack_ext.rb
+++ b/lib/ransack_ext.rb
@@ -2,19 +2,19 @@
 # identically to the versions given in Ransack.
 #
 Ransack.configure do |config|
-  { 'contains' => 'cont', 'starts_with' => 'start', 'ends_with' => 'end' }.each do |old, current|
+  { "contains" => "cont", "starts_with" => "start", "ends_with" => "end" }.each do |old, current|
     config.add_predicate old, Ransack::Constants::DERIVED_PREDICATES.detect { |q, _| q == current }[1]
   end
 
-  { 'equals' => 'eq', 'greater_than' => 'gt', 'less_than' => 'lt' }.each do |old, current|
+  { "equals" => "eq", "greater_than" => "gt", "less_than" => "lt" }.each do |old, current|
     config.add_predicate old, arel_predicate: current
   end
 
-  config.add_predicate 'gteq_datetime',
-    arel_predicate: 'gteq',
+  config.add_predicate "gteq_datetime",
+    arel_predicate: "gteq",
     formatter: ->(v) { v.beginning_of_day }
 
-  config.add_predicate 'lteq_datetime',
-  	arel_predicate: 'lt',
+  config.add_predicate "lteq_datetime",
+  	arel_predicate: "lt",
   	formatter: ->(v) { v + 1.day }
 end

--- a/spec/changelog_spec.lint.rb
+++ b/spec/changelog_spec.lint.rb
@@ -7,57 +7,57 @@ RSpec.describe "Changelog" do
     File.read("CHANGELOG.md")
   end
 
-  it 'uses the simplest style for implicit links' do
+  it "uses the simplest style for implicit links" do
     expect(changelog).not_to match(/\[([^\]]+)\]\[\]/)
   end
 
-  it 'has definitions for all issue/pr references' do
+  it "has definitions for all issue/pr references" do
     implicit_link_names = changelog.scan(/\[#(\d+)\] /).flatten.uniq
     implicit_link_names.each do |name|
       expect(changelog).to include("[##{name}]: https://github.com/activeadmin/activeadmin/pull/#{name}").or include("[##{name}]: https://github.com/activeadmin/activeadmin/issues/#{name}")
     end
   end
 
-  it 'does not include explicit pr links' do
+  it "does not include explicit pr links" do
     explicit_link_names = changelog.scan(/\[#(\d+)\]\(https:\/\/github\.com\/activeadmin\/activeadmin\/pull\/\1\)/).flatten.uniq
     expect(explicit_link_names).to be_empty
   end
 
-  it 'has definitions for users' do
+  it "has definitions for users" do
     implicit_link_names = changelog.scan(/\[@([^\]]+)\]/).flatten.uniq
     implicit_link_names.each do |name|
       expect(changelog).to include("[@#{name}]: https://github.com/#{name}")
     end
   end
 
-  it 'sorts contributors' do
+  it "sorts contributors" do
     contributors = changelog.scan(/^\[@([^\]]+)\]: https:\/\/github\.com\/\1$/).flatten
     expect(contributors).to eq(contributors.sort { |a, b| a.downcase <=> b.downcase })
   end
 
-  it 'sorts pull requests' do
+  it "sorts pull requests" do
     pull_requests = changelog.scan(/^\[#(\d+)\]\: https:\/\/github\.com\/activeadmin\/activeadmin\/pull\/\1$/).flatten
     expect(pull_requests).to eq(pull_requests.sort)
   end
 
-  it 'has well defined third level entries' do
+  it "has well defined third level entries" do
     third_level_entries = changelog.scan(/^### (.*)$/).flatten.uniq.sort
     expect(third_level_entries).to eq(["Breaking Changes", "Bug Fixes", "Dependency Changes", "Deprecations", "Documentation", "Enhancements", "Security Fixes", "Translation Improvements"])
   end
 
-  describe 'entry' do
+  describe "entry" do
     let(:lines) { changelog.each_line }
 
     subject(:entries) { lines.grep(/^\*/) }
 
-    it 'does not end with a punctuation' do
+    it "does not end with a punctuation" do
       entries.each do |entry|
         expect(entry).not_to match(/\.$/)
       end
     end
   end
 
-  describe 'warnings' do
+  describe "warnings" do
     subject(:document) { Kramdown::Document.new(changelog) }
 
     specify { expect(document.warnings).to be_empty }

--- a/spec/i18n_spec.lint.rb
+++ b/spec/i18n_spec.lint.rb
@@ -1,18 +1,18 @@
-require 'i18n/tasks'
-require 'i18n-spec'
+require "i18n/tasks"
+require "i18n-spec"
 
-Dir.glob('config/locales/*.yml') do |locale_file|
+Dir.glob("config/locales/*.yml") do |locale_file|
   RSpec.describe locale_file do
     it { is_expected.to be_parseable }
     it { is_expected.to have_one_top_level_namespace }
     it { is_expected.to be_named_like_top_level_namespace }
     it { is_expected.to_not have_legacy_interpolations }
     it { is_expected.to have_a_valid_locale }
-    it { is_expected.to be_a_subset_of 'config/locales/en.yml' }
+    it { is_expected.to be_a_subset_of "config/locales/en.yml" }
   end
 end
 
-RSpec.describe 'I18n' do
+RSpec.describe "I18n" do
   let(:i18n) { I18n::Tasks::BaseTask.new }
 
   let(:unused_keys) { i18n.unused_keys }
@@ -27,11 +27,11 @@ RSpec.describe 'I18n' do
     "#{inconsistent_interpolation_key_count} inconsistent interpolations, run `bin/i18n-tasks check-consistent-interpolations` to show them"
   end
 
-  it 'does not have unused keys' do
+  it "does not have unused keys" do
     expect(unused_keys).to be_empty, unused_key_failure_msg
   end
 
-  it 'does not have inconsistent interpolations' do
+  it "does not have inconsistent interpolations" do
     expect(inconsistent_interpolations).to be_empty, inconsistent_interpolation_failure_msg
   end
 end

--- a/spec/javascripts/support/jasmine_runner.rb
+++ b/spec/javascripts/support/jasmine_runner.rb
@@ -1,7 +1,7 @@
-$:.unshift(ENV['JASMINE_GEM_PATH']) if ENV['JASMINE_GEM_PATH'] # for gem testing purposes
+$:.unshift(ENV["JASMINE_GEM_PATH"]) if ENV["JASMINE_GEM_PATH"] # for gem testing purposes
 
-require 'jasmine'
-require 'spec'
+require "jasmine"
+require "spec"
 
 jasmine_config = Jasmine::Config.new
 spec_builder = Jasmine::SpecBuilder.new(jasmine_config)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,12 +1,12 @@
-require 'spec_helper'
+require "spec_helper"
 
-ENV['RAILS_ENV'] = 'test'
+ENV["RAILS_ENV"] = "test"
 
 require_relative "../tasks/test_application"
 
 require "#{ActiveAdmin::TestApplication.new.full_app_dir}/config/environment.rb"
 
-require 'rspec/rails'
+require "rspec/rails"
 
 # Disabling authentication in specs so that we don't have to worry about
 # it allover the place
@@ -20,7 +20,7 @@ RSpec.configure do |config|
 
   config.include Devise::Test::ControllerHelpers, type: :controller
 
-  require 'support/active_admin_integration_spec_helper'
+  require "support/active_admin_integration_spec_helper"
   config.include ActiveAdminIntegrationSpecHelper
 end
 

--- a/spec/requests/default_namespace_spec.rb
+++ b/spec/requests/default_namespace_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Application, type: :request do
   let(:resource) { ActiveAdmin.register Category }

--- a/spec/requests/memory_spec.rb
+++ b/spec/requests/memory_spec.rb
@@ -1,6 +1,6 @@
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe "Memory Leak", type: :request, if: RUBY_ENGINE == 'ruby' do
+RSpec.describe "Memory Leak", type: :request, if: RUBY_ENGINE == "ruby" do
   around do |example|
     with_resources_during(example) { ActiveAdmin.register(Category) }
   end

--- a/spec/requests/stylesheets_spec.rb
+++ b/spec/requests/stylesheets_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Stylesheets", type: :request, unless: ActiveAdmin.application.use_webpacker do
   require "sprockets"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-require 'simplecov' if ENV["COVERAGE"] == "true"
+require "simplecov" if ENV["COVERAGE"] == "true"
 
 RSpec.configure do |config|
   config.disable_monkey_patching!

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -3,56 +3,56 @@
 webpacker_app = ENV["BUNDLE_GEMFILE"] == File.expand_path("../../gemfiles/rails_60_webpacker/Gemfile", __dir__)
 
 if webpacker_app
-  create_file 'app/javascript/packs/some-random-css.css'
-  create_file 'app/javascript/packs/some-random-js.js'
+  create_file "app/javascript/packs/some-random-css.css"
+  create_file "app/javascript/packs/some-random-js.js"
 else
-  create_file 'app/assets/stylesheets/some-random-css.css'
-  create_file 'app/assets/javascripts/some-random-js.js'
+  create_file "app/assets/stylesheets/some-random-css.css"
+  create_file "app/assets/javascripts/some-random-js.js"
 end
 
-create_file 'app/assets/images/a/favicon.ico'
+create_file "app/assets/images/a/favicon.ico"
 
-require 'active_admin/dependency'
+require "active_admin/dependency"
 
-timestamps = ActiveAdmin::Dependency.rails?('>= 6.1.0.a') ? '--timestamps' : 'created_at:datetime updated_at:datetime'
+timestamps = ActiveAdmin::Dependency.rails?(">= 6.1.0.a") ? "--timestamps" : "created_at:datetime updated_at:datetime"
 
-generate :migration, 'create_posts title:string body:text published_date:date author_id:integer ' +
+generate :migration, "create_posts title:string body:text published_date:date author_id:integer " +
   "position:integer custom_category_id:integer starred:boolean foo_id:integer #{timestamps}"
 
-copy_file File.expand_path('templates/models/post.rb', __dir__), 'app/models/post.rb'
-copy_file File.expand_path('templates/post_decorator.rb', __dir__), 'app/models/post_decorator.rb'
-copy_file File.expand_path('templates/post_poro_decorator.rb', __dir__), 'app/models/post_poro_decorator.rb'
+copy_file File.expand_path("templates/models/post.rb", __dir__), "app/models/post.rb"
+copy_file File.expand_path("templates/post_decorator.rb", __dir__), "app/models/post_decorator.rb"
+copy_file File.expand_path("templates/post_poro_decorator.rb", __dir__), "app/models/post_poro_decorator.rb"
 
-generate :migration, 'create_blog_posts title:string body:text published_date:date author_id:integer ' +
+generate :migration, "create_blog_posts title:string body:text published_date:date author_id:integer " +
   "position:integer custom_category_id:integer starred:boolean foo_id:integer #{timestamps}"
 
-copy_file File.expand_path('templates/models/blog/post.rb', __dir__), 'app/models/blog/post.rb'
+copy_file File.expand_path("templates/models/blog/post.rb", __dir__), "app/models/blog/post.rb"
 
 generate :migration, "create_profiles user_id:integer bio:text #{timestamps}"
 
-copy_file File.expand_path('templates/models/user.rb', __dir__), 'app/models/user.rb'
+copy_file File.expand_path("templates/models/user.rb", __dir__), "app/models/user.rb"
 
 generate :migration, "create_users type:string first_name:string last_name:string username:string age:integer encrypted_password:string reason_of_sign_in:string #{timestamps}"
 
-copy_file File.expand_path('templates/models/profile.rb', __dir__), 'app/models/profile.rb'
+copy_file File.expand_path("templates/models/profile.rb", __dir__), "app/models/profile.rb"
 
-generate :model, 'publisher --migration=false --parent=User'
+generate :model, "publisher --migration=false --parent=User"
 
 generate :migration, "create_categories name:string description:text #{timestamps}"
 
-copy_file File.expand_path('templates/models/category.rb', __dir__), 'app/models/category.rb'
+copy_file File.expand_path("templates/models/category.rb", __dir__), "app/models/category.rb"
 
-generate :model, 'store name:string user_id:integer'
+generate :model, "store name:string user_id:integer"
 
 generate :migration, "create_tags name:string #{timestamps}"
 
-copy_file File.expand_path('templates/models/tag.rb', __dir__), 'app/models/tag.rb'
+copy_file File.expand_path("templates/models/tag.rb", __dir__), "app/models/tag.rb"
 
 generate :migration, "create_taggings post_id:integer tag_id:integer position:integer #{timestamps}"
 
-copy_file File.expand_path('templates/models/tagging.rb', __dir__), 'app/models/tagging.rb'
+copy_file File.expand_path("templates/models/tagging.rb", __dir__), "app/models/tagging.rb"
 
-gsub_file 'config/environments/test.rb', /  config.cache_classes = true/, <<-RUBY
+gsub_file "config/environments/test.rb", /  config.cache_classes = true/, <<-RUBY
 
   config.cache_classes = !ENV['CLASS_RELOADING']
   config.action_mailer.default_url_options = {host: 'example.com'}
@@ -62,48 +62,48 @@ gsub_file 'config/environments/test.rb', /  config.cache_classes = true/, <<-RUB
 
 RUBY
 
-gsub_file 'config/boot.rb', /^.*BUNDLE_GEMFILE.*$/, <<-RUBY
+gsub_file "config/boot.rb", /^.*BUNDLE_GEMFILE.*$/, <<-RUBY
   ENV['BUNDLE_GEMFILE'] = "#{File.expand_path(ENV['BUNDLE_GEMFILE'])}"
 RUBY
 
 # Setup webpacker if necessary
 if webpacker_app
   rails_command "webpacker:install"
-  gsub_file 'config/webpacker.yml', /^(.*)extract_css.*$/, '\1extract_css: true' if ENV['RAILS_ENV'] == 'test'
+  gsub_file "config/webpacker.yml", /^(.*)extract_css.*$/, '\1extract_css: true' if ENV["RAILS_ENV"] == "test"
 end
 
 # Setup Active Admin
 generate "active_admin:install#{" --use-webpacker" if webpacker_app}"
 
 # Force strong parameters to raise exceptions
-inject_into_file 'config/application.rb', after: 'class Application < Rails::Application' do
+inject_into_file "config/application.rb", after: "class Application < Rails::Application" do
   "\n    config.action_controller.action_on_unpermitted_parameters = :raise\n"
 end
 
 # Add some translations
-append_file 'config/locales/en.yml', File.read(File.expand_path('templates/en.yml', __dir__))
+append_file "config/locales/en.yml", File.read(File.expand_path("templates/en.yml", __dir__))
 
 # Add predefined admin resources
-directory File.expand_path('templates/admin', __dir__), 'app/admin'
+directory File.expand_path("templates/admin", __dir__), "app/admin"
 
 # Add predefined policies
-directory File.expand_path('templates/policies', __dir__), 'app/policies'
+directory File.expand_path("templates/policies", __dir__), "app/policies"
 
 # Require turbolinks if necessary
 if ENV["BUNDLE_GEMFILE"] == File.expand_path("../../gemfiles/rails_60_turbolinks/Gemfile", __dir__)
-  append_file 'app/assets/javascripts/active_admin.js', "//= require turbolinks\n"
+  append_file "app/assets/javascripts/active_admin.js", "//= require turbolinks\n"
 end
 
-if ENV['RAILS_ENV'] != 'test'
-  inject_into_file 'config/routes.rb', "\n  root to: redirect('admin')", after: /.*routes.draw do/
+if ENV["RAILS_ENV"] != "test"
+  inject_into_file "config/routes.rb", "\n  root to: redirect('admin')", after: /.*routes.draw do/
 end
 
-rails_command "db:drop db:create db:migrate", env: ENV['RAILS_ENV']
+rails_command "db:drop db:create db:migrate", env: ENV["RAILS_ENV"]
 
-if ENV['RAILS_ENV'] == 'test'
-  inject_into_file 'config/database.yml', "<%= ENV['TEST_ENV_NUMBER'] %>", after: 'test.sqlite3'
+if ENV["RAILS_ENV"] == "test"
+  inject_into_file "config/database.yml", "<%= ENV['TEST_ENV_NUMBER'] %>", after: "test.sqlite3"
 
-  rails_command "parallel:drop parallel:create parallel:load_schema", env: ENV['RAILS_ENV']
+  rails_command "parallel:drop parallel:create parallel:load_schema", env: ENV["RAILS_ENV"]
 end
 
 git add: "."

--- a/spec/support/rails_template_with_data.rb
+++ b/spec/support/rails_template_with_data.rb
@@ -1,16 +1,16 @@
-apply File.expand_path('rails_template.rb', __dir__)
+apply File.expand_path("rails_template.rb", __dir__)
 
-inject_into_file 'config/initializers/active_admin.rb', <<-RUBY, after: "ActiveAdmin.setup do |config|"
+inject_into_file "config/initializers/active_admin.rb", <<-RUBY, after: "ActiveAdmin.setup do |config|"
 
   config.comments_menu = { parent: 'Administrative' }
 RUBY
 
-inject_into_file 'app/admin/admin_users.rb', <<-RUBY, after: "ActiveAdmin.register AdminUser do"
+inject_into_file "app/admin/admin_users.rb", <<-RUBY, after: "ActiveAdmin.register AdminUser do"
 
   menu parent: "Administrative", priority: 1
 RUBY
 
-copy_file File.expand_path('templates_with_data/admin/kitchen_sink.rb', __dir__), 'app/admin/kitchen_sink.rb'
+copy_file File.expand_path("templates_with_data/admin/kitchen_sink.rb", __dir__), "app/admin/kitchen_sink.rb"
 
 %w{posts users categories tags}.each do |resource|
   copy_file File.expand_path("templates_with_data/admin/#{resource}.rb", __dir__), "app/admin/#{resource}.rb"
@@ -54,7 +54,7 @@ append_file "db/seeds.rb", "\n\n" + <<-RUBY.strip_heredoc
   end
 RUBY
 
-rails_command 'db:seed'
+rails_command "db:seed"
 
-git add: '.'
+git add: "."
 git commit: "-m 'Bare application with data'"

--- a/spec/support/simplecov_regular_env.rb
+++ b/spec/support/simplecov_regular_env.rb
@@ -1,5 +1,5 @@
 if ENV["COVERAGE"] == "true"
   require "simplecov"
 
-  SimpleCov.command_name ["regular specs", ENV['TEST_ENV_NUMBER']].join(" ").rstrip
+  SimpleCov.command_name ["regular specs", ENV["TEST_ENV_NUMBER"]].join(" ").rstrip
 end

--- a/spec/support/templates/models/blog/post.rb
+++ b/spec/support/templates/models/blog/post.rb
@@ -1,6 +1,6 @@
 class Blog::Post < ActiveRecord::Base
   belongs_to :category, foreign_key: :custom_category_id
-  belongs_to :author, class_name: 'User'
+  belongs_to :author, class_name: "User"
   has_many :taggings
   accepts_nested_attributes_for :author
   accepts_nested_attributes_for :taggings, allow_destroy: true

--- a/spec/support/templates/models/post.rb
+++ b/spec/support/templates/models/post.rb
@@ -1,6 +1,6 @@
 class Post < ActiveRecord::Base
   belongs_to :category, foreign_key: :custom_category_id, optional: true
-  belongs_to :author, class_name: 'User', optional: true
+  belongs_to :author, class_name: "User", optional: true
   has_many :taggings
   has_many :tags, through: :taggings
   accepts_nested_attributes_for :author

--- a/spec/support/templates/models/user.rb
+++ b/spec/support/templates/models/user.rb
@@ -1,8 +1,8 @@
 class User < ActiveRecord::Base
   class VIP < self
   end
-  has_many :posts, foreign_key: 'author_id'
-  has_many :articles, class_name: 'Post', foreign_key: 'author_id'
+  has_many :posts, foreign_key: "author_id"
+  has_many :articles, class_name: "Post", foreign_key: "author_id"
   has_one :profile
   accepts_nested_attributes_for :profile, allow_destroy: true
   accepts_nested_attributes_for :posts, allow_destroy: true

--- a/spec/support/templates/post_decorator.rb
+++ b/spec/support/templates/post_decorator.rb
@@ -1,4 +1,4 @@
-require 'draper'
+require "draper"
 
 class PostDecorator < Draper::Decorator
   decorates :post
@@ -19,6 +19,6 @@ class PostDecorator < Draper::Decorator
   end
 
   def decorator_method
-    'A method only available on the decorator'
+    "A method only available on the decorator"
   end
 end

--- a/spec/support/templates/post_poro_decorator.rb
+++ b/spec/support/templates/post_poro_decorator.rb
@@ -6,7 +6,7 @@ class PostPoroDecorator
   end
 
   def decorator_method
-    'A method only available on the PORO decorator'
+    "A method only available on the PORO decorator"
   end
 
   private

--- a/spec/support/templates_with_data/admin/posts.rb
+++ b/spec/support/templates_with_data/admin/posts.rb
@@ -24,7 +24,7 @@ ActiveAdmin.register Post do
   end
 
   batch_action :set_starred, form: { starred: :checkbox } do |ids, inputs|
-    Post.where(id: ids).update_all(starred: inputs['starred'].present?)
+    Post.where(id: ids).update_all(starred: inputs["starred"].present?)
     redirect_to collection_path(user_id: params["user_id"]), notice: "The posts have been updated."
   end
 
@@ -59,7 +59,7 @@ ActiveAdmin.register Post do
   end
 
   action_item :toggle_starred, only: :show do
-    link_to 'Toggle Starred', toggle_starred_admin_user_post_path(post.author, post), method: :put
+    link_to "Toggle Starred", toggle_starred_admin_user_post_path(post.author, post), method: :put
   end
 
   show do |post|
@@ -78,7 +78,7 @@ ActiveAdmin.register Post do
 
     columns do
       column do
-        panel 'Tags' do
+        panel "Tags" do
           table_for(post.taggings.order(:position)) do
             column :id do |tagging|
               link_to tagging.tag_id, admin_tag_path(tagging.tag)
@@ -90,7 +90,7 @@ ActiveAdmin.register Post do
         end
       end
       column do
-        panel 'Category' do
+        panel "Category" do
           attributes_table_for post.category do
             row :id do |category|
               link_to category.id, admin_category_path(category)
@@ -105,7 +105,7 @@ ActiveAdmin.register Post do
   form do |f|
     columns do
       column do
-        f.inputs 'Details' do
+        f.inputs "Details" do
           f.input :title
           f.input :author
           f.input :published_date,
@@ -117,7 +117,7 @@ ActiveAdmin.register Post do
         end
       end
       column do
-        f.inputs 'Content' do
+        f.inputs "Content" do
           f.input :body
         end
       end

--- a/spec/support/templates_with_data/admin/users.rb
+++ b/spec/support/templates_with_data/admin/users.rb
@@ -6,12 +6,12 @@ ActiveAdmin.register User do
   index as: :grid do |user|
     div for: user do
       resource_selection_cell user
-      h2 link_to(user.display_name, admin_user_path(user)), style: 'margin-bottom: 0'
+      h2 link_to(user.display_name, admin_user_path(user)), style: "margin-bottom: 0"
       para do
-        strong user.username, style: 'text-transform: uppercase; font-size: 10px;'
+        strong user.username, style: "text-transform: uppercase; font-size: 10px;"
         br
         em user.age
-        text_node 'years old'
+        text_node "years old"
       end
     end
   end
@@ -27,7 +27,7 @@ ActiveAdmin.register User do
       row :updated_at
     end
 
-    panel 'Posts' do
+    panel "Posts" do
       paginated_collection(user.posts.includes(:category).order(:updated_at).page(params[:page]).per(10), download_links: false) do
         table_for(collection) do
           column :id do |post|

--- a/spec/unit/abstract_view_factory_spec.rb
+++ b/spec/unit/abstract_view_factory_spec.rb
@@ -1,6 +1,6 @@
-require 'rails_helper'
+require "rails_helper"
 
-require 'active_admin/abstract_view_factory'
+require "active_admin/abstract_view_factory"
 
 RSpec.describe ActiveAdmin::AbstractViewFactory do
   let(:view_factory) { ActiveAdmin::AbstractViewFactory.new }

--- a/spec/unit/action_builder_spec.rb
+++ b/spec/unit/action_builder_spec.rb
@@ -1,6 +1,6 @@
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'defining actions from registration blocks', type: :controller do
+RSpec.describe "defining actions from registration blocks", type: :controller do
   let(:klass) { Admin::PostsController }
 
   before do
@@ -9,12 +9,12 @@ RSpec.describe 'defining actions from registration blocks', type: :controller do
     @controller = klass.new
   end
 
-  describe 'creates a member action' do
+  describe "creates a member action" do
     after do
       klass.clear_member_actions!
     end
 
-    context 'with a block' do
+    context "with a block" do
       let(:action!) do
         ActiveAdmin.register Post do
           member_action :comment do
@@ -23,54 +23,54 @@ RSpec.describe 'defining actions from registration blocks', type: :controller do
         end
       end
 
-      it 'should create a new public instance method' do
-        expect(klass.public_instance_methods.collect(&:to_s)).to include('comment')
+      it "should create a new public instance method" do
+        expect(klass.public_instance_methods.collect(&:to_s)).to include("comment")
       end
 
-      it 'should add itself to the member actions config' do
+      it "should add itself to the member actions config" do
         expect(klass.active_admin_config.member_actions.size).to eq 1
       end
 
-      it 'should create a new named route' do
-        expect(Rails.application.routes.url_helpers.methods.collect(&:to_s)).to include('comment_admin_post_path')
+      it "should create a new named route" do
+        expect(Rails.application.routes.url_helpers.methods.collect(&:to_s)).to include("comment_admin_post_path")
       end
     end
 
-    context 'without a block' do
+    context "without a block" do
       let(:action!) do
         ActiveAdmin.register Post do
           member_action :comment
         end
       end
 
-      it 'should still generate a new empty action' do
-        expect(klass.public_instance_methods.collect(&:to_s)).to include('comment')
+      it "should still generate a new empty action" do
+        expect(klass.public_instance_methods.collect(&:to_s)).to include("comment")
       end
     end
 
-    context 'with :title' do
+    context "with :title" do
       let(:action!) do
         ActiveAdmin.register Post do
-          member_action :comment, title: 'My Awesome Comment' do
+          member_action :comment, title: "My Awesome Comment" do
             render json: { a: 2 }
           end
         end
       end
 
-      it 'sets the page title' do
+      it "sets the page title" do
         get :comment, params: { id: 1 }
 
-        expect(controller.instance_variable_get(:@page_title)).to eq 'My Awesome Comment'
+        expect(controller.instance_variable_get(:@page_title)).to eq "My Awesome Comment"
       end
     end
   end
 
-  describe 'creates a collection action' do
+  describe "creates a collection action" do
     after do
       klass.clear_collection_actions!
     end
 
-    context 'with a block' do
+    context "with a block" do
       let(:action!) do
         ActiveAdmin.register Post do
           collection_action :comments do
@@ -79,49 +79,49 @@ RSpec.describe 'defining actions from registration blocks', type: :controller do
         end
       end
 
-      it 'should create a public instance method' do
-        expect(klass.public_instance_methods.collect(&:to_s)).to include('comments')
+      it "should create a public instance method" do
+        expect(klass.public_instance_methods.collect(&:to_s)).to include("comments")
       end
 
-      it 'should add itself to the member actions config' do
+      it "should add itself to the member actions config" do
         expect(klass.active_admin_config.collection_actions.size).to eq 1
       end
 
-      it 'should create a named route' do
-        expect(Rails.application.routes.url_helpers.methods.collect(&:to_s)).to include('comments_admin_posts_path')
+      it "should create a named route" do
+        expect(Rails.application.routes.url_helpers.methods.collect(&:to_s)).to include("comments_admin_posts_path")
       end
     end
 
-    context 'without a block' do
+    context "without a block" do
       let(:action!) do
         ActiveAdmin.register Post do
           collection_action :comments
         end
       end
 
-      it 'should still generate a new empty action' do
-        expect(klass.public_instance_methods.collect(&:to_s)).to include('comments')
+      it "should still generate a new empty action" do
+        expect(klass.public_instance_methods.collect(&:to_s)).to include("comments")
       end
     end
 
-    context 'with :title' do
+    context "with :title" do
       let(:action!) do
         ActiveAdmin.register Post do
-          collection_action :comments, title: 'My Awesome Comments' do
+          collection_action :comments, title: "My Awesome Comments" do
             render json: { a: 2 }
           end
         end
       end
 
-      it 'sets the page title' do
+      it "sets the page title" do
         get :comments
 
-        expect(controller.instance_variable_get(:@page_title)).to eq 'My Awesome Comments'
+        expect(controller.instance_variable_get(:@page_title)).to eq "My Awesome Comments"
       end
     end
   end
 
-  context 'when method with given name is already defined' do
+  context "when method with given name is already defined" do
     around do |example|
       original_stderr = $stderr
       $stderr = StringIO.new
@@ -129,27 +129,27 @@ RSpec.describe 'defining actions from registration blocks', type: :controller do
       $stderr = original_stderr
     end
 
-    describe 'defining member action' do
+    describe "defining member action" do
       let :action! do
         ActiveAdmin.register Post do
           member_action :process
         end
       end
 
-      it 'writes warning to $stderr' do
-        expect($stderr.string).to include('Warning: method `process` already defined in Admin::PostsController')
+      it "writes warning to $stderr" do
+        expect($stderr.string).to include("Warning: method `process` already defined in Admin::PostsController")
       end
     end
 
-    describe 'defining collection action' do
+    describe "defining collection action" do
       let :action! do
         ActiveAdmin.register Post do
           collection_action :process
         end
       end
 
-      it 'writes warning to $stderr' do
-        expect($stderr.string).to include('Warning: method `process` already defined in Admin::PostsController')
+      it "writes warning to $stderr" do
+        expect($stderr.string).to include("Warning: method `process` already defined in Admin::PostsController")
       end
     end
   end

--- a/spec/unit/active_admin_spec.rb
+++ b/spec/unit/active_admin_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin do
   %w(register register_page unload! load! routes).each do |method|

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -1,11 +1,11 @@
-require 'rails_helper'
-require 'fileutils'
+require "rails_helper"
+require "fileutils"
 
 RSpec.describe ActiveAdmin::Application do
   let(:application) { ActiveAdmin::Application.new }
 
   it "should have a default load path of ['app/admin']" do
-    expect(application.load_paths).to eq [File.expand_path('app/admin', application.app_path)]
+    expect(application.load_paths).to eq [File.expand_path("app/admin", application.app_path)]
   end
 
   describe "#prepare" do
@@ -122,7 +122,7 @@ RSpec.describe ActiveAdmin::Application do
   end
 
   describe "files in load path" do
-    it 'it should load sorted files' do
+    it "it should load sorted files" do
       expect(application.files.map { |f| File.basename(f) }).to eq(%w(admin_users.rb dashboard.rb stores.rb))
     end
 

--- a/spec/unit/asset_registration_spec.rb
+++ b/spec/unit/asset_registration_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::AssetRegistration do
   include ActiveAdmin::AssetRegistration

--- a/spec/unit/authorization/authorization_adapter_spec.rb
+++ b/spec/unit/authorization/authorization_adapter_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::AuthorizationAdapter do
   let(:adapter) { ActiveAdmin::AuthorizationAdapter.new(double, double) }
@@ -36,15 +36,15 @@ RSpec.describe ActiveAdmin::AuthorizationAdapter do
       expect(adapter.authorized?(:read, String)).to eq true
     end
 
-    it 'should match against an instance' do
+    it "should match against an instance" do
       expect(adapter.authorized?(:read, "String")).to eq true
     end
 
-    it 'should not match a different class' do
+    it "should not match a different class" do
       expect(adapter.authorized?(:read, Hash)).to eq false
     end
 
-    it 'should not match a different instance' do
+    it "should not match a different instance" do
       expect(adapter.authorized?(:read, {})).to eq false
     end
   end

--- a/spec/unit/authorization/controller_authorization_spec.rb
+++ b/spec/unit/authorization/controller_authorization_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Controller Authorization", type: :controller do
   let(:authorization) { controller.send(:active_admin_authorization) }
@@ -24,14 +24,14 @@ RSpec.describe "Controller Authorization", type: :controller do
   it "should authorize the create action with the new resource" do
     expect(authorization).to receive(:authorized?).with(auth::CREATE, an_instance_of(Post)).and_return true
     post :create
-    expect(response).to redirect_to action: 'show', id: Post.last.id
+    expect(response).to redirect_to action: "show", id: Post.last.id
   end
 
   it "should redirect when the user isn't authorized" do
     expect(authorization).to receive(:authorized?).with(auth::READ, Post).and_return false
     get :index
     expect(response.body).to eq '<html><body>You are being <a href="http://test.host/admin">redirected</a>.</body></html>'
-    expect(response).to redirect_to '/admin'
+    expect(response).to redirect_to "/admin"
   end
 
   private

--- a/spec/unit/authorization/index_overriding_spec.rb
+++ b/spec/unit/authorization/index_overriding_spec.rb
@@ -1,6 +1,6 @@
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'Index overriding', type: :controller do
+RSpec.describe "Index overriding", type: :controller do
   before do
     load_resources { ActiveAdmin.register Post }
     @controller = Admin::PostsController.new
@@ -8,15 +8,15 @@ RSpec.describe 'Index overriding', type: :controller do
     @controller.instance_eval do
       def index
         super do
-          render body: 'Rendered from passed block'
+          render body: "Rendered from passed block"
           return
         end
       end
     end
   end
 
-  it 'should call block passed to overridden index' do
+  it "should call block passed to overridden index" do
     get :index
-    expect(response.body).to eq 'Rendered from passed block'
+    expect(response.body).to eq "Rendered from passed block"
   end
 end

--- a/spec/unit/auto_link_spec.rb
+++ b/spec/unit/auto_link_spec.rb
@@ -1,8 +1,8 @@
-require 'rails_helper'
-require 'active_admin/view_helpers/active_admin_application_helper'
-require 'active_admin/view_helpers/auto_link_helper'
-require 'active_admin/view_helpers/display_helper'
-require 'active_admin/view_helpers/method_or_proc_helper'
+require "rails_helper"
+require "active_admin/view_helpers/active_admin_application_helper"
+require "active_admin/view_helpers/auto_link_helper"
+require "active_admin/view_helpers/display_helper"
+require "active_admin/view_helpers/method_or_proc_helper"
 
 RSpec.describe "#auto_link" do
   let(:view_klass) do
@@ -50,7 +50,7 @@ RSpec.describe "#auto_link" do
     end
 
     it "should keep locale in the url if present" do
-      expect(view).to receive(:url_options).and_return(locale: 'en')
+      expect(view).to receive(:url_options).and_return(locale: "en")
 
       expect(linked_post).to \
         match(%r{<a href="/admin/posts/\d+\?locale=en">Hello World</a>})
@@ -80,7 +80,7 @@ RSpec.describe "#auto_link" do
     end
 
     it "should keep locale in the url if present" do
-      expect(view).to receive(:url_options).and_return(locale: 'en')
+      expect(view).to receive(:url_options).and_return(locale: "en")
 
       expect(linked_post).to \
         match(%r{<a href="/admin/posts/\d+/edit\?locale=en">Hello World</a>})

--- a/spec/unit/batch_actions/resource_spec.rb
+++ b/spec/unit/batch_actions/resource_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::BatchActions::ResourceExtension do
   let(:resource) do

--- a/spec/unit/batch_actions/settings_spec.rb
+++ b/spec/unit/batch_actions/settings_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Batch Actions Settings" do
   let(:app) { ActiveAdmin::Application.new }

--- a/spec/unit/belongs_to_spec.rb
+++ b/spec/unit/belongs_to_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Resource::BelongsTo do
   before do
@@ -60,16 +60,16 @@ RSpec.describe ActiveAdmin::Resource::BelongsTo do
     let(:user) { User.create! }
 
     before do
-      request = double 'Request', format: 'application/json'
+      request = double "Request", format: "application/json"
       allow(controller).to receive(:params) { ActionController::Parameters.new(http_params) }
       allow(controller).to receive(:request) { request }
     end
 
-    it 'should be able to access the collection' do
+    it "should be able to access the collection" do
       expect(controller.send :collection).to be_a ActiveRecord::Relation
     end
 
-    it 'should be able to build a new resource' do
+    it "should be able to build a new resource" do
       expect(controller.send :build_resource).to be_a Post
     end
   end

--- a/spec/unit/cancan_adapter_spec.rb
+++ b/spec/unit/cancan_adapter_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::CanCanAdapter do
   describe "full integration" do

--- a/spec/unit/collection_decorator_spec.rb
+++ b/spec/unit/collection_decorator_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 class NumberDecorator
   def initialize(number)
@@ -11,19 +11,19 @@ class NumberDecorator
 end
 
 RSpec.describe ActiveAdmin::CollectionDecorator do
-  describe '#decorated_collection' do
+  describe "#decorated_collection" do
     subject { collection.decorated_collection }
     let(:collection) { ActiveAdmin::CollectionDecorator.decorate((1..10).to_a, with: NumberDecorator) }
 
-    it 'returns an array of decorated objects' do
+    it "returns an array of decorated objects" do
       expect(subject).to all(be_a(NumberDecorator))
     end
   end
 
-  describe 'array methods' do
+  describe "array methods" do
     subject { ActiveAdmin::CollectionDecorator.decorate((1..10).to_a, with: NumberDecorator) }
 
-    it 'delegates them to the decorated collection' do
+    it "delegates them to the decorated collection" do
       expect(subject.select(&:selectable?).count).to eq(5)
     end
   end

--- a/spec/unit/comments_spec.rb
+++ b/spec/unit/comments_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Comments" do
   let(:application) { ActiveAdmin::Application.new }
@@ -53,7 +53,7 @@ RSpec.describe "Comments" do
 
       it "should not return a comment for the same resource in a different namespace" do
         ActiveAdmin.application.namespaces[:public] = ActiveAdmin.application.namespaces[:admin]
-        expect(ActiveAdmin::Comment.find_for_resource_in_namespace(post, 'public')).to eq []
+        expect(ActiveAdmin::Comment.find_for_resource_in_namespace(post, "public")).to eq []
         ActiveAdmin.application.namespaces.instance_variable_get(:@namespaces).delete(:public)
       end
 
@@ -113,7 +113,7 @@ RSpec.describe "Comments" do
 
     describe ".resource_type" do
       let(:post) { Post.create!(title: "Testing.") }
-      let(:post_decorator) { double 'PostDecorator' }
+      let(:post_decorator) { double "PostDecorator" }
 
       before do
         allow(post_decorator).to receive(:model).and_return(post)
@@ -124,7 +124,7 @@ RSpec.describe "Comments" do
         let(:resource) { post_decorator }
 
         it "returns undeorated object class string" do
-          expect(ActiveAdmin::Comment.resource_type resource).to eql 'Post'
+          expect(ActiveAdmin::Comment.resource_type resource).to eql "Post"
         end
       end
 
@@ -132,7 +132,7 @@ RSpec.describe "Comments" do
         let(:resource) { post }
 
         it "returns object class string" do
-          expect(ActiveAdmin::Comment.resource_type resource).to eql 'Post'
+          expect(ActiveAdmin::Comment.resource_type resource).to eql "Post"
         end
       end
     end

--- a/spec/unit/component_spec.rb
+++ b/spec/unit/component_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 class MockComponentClass < ActiveAdmin::Component; end
 
@@ -11,6 +11,6 @@ RSpec.describe ActiveAdmin::Component do
   end
 
   it "should render to a div, even as a subclass" do
-    expect(component.tag_name).to eq 'div'
+    expect(component.tag_name).to eq "div"
   end
 end

--- a/spec/unit/controller_filters_spec.rb
+++ b/spec/unit/controller_filters_spec.rb
@@ -1,10 +1,10 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Application do
   let(:application) { ActiveAdmin::Application.new }
   let(:controllers) { application.controllers_for_filters }
 
-  it 'controllers_for_filters' do
+  it "controllers_for_filters" do
     expect(application.controllers_for_filters).to eq [
       ActiveAdmin::BaseController, ActiveAdmin::Devise::SessionsController,
       ActiveAdmin::Devise::PasswordsController, ActiveAdmin::Devise::UnlocksController,

--- a/spec/unit/csv_builder_spec.rb
+++ b/spec/unit/csv_builder_spec.rb
@@ -1,18 +1,18 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::CSVBuilder do
-  describe '.default_for_resource using Post' do
+  describe ".default_for_resource using Post" do
     let(:application) { ActiveAdmin::Application.new }
     let(:namespace) { ActiveAdmin::Namespace.new(application, :admin) }
     let(:resource) { ActiveAdmin::Resource.new(namespace, Post, {}) }
     let(:csv_builder) { ActiveAdmin::CSVBuilder.default_for_resource(resource).tap(&:exec_columns) }
 
-    it 'returns a default csv_builder for Post' do
+    it "returns a default csv_builder for Post" do
       expect(csv_builder).to be_a(ActiveAdmin::CSVBuilder)
     end
 
-    it 'defines Id as the first column' do
-      expect(csv_builder.columns.first.name).to eq 'Id'
+    it "defines Id as the first column" do
+      expect(csv_builder.columns.first.name).to eq "Id"
       expect(csv_builder.columns.first.data).to eq :id
     end
 
@@ -23,30 +23,30 @@ RSpec.describe ActiveAdmin::CSVBuilder do
       end
     end
 
-    context 'when column has a localized name' do
-      let(:localized_name) { 'Titulo' }
+    context "when column has a localized name" do
+      let(:localized_name) { "Titulo" }
 
       before do
         allow(Post).to receive(:human_attribute_name).and_call_original
         allow(Post).to receive(:human_attribute_name).with(:title) { localized_name }
       end
 
-      it 'gets name from I18n' do
+      it "gets name from I18n" do
         title_index = resource.content_columns.index(:title) + 1 # First col is always id
         expect(csv_builder.columns[title_index].name).to eq localized_name
       end
     end
 
-    context 'for models having sensitive attributes' do
+    context "for models having sensitive attributes" do
       let(:resource) { ActiveAdmin::Resource.new(namespace, User, {}) }
 
-      it 'omits sensitive fields' do
+      it "omits sensitive fields" do
         expect(csv_builder.columns.map(&:data)).to_not include :encrypted_password
       end
     end
   end
 
-  context 'when empty' do
+  context "when empty" do
     let(:builder) { ActiveAdmin::CSVBuilder.new.tap(&:exec_columns) }
 
     it "should have no columns" do
@@ -207,7 +207,7 @@ RSpec.describe ActiveAdmin::CSVBuilder do
         end
 
         def collection
-          Post.order('published_date DESC')
+          Post.order("published_date DESC")
         end
 
         def apply_decorator(resource)

--- a/spec/unit/dependency_spec.rb
+++ b/spec/unit/dependency_spec.rb
@@ -1,143 +1,143 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Dependency do
   k = ActiveAdmin::Dependency
 
-  describe 'method_missing' do
+  describe "method_missing" do
     before do
       allow(Gem).to receive(:loaded_specs)
-        .and_return 'foo' => Gem::Specification.new('foo', '1.2.3')
+        .and_return "foo" => Gem::Specification.new("foo", "1.2.3")
     end
 
-    it 'returns a Matcher' do
+    it "returns a Matcher" do
       expect(k.foo).to be_a ActiveAdmin::Dependency::Matcher
-      expect(k.foo.inspect).to eq '<ActiveAdmin::Dependency::Matcher for foo 1.2.3>'
-      expect(k.bar.inspect).to eq '<ActiveAdmin::Dependency::Matcher for (missing)>'
+      expect(k.foo.inspect).to eq "<ActiveAdmin::Dependency::Matcher for foo 1.2.3>"
+      expect(k.bar.inspect).to eq "<ActiveAdmin::Dependency::Matcher for (missing)>"
     end
 
-    describe '`?`' do
-      it 'base' do
+    describe "`?`" do
+      it "base" do
         expect(k.foo?).to eq true
         expect(k.bar?).to eq false
       end
 
-      it '=' do
-        expect(k.foo? '= 1.2.3').to eq true
-        expect(k.foo? '= 1').to eq false
+      it "=" do
+        expect(k.foo? "= 1.2.3").to eq true
+        expect(k.foo? "= 1").to eq false
       end
 
-      it '>' do
-        expect(k.foo? '> 1').to eq true
-        expect(k.foo? '> 2').to eq false
+      it ">" do
+        expect(k.foo? "> 1").to eq true
+        expect(k.foo? "> 2").to eq false
       end
 
-      it '<' do
-        expect(k.foo? '< 2').to eq true
-        expect(k.foo? '< 1').to eq false
+      it "<" do
+        expect(k.foo? "< 2").to eq true
+        expect(k.foo? "< 1").to eq false
       end
 
-      it '>=' do
-        expect(k.foo? '>= 1.2.3').to eq true
-        expect(k.foo? '>= 1.2.2').to eq true
-        expect(k.foo? '>= 1.2.4').to eq false
+      it ">=" do
+        expect(k.foo? ">= 1.2.3").to eq true
+        expect(k.foo? ">= 1.2.2").to eq true
+        expect(k.foo? ">= 1.2.4").to eq false
       end
 
-      it '<=' do
-        expect(k.foo? '<= 1.2.3').to eq true
-        expect(k.foo? '<= 1.2.4').to eq true
-        expect(k.foo? '<= 1.2.2').to eq false
+      it "<=" do
+        expect(k.foo? "<= 1.2.3").to eq true
+        expect(k.foo? "<= 1.2.4").to eq true
+        expect(k.foo? "<= 1.2.2").to eq false
       end
 
-      it '~>' do
-        expect(k.foo? '~> 1.2.0').to eq true
-        expect(k.foo? '~> 1.1').to eq true
-        expect(k.foo? '~> 1.2.4').to eq false
+      it "~>" do
+        expect(k.foo? "~> 1.2.0").to eq true
+        expect(k.foo? "~> 1.1").to eq true
+        expect(k.foo? "~> 1.2.4").to eq false
       end
     end
 
-    describe '`!`' do
-      it 'raises an error if requirement not met' do
-        expect { k.foo! '5' }.to raise_error ActiveAdmin::DependencyError,
-          'You provided foo 1.2.3 but we need: 5.'
+    describe "`!`" do
+      it "raises an error if requirement not met" do
+        expect { k.foo! "5" }.to raise_error ActiveAdmin::DependencyError,
+          "You provided foo 1.2.3 but we need: 5."
       end
 
-      it 'accepts multiple arguments' do
-        expect { k.foo! '> 1', '< 1.2' }.to raise_error ActiveAdmin::DependencyError,
-          'You provided foo 1.2.3 but we need: > 1, < 1.2.'
+      it "accepts multiple arguments" do
+        expect { k.foo! "> 1", "< 1.2" }.to raise_error ActiveAdmin::DependencyError,
+          "You provided foo 1.2.3 but we need: > 1, < 1.2."
       end
 
-      it 'raises an error if not provided' do
+      it "raises an error if not provided" do
         expect { k.bar! }.to raise_error ActiveAdmin::DependencyError,
-          'To use bar you need to specify it in your Gemfile.'
+          "To use bar you need to specify it in your Gemfile."
       end
     end
   end
 
-  describe '[]' do
+  describe "[]" do
     before do
       allow(Gem).to receive(:loaded_specs)
-        .and_return 'a-b' => Gem::Specification.new('a-b', '1.2.3')
+        .and_return "a-b" => Gem::Specification.new("a-b", "1.2.3")
     end
 
-    it 'allows access to gems with an arbitrary name' do
-      expect(k['a-b']).to be_a ActiveAdmin::Dependency::Matcher
-      expect(k['a-b'].inspect).to eq '<ActiveAdmin::Dependency::Matcher for a-b 1.2.3>'
-      expect(k['c-d'].inspect).to eq '<ActiveAdmin::Dependency::Matcher for (missing)>'
+    it "allows access to gems with an arbitrary name" do
+      expect(k["a-b"]).to be_a ActiveAdmin::Dependency::Matcher
+      expect(k["a-b"].inspect).to eq "<ActiveAdmin::Dependency::Matcher for a-b 1.2.3>"
+      expect(k["c-d"].inspect).to eq "<ActiveAdmin::Dependency::Matcher for (missing)>"
     end
 
     # Note: more extensive tests for match? and match! are above.
 
-    it 'match?' do
-      expect(k['a-b'].match?).to eq true
-      expect(k['a-b'].match? '1.2.3').to eq true
-      expect(k['b-c'].match?).to eq false
+    it "match?" do
+      expect(k["a-b"].match?).to eq true
+      expect(k["a-b"].match? "1.2.3").to eq true
+      expect(k["b-c"].match?).to eq false
     end
 
-    it 'match!' do
-      expect(k['a-b'].match!).to eq nil
-      expect(k['a-b'].match! '1.2.3').to eq nil
+    it "match!" do
+      expect(k["a-b"].match!).to eq nil
+      expect(k["a-b"].match! "1.2.3").to eq nil
 
-      expect { k['a-b'].match! '2.5' }.to raise_error ActiveAdmin::DependencyError,
-        'You provided a-b 1.2.3 but we need: 2.5.'
+      expect { k["a-b"].match! "2.5" }.to raise_error ActiveAdmin::DependencyError,
+        "You provided a-b 1.2.3 but we need: 2.5."
 
-      expect { k['b-c'].match! }.to raise_error ActiveAdmin::DependencyError,
-        'To use b-c you need to specify it in your Gemfile.'
+      expect { k["b-c"].match! }.to raise_error ActiveAdmin::DependencyError,
+        "To use b-c you need to specify it in your Gemfile."
     end
 
     # Note: Ruby comparison operators are separate from the `foo? '> 1'` syntax
 
-    describe 'Ruby comparison syntax' do
-      it '==' do
-        expect(k['a-b'] == '1.2.3').to eq true
-        expect(k['a-b'] == '1.2').to eq false
-        expect(k['a-b'] == 1).to eq false
+    describe "Ruby comparison syntax" do
+      it "==" do
+        expect(k["a-b"] == "1.2.3").to eq true
+        expect(k["a-b"] == "1.2").to eq false
+        expect(k["a-b"] == 1).to eq false
       end
 
-      it '>' do
-        expect(k['a-b'] > 1).to eq true
-        expect(k['a-b'] > 2).to eq false
+      it ">" do
+        expect(k["a-b"] > 1).to eq true
+        expect(k["a-b"] > 2).to eq false
       end
 
-      it '<' do
-        expect(k['a-b'] < 2).to eq true
-        expect(k['a-b'] < 1).to eq false
+      it "<" do
+        expect(k["a-b"] < 2).to eq true
+        expect(k["a-b"] < 1).to eq false
       end
 
-      it '>=' do
-        expect(k['a-b'] >= '1.2.3').to eq true
-        expect(k['a-b'] >= '1.2.2').to eq true
-        expect(k['a-b'] >= '1.2.4').to eq false
+      it ">=" do
+        expect(k["a-b"] >= "1.2.3").to eq true
+        expect(k["a-b"] >= "1.2.2").to eq true
+        expect(k["a-b"] >= "1.2.4").to eq false
       end
 
-      it '<=' do
-        expect(k['a-b'] <= '1.2.3').to eq true
-        expect(k['a-b'] <= '1.2.4').to eq true
-        expect(k['a-b'] <= '1.2.2').to eq false
+      it "<=" do
+        expect(k["a-b"] <= "1.2.3").to eq true
+        expect(k["a-b"] <= "1.2.4").to eq true
+        expect(k["a-b"] <= "1.2.2").to eq false
       end
 
-      it 'throws a custom error if the gem is missing' do
-        expect { k['b-c'] < 23 }.to raise_error ActiveAdmin::DependencyError,
-          'To use b-c you need to specify it in your Gemfile.'
+      it "throws a custom error if the gem is missing" do
+        expect { k["b-c"] < 23 }.to raise_error ActiveAdmin::DependencyError,
+          "To use b-c you need to specify it in your Gemfile."
       end
     end
   end

--- a/spec/unit/devise_spec.rb
+++ b/spec/unit/devise_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Devise::Controller do
   let(:controller_class) do
@@ -22,9 +22,9 @@ RSpec.describe ActiveAdmin::Devise::Controller do
     action_controller_config[:relative_url_root] = previous_relative_url_root
   end
 
-  context 'with a RAILS_RELATIVE_URL_ROOT set' do
+  context "with a RAILS_RELATIVE_URL_ROOT set" do
     around do |example|
-      with_temp_relative_url_root('/foo') { example.call }
+      with_temp_relative_url_root("/foo") { example.call }
     end
 
     it "should set the root path to the default namespace" do
@@ -37,7 +37,7 @@ RSpec.describe ActiveAdmin::Devise::Controller do
     end
   end
 
-  context 'without a RAILS_RELATIVE_URL_ROOT set' do
+  context "without a RAILS_RELATIVE_URL_ROOT set" do
     around do |example|
       with_temp_relative_url_root(nil) { example.call }
     end
@@ -53,7 +53,7 @@ RSpec.describe ActiveAdmin::Devise::Controller do
   end
 
   context "within a scoped route" do
-    SCOPE = '/aa_scoped'
+    SCOPE = "/aa_scoped"
 
     before do
       # Remove existing routes

--- a/spec/unit/dsl_spec.rb
+++ b/spec/unit/dsl_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 module MockModuleToInclude
   def self.included(dsl)
@@ -20,7 +20,7 @@ RSpec.describe ActiveAdmin::DSL do
     end
   end
 
-  describe '#action_item' do
+  describe "#action_item" do
     before do
       @default_items_count = resource_config.action_items.size
 
@@ -71,7 +71,7 @@ RSpec.describe ActiveAdmin::DSL do
       dsl.run_registration_block do
         sidebar :help
       end
-      expect(dsl.config.sidebar_sections.map(&:name)).to match_array ['filters', 'search_status', 'email', 'help']
+      expect(dsl.config.sidebar_sections.map(&:name)).to match_array ["filters", "search_status", "email", "help"]
     end
   end
 

--- a/spec/unit/dynamic_settings_spec.rb
+++ b/spec/unit/dynamic_settings_spec.rb
@@ -1,10 +1,10 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::DynamicSettingsNode do
   subject { ActiveAdmin::DynamicSettingsNode.build }
 
   context "StringSymbolOrProcSetting" do
-    before { subject.register :foo, 'bar', :string_symbol_or_proc }
+    before { subject.register :foo, "bar", :string_symbol_or_proc }
 
     it "should pass through a string" do
       subject.foo = "string"
@@ -20,9 +20,9 @@ RSpec.describe ActiveAdmin::DynamicSettingsNode do
 
     it "should send message if symbol given" do
       ctx = double
-      expect(ctx).to receive(:quux).and_return 'qqq'
+      expect(ctx).to receive(:quux).and_return "qqq"
       subject.foo = :quux
-      expect(subject.foo(ctx)).to eq 'qqq'
+      expect(subject.foo(ctx)).to eq "qqq"
     end
   end
 end

--- a/spec/unit/filters/active_filter_spec.rb
+++ b/spec/unit/filters/active_filter_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Filters::ActiveFilter do
   let(:namespace) do
@@ -25,49 +25,49 @@ RSpec.describe ActiveAdmin::Filters::ActiveFilter do
     ActiveAdmin::Filters::ActiveFilter.new(resource, condition)
   end
 
-  it 'should have valid values' do
+  it "should have valid values" do
     expect(subject.values).to eq([post.title])
   end
 
-  describe 'label' do
-    context 'by default' do
-      it 'should have valid label' do
+  describe "label" do
+    context "by default" do
+      it "should have valid label" do
         expect(subject.label).to eq("Title equals")
       end
     end
 
-    context 'with formtastic translations' do
-      it 'should pick up formtastic label' do
-        with_translation formtastic: { labels: { title: 'Supertitle' } } do
+    context "with formtastic translations" do
+      it "should pick up formtastic label" do
+        with_translation formtastic: { labels: { title: "Supertitle" } } do
           expect(subject.label).to eq("Supertitle equals")
         end
       end
     end
   end
 
-  it 'should pick predicate name translation' do
+  it "should pick predicate name translation" do
     expect(subject.predicate_name).to eq(I18n.t("active_admin.filters.predicates.equals"))
   end
 
-  context 'search by belongs_to association' do
+  context "search by belongs_to association" do
     let(:search) do
       Post.ransack(custom_category_id_eq: category.id)
     end
 
-    it 'should have valid values' do
+    it "should have valid values" do
       expect(subject.values[0]).to be_a(Category)
     end
 
-    it 'should have valid label' do
+    it "should have valid label" do
       expect(subject.label).to eq("Category equals")
     end
 
-    it 'should pick predicate name translation' do
-      expect(subject.predicate_name).to eq(Ransack::Translate.predicate('eq'))
+    it "should pick predicate name translation" do
+      expect(subject.predicate_name).to eq(Ransack::Translate.predicate("eq"))
     end
   end
 
-  context 'search by polymorphic association' do
+  context "search by polymorphic association" do
     let(:resource) do
       namespace.register(ActiveAdmin::Comment)
     end
@@ -76,35 +76,35 @@ RSpec.describe ActiveAdmin::Filters::ActiveFilter do
       ActiveAdmin::Comment.ransack(resource_id_eq: post.id, resource_type_eq: post.class.to_s)
     end
 
-    context 'id filter' do
+    context "id filter" do
       let(:condition) do
         search.conditions[0]
       end
-      it 'should have valid values' do
+      it "should have valid values" do
         expect(subject.values[0]).to eq(post.id)
       end
 
-      it 'should have valid label' do
+      it "should have valid label" do
         expect(subject.label).to eq("Resource equals")
       end
     end
 
-    context 'type filter' do
+    context "type filter" do
       let(:condition) do
         search.conditions[1]
       end
 
-      it 'should have valid values' do
+      it "should have valid values" do
         expect(subject.values[0]).to eq(post.class.to_s)
       end
 
-      it 'should have valid label' do
+      it "should have valid label" do
         expect(subject.label).to eq("Resource type equals")
       end
     end
   end
 
-  context 'search by has many association' do
+  context "search by has many association" do
     let(:resource) do
       namespace.register(Category)
     end
@@ -113,15 +113,15 @@ RSpec.describe ActiveAdmin::Filters::ActiveFilter do
       Category.ransack(posts_id_eq: post.id)
     end
 
-    it 'should have valid values' do
+    it "should have valid values" do
       expect(subject.values[0]).to be_a(Post)
     end
 
-    it 'should have valid label' do
+    it "should have valid label" do
       expect(subject.label).to eq("Post equals")
     end
 
-    context 'search by has many through association' do
+    context "search by has many through association" do
       let(:resource) do
         namespace.register(User)
       end
@@ -130,61 +130,61 @@ RSpec.describe ActiveAdmin::Filters::ActiveFilter do
         User.ransack(posts_category_id_eq: category.id)
       end
 
-      it 'should have valid values' do
+      it "should have valid values" do
         expect(subject.values[0]).to be_a(Category)
       end
 
-      it 'should have valid label' do
+      it "should have valid label" do
         expect(subject.label).to eq("Category equals")
       end
     end
   end
 
-  context 'search has no matching records' do
+  context "search has no matching records" do
     let(:search) { Post.ransack(author_id_eq: "foo") }
 
-    it 'should not produce and error' do
+    it "should not produce and error" do
       expect { subject.values }.not_to raise_error
     end
 
-    it 'should return an enumerable' do
+    it "should return an enumerable" do
       expect(subject.values).to respond_to(:map)
     end
   end
 
-  context 'a label is set on the filter' do
-    it 'should use the filter label as the label prefix' do
+  context "a label is set on the filter" do
+    it "should use the filter label as the label prefix" do
       label = "#{user.first_name}'s Post Title"
       resource.add_filter(:title, label: label)
 
       expect(subject.label).to eq("#{label} equals")
     end
 
-    it 'should use the filter label as the label prefix' do
+    it "should use the filter label as the label prefix" do
       label = proc { "#{user.first_name}'s Post Title" }
       resource.add_filter(:title, label: label)
 
       expect(subject.label).to eq("#{label.call} equals")
     end
 
-    context 'when filter condition has a predicate' do
+    context "when filter condition has a predicate" do
       let(:search) do
         Post.ransack(title_cont: "Hello")
       end
 
-      it 'should use the filter label as the label prefix' do
+      it "should use the filter label as the label prefix" do
         label = "#{user.first_name}'s Post"
         resource.add_filter(:title_cont, label: label)
         expect(subject.label).to eq("#{label} contains")
       end
     end
 
-    context 'when filter condition has multiple fields' do
+    context "when filter condition has multiple fields" do
       let(:search) do
         Post.ransack(title_or_body_cont: "Hello World")
       end
 
-      it 'should use the filter label as the label prefix' do
+      it "should use the filter label as the label prefix" do
         label = "#{user.first_name}'s Post"
         resource.add_filter(:title_or_body_cont, label: label)
         expect(subject.label).to eq("#{label} contains")
@@ -225,14 +225,14 @@ RSpec.describe ActiveAdmin::Filters::ActiveFilter do
     end
   end
 
-  context 'when the resource has a custom primary key' do
+  context "when the resource has a custom primary key" do
     let(:resource_klass) do
       Class.new(Store) do
-        self.primary_key = 'name'
+        self.primary_key = "name"
         belongs_to :user
 
         def self.name
-          'SubStore'
+          "SubStore"
         end
       end
     end
@@ -241,8 +241,8 @@ RSpec.describe ActiveAdmin::Filters::ActiveFilter do
       namespace.register(resource_klass)
     end
 
-    let(:user) { User.create! first_name: 'John', last_name: 'Doe' }
-    let(:store) { resource_klass.create! name: 'Store 1', user_id: user.id }
+    let(:user) { User.create! first_name: "John", last_name: "Doe" }
+    let(:store) { resource_klass.create! name: "Store 1", user_id: user.id }
 
     let(:search) do
       resource_klass.ransack(user_id_eq: user.id)

--- a/spec/unit/filters/active_spec.rb
+++ b/spec/unit/filters/active_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Filters::Active do
   let(:resource) do
@@ -16,7 +16,7 @@ RSpec.describe ActiveAdmin::Filters::Active do
     Post.ransack(params[:q])
   end
 
-  it 'should have filters' do
+  it "should have filters" do
     expect(subject.filters.size).to eq(1)
   end
 end

--- a/spec/unit/filters/filter_form_builder_spec.rb
+++ b/spec/unit/filters/filter_form_builder_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Filters::ViewHelper do
   # Setup an ActionView::Base object which can be used for
@@ -50,7 +50,7 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
     end
 
     describe "label as proc" do
-      let(:body) { filter :title, label: proc { 'Title from proc' } }
+      let(:body) { filter :title, label: proc { "Title from proc" } }
 
       it "should render proper label" do
         expect(body).to have_selector("label", text: "Title from proc")
@@ -58,7 +58,7 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
     end
 
     describe "input html as proc" do
-      let(:body) { filter :title, as: :select, input_html: proc { { 'data-ajax-url': '/' } } }
+      let(:body) { filter :title, as: :select, input_html: proc { { 'data-ajax-url': "/" } } }
 
       it "should render proper label" do
         expect(body).to have_selector('select[data-ajax-url="/"]')
@@ -90,7 +90,7 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
     end
 
     it "should translate the label for text field" do
-      with_translation activerecord: { attributes: { post: { title: 'Name' } } } do
+      with_translation activerecord: { attributes: { post: { title: "Name" } } } do
         expect(body).to have_selector("label", text: "Name")
       end
     end
@@ -131,7 +131,7 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
     end
   end
 
-  describe 'string attribute ended with ransack predicate' do
+  describe "string attribute ended with ransack predicate" do
     let(:scope) { User.ransack }
     let(:body) { filter :reason_of_sign_in }
 
@@ -165,8 +165,8 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
       end
 
       it "should remove original ordering to prevent PostgreSQL error" do
-        expect(scope.object.klass).to receive(:reorder).with('title asc') {
-          m = double distinct: double(pluck: ['A Title'])
+        expect(scope.object.klass).to receive(:reorder).with("title asc") {
+          m = double distinct: double(pluck: ["A Title"])
           expect(m.distinct).to receive(:pluck).with :title
           m
         }
@@ -198,7 +198,7 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
     end
 
     context "with input_html" do
-      let(:body) { filter :published_date, input_html: { 'autocomplete': 'off' } }
+      let(:body) { filter :published_date, input_html: { 'autocomplete': "off" } }
 
       it "should generate provided input html for both ends of date range" do
         expect(body).to have_selector("input.datepicker[name='q[published_date_gteq]'][autocomplete=off]")
@@ -207,7 +207,7 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
     end
 
     context "with input_html overriding the defaults" do
-      let(:body) { filter :published_date, input_html: { 'class': 'custom_class' } }
+      let(:body) { filter :published_date, input_html: { 'class': "custom_class" } }
 
       it "should override the default attribute values for both ends of date range" do
         expect(body).to have_selector("input.custom_class[name='q[published_date_gteq]']")
@@ -228,7 +228,7 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
     end
 
     context "with input_html" do
-      let(:body) { filter :created_at, input_html: { 'autocomplete': 'off' } }
+      let(:body) { filter :created_at, input_html: { 'autocomplete': "off" } }
 
       it "should generate provided input html for both ends of date range" do
         expect(body).to have_selector("input.datepicker[name='q[created_at_gteq_datetime]'][autocomplete=off]")
@@ -237,7 +237,7 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
     end
 
     context "with input_html overriding the defaults" do
-      let(:body) { filter :created_at, input_html: { 'class': 'custom_class' } }
+      let(:body) { filter :created_at, input_html: { 'class': "custom_class" } }
 
       it "should override the default attribute values for both ends of date range" do
         expect(body).to have_selector("input.custom_class[name='q[created_at_gteq_datetime]']")
@@ -305,7 +305,7 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
       end
 
       it "should translate the label for boolean field" do
-        with_translation activerecord: { attributes: { post: { starred: 'Faved' } } } do
+        with_translation activerecord: { attributes: { post: { starred: "Faved" } } } do
           expect(body).to have_selector("label", text: "Faved")
         end
       end
@@ -363,7 +363,7 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
 
       context "with a proc" do
         let :body do
-          filter :title, as: :select, collection: proc { ['Title One', 'Title Two'] }
+          filter :title, as: :select, collection: proc { ["Title One", "Title Two"] }
         end
 
         it "should use call the proc as the collection" do
@@ -525,7 +525,7 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
     end
 
     it "should work as select" do
-      body = filter :custom_title_searcher, as: :select, collection: ['foo']
+      body = filter :custom_title_searcher, as: :select, collection: ["foo"]
       expect(body).to have_selector("select[name='q[custom_title_searcher_eq]']")
     end
 

--- a/spec/unit/filters/resource_spec.rb
+++ b/spec/unit/filters/resource_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Filters::ResourceExtension do
   let(:resource) do
@@ -47,7 +47,7 @@ RSpec.describe ActiveAdmin::Filters::ResourceExtension do
 
     it "should work as a string" do
       expect(resource.filters.keys).to include :author
-      resource.remove_filter 'author'
+      resource.remove_filter "author"
       expect(resource.filters.keys).to_not include :author
     end
 
@@ -82,7 +82,7 @@ RSpec.describe ActiveAdmin::Filters::ResourceExtension do
     end
 
     it "should work as a string" do
-      resource.add_filter 'title'
+      resource.add_filter "title"
       expect(resource.filters).to eq title: {}
     end
 

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 require "rspec/mocks/standalone"
 
 RSpec.describe ActiveAdmin::FormBuilder do
@@ -23,7 +23,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
     end
 
     def view.action_name
-      'edit'
+      "edit"
     end
 
     view
@@ -61,7 +61,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
     context "it with custom settings" do
       let :body do
         build_form do |f|
-          f.inputs class: "custom_class", name: 'custom_name', custom_attr: 'custom_attr' do
+          f.inputs class: "custom_class", name: "custom_name", custom_attr: "custom_attr" do
             f.input :title
             f.input :body
           end
@@ -73,7 +73,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
       end
 
       it "should generate a fieldset with a custom legend" do
-        expect(body).to have_css("legend", text: 'custom_name')
+        expect(body).to have_css("legend", text: "custom_name")
       end
 
       it "should generate a fieldset with a custom attributes" do
@@ -208,14 +208,14 @@ RSpec.describe ActiveAdmin::FormBuilder do
     it "should render the Arbre in the expected place" do
       body = build_form do |f|
         div do
-          h1 'Heading'
+          h1 "Heading"
         end
         f.inputs do
-          span 'Top note'
+          span "Top note"
           f.input :title
-          span 'Bottom note'
+          span "Bottom note"
         end
-        h3 'Footer'
+        h3 "Footer"
         f.actions
       end
 
@@ -228,14 +228,14 @@ RSpec.describe ActiveAdmin::FormBuilder do
     it "should allow a simplified syntax" do
       body = build_form do |f|
         div do
-          h1 'Heading'
+          h1 "Heading"
         end
         inputs do
-          span 'Top note'
+          span "Top note"
           input :title
-          span 'Bottom note'
+          span "Bottom note"
         end
-        h3 'Footer'
+        h3 "Footer"
         actions
       end
 
@@ -313,7 +313,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
   context "with inputs component inside has_many" do
     def user
       u = User.new
-      u.profile = Profile.new(bio: 'bio')
+      u.profile = Profile.new(bio: "bio")
       u
     end
 
@@ -323,7 +323,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
         f.form_builder.instance_eval do
           @object.author = author
         end
-        f.inputs name: 'Author', for: :author do |author|
+        f.inputs name: "Author", for: :author do |author|
           author.has_many :profile, allow_destroy: true do |profile|
             profile.inputs "inputs for profile #{profile.object.bio}" do
               profile.input :bio
@@ -350,7 +350,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
         f.form_builder.instance_eval do
           @object.author = author
         end
-        f.inputs name: 'Author', for: :author do |author|
+        f.inputs name: "Author", for: :author do |author|
           author.has_many :profile, allow_destroy: true do |profile|
             profile.input :bio
           end
@@ -398,7 +398,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
         f.form_builder.instance_eval do
           @object.author = User.new
         end
-        f.inputs name: 'Author', for: :author do |author|
+        f.inputs name: "Author", for: :author do |author|
           author.inputs :first_name, :last_name
         end
       end
@@ -417,7 +417,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
         f.form_builder.instance_eval do
           @object.author = User.new
         end
-        f.inputs name: 'Author', for: :author do |author|
+        f.inputs name: "Author", for: :author do |author|
           author.input :first_name
           author.input :last_name
         end
@@ -433,7 +433,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
         f.form_builder.instance_eval do
           @object.author = User.new
         end
-        f.inputs name: 'Author', for: :author do |author|
+        f.inputs name: "Author", for: :author do |author|
           author.input :first_name
           author.input :last_name
         end
@@ -483,7 +483,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
   context "with has many inputs" do
     describe "with simple block" do
       let :body do
-        build_form({ url: '/categories' }, Category.new) do |f|
+        build_form({ url: "/categories" }, Category.new) do |f|
           f.object.posts.build
           f.has_many :posts do |p|
             p.input :title
@@ -496,7 +496,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
       let(:valid_html_id) { /^[A-Za-z]+[\w\-\:\.]*$/ }
 
       it "should translate the association name in header" do
-        with_translation activerecord: { models: { post: { one: 'Blog Post', other: 'Blog Posts' } } } do
+        with_translation activerecord: { models: { post: { one: "Blog Post", other: "Blog Posts" } } } do
           expect(body).to have_selector("h3", text: "Blog Posts")
         end
       end
@@ -506,13 +506,13 @@ RSpec.describe ActiveAdmin::FormBuilder do
       end
 
       it "should translate the association name in has many new button" do
-        with_translation activerecord: { models: { post: { one: 'Blog Post', other: 'Blog Posts' } } } do
+        with_translation activerecord: { models: { post: { one: "Blog Post", other: "Blog Posts" } } } do
           expect(body).to have_selector("a", text: "Add New Blog Post")
         end
       end
 
       it "should translate the attribute name" do
-        with_translation activerecord: { attributes: { post: { title: 'A very nice title' } } } do
+        with_translation activerecord: { attributes: { post: { title: "A very nice title" } } } do
           expect(body).to have_selector("label", text: "A very nice title")
         end
       end
@@ -535,14 +535,14 @@ RSpec.describe ActiveAdmin::FormBuilder do
       end
 
       it "should set an HTML-id valid placeholder" do
-        link = body.find('.has_many_container > a.button.has_many_add')
+        link = body.find(".has_many_container > a.button.has_many_add")
         expect(link[:'data-placeholder']).to match valid_html_id
       end
 
       describe "with namespaced model" do
         it "should set an HTML-id valid placeholder" do
           allow(Post).to receive(:name).and_return "ActiveAdmin::Post"
-          link = body.find('.has_many_container > a.button.has_many_add')
+          link = body.find(".has_many_container > a.button.has_many_add")
           expect(link[:'data-placeholder']).to match valid_html_id
         end
       end
@@ -550,7 +550,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
 
     describe "with complex block" do
       let :body do
-        build_form({ url: '/categories' }, Category.new) do |f|
+        build_form({ url: "/categories" }, Category.new) do |f|
           f.object.posts.build
           f.has_many :posts do |p, i|
             p.input :title, label: "Title #{i}"
@@ -569,7 +569,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
 
     describe "without heading and new record link" do
       let :body do
-        build_form({ url: '/categories' }, Category.new) do |f|
+        build_form({ url: "/categories" }, Category.new) do |f|
           f.object.posts.build
           f.has_many :posts, heading: false, new_record: false do |p|
             p.input :title
@@ -592,7 +592,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
 
     describe "with custom heading" do
       let :body do
-        build_form({ url: '/categories' }, Category.new) do |f|
+        build_form({ url: "/categories" }, Category.new) do |f|
           f.object.posts.build
           f.has_many :posts, heading: "Test heading" do |p|
             p.input :title
@@ -607,9 +607,9 @@ RSpec.describe ActiveAdmin::FormBuilder do
 
     describe "with custom new record link" do
       let :body do
-        build_form({ url: '/categories' }, Category.new) do |f|
+        build_form({ url: "/categories" }, Category.new) do |f|
           f.object.posts.build
-          f.has_many :posts, new_record: 'My Custom New Post' do |p|
+          f.has_many :posts, new_record: "My Custom New Post" do |p|
             p.input :title
           end
         end
@@ -656,7 +656,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
       shared_examples_for "has many with allow_destroy as String, Symbol or Proc" do |allow_destroy_option|
         let :body do
           s = self
-          build_form({ url: '/categories' }, Category.new) do |f|
+          build_form({ url: "/categories" }, Category.new) do |f|
             s.instance_exec do
               allow(f.object.posts.build).to receive(:foo?).and_return(true)
               allow(f.object.posts.build).to receive(:foo?).and_return(false)
@@ -671,11 +671,11 @@ RSpec.describe ActiveAdmin::FormBuilder do
           end
         end
 
-        context 'for the child that responds with true' do
+        context "for the child that responds with true" do
           it_behaves_like "has many with allow_destroy = true", 0
         end
 
-        context 'for the child that responds with false' do
+        context "for the child that responds with false" do
           it_behaves_like "has many with allow_destroy = false", 1
         end
       end
@@ -684,7 +684,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
         context "with allow_destroy = true" do
           let :body do
             s = self
-            build_form({ url: '/categories' }, Category.new) do |f|
+            build_form({ url: "/categories" }, Category.new) do |f|
               s.instance_exec do
                 allow(f.object.posts.build).to receive(:new_record?).and_return(false)
               end
@@ -700,7 +700,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
         context "with allow_destroy = false" do
           let :body do
             s = self
-            build_form({ url: '/categories' }, Category.new) do |f|
+            build_form({ url: "/categories" }, Category.new) do |f|
               s.instance_exec do
                 allow(f.object.posts.build).to receive(:new_record?).and_return(false)
               end
@@ -716,7 +716,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
         context "with allow_destroy = nil" do
           let :body do
             s = self
-            build_form({ url: '/categories' }, Category.new) do |f|
+            build_form({ url: "/categories" }, Category.new) do |f|
               s.instance_exec do
                 allow(f.object.posts.build).to receive(:new_record?).and_return(false)
               end
@@ -750,7 +750,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
         context "with allow_destroy as any other expression that evaluates to true" do
           let :body do
             s = self
-            build_form({ url: '/categories' }, Category.new) do |f|
+            build_form({ url: "/categories" }, Category.new) do |f|
               s.instance_exec do
                 allow(f.object.posts.build).to receive(:new_record?).and_return(false)
               end
@@ -767,7 +767,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
       context "with a new post" do
         context "with allow_destroy = true" do
           let :body do
-            build_form({ url: '/categories' }, Category.new) do |f|
+            build_form({ url: "/categories" }, Category.new) do |f|
               f.object.posts.build
               f.has_many :posts, allow_destroy: true do |p|
                 p.input :title
@@ -784,7 +784,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
       # TODO: it doesn't make any sense to use your foreign key as something that's sortable (and therefore editable)
       context "with a new post" do
         let :body do
-          build_form({ url: '/categories' }, Category.new) do |f|
+          build_form({ url: "/categories" }, Category.new) do |f|
             f.object.posts.build
             f.has_many :posts, sortable: :position do |p|
               p.input :title
@@ -799,7 +799,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
 
       context "with post returning nil for the sortable attribute" do
         let :body do
-          build_form({ url: '/categories' }, Category.new) do |f|
+          build_form({ url: "/categories" }, Category.new) do |f|
             f.object.posts.build position: 3
             f.object.posts.build
             f.has_many :posts, sortable: :position do |p|
@@ -815,13 +815,13 @@ RSpec.describe ActiveAdmin::FormBuilder do
 
       context "with existing and new posts" do
         let! :category do
-          Category.create name: 'Name'
+          Category.create name: "Name"
         end
         let! :post do
           category.posts.create
         end
         let :body do
-          build_form({ url: '/categories' }, category) do |f|
+          build_form({ url: "/categories" }, category) do |f|
             f.object.posts.build
             f.has_many :posts, sortable: :position do |p|
               p.input :title
@@ -836,7 +836,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
 
       context "without sortable_start set" do
         let :body do
-          build_form({ url: '/categories' }, Category.new) do |f|
+          build_form({ url: "/categories" }, Category.new) do |f|
             f.object.posts.build
             f.has_many :posts, sortable: :position do |p|
               p.input :title
@@ -851,7 +851,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
 
       context "with sortable_start set" do
         let :body do
-          build_form({ url: '/categories' }, Category.new) do |f|
+          build_form({ url: "/categories" }, Category.new) do |f|
             f.object.posts.build
             f.has_many :posts, sortable: :position, sortable_start: 15 do |p|
               p.input :title
@@ -868,7 +868,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
     describe "with nesting" do
       context "in an inputs block" do
         let :body do
-          build_form({ url: '/categories' }, Category.new) do |f|
+          build_form({ url: "/categories" }, Category.new) do |f|
             f.inputs "Field Wrapper" do
               f.object.posts.build
               f.has_many :posts do |p|
@@ -893,7 +893,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
 
       context "in another has_many block" do
         let :body_html do
-          form_html({ url: '/categories' }, Category.new) do |f|
+          form_html({ url: "/categories" }, Category.new) do |f|
             f.object.posts.build
             f.has_many :posts do |p|
               p.object.taggings.build
@@ -920,7 +920,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
     end
 
     it "should render the block if it returns nil" do
-      body = build_form({ url: '/categories' }, Category.new) do |f|
+      body = build_form({ url: "/categories" }, Category.new) do |f|
         f.object.posts.build
         f.has_many :posts do |p|
           p.input :title
@@ -956,7 +956,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
   end
 
   describe "datepicker input" do
-    context 'with default options' do
+    context "with default options" do
       let :body do
         build_form do |f|
           f.inputs do
@@ -969,7 +969,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
       end
     end
 
-    context 'with date range options' do
+    context "with date range options" do
       let :body do
         build_form do |f|
           f.inputs do
@@ -981,10 +981,10 @@ RSpec.describe ActiveAdmin::FormBuilder do
         end
       end
 
-      it 'should generate a datepicker text input with data min and max dates' do
+      it "should generate a datepicker text input with data min and max dates" do
         selector = "input.datepicker[type=text][name='post[created_at]']"
         expect(body).to have_selector(selector)
-        expect(body.find(selector)["data-datepicker-options"]).to eq({ minDate: '2013-10-18', maxDate: '2013-12-31' }.to_json)
+        expect(body.find(selector)["data-datepicker-options"]).to eq({ minDate: "2013-10-18", maxDate: "2013-12-31" }.to_json)
       end
     end
 
@@ -992,7 +992,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
       let :body do
         build_form do |f|
           f.inputs do
-            f.input :created_at, as: :datepicker, label: proc { 'Title from proc' }
+            f.input :created_at, as: :datepicker, label: proc { "Title from proc" }
           end
         end
       end

--- a/spec/unit/generators/install_spec.rb
+++ b/spec/unit/generators/install_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "AA installation" do
   context "should create" do

--- a/spec/unit/helpers/collection_spec.rb
+++ b/spec/unit/helpers/collection_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Helpers::Collection do
   include ActiveAdmin::Helpers::Collection

--- a/spec/unit/helpers/scope_chain_spec.rb
+++ b/spec/unit/helpers/scope_chain_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::ScopeChain do
   include ActiveAdmin::ScopeChain

--- a/spec/unit/localizers/resource_localizer_spec.rb
+++ b/spec/unit/localizers/resource_localizer_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.shared_examples_for "ActiveAdmin::Localizers::ResourceLocalizer" do
   it "should use proper translation" do
@@ -14,23 +14,23 @@ RSpec.shared_examples_for "ActiveAdmin::Localizers::ResourceLocalizer" do
 end
 
 RSpec.describe ActiveAdmin::Localizers::ResourceLocalizer do
-  let(:action) { 'new_model' }
-  let(:model) { 'Comment' }
-  let(:model_name) { 'comment' }
+  let(:action) { "new_model" }
+  let(:model) { "Comment" }
+  let(:model_name) { "comment" }
 
   it_behaves_like "ActiveAdmin::Localizers::ResourceLocalizer" do
-    let(:translation) { 'New Comment' }
+    let(:translation) { "New Comment" }
   end
 
   describe "model action specified" do
     around do |example|
-      with_translation active_admin: { resources: { comment: { new_model: 'Write comment' } } } do
+      with_translation active_admin: { resources: { comment: { new_model: "Write comment" } } } do
         example.call
       end
     end
 
     it_behaves_like "ActiveAdmin::Localizers::ResourceLocalizer" do
-      let(:translation) { 'Write comment' }
+      let(:translation) { "Write comment" }
     end
   end
 end

--- a/spec/unit/menu_collection_spec.rb
+++ b/spec/unit/menu_collection_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::MenuCollection do
   let(:menus) { ActiveAdmin::MenuCollection.new }

--- a/spec/unit/menu_item_spec.rb
+++ b/spec/unit/menu_item_spec.rb
@@ -1,6 +1,6 @@
-require 'rails_helper'
-require 'active_admin/menu'
-require 'active_admin/menu_item'
+require "rails_helper"
+require "active_admin/menu"
+require "active_admin/menu_item"
 
 module ActiveAdmin
   RSpec.describe MenuItem do
@@ -59,7 +59,7 @@ module ActiveAdmin
       end
 
       it "should give access to the menu item as an array" do
-        expect(item['Blog'].label).to eq 'Blog'
+        expect(item["Blog"].label).to eq "Blog"
       end
 
       it "children should hold a reference to their parent" do

--- a/spec/unit/menu_spec.rb
+++ b/spec/unit/menu_spec.rb
@@ -1,6 +1,6 @@
-require 'rails_helper'
-require 'active_admin/menu'
-require 'active_admin/menu_item'
+require "rails_helper"
+require "active_admin/menu"
+require "active_admin/menu_item"
 
 include ActiveAdmin
 
@@ -27,7 +27,7 @@ RSpec.describe ActiveAdmin::Menu do
     end
 
     it "should give access to the menu item as an array" do
-      expect(menu['Dashboard'].label).to eq 'Dashboard'
+      expect(menu["Dashboard"].label).to eq "Dashboard"
     end
   end
 

--- a/spec/unit/namespace/authorization_spec.rb
+++ b/spec/unit/namespace/authorization_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Resource, "authorization" do
   let(:app) { ActiveAdmin::Application.new }

--- a/spec/unit/namespace/register_page_spec.rb
+++ b/spec/unit/namespace/register_page_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Namespace, "registering a page" do
   let(:application) { ActiveAdmin::Application.new }
@@ -11,11 +11,11 @@ RSpec.describe ActiveAdmin::Namespace, "registering a page" do
     end
 
     it "should store the namespaced registered configuration" do
-      expect(namespace.resources.keys).to include('Status')
+      expect(namespace.resources.keys).to include("Status")
     end
 
     it "should create a new controller in the default namespace" do
-      expect(defined?(Admin::StatusController)).to eq 'constant'
+      expect(defined?(Admin::StatusController)).to eq "constant"
     end
 
     it "should create a menu item" do
@@ -38,23 +38,23 @@ RSpec.describe ActiveAdmin::Namespace, "registering a page" do
       end
 
       it "should add a new menu item" do
-        expect(menu['Status']).to_not eq nil
+        expect(menu["Status"]).to_not eq nil
       end
     end
 
     describe "adding as a child" do
       before do
         namespace.register_page "Status" do
-          menu parent: 'Extra'
+          menu parent: "Extra"
         end
       end
 
       it "should generate the parent menu item" do
-        expect(menu['Extra']).to_not eq nil
+        expect(menu["Extra"]).to_not eq nil
       end
 
       it "should generate its own child item" do
-        expect(menu['Extra']['Status']).to_not eq nil
+        expect(menu["Extra"]["Status"]).to_not eq nil
       end
     end
 

--- a/spec/unit/namespace/register_resource_spec.rb
+++ b/spec/unit/namespace/register_resource_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Namespace, "registering a resource" do
   let(:application) { ActiveAdmin::Application.new }
@@ -13,15 +13,15 @@ RSpec.describe ActiveAdmin::Namespace, "registering a resource" do
     end
 
     it "should store the namespaced registered configuration" do
-      expect(namespace.resources.keys).to include('Category')
+      expect(namespace.resources.keys).to include("Category")
     end
 
     it "should create a new controller in the default namespace" do
-      expect(defined?(SuperAdmin::CategoriesController)).to eq 'constant'
+      expect(defined?(SuperAdmin::CategoriesController)).to eq "constant"
     end
 
     it "should not create the dashboard controller" do
-      expect(defined?(SuperAdmin::DashboardController)).to_not eq 'constant'
+      expect(defined?(SuperAdmin::DashboardController)).to_not eq "constant"
     end
 
     it "should create a menu item" do
@@ -45,11 +45,11 @@ RSpec.describe ActiveAdmin::Namespace, "registering a resource" do
     end
 
     it "should store the namespaced registered configuration" do
-      expect(namespace.resources.keys).to include('Mock::Resource')
+      expect(namespace.resources.keys).to include("Mock::Resource")
     end
 
     it "should create a new controller in the default namespace" do
-      expect(defined?(SuperAdmin::MockResourcesController)).to eq 'constant'
+      expect(defined?(SuperAdmin::MockResourcesController)).to eq "constant"
     end
 
     it "should create a menu item" do
@@ -67,7 +67,7 @@ RSpec.describe ActiveAdmin::Namespace, "registering a resource" do
       expect(namespace.resource_for(Post)).to eq post
     end
 
-    it 'should return nil when the resource has not been registered' do
+    it "should return nil when the resource has not been registered" do
       expect(namespace.resource_for(Post)).to eq nil
     end
 
@@ -89,22 +89,22 @@ RSpec.describe ActiveAdmin::Namespace, "registering a resource" do
         namespace.register Category
       end
       it "should add a new menu item" do
-        expect(menu['Categories']).to_not eq nil
+        expect(menu["Categories"]).to_not eq nil
       end
     end # describe "adding as a top level item"
 
     describe "adding as a child" do
       before do
         namespace.register Category do
-          menu parent: 'Blog'
+          menu parent: "Blog"
         end
       end
       it "should generate the parent menu item" do
-        expect(menu['Blog']).to_not eq nil
+        expect(menu["Blog"]).to_not eq nil
       end
 
       it "should generate its own child item" do
-        expect(menu['Blog']['Categories']).to_not eq nil
+        expect(menu["Blog"]["Categories"]).to_not eq nil
       end
     end # describe "adding as a child"
 
@@ -149,7 +149,7 @@ RSpec.describe ActiveAdmin::Namespace, "registering a resource" do
       it "should be namespaced" do
         namespace = ActiveAdmin::Namespace.new(application, :one)
         namespace.register Category
-        expect(defined?(One::CategoriesController)).to eq 'constant'
+        expect(defined?(One::CategoriesController)).to eq "constant"
       end
     end
 
@@ -157,7 +157,7 @@ RSpec.describe ActiveAdmin::Namespace, "registering a resource" do
       it "should not be namespaced" do
         namespace = ActiveAdmin::Namespace.new(application, :two)
         namespace.register Category
-        expect(defined?(Two::CategoriesController)).to eq 'constant'
+        expect(defined?(Two::CategoriesController)).to eq "constant"
       end
     end
   end # describe "dashboard controller name"

--- a/spec/unit/namespace_spec.rb
+++ b/spec/unit/namespace_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Namespace do
   let(:application) { ActiveAdmin::Application.new }
@@ -36,7 +36,7 @@ RSpec.describe ActiveAdmin::Namespace do
         ActiveAdmin.application.namespaces.instance_variable_get(:@namespaces).delete(:root)
 
         # To force Admin::PostsController to not be there
-        Admin.send(:remove_const, 'PostsController')
+        Admin.send(:remove_const, "PostsController")
       end
 
       after do

--- a/spec/unit/order_clause_spec.rb
+++ b/spec/unit/order_clause_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::OrderClause do
   subject { described_class.new(config, clause) }
@@ -7,42 +7,42 @@ RSpec.describe ActiveAdmin::OrderClause do
   let(:namespace) { ActiveAdmin::Namespace.new application, :admin }
   let(:config) { ActiveAdmin::Resource.new namespace, Post }
 
-  describe 'id_asc (existing column)' do
-    let(:clause) { 'id_asc' }
+  describe "id_asc (existing column)" do
+    let(:clause) { "id_asc" }
 
     it { is_expected.to be_valid }
 
-    describe '#field' do
+    describe "#field" do
       subject { super().field }
-      it { is_expected.to eq('id') }
+      it { is_expected.to eq("id") }
     end
 
-    describe '#order' do
+    describe "#order" do
       subject { super().order }
-      it { is_expected.to eq('asc') }
+      it { is_expected.to eq("asc") }
     end
 
-    specify '#to_sql prepends table name' do
+    specify "#to_sql prepends table name" do
       expect(subject.to_sql).to eq '"posts"."id" asc'
     end
   end
 
-  describe 'virtual_column_asc' do
-    let(:clause) { 'virtual_column_asc' }
+  describe "virtual_column_asc" do
+    let(:clause) { "virtual_column_asc" }
 
     it { is_expected.to be_valid }
 
-    describe '#field' do
+    describe "#field" do
       subject { super().field }
-      it { is_expected.to eq('virtual_column') }
+      it { is_expected.to eq("virtual_column") }
     end
 
-    describe '#order' do
+    describe "#order" do
       subject { super().order }
-      it { is_expected.to eq('asc') }
+      it { is_expected.to eq("asc") }
     end
 
-    specify '#to_sql' do
+    specify "#to_sql" do
       expect(subject.to_sql).to eq '"virtual_column" asc'
     end
   end
@@ -52,28 +52,28 @@ RSpec.describe ActiveAdmin::OrderClause do
 
     it { is_expected.to be_valid }
 
-    describe '#field' do
+    describe "#field" do
       subject { super().field }
       it { is_expected.to eq("hstore_col->'field'") }
     end
 
-    describe '#order' do
+    describe "#order" do
       subject { super().order }
-      it { is_expected.to eq('desc') }
+      it { is_expected.to eq("desc") }
     end
 
-    it 'converts to sql' do
+    it "converts to sql" do
       expect(subject.to_sql).to eq %Q("hstore_col"->'field' desc)
     end
   end
 
-  describe '_asc' do
-    let(:clause) { '_asc' }
+  describe "_asc" do
+    let(:clause) { "_asc" }
 
     it { is_expected.not_to be_valid }
   end
 
-  describe 'nil' do
+  describe "nil" do
     let(:clause) { nil }
 
     it { is_expected.not_to be_valid }

--- a/spec/unit/page_controller_spec.rb
+++ b/spec/unit/page_controller_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::PageController do
   let(:controller) { ActiveAdmin::PageController.new }

--- a/spec/unit/page_spec.rb
+++ b/spec/unit/page_spec.rb
@@ -1,5 +1,5 @@
-require 'rails_helper'
-require File.expand_path('config_shared_examples', __dir__)
+require "rails_helper"
+require File.expand_path("config_shared_examples", __dir__)
 
 module ActiveAdmin
   RSpec.describe Page do

--- a/spec/unit/pretty_format_spec.rb
+++ b/spec/unit/pretty_format_spec.rb
@@ -1,5 +1,5 @@
-require 'rails_helper'
-require 'active_admin/view_helpers/display_helper'
+require "rails_helper"
+require "active_admin/view_helpers/display_helper"
 
 RSpec.describe "#pretty_format" do
   let(:view_klass) do
@@ -12,49 +12,49 @@ RSpec.describe "#pretty_format" do
 
   let(:formatted_obj) { view.pretty_format(obj) }
 
-  shared_examples_for 'an object convertible to string' do
+  shared_examples_for "an object convertible to string" do
     it "should call `to_s` on the given object" do
       expect(formatted_obj).to eq obj.to_s
     end
   end
 
-  context 'when given a string' do
-    let(:obj) { 'hello' }
+  context "when given a string" do
+    let(:obj) { "hello" }
 
-    it_behaves_like 'an object convertible to string'
+    it_behaves_like "an object convertible to string"
   end
 
-  context 'when given an integer' do
+  context "when given an integer" do
     let(:obj) { 23 }
 
-    it_behaves_like 'an object convertible to string'
+    it_behaves_like "an object convertible to string"
   end
 
-  context 'when given a float' do
+  context "when given a float" do
     let(:obj) { 5.67 }
 
-    it_behaves_like 'an object convertible to string'
+    it_behaves_like "an object convertible to string"
   end
 
-  context 'when given an exponential' do
+  context "when given an exponential" do
     let(:obj) { 10**30 }
 
-    it_behaves_like 'an object convertible to string'
+    it_behaves_like "an object convertible to string"
   end
 
-  context 'when given a symbol' do
+  context "when given a symbol" do
     let(:obj) { :foo }
 
-    it_behaves_like 'an object convertible to string'
+    it_behaves_like "an object convertible to string"
   end
 
-  context 'when given an arbre element' do
+  context "when given an arbre element" do
     let(:obj) { Arbre::Element.new.br }
 
-    it_behaves_like 'an object convertible to string'
+    it_behaves_like "an object convertible to string"
   end
 
-  shared_examples_for 'a time-ish object' do
+  shared_examples_for "a time-ish object" do
     it "formats it with the default long format" do
       expect(formatted_obj).to eq "February 28, 1985 20:15"
     end
@@ -101,16 +101,16 @@ RSpec.describe "#pretty_format" do
     end
   end
 
-  context 'when given a Time in utc' do
+  context "when given a Time in utc" do
     let(:obj) { Time.utc(1985, "feb", 28, 20, 15, 1) }
 
-    it_behaves_like 'a time-ish object'
+    it_behaves_like "a time-ish object"
   end
 
-  context 'when given a DateTime' do
+  context "when given a DateTime" do
     let(:obj) { DateTime.new(1985, 2, 28, 20, 15, 1) }
 
-    it_behaves_like 'a time-ish object'
+    it_behaves_like "a time-ish object"
   end
 
   context "given an ActiveRecord object" do

--- a/spec/unit/pundit_adapter_spec.rb
+++ b/spec/unit/pundit_adapter_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 class DefaultPolicy < ApplicationPolicy
   def respond_to_missing?(method, include_private = false)
@@ -90,7 +90,7 @@ RSpec.describe ActiveAdmin::PunditAdapter do
       auth.authorized?(:index)
     end
 
-    context 'when Pundit is unable to find policy scope' do
+    context "when Pundit is unable to find policy scope" do
       let(:collection) { double("collection", to_sym: :collection) }
       subject(:scope) { auth.scope_collection(collection, :read) }
 

--- a/spec/unit/resource/action_items_spec.rb
+++ b/spec/unit/resource/action_items_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Resource::ActionItems do
   let(:resource) do
@@ -30,7 +30,7 @@ RSpec.describe ActiveAdmin::Resource::ActionItems do
       expect(resource.action_items.first.html_class).to eq("action_item test")
     end
 
-    it 'should be ordered by priority' do
+    it "should be ordered by priority" do
       resource.add_action_item :first, priority: 0 do
         # Empty ...
       end
@@ -69,7 +69,7 @@ RSpec.describe ActiveAdmin::Resource::ActionItems do
       expect(resource.action_items.size).to eq 3
     end
 
-    it 'can be removed by name' do
+    it "can be removed by name" do
       resource.remove_action_item :new
       expect(resource.action_items.size).to eq 2
     end

--- a/spec/unit/resource/attributes_spec.rb
+++ b/spec/unit/resource/attributes_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 module ActiveAdmin
   RSpec.describe Resource, "Attributes" do
@@ -11,7 +11,7 @@ module ActiveAdmin
         resource_config.resource_attributes
       end
 
-      it 'should return attributes hash' do
+      it "should return attributes hash" do
         expect(subject).to eq(author_id: :author,
                               body: :body,
                               created_at: :created_at,
@@ -24,7 +24,7 @@ module ActiveAdmin
                               updated_at: :updated_at)
       end
 
-      it 'does not return sensitive attributes' do
+      it "does not return sensitive attributes" do
         keep = ActiveAdmin.application.filter_attributes
         ActiveAdmin.application.filter_attributes = [:published_date]
         expect(subject).to_not include :published_date
@@ -37,7 +37,7 @@ module ActiveAdmin
         resource_config.association_columns
       end
 
-      it 'should return associations' do
+      it "should return associations" do
         expect(subject).to eq([:author, :category])
       end
     end
@@ -47,7 +47,7 @@ module ActiveAdmin
         resource_config.content_columns
       end
 
-      it 'should return columns without associations' do
+      it "should return columns without associations" do
         expect(subject).to eq([:title, :body, :published_date, :position, :starred, :foo_id, :created_at, :updated_at])
       end
     end

--- a/spec/unit/resource/includes_spec.rb
+++ b/spec/unit/resource/includes_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 module ActiveAdmin
   RSpec.describe Resource, "Includes" do

--- a/spec/unit/resource/naming_spec.rb
+++ b/spec/unit/resource/naming_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 module ActiveAdmin
   RSpec.describe Resource, "Naming" do
@@ -83,7 +83,7 @@ module ActiveAdmin
         context "when the :as option is given" do
           describe "singular label" do
             it "should translate the custom name" do
-              config = config(as: 'My Category')
+              config = config(as: "My Category")
               expect(config.resource_name).to receive(:translate).and_return "Translated category"
               expect(config.resource_label).to eq "Translated category"
             end
@@ -91,7 +91,7 @@ module ActiveAdmin
 
           describe "plural label" do
             it "should translate the custom name" do
-              config = config(as: 'My Category')
+              config = config(as: "My Category")
               expect(config.resource_name).to receive(:translate).at_least(:once).and_return "Translated categories"
               expect(config.plural_resource_label).to eq "Translated categories"
             end

--- a/spec/unit/resource/ordering_spec.rb
+++ b/spec/unit/resource/ordering_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 module ActiveAdmin
   RSpec.describe Resource, "Ordering" do

--- a/spec/unit/resource/page_presenters_spec.rb
+++ b/spec/unit/resource/page_presenters_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Resource::PagePresenters do
   let(:namespace) { ActiveAdmin::Namespace.new(ActiveAdmin::Application.new, :admin) }

--- a/spec/unit/resource/pagination_spec.rb
+++ b/spec/unit/resource/pagination_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 module ActiveAdmin
   RSpec.describe Resource, "Pagination" do

--- a/spec/unit/resource/routes_spec.rb
+++ b/spec/unit/resource/routes_spec.rb
@@ -1,11 +1,11 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Resource::Routes do
   let(:application) { ActiveAdmin.application }
   let(:namespace) { application.namespace(:admin) }
 
   context "when in the admin namespace" do
-    let(:config) { namespace.resource_for('Category') }
+    let(:config) { namespace.resource_for("Category") }
 
     around do |example|
       with_resources_during(example) { ActiveAdmin.register Category }
@@ -14,15 +14,15 @@ RSpec.describe ActiveAdmin::Resource::Routes do
     let(:category) { Category.new { |c| c.id = 123 } }
 
     it "should return the route prefix" do
-      expect(config.route_prefix).to eq 'admin'
+      expect(config.route_prefix).to eq "admin"
     end
 
     it "should return the route collection path" do
-      expect(config.route_collection_path).to eq '/admin/categories'
+      expect(config.route_collection_path).to eq "/admin/categories"
     end
 
     it "should return the route instance path" do
-      expect(config.route_instance_path(category)).to eq '/admin/categories/123'
+      expect(config.route_instance_path(category)).to eq "/admin/categories/123"
     end
   end
 
@@ -61,7 +61,7 @@ RSpec.describe ActiveAdmin::Resource::Routes do
   end
 
   context "when the resource belongs to another resource" do
-    let(:config) { namespace.resource_for('Post') }
+    let(:config) { namespace.resource_for("Post") }
 
     let :post do
       Post.new do |p|
@@ -109,7 +109,7 @@ RSpec.describe ActiveAdmin::Resource::Routes do
 
       it "should include :scope and :q params" do
         params = ActionController::Parameters.new(category_id: 1, q: { name_equals: "Any" }, scope: :all)
-        additional_params = { locale: 'en' }
+        additional_params = { locale: "en" }
         batch_action_path = "/admin/categories/1/posts/batch_action?locale=en&q%5Bname_equals%5D=Any&scope=all"
 
         expect(config.route_batch_action_path(params, additional_params)).to eq batch_action_path
@@ -122,7 +122,7 @@ RSpec.describe ActiveAdmin::Resource::Routes do
 
       it "should return the plural batch action route with _index and given params" do
         params = ActionController::Parameters.new(q: { name_equals: "Any" }, scope: :all)
-        additional_params = { locale: 'en' }
+        additional_params = { locale: "en" }
         batch_action_path = "/admin/news/batch_action?locale=en&q%5Bname_equals%5D=Any&scope=all"
         expect(config.route_batch_action_path(params, additional_params)).to eq batch_action_path
       end

--- a/spec/unit/resource/scopes_spec.rb
+++ b/spec/unit/resource/scopes_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 module ActiveAdmin
   RSpec.describe Resource, "Scopes" do

--- a/spec/unit/resource/sidebars_spec.rb
+++ b/spec/unit/resource/sidebars_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Resource::Sidebars do
   let(:resource) do

--- a/spec/unit/resource_collection_spec.rb
+++ b/spec/unit/resource_collection_spec.rb
@@ -1,5 +1,5 @@
-require 'rails_helper'
-require 'active_admin/resource_collection'
+require "rails_helper"
+require "active_admin/resource_collection"
 
 RSpec.describe ActiveAdmin::ResourceCollection do
   let(:application) { ActiveAdmin::Application.new }
@@ -60,7 +60,7 @@ RSpec.describe ActiveAdmin::ResourceCollection do
     it "shouldn't allow a Page/Resource mismatch to occur" do
       expect do
         ActiveAdmin.register User
-        ActiveAdmin.register_page 'User'
+        ActiveAdmin.register_page "User"
       end.to raise_error ActiveAdmin::ResourceCollection::IncorrectClass
     end
 

--- a/spec/unit/resource_controller/data_access_spec.rb
+++ b/spec/unit/resource_controller/data_access_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::ResourceController::DataAccess do
   before do
@@ -75,7 +75,7 @@ RSpec.describe ActiveAdmin::ResourceController::DataAccess do
         expect(controller.send(:active_admin_config)).to receive(:ordering).twice.and_return(
           {
             published_date: proc do |order_clause|
-              [order_clause.to_sql, 'NULLS LAST'].join(' ') if order_clause.order == 'desc'
+              [order_clause.to_sql, "NULLS LAST"].join(" ") if order_clause.order == "desc"
             end
           }.with_indifferent_access
         )
@@ -202,7 +202,7 @@ RSpec.describe ActiveAdmin::ResourceController::DataAccess do
     let!(:category) { Category.create! }
 
     let(:params) do
-      ActionController::Parameters.new(user: { type: 'User::VIP', posts_attributes: [custom_category_id: category.id] })
+      ActionController::Parameters.new(user: { type: "User::VIP", posts_attributes: [custom_category_id: category.id] })
     end
 
     subject do

--- a/spec/unit/resource_controller/decorators_spec.rb
+++ b/spec/unit/resource_controller/decorators_spec.rb
@@ -1,21 +1,21 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::ResourceController::Decorators do
-  describe '#apply_decorator' do
+  describe "#apply_decorator" do
     let(:resource) { Post.new }
     let(:controller) { controller_with_decorator(action, decorator_class) }
     subject(:applied) { controller.apply_decorator(resource) }
 
     context "in show action" do
-      let(:action) { 'show' }
+      let(:action) { "show" }
 
-      context 'with a Draper decorator' do
+      context "with a Draper decorator" do
         let(:decorator_class) { PostDecorator }
 
         it { is_expected.to be_kind_of(PostDecorator) }
       end
 
-      context 'with a PORO decorator' do
+      context "with a PORO decorator" do
         let(:decorator_class) { PostPoroDecorator }
 
         it { is_expected.to be_kind_of(PostPoroDecorator) }
@@ -23,69 +23,69 @@ RSpec.describe ActiveAdmin::ResourceController::Decorators do
     end
 
     context "in update action" do
-      let(:action) { 'update' }
+      let(:action) { "update" }
       let(:decorator_class) { nil }
 
       it { is_expected.not_to be_kind_of(PostDecorator) }
     end
   end
 
-  describe '#apply_collection_decorator' do
+  describe "#apply_collection_decorator" do
     before { Post.create! }
     let(:collection) { Post.where nil }
 
-    context 'with a Draper decorator' do
+    context "with a Draper decorator" do
       let(:controller) { controller_with_decorator("index", PostDecorator) }
       subject(:applied) { controller.apply_collection_decorator(collection) }
 
-      context 'when a decorator is configured' do
-        context 'and it is using a recent version of draper' do
-          it 'calling certain scope collections work' do
+      context "when a decorator is configured" do
+        context "and it is using a recent version of draper" do
+          it "calling certain scope collections work" do
             # This is an example of one of the methods that was consistently
             # failing before this feature existed
-            expect(applied.reorder('').count).to eq applied.count
+            expect(applied.reorder("").count).to eq applied.count
           end
 
-          it 'has a good description for the generated class' do
+          it "has a good description for the generated class" do
             expect(applied.class.name).to eq "Draper::CollectionDecorator of PostDecorator + ActiveAdmin"
           end
         end
       end
     end
 
-    context 'with a PORO decorator' do
+    context "with a PORO decorator" do
       let(:controller) { controller_with_decorator("index", PostPoroDecorator) }
       subject(:applied) { controller.apply_collection_decorator(collection) }
 
-      it 'returns a presented collection' do
+      it "returns a presented collection" do
         expect(subject).to be_kind_of(ActiveAdmin::CollectionDecorator)
         expect(subject).to all(be_a(PostPoroDecorator))
       end
 
-      it 'has a good description for the generated class' do
+      it "has a good description for the generated class" do
         expect(applied.class.name).to eq "ActiveAdmin::CollectionDecorator of PostPoroDecorator + ActiveAdmin"
       end
     end
   end
 
-  describe 'form actions' do
+  describe "form actions" do
     let(:resource) { Post.new }
     let(:controller) { controller_with_decorator("edit", decorator_class) }
 
     subject(:applied) { controller.apply_decorator(resource) }
 
-    context 'when the form is not configured to decorate' do
+    context "when the form is not configured to decorate" do
       let(:decorator_class) { nil }
       it { is_expected.to be_kind_of(Post) }
     end
 
-    context 'when the form is configured to decorate' do
-      context 'with a Draper decorator' do
+    context "when the form is configured to decorate" do
+      context "with a Draper decorator" do
         let(:decorator_class) { PostDecorator }
         it { is_expected.to be_kind_of(PostDecorator) }
       end
 
-      context 'with a PORO decorator' do
+      context "with a PORO decorator" do
         let(:decorator_class) { PostPoroDecorator }
         it { is_expected.to be_kind_of(PostPoroDecorator) }
       end

--- a/spec/unit/resource_controller/polymorphic_routes_spec.rb
+++ b/spec/unit/resource_controller/polymorphic_routes_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::ResourceController::PolymorphicRoutes, type: :controller do
   let(:klass) { Admin::PostsController }
@@ -18,16 +18,16 @@ RSpec.describe ActiveAdmin::ResourceController::PolymorphicRoutes, type: :contro
         get :index, params: params
       end
 
-      context 'without belongs_to' do
+      context "without belongs_to" do
         let(:post_config) { ActiveAdmin.register Post }
         let(:post) { Post.create! title: "Hello World" }
 
-        it 'works with no parent' do
+        it "works with no parent" do
           expect(controller.send(method, [:admin, post])).to include("/admin/posts/#{post.id}")
         end
       end
 
-      context 'with belongs_to' do
+      context "with belongs_to" do
         let(:user) { User.create! }
         let(:post) { Post.create! title: "Hello World", author: user }
 
@@ -43,18 +43,18 @@ RSpec.describe ActiveAdmin::ResourceController::PolymorphicRoutes, type: :contro
             let(:filter_param) { current_page.sub(/_?posts/, "").presence }
             let(:params) { filter_param ? { "#{filter_param}_id" => send(filter_param).id } : {} }
 
-            it 'works with no parent' do
+            it "works with no parent" do
               expect(controller.send(method, [:admin, post])).to include("/admin/posts/#{post.id}")
             end
 
-            it 'works with a user as parent' do
+            it "works with a user as parent" do
               expect(controller.send(method, [:admin, user, post])).to include("/admin/users/#{user.id}/posts/#{post.id}")
             end
           end
         end
       end
 
-      context 'with multiple belongs_to (not fully supported yet)' do
+      context "with multiple belongs_to (not fully supported yet)" do
         let(:user) { User.create! }
         let(:category) { Category.create! name: "Category" }
         let(:post) { Post.create! title: "Hello World", author: user, category: category }
@@ -88,15 +88,15 @@ RSpec.describe ActiveAdmin::ResourceController::PolymorphicRoutes, type: :contro
             let(:filter_param) { current_page.sub(/_?posts/, "").presence }
             let(:params) { filter_param ? { "#{filter_param}_id" => send(filter_param).id } : {} }
 
-            it 'works with no parent' do
+            it "works with no parent" do
               expect(controller.send(method, [:admin, post])).to include("/admin/posts/#{post.id}")
             end
 
-            it 'works with a user as parent' do
+            it "works with a user as parent" do
               expect(controller.send(method, [:admin, user, post])).to include("/admin/users/#{user.id}/posts/#{post.id}")
             end
 
-            it 'works with a category as parent' do
+            it "works with a category as parent" do
               expect(controller.send(method, [:admin, category, post])).to include("/admin/categories/#{category.id}/posts/#{post.id}")
             end
           end

--- a/spec/unit/resource_controller/sidebars_spec.rb
+++ b/spec/unit/resource_controller/sidebars_spec.rb
@@ -1,9 +1,9 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::ResourceController::Sidebars, type: :controller do
   let(:klass) { Admin::PostsController }
 
-  shared_context 'with post config' do
+  shared_context "with post config" do
     before do
       load_resources { post_config }
 
@@ -13,24 +13,24 @@ RSpec.describe ActiveAdmin::ResourceController::Sidebars, type: :controller do
     end
   end
 
-  context 'without skip_sidebar! before filter' do
-    include_context 'with post config' do
+  context "without skip_sidebar! before filter" do
+    include_context "with post config" do
       let(:post_config) { ActiveAdmin.register Post }
     end
 
-    it 'does not set @skip_sidebar' do
+    it "does not set @skip_sidebar" do
       expect(controller.instance_variable_get(:@skip_sidebar)).to eq nil
     end
   end
 
-  context 'with skip_sidebar! before_action' do
-    include_context 'with post config' do
+  context "with skip_sidebar! before_action" do
+    include_context "with post config" do
       let(:post_config) do
         ActiveAdmin.register(Post) { before_action :skip_sidebar! }
       end
     end
 
-    it 'works' do
+    it "works" do
       expect(controller.instance_variable_get(:@skip_sidebar)).to eq true
     end
   end

--- a/spec/unit/resource_controller_spec.rb
+++ b/spec/unit/resource_controller_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::ResourceController do
   let(:controller) { Admin::PostsController.new }
@@ -171,9 +171,9 @@ RSpec.describe "A specific resource controller", type: :controller do
     end
   end
 
-  describe 'retrieving the resource' do
+  describe "retrieving the resource" do
     let(:post) { Post.new title: "An incledibly unique Post Title" }
-    let(:http_params) { { id: '1' } }
+    let(:http_params) { { id: "1" } }
 
     before do
       allow(Post).to receive(:find).and_return(post)
@@ -187,41 +187,41 @@ RSpec.describe "A specific resource controller", type: :controller do
       expect(subject).to be_kind_of(Post)
     end
 
-    context 'with a decorator' do
+    context "with a decorator" do
       let(:config) { controller.class.active_admin_config }
 
-      context 'with a Draper decorator' do
-        before { config.decorator_class_name = '::PostDecorator' }
+      context "with a Draper decorator" do
+        before { config.decorator_class_name = "::PostDecorator" }
 
-        it 'returns a PostDecorator' do
+        it "returns a PostDecorator" do
           expect(subject).to be_kind_of(PostDecorator)
         end
 
-        it 'returns a PostDecorator that wraps the post' do
+        it "returns a PostDecorator that wraps the post" do
           expect(subject.title).to eq post.title
         end
       end
 
-      context 'with a PORO decorator' do
-        before { config.decorator_class_name = '::PostPoroDecorator' }
+      context "with a PORO decorator" do
+        before { config.decorator_class_name = "::PostPoroDecorator" }
 
-        it 'returns a PostDecorator' do
+        it "returns a PostDecorator" do
           expect(subject).to be_kind_of(PostPoroDecorator)
         end
 
-        it 'returns a PostDecorator that wraps the post' do
+        it "returns a PostDecorator that wraps the post" do
           expect(subject.title).to eq post.title
         end
       end
     end
   end
 
-  describe 'retrieving the resource collection' do
+  describe "retrieving the resource collection" do
     let(:config) { controller.class.active_admin_config }
     before do
       Post.create!(title: "An incledibly unique Post Title")
       config.decorator_class_name = nil
-      request = double 'Request', format: 'application/json'
+      request = double "Request", format: "application/json"
       allow(controller).to receive(:params) { {} }
       allow(controller).to receive(:request) { request }
     end
@@ -236,15 +236,15 @@ RSpec.describe "A specific resource controller", type: :controller do
       expect(subject.first).to be_kind_of(Post)
     end
 
-    context 'with a decorator' do
-      before { config.decorator_class_name = 'PostDecorator' }
+    context "with a decorator" do
+      before { config.decorator_class_name = "PostDecorator" }
 
-      it 'returns a collection decorator using PostDecorator' do
+      it "returns a collection decorator using PostDecorator" do
         expect(subject).to be_a Draper::CollectionDecorator
         expect(subject.decorator_class).to eq PostDecorator
       end
 
-      it 'returns a collection decorator that wraps the post' do
+      it "returns a collection decorator that wraps the post" do
         expect(subject.first.title).to eq Post.first.title
       end
     end

--- a/spec/unit/resource_registration_spec.rb
+++ b/spec/unit/resource_registration_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Registering an object to administer" do
   let(:application) { ActiveAdmin::Application.new }

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -1,5 +1,5 @@
-require 'rails_helper'
-require File.expand_path('config_shared_examples', __dir__)
+require "rails_helper"
+require File.expand_path("config_shared_examples", __dir__)
 
 module ActiveAdmin
   RSpec.describe Resource do
@@ -36,22 +36,22 @@ module ActiveAdmin
       end
     end
 
-    describe '#decorator_class' do
-      it 'returns nil by default' do
+    describe "#decorator_class" do
+      it "returns nil by default" do
         expect(config.decorator_class).to eq nil
       end
 
-      context 'when a decorator is defined' do
+      context "when a decorator is defined" do
         around do |example|
           with_resources_during(example) { resource }
         end
 
         let(:resource) { namespace.register(Post) { decorate_with PostDecorator } }
-        specify '#decorator_class_name should return PostDecorator' do
-          expect(resource.decorator_class_name).to eq '::PostDecorator'
+        specify "#decorator_class_name should return PostDecorator" do
+          expect(resource.decorator_class_name).to eq "::PostDecorator"
         end
 
-        it 'returns the decorator class' do
+        it "returns the decorator class" do
           expect(resource.decorator_class).to eq PostDecorator
         end
       end
@@ -189,7 +189,7 @@ module ActiveAdmin
         expect(config.scopes.first.show_count).to eq true
       end
 
-      context 'when show_count disabled' do
+      context "when show_count disabled" do
         it "should add a scope show_count = false" do
           namespace.scopes_show_count = false
           config.scope :published
@@ -245,50 +245,50 @@ module ActiveAdmin
       end
     end
 
-    describe '#find_resource' do
+    describe "#find_resource" do
       let(:post) { double }
 
       around do |example|
         with_resources_during(example) { resource }
       end
 
-      context 'without a decorator' do
+      context "without a decorator" do
         let(:resource) { namespace.register(Post) }
 
-        it 'can find the resource' do
+        it "can find the resource" do
           allow(Post).to receive(:find_by).with("id" => "12345") { post }
-          expect(resource.find_resource('12345')).to eq post
+          expect(resource.find_resource("12345")).to eq post
         end
       end
 
-      context 'with a decorator' do
+      context "with a decorator" do
         let(:resource) { namespace.register(Post) { decorate_with PostDecorator } }
 
-        it 'decorates the resource' do
+        it "decorates the resource" do
           allow(Post).to receive(:find_by).with("id" => "12345") { post }
-          expect(resource.find_resource('12345')).to eq PostDecorator.new(post)
+          expect(resource.find_resource("12345")).to eq PostDecorator.new(post)
         end
 
-        it 'does not decorate a not found resource' do
+        it "does not decorate a not found resource" do
           allow(Post).to receive(:find_by).with("id" => "54321") { nil }
-          expect(resource.find_resource('54321')).to equal nil
+          expect(resource.find_resource("54321")).to equal nil
         end
       end
 
-      context 'when using a nonstandard primary key' do
+      context "when using a nonstandard primary key" do
         let(:resource) { namespace.register(Post) }
 
         before do
-          allow(Post).to receive(:primary_key).and_return 'something_else'
+          allow(Post).to receive(:primary_key).and_return "something_else"
           allow(Post).to receive(:find_by).with("something_else" => "55555") { post }
         end
 
-        it 'can find the post by the custom primary key' do
-          expect(resource.find_resource('55555')).to eq post
+        it "can find the post by the custom primary key" do
+          expect(resource.find_resource("55555")).to eq post
         end
       end
 
-      context 'when using controller finder' do
+      context "when using controller finder" do
         let(:resource) do
           namespace.register(Post) do
             controller do
@@ -301,10 +301,10 @@ module ActiveAdmin
           Admin.send(:remove_const, :"PostsController")
         end
 
-        it 'can find the post by controller finder' do
-          allow(Post).to receive(:find_by_title!).with('title-name').and_return(post)
+        it "can find the post by controller finder" do
+          allow(Post).to receive(:find_by_title!).with("title-name").and_return(post)
 
-          expect(resource.find_resource('title-name')).to eq post
+          expect(resource.find_resource("title-name")).to eq post
         end
       end
     end

--- a/spec/unit/routing_spec.rb
+++ b/spec/unit/routing_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Routing", type: :routing do
   let(:namespaces) { ActiveAdmin.application.namespaces }
@@ -13,7 +13,7 @@ RSpec.describe "Routing", type: :routing do
     end
 
     it "should route to the admin dashboard" do
-      expect(get('/admin')).to route_to 'admin/dashboard#index'
+      expect(get("/admin")).to route_to "admin/dashboard#index"
     end
   end
 
@@ -36,7 +36,7 @@ RSpec.describe "Routing", type: :routing do
 
     context "with a custom path set in route_options" do
       before do
-        namespaces[:admin].route_options = { path: '/custom-path' }
+        namespaces[:admin].route_options = { path: "/custom-path" }
         reload_routes!
       end
 
@@ -182,7 +182,7 @@ RSpec.describe "Routing", type: :routing do
 
       it "should properly route the collection action" do
         expect({ get: "/admin/users/do_something" }).to \
-          route_to({ controller: 'admin/users', action: 'do_something' })
+          route_to({ controller: "admin/users", action: "do_something" })
       end
     end
   end

--- a/spec/unit/scope_spec.rb
+++ b/spec/unit/scope_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Scope do
   describe "creating a scope" do
@@ -7,17 +7,17 @@ RSpec.describe ActiveAdmin::Scope do
     context "when just a scope method" do
       let(:scope) { ActiveAdmin::Scope.new :published }
 
-      describe '#name' do
+      describe "#name" do
         subject { super().name }
         it { is_expected.to eq("Published") }
       end
 
-      describe '#id' do
+      describe "#id" do
         subject { super().id }
         it { is_expected.to eq("published") }
       end
 
-      describe '#scope_method' do
+      describe "#scope_method" do
         subject { super().scope_method }
         it { is_expected.to eq(:published) }
       end
@@ -26,43 +26,43 @@ RSpec.describe ActiveAdmin::Scope do
     context "when scope method is :all" do
       let(:scope) { ActiveAdmin::Scope.new :all }
 
-      describe '#name' do
+      describe "#name" do
         subject { super().name }
         it { is_expected.to eq("All") }
       end
 
-      describe '#id' do
+      describe "#id" do
         subject { super().id }
         it { is_expected.to eq("all") }
       end
       # :all does not return a chain but an array of active record
       # instances. We set the scope_method to nil then.
 
-      describe '#scope_method' do
+      describe "#scope_method" do
         subject { super().scope_method }
         it { is_expected.to eq(nil) }
       end
 
-      describe '#scope_block' do
+      describe "#scope_block" do
         subject { super().scope_block }
         it { is_expected.to eq(nil) }
       end
     end
 
-    context 'when a name and scope method is :all' do
-      let(:scope) { ActiveAdmin::Scope.new 'Tous', :all }
+    context "when a name and scope method is :all" do
+      let(:scope) { ActiveAdmin::Scope.new "Tous", :all }
 
-      describe '#name' do
+      describe "#name" do
         subject { super().name }
-        it { is_expected.to eq 'Tous' }
+        it { is_expected.to eq "Tous" }
       end
 
-      describe '#scope_method' do
+      describe "#scope_method" do
         subject { super().scope_method }
         it { is_expected.to eq nil }
       end
 
-      describe '#scope_block' do
+      describe "#scope_block" do
         subject { super().scope_block }
         it { is_expected.to eq nil }
       end
@@ -71,17 +71,17 @@ RSpec.describe ActiveAdmin::Scope do
     context "when a name and scope method" do
       let(:scope) { ActiveAdmin::Scope.new "With API Access", :with_api_access }
 
-      describe '#name' do
+      describe "#name" do
         subject { super().name }
         it { is_expected.to eq("With API Access") }
       end
 
-      describe '#id' do
+      describe "#id" do
         subject { super().id }
         it { is_expected.to eq("with_api_access") }
       end
 
-      describe '#scope_method' do
+      describe "#scope_method" do
         subject { super().scope_method }
         it { is_expected.to eq(:with_api_access) }
       end
@@ -90,22 +90,22 @@ RSpec.describe ActiveAdmin::Scope do
     context "when a name and scope block" do
       let(:scope) { ActiveAdmin::Scope.new("My Scope") { |s| s } }
 
-      describe '#name' do
+      describe "#name" do
         subject { super().name }
         it { is_expected.to eq("My Scope") }
       end
 
-      describe '#id' do
+      describe "#id" do
         subject { super().id }
         it { is_expected.to eq("my_scope") }
       end
 
-      describe '#scope_method' do
+      describe "#scope_method" do
         subject { super().scope_method }
         it { is_expected.to eq(nil) }
       end
 
-      describe '#scope_block' do
+      describe "#scope_block" do
         subject { super().scope_block }
         it { is_expected.to be_a(Proc) }
       end
@@ -114,12 +114,12 @@ RSpec.describe ActiveAdmin::Scope do
     context "when a name has a space and lowercase" do
       let(:scope) { ActiveAdmin::Scope.new("my scope") }
 
-      describe '#name' do
+      describe "#name" do
         subject { super().name }
         it { is_expected.to eq("my scope") }
       end
 
-      describe '#id' do
+      describe "#id" do
         subject { super().id }
         it { is_expected.to eq("my_scope") }
       end
@@ -128,35 +128,35 @@ RSpec.describe ActiveAdmin::Scope do
     context "with a proc as the label" do
       it "should raise an exception if a second argument isn't provided" do
         expect do
-          ActiveAdmin::Scope.new proc { Date.today.strftime '%A' }
-        end.to raise_error 'A string/symbol is required as the second argument if your label is a proc.'
+          ActiveAdmin::Scope.new proc { Date.today.strftime "%A" }
+        end.to raise_error "A string/symbol is required as the second argument if your label is a proc."
       end
 
       it "should properly render the proc" do
-        scope = ActiveAdmin::Scope.new proc { Date.today.strftime '%A' }, :foobar
-        expect(scope.name.call).to eq Date.today.strftime '%A'
+        scope = ActiveAdmin::Scope.new proc { Date.today.strftime "%A" }, :foobar
+        expect(scope.name.call).to eq Date.today.strftime "%A"
       end
     end
 
     context "with scope method and localizer" do
       let(:localizer) do
         loc = double(:localizer)
-        allow(loc).to receive(:t).with(:published, scope: 'scopes').and_return("All published")
+        allow(loc).to receive(:t).with(:published, scope: "scopes").and_return("All published")
         loc
       end
       let(:scope) { ActiveAdmin::Scope.new :published, :published, localizer: localizer }
 
-      describe '#name' do
+      describe "#name" do
         subject { super().name }
         it { is_expected.to eq("All published") }
       end
 
-      describe '#id' do
+      describe "#id" do
         subject { super().id }
         it { is_expected.to eq("published") }
       end
 
-      describe '#scope_method' do
+      describe "#scope_method" do
         subject { super().scope_method }
         it { is_expected.to eq(:published) }
       end

--- a/spec/unit/settings_node_spec.rb
+++ b/spec/unit/settings_node_spec.rb
@@ -1,23 +1,23 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::SettingsNode do
   subject { ActiveAdmin::SettingsNode.build }
   let!(:child) { ActiveAdmin::SettingsNode.build(subject) }
 
-  context 'parent setting includes foo' do
+  context "parent setting includes foo" do
     before { subject.register :foo, true }
 
-    it 'returns parent settings' do
+    it "returns parent settings" do
       expect(child.foo).to eq true
     end
 
-    it 'fails if setting undefined' do
+    it "fails if setting undefined" do
       expect do
         child.bar
       end.to raise_error(NoMethodError)
     end
 
-    context 'child overrides foo' do
+    context "child overrides foo" do
       before { child.foo = false }
 
       it { expect(child.foo).to eq false }

--- a/spec/unit/view_factory_spec.rb
+++ b/spec/unit/view_factory_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 def it_should_have_view(key, value)
   it "should have #{value} for view key '#{key}'" do

--- a/spec/unit/view_helpers/breadcrumbs_spec.rb
+++ b/spec/unit/view_helpers/breadcrumbs_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Breadcrumbs" do
   include ActiveAdmin::ViewHelpers
@@ -9,14 +9,14 @@ RSpec.describe "Breadcrumbs" do
 
     actions = ActiveAdmin::BaseController::ACTIVE_ADMIN_ACTIONS
 
-    let(:user) { double display_name: 'Jane Doe' }
+    let(:user) { double display_name: "Jane Doe" }
     let(:user_config) do
-      double find_resource: user, resource_name: double(route_key: 'users'),
+      double find_resource: user, resource_name: double(route_key: "users"),
              defined_actions: actions
     end
-    let(:post) { double display_name: 'Hello World' }
+    let(:post) { double display_name: "Hello World" }
     let(:post_config) do
-      double find_resource: post, resource_name: double(route_key: 'posts'),
+      double find_resource: post, resource_name: double(route_key: "posts"),
              defined_actions: actions, belongs_to_config: double(target: user_config)
     end
 
@@ -35,15 +35,15 @@ RSpec.describe "Breadcrumbs" do
     end
 
     context "when path 'admin/users'" do
-      let(:path) { 'admin/users' }
+      let(:path) { "admin/users" }
 
-      it 'should have one item' do
+      it "should have one item" do
         expect(trail.size).to eq 1
       end
 
-      it 'should have a link to /admin' do
-        expect(trail[0][:name]).to eq 'Admin'
-        expect(trail[0][:path]).to eq '/admin'
+      it "should have a link to /admin" do
+        expect(trail[0][:name]).to eq "Admin"
+        expect(trail[0][:path]).to eq "/admin"
       end
     end
 
@@ -138,7 +138,7 @@ RSpec.describe "Breadcrumbs" do
 
       context "when User.find(4e24d6249ccf967313000000) does exist" do
         before do
-          display_name = double(display_name: 'Hello :)')
+          display_name = double(display_name: "Hello :)")
           allow(user_config).to receive(:find_resource).and_return(display_name)
         end
         it "should have a link to /admin/users/4e24d6249ccf967313000000 using display name" do
@@ -175,7 +175,7 @@ RSpec.describe "Breadcrumbs" do
 
       context "when User.find(2b2f0fc2-9a0d-41b8-b39d-aa21963aaee4) does exist" do
         before do
-          display_name = double(display_name: 'Hello :)')
+          display_name = double(display_name: "Hello :)")
           allow(user_config).to receive(:find_resource).and_return(display_name)
         end
         it "should have a link to /admin/users/2b2f0fc2-9a0d-41b8-b39d-aa21963aaee4 using display name" do
@@ -248,7 +248,7 @@ RSpec.describe "Breadcrumbs" do
 
     context "when the 'show' action is disabled" do
       let(:post_config) do
-        double find_resource: post, resource_name: double(route_key: 'posts'),
+        double find_resource: post, resource_name: double(route_key: "posts"),
                defined_actions: actions - [:show], # this is the change
                belongs_to_config: double(target: user_config)
       end

--- a/spec/unit/view_helpers/display_helper_spec.rb
+++ b/spec/unit/view_helpers/display_helper_spec.rb
@@ -1,8 +1,8 @@
-require 'rails_helper'
-require 'active_admin/view_helpers/active_admin_application_helper'
-require 'active_admin/view_helpers/auto_link_helper'
-require 'active_admin/view_helpers/display_helper'
-require 'active_admin/view_helpers/method_or_proc_helper'
+require "rails_helper"
+require "active_admin/view_helpers/active_admin_application_helper"
+require "active_admin/view_helpers/auto_link_helper"
+require "active_admin/view_helpers/display_helper"
+require "active_admin/view_helpers/method_or_proc_helper"
 
 RSpec.describe ActiveAdmin::ViewHelpers::DisplayHelper do
   let(:view_klass) do
@@ -33,7 +33,7 @@ RSpec.describe ActiveAdmin::ViewHelpers::DisplayHelper do
     end
   end
 
-  describe '#display_name' do
+  describe "#display_name" do
     let(:resource) { klass.new }
 
     ActiveAdmin::Application.new.display_name_methods.map(&:to_s).each do |m|
@@ -52,12 +52,12 @@ RSpec.describe ActiveAdmin::ViewHelpers::DisplayHelper do
       context "when it includes js" do
         let(:klass) do
           Class.new do
-            define_method(m) { '<script>alert(1)</script>' }
+            define_method(m) { "<script>alert(1)</script>" }
           end
         end
 
         it "should sanitize the result of #{m}" do
-          expect(displayed_name).to eq '&lt;script&gt;alert(1)&lt;/script&gt;'
+          expect(displayed_name).to eq "&lt;script&gt;alert(1)&lt;/script&gt;"
         end
       end
     end
@@ -77,9 +77,9 @@ RSpec.describe ActiveAdmin::ViewHelpers::DisplayHelper do
         allow(klass).to receive(:reflect_on_all_associations).and_return [ double(name: :login) ]
         allow(resource).to receive :login
         expect(resource).to_not receive :login
-        allow(resource).to receive(:email).and_return 'foo@bar.baz'
+        allow(resource).to receive(:email).and_return "foo@bar.baz"
 
-        expect(displayed_name).to eq 'foo@bar.baz'
+        expect(displayed_name).to eq "foo@bar.baz"
       end
     end
 
@@ -140,23 +140,23 @@ RSpec.describe ActiveAdmin::ViewHelpers::DisplayHelper do
     end
   end
 
-  describe '#format_attribute' do
-    it 'calls the provided block to format the value' do
+  describe "#format_attribute" do
+    it "calls the provided block to format the value" do
       value = view.format_attribute double(foo: 2), ->r { r.foo + 1 }
 
-      expect(value).to eq '3'
+      expect(value).to eq "3"
     end
 
-    it 'finds values as methods' do
-      value = view.format_attribute double(name: 'Joe'), :name
+    it "finds values as methods" do
+      value = view.format_attribute double(name: "Joe"), :name
 
-      expect(value).to eq 'Joe'
+      expect(value).to eq "Joe"
     end
 
-    it 'finds values from hashes' do
+    it "finds values from hashes" do
       value = view.format_attribute({ id: 100 }, :id)
 
-      expect(value).to eq '100'
+      expect(value).to eq "100"
     end
 
     [1, 1.2, :a_symbol].each do |val|
@@ -167,31 +167,31 @@ RSpec.describe ActiveAdmin::ViewHelpers::DisplayHelper do
       end
     end
 
-    it 'localizes dates' do
-      date = Date.parse '2016/02/28'
+    it "localizes dates" do
+      date = Date.parse "2016/02/28"
 
       value = view.format_attribute double(date: date), :date
 
-      expect(value).to eq 'February 28, 2016'
+      expect(value).to eq "February 28, 2016"
     end
 
-    it 'localizes times' do
-      time = Time.parse '2016/02/28 9:34 PM'
+    it "localizes times" do
+      time = Time.parse "2016/02/28 9:34 PM"
 
       value = view.format_attribute double(time: time), :time
 
-      expect(value).to eq 'February 28, 2016 21:34'
+      expect(value).to eq "February 28, 2016 21:34"
     end
 
-    it 'uses a display_name method for arbitrary objects' do
+    it "uses a display_name method for arbitrary objects" do
       object = double to_s: :wrong, display_name: :right
 
       value = view.format_attribute double(object: object), :object
 
-      expect(value).to eq 'right'
+      expect(value).to eq "right"
     end
 
-    it 'auto-links ActiveRecord records by association' do
+    it "auto-links ActiveRecord records by association" do
       post = Post.create! author: User.new
 
       value = view.format_attribute post, :author
@@ -199,17 +199,17 @@ RSpec.describe ActiveAdmin::ViewHelpers::DisplayHelper do
       expect(value).to match /<a href="\/admin\/users\/\d+"> <\/a>/
     end
 
-    it 'auto-links ActiveRecord records & uses a display_name method' do
-      post = Post.create! author: User.new(first_name: 'A', last_name: 'B')
+    it "auto-links ActiveRecord records & uses a display_name method" do
+      post = Post.create! author: User.new(first_name: "A", last_name: "B")
 
       value = view.format_attribute post, :author
 
       expect(value).to match /<a href="\/admin\/users\/\d+">A B<\/a>/
     end
 
-    pending 'auto-links Mongoid records'
+    pending "auto-links Mongoid records"
 
-    it 'calls status_tag for boolean values' do
+    it "calls status_tag for boolean values" do
       post = Post.new starred: true
 
       value = view.format_attribute post, :starred
@@ -217,7 +217,7 @@ RSpec.describe ActiveAdmin::ViewHelpers::DisplayHelper do
       expect(value.to_s).to eq "<span class=\"status_tag yes\">Yes</span>\n"
     end
 
-    it 'calls status_tag for boolean non-database values' do
+    it "calls status_tag for boolean non-database values" do
       post = Post.new
       post.define_singleton_method(:true_method) do
         true
@@ -231,7 +231,7 @@ RSpec.describe ActiveAdmin::ViewHelpers::DisplayHelper do
       expect(false_value.to_s).to eq "<span class=\"status_tag no\">No</span>\n"
     end
 
-    it 'renders ActiveRecord relations as a list' do
+    it "renders ActiveRecord relations as a list" do
       tags = (1..3).map do |i|
         Tag.create!(name: "abc#{i}")
       end
@@ -242,7 +242,7 @@ RSpec.describe ActiveAdmin::ViewHelpers::DisplayHelper do
       expect(value.to_s).to eq "abc1, abc2, abc3"
     end
 
-    it 'renders arrays as a list' do
+    it "renders arrays as a list" do
       items = (1..3).map { |i| "abc#{i}" }
       post = Post.create!
       allow(post).to receive(:items).and_return(items)

--- a/spec/unit/view_helpers/download_format_links_helper_spec.rb
+++ b/spec/unit/view_helpers/download_format_links_helper_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::ViewHelpers::DownloadFormatLinksHelper do
   describe "class methods" do
@@ -28,7 +28,7 @@ RSpec.describe ActiveAdmin::ViewHelpers::DownloadFormatLinksHelper do
     end
 
     it "raises an exception if you provide an unregisterd mime type extension" do
-      expect { subject.add_format :hoge }.to raise_error 'Please register the hoge mime type with `Mime::Type.register`'
+      expect { subject.add_format :hoge }.to raise_error "Please register the hoge mime type with `Mime::Type.register`"
     end
   end
 end

--- a/spec/unit/view_helpers/fields_for_spec.rb
+++ b/spec/unit/view_helpers/fields_for_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::ViewHelpers::FormHelper, ".fields_for" do
   include ActiveAdmin::ViewHelpers::FormHelper

--- a/spec/unit/view_helpers/flash_helper_spec.rb
+++ b/spec/unit/view_helpers/flash_helper_spec.rb
@@ -1,22 +1,22 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::ViewHelpers::FlashHelper do
-  describe '.flash_messages' do
+  describe ".flash_messages" do
     let(:view) { mock_action_view }
 
     it "should not include 'timedout' flash messages by default" do
       view.request.flash[:alert] = "Alert"
       view.request.flash[:timedout] = true
-      expect(view.flash_messages).to include 'alert'
-      expect(view.flash_messages).to_not include 'timedout'
+      expect(view.flash_messages).to include "alert"
+      expect(view.flash_messages).to_not include "timedout"
     end
 
     it "should not return flash messages included in flash_keys_to_except" do
       expect(view.active_admin_application).to receive(:flash_keys_to_except).and_return ["hideme"]
       view.request.flash[:alert] = "Alert"
       view.request.flash[:hideme] = "Do not show"
-      expect(view.flash_messages).to include 'alert'
-      expect(view.flash_messages).to_not include 'hideme'
+      expect(view.flash_messages).to include "alert"
+      expect(view.flash_messages).to_not include "hideme"
     end
   end
 end

--- a/spec/unit/view_helpers/form_helper_spec.rb
+++ b/spec/unit/view_helpers/form_helper_spec.rb
@@ -1,17 +1,17 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::ViewHelpers::FormHelper do
-  describe '.active_admin_form_for' do
+  describe ".active_admin_form_for" do
     let(:view) { mock_action_view }
-    let(:resource) { double 'resource' }
+    let(:resource) { double "resource" }
     let(:default_options) { { builder: ActiveAdmin::FormBuilder } }
 
-    it 'calls semantic_form_for with the ActiveAdmin form builder' do
+    it "calls semantic_form_for with the ActiveAdmin form builder" do
       expect(view).to receive(:semantic_form_for).with(resource, builder: ActiveAdmin::FormBuilder)
       view.active_admin_form_for(resource)
     end
 
-    it 'allows the form builder to be customized' do
+    it "allows the form builder to be customized" do
       # We can't use a stub here because options gets marshalled, and a new
       # instance built. Any constant will work.
       custom_builder = Object

--- a/spec/unit/view_helpers/method_or_proc_helper_spec.rb
+++ b/spec/unit/view_helpers/method_or_proc_helper_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe MethodOrProcHelper do
   let(:receiver) { double }
@@ -28,18 +28,18 @@ RSpec.describe MethodOrProcHelper do
   end
 
   describe "#call_method_or_proc_on" do
-    [:hello, 'hello'].each do |key|
+    [:hello, "hello"].each do |key|
       context "when a #{key.class}" do
         it "should call the method on the receiver" do
-          expect(receiver).to receive(key).and_return 'hello'
+          expect(receiver).to receive(key).and_return "hello"
 
-          expect(context.call_method_or_proc_on(receiver, key)).to eq 'hello'
+          expect(context.call_method_or_proc_on(receiver, key)).to eq "hello"
         end
 
         it "should receive additional arguments" do
-          expect(receiver).to receive(key).with(:world).and_return 'hello world'
+          expect(receiver).to receive(key).with(:world).and_return "hello world"
 
-          expect(context.call_method_or_proc_on(receiver, key, :world)).to eq 'hello world'
+          expect(context.call_method_or_proc_on(receiver, key, :world)).to eq "hello world"
         end
       end
     end

--- a/spec/unit/views/components/attributes_table_spec.rb
+++ b/spec/unit/views/components/attributes_table_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::AttributesTable do
   describe "creating with the dsl" do
@@ -60,8 +60,8 @@ RSpec.describe ActiveAdmin::Views::AttributesTable do
         let(:table) { instance_eval &table_decleration }
 
         it "should render a div wrapper with the class '.attributes_table'" do
-          expect(table.tag_name).to eq 'div'
-          expect(table.attr(:class)).to include('attributes_table')
+          expect(table.tag_name).to eq "div"
+          expect(table.attr(:class)).to include("attributes_table")
         end
 
         it "should add id and type class" do
@@ -124,31 +124,31 @@ RSpec.describe ActiveAdmin::Views::AttributesTable do
     it "should allow html content inside the attributes table" do
       table = render_arbre_component(assigns) do
         attributes_table_for(post) do
-          row("ID") { span(post.id, class: 'id') }
+          row("ID") { span(post.id, class: "id") }
         end
       end
       expect(table.find_by_tag("td").first.content.chomp.strip).to eq "<span class=\"id\">1</span>"
     end
 
-    context 'an attribute ending in _id' do
+    context "an attribute ending in _id" do
       before do
         post.foo_id = 23
-        post.author = User.new username: 'john_doe', first_name: 'John', last_name: 'Doe'
+        post.author = User.new username: "john_doe", first_name: "John", last_name: "Doe"
       end
-      it 'should call the association if one exists' do
+      it "should call the association if one exists" do
         table = render_arbre_component assigns do
           attributes_table_for post, :author
         end
-        expect(table.find_by_tag('th').first.content).to eq 'Author'
-        expect(table.find_by_tag('td').first.content).to eq 'John Doe'
+        expect(table.find_by_tag("th").first.content).to eq "Author"
+        expect(table.find_by_tag("td").first.content).to eq "John Doe"
       end
 
-      it 'should not attempt to call a nonexistant association' do
+      it "should not attempt to call a nonexistant association" do
         table = render_arbre_component assigns do
           attributes_table_for post, :foo_id
         end
-        expect(table.find_by_tag('th').first.content).to eq 'Foo'
-        expect(table.find_by_tag('td').first.content).to eq '23'
+        expect(table.find_by_tag("th").first.content).to eq "Foo"
+        expect(table.find_by_tag("td").first.content).to eq "23"
       end
     end
 
@@ -218,7 +218,7 @@ RSpec.describe ActiveAdmin::Views::AttributesTable do
 
             context "with defined attribute name translation" do
               it "should have the translated attribute name in the title" do
-                with_translation activerecord: { attributes: { post: { title: 'Translated Title', id: 'Translated Id' } } } do
+                with_translation activerecord: { attributes: { post: { title: "Translated Title", id: "Translated Id" } } } do
                   expect(current_row.find_by_tag("th").first.content).to eq "Translated #{title}"
                 end
               end

--- a/spec/unit/views/components/batch_action_selector_spec.rb
+++ b/spec/unit/views/components/batch_action_selector_spec.rb
@@ -1,5 +1,5 @@
-require 'rails_helper'
-require 'active_admin/batch_actions/views/batch_action_selector'
+require "rails_helper"
+require "active_admin/batch_actions/views/batch_action_selector"
 
 RSpec.describe ActiveAdmin::BatchActions::BatchActionSelector do
   let(:dropdown) do
@@ -17,22 +17,22 @@ RSpec.describe ActiveAdmin::BatchActions::BatchActionSelector do
       dropdown.find_by_class("dropdown_menu_list").first
     end
 
-    describe '#tag_name' do
+    describe "#tag_name" do
       subject { super().tag_name }
       it { is_expected.to eql("ul") }
     end
 
-    describe '#content' do
+    describe "#content" do
       subject { super().content }
       it { is_expected.to include("class=\"batch_action\" data-action=\"action_1\"") }
     end
 
-    describe '#content' do
+    describe "#content" do
       subject { super().content }
       it { is_expected.to include("class=\"batch_action\" data-action=\"action_2\"") }
     end
 
-    describe '#content' do
+    describe "#content" do
       subject { super().content }
       it { is_expected.to include("class=\"batch_action\" data-action=\"action_3\"") }
     end

--- a/spec/unit/views/components/blank_slate_spec.rb
+++ b/spec/unit/views/components/blank_slate_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::BlankSlate do
   describe "#blank_slate" do
@@ -8,17 +8,17 @@ RSpec.describe ActiveAdmin::Views::BlankSlate do
       end
     end
 
-    describe '#tag_name' do
+    describe "#tag_name" do
       subject { super().tag_name }
-      it { is_expected.to eql 'div' }
+      it { is_expected.to eql "div" }
     end
 
-    describe '#class_list' do
+    describe "#class_list" do
       subject { super().class_list }
-      it { is_expected.to include('blank_slate_container') }
+      it { is_expected.to include("blank_slate_container") }
     end
 
-    describe '#content' do
+    describe "#content" do
       subject { super().content }
       it { is_expected.to include '<span class="blank_slate">There are no Posts yet. <a href="/posts/new">Create one</a></span>' }
     end

--- a/spec/unit/views/components/columns_spec.rb
+++ b/spec/unit/views/components/columns_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::Columns do
   describe "Rendering zero columns" do

--- a/spec/unit/views/components/index_list_spec.rb
+++ b/spec/unit/views/components/index_list_spec.rb
@@ -1,11 +1,11 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::IndexList do
   describe "#index_list_renderer" do
     let(:index_classes) { [ActiveAdmin::Views::IndexAsTable, ActiveAdmin::Views::IndexAsBlock] }
 
     let(:collection) do
-      Post.create(title: 'First Post', starred: true)
+      Post.create(title: "First Post", starred: true)
       Post.where(nil)
     end
 
@@ -24,9 +24,9 @@ RSpec.describe ActiveAdmin::Views::IndexList do
       end
     end
 
-    describe '#tag_name' do
+    describe "#tag_name" do
       subject { super().tag_name }
-      it { is_expected.to eq 'ul' }
+      it { is_expected.to eq "ul" }
     end
 
     it "should contain the names of available indexes in links" do

--- a/spec/unit/views/components/index_table_for_spec.rb
+++ b/spec/unit/views/components/index_table_for_spec.rb
@@ -1,13 +1,13 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::IndexAsTable::IndexTableFor do
-  describe 'creating with the dsl' do
+  describe "creating with the dsl" do
     let(:collection) do
-      [Post.new(title: 'First Post', starred: true)]
+      [Post.new(title: "First Post", starred: true)]
     end
     let(:active_admin_config) do
       namespace = ActiveAdmin::Namespace.new(ActiveAdmin::Application.new, :admin)
-      namespace.batch_actions = [ActiveAdmin::BatchAction.new(:flag, 'Flag') {}]
+      namespace.batch_actions = [ActiveAdmin::BatchAction.new(:flag, "Flag") {}]
       namespace
     end
 
@@ -19,7 +19,7 @@ RSpec.describe ActiveAdmin::Views::IndexAsTable::IndexTableFor do
     end
     let(:helpers) { mock_action_view }
 
-    context 'when creating a selectable column' do
+    context "when creating a selectable column" do
       let(:table) do
         render_arbre_component assigns, helpers do
           insert_tag(ActiveAdmin::Views::IndexAsTable::IndexTableFor, collection, { sortable: true }) do
@@ -28,28 +28,28 @@ RSpec.describe ActiveAdmin::Views::IndexAsTable::IndexTableFor do
         end
       end
 
-      context 'creates a table header based on the selectable column' do
+      context "creates a table header based on the selectable column" do
         let(:header) do
-          table.find_by_tag('th').first
+          table.find_by_tag("th").first
         end
 
-        it 'with selectable column class name' do
-          expect(header.attributes[:class]).to include 'col-selectable'
+        it "with selectable column class name" do
+          expect(header.attributes[:class]).to include "col-selectable"
         end
 
-        it 'not sortable' do
-          expect(header.attributes[:class]).not_to include 'sortable'
+        it "not sortable" do
+          expect(header.attributes[:class]).not_to include "sortable"
         end
       end
     end
 
-    context 'when creating an index column' do
+    context "when creating an index column" do
       let(:base_collection) do
         posts = [
-          Post.new(title: 'First Post', starred: true),
-          Post.new(title: 'Second Post', starred: true),
-          Post.new(title: 'Third Post', starred: true),
-          Post.new(title: 'Fourth Post', starred: true)
+          Post.new(title: "First Post", starred: true),
+          Post.new(title: "Second Post", starred: true),
+          Post.new(title: "Third Post", starred: true),
+          Post.new(title: "Fourth Post", starred: true)
         ]
         Kaminari.paginate_array(posts, limit: 2)
       end
@@ -65,45 +65,45 @@ RSpec.describe ActiveAdmin::Views::IndexAsTable::IndexTableFor do
         end
       end
 
-      context 'creates a table header based on the index column' do
+      context "creates a table header based on the index column" do
         let(:header) do
-          table.find_by_tag('th').first
+          table.find_by_tag("th").first
         end
 
-        it 'with index column class name' do
-          expect(header.attributes[:class]).to include 'col-index'
+        it "with index column class name" do
+          expect(header.attributes[:class]).to include "col-index"
         end
 
-        it 'not sortable' do
-          expect(header.attributes[:class]).not_to include 'sortable'
+        it "not sortable" do
+          expect(header.attributes[:class]).not_to include "sortable"
         end
       end
 
-      context 'verifying the indices for the rows' do
+      context "verifying the indices for the rows" do
         let(:index_values) do
-          table.find_by_tag('tr').map do |row|
-            next unless row.find_by_tag('td').first
-            row.find_by_tag('td').first.content
+          table.find_by_tag("tr").map do |row|
+            next unless row.find_by_tag("td").first
+            row.find_by_tag("td").first.content
           end.compact
         end
 
-        context 'viewing the first page' do
-          it 'shows the correct indices' do
-            expect(index_values).to eq(['1', '2'])
+        context "viewing the first page" do
+          it "shows the correct indices" do
+            expect(index_values).to eq(["1", "2"])
           end
         end
 
-        context 'viewing the second page' do
+        context "viewing the second page" do
           let(:collection) do
             base_collection.page(2)
           end
-          it 'shows the correct indices' do
-            expect(index_values).to eq(['3', '4'])
+          it "shows the correct indices" do
+            expect(index_values).to eq(["3", "4"])
           end
         end
       end
 
-      context 'allows for zero-based indices' do
+      context "allows for zero-based indices" do
         let(:table) do
           render_arbre_component assigns, helpers do
             insert_tag(ActiveAdmin::Views::IndexAsTable::IndexTableFor, collection, { sortable: true }) do
@@ -113,14 +113,14 @@ RSpec.describe ActiveAdmin::Views::IndexAsTable::IndexTableFor do
         end
 
         let(:index_values) do
-          table.find_by_tag('tr').map do |row|
-            next unless row.find_by_tag('td').first
-            row.find_by_tag('td').first.content
+          table.find_by_tag("tr").map do |row|
+            next unless row.find_by_tag("td").first
+            row.find_by_tag("td").first.content
           end.compact
         end
 
-        it 'shows the correct indices' do
-          expect(index_values).to eq(['0', '1'])
+        it "shows the correct indices" do
+          expect(index_values).to eq(["0", "1"])
         end
       end
     end

--- a/spec/unit/views/components/menu_item_spec.rb
+++ b/spec/unit/views/components/menu_item_spec.rb
@@ -1,16 +1,16 @@
-require 'rails_helper'
-require 'active_admin/menu_item'
-require 'active_admin/views/components/menu_item'
+require "rails_helper"
+require "active_admin/menu_item"
+require "active_admin/views/components/menu_item"
 
 RSpec.describe ActiveAdmin::Views::MenuItem do
   let(:item) do
     i = ActiveAdmin::MenuItem.new(label: "Dashboard")
-    i.add label: "Blog", url: 'blogs'
-    i.add label: "Cars", url: 'cars'
-    i.add label: "Restricted", url: 'secret', if: proc { false }
-    i.add label: "Users", priority: 1, url: 'admin_users'
-    i.add label: "Settings", priority: 2, url: 'setup'
-    i.add label: "Analytics", priority: 44, url: 'reports'
+    i.add label: "Blog", url: "blogs"
+    i.add label: "Cars", url: "cars"
+    i.add label: "Restricted", url: "secret", if: proc { false }
+    i.add label: "Users", priority: 1, url: "admin_users"
+    i.add label: "Settings", priority: 2, url: "setup"
+    i.add label: "Analytics", priority: 44, url: "reports"
     i
   end
 
@@ -23,7 +23,7 @@ RSpec.describe ActiveAdmin::Views::MenuItem do
   let(:html) { Capybara.string(arbe_menu_item.to_s) }
 
   it "sorts the child items" do
-    ids = html.all('li').map { |i| i[:id] }
+    ids = html.all("li").map { |i| i[:id] }
     expect(ids).to eq %w(dashboard users settings blog cars analytics)
   end
 end

--- a/spec/unit/views/components/menu_spec.rb
+++ b/spec/unit/views/components/menu_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::Menu do
   let(:menu) { ActiveAdmin::Menu.new }
@@ -31,18 +31,18 @@ RSpec.describe ActiveAdmin::Views::Menu do
 
       menu.add label: "Administration", url: "/admin/administration" do |administration|
         administration.add label: "User administration",
-                           url: '/admin/user-administration',
+                           url: "/admin/user-administration",
                            priority: 10,
                            if: proc { false }
       end
 
       menu.add label: "Management", url: "#" do |management|
         management.add label: "Order management",
-                       url: '/admin/order-management',
+                       url: "/admin/order-management",
                        priority: 10,
                        if: proc { false }
         management.add label: "Bill management",
-                       url: '/admin/bill-management',
+                       url: "/admin/bill-management",
                        priority: 10,
                        if: :admin_logged_in?
       end
@@ -137,7 +137,7 @@ RSpec.describe ActiveAdmin::Views::Menu do
       menu.add label: "Parent", url: "#" do |p|
         p.add label: "Child", url: "/", priority: 10, if: proc { false }
       end
-      expect(html.all('li')).to be_empty
+      expect(html.all("li")).to be_empty
     end
 
     it "should display a parent that has a child to display" do

--- a/spec/unit/views/components/paginated_collection_spec.rb
+++ b/spec/unit/views/components/paginated_collection_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::PaginatedCollection do
   describe "creating with the dsl" do
@@ -8,8 +8,8 @@ RSpec.describe ActiveAdmin::Views::PaginatedCollection do
 
     let(:view) do
       view = mock_action_view
-      allow(view.request).to receive(:query_parameters).and_return page: '1'
-      allow(view.request).to receive(:path_parameters).and_return controller: 'admin/posts', action: 'index'
+      allow(view.request).to receive(:query_parameters).and_return page: "1"
+      allow(view.request).to receive(:path_parameters).and_return controller: "admin/posts", action: "index"
       view
     end
 
@@ -33,7 +33,7 @@ RSpec.describe ActiveAdmin::Views::PaginatedCollection do
     let(:pagination) { paginated_collection collection }
 
     it "should set :collection as the passed in collection" do
-      expect(pagination.find_by_class('pagination_information').first.content).to eq "Displaying <b>all 3</b> posts"
+      expect(pagination.find_by_class("pagination_information").first.content).to eq "Displaying <b>all 3</b> posts"
     end
 
     it "should raise error if collection has no pagination scope" do
@@ -42,12 +42,12 @@ RSpec.describe ActiveAdmin::Views::PaginatedCollection do
       end.to raise_error(StandardError, "Collection is not a paginated scope. Set collection.page(params[:page]).per(10) before calling :paginated_collection.")
     end
 
-    it 'should preserve custom query params' do
-      allow(view.request).to receive(:query_parameters).and_return page: '1', something: 'else'
+    it "should preserve custom query params" do
+      allow(view.request).to receive(:query_parameters).and_return page: "1", something: "else"
       pagination_content = pagination.content
-      expect(pagination_content).to include '/admin/posts.csv?page=1&amp;something=else'
-      expect(pagination_content).to include '/admin/posts.xml?page=1&amp;something=else'
-      expect(pagination_content).to include '/admin/posts.json?page=1&amp;something=else'
+      expect(pagination_content).to include "/admin/posts.csv?page=1&amp;something=else"
+      expect(pagination_content).to include "/admin/posts.xml?page=1&amp;something=else"
+      expect(pagination_content).to include "/admin/posts.json?page=1&amp;something=else"
     end
 
     context "when specifying :param_name option" do
@@ -69,7 +69,7 @@ RSpec.describe ActiveAdmin::Views::PaginatedCollection do
         Kaminari.paginate_array(posts).page(1).per(5)
       end
 
-      let(:pagination) { paginated_collection(collection, param_name: :post_page, params: { anchor: 'here' }) }
+      let(:pagination) { paginated_collection(collection, param_name: :post_page, params: { anchor: "here" }) }
 
       it "should pass it through to Kaminari" do
         expect(pagination.children.last.content).to match(/\/admin\/posts\?post_page=2#here/)
@@ -85,7 +85,7 @@ RSpec.describe ActiveAdmin::Views::PaginatedCollection do
       let(:pagination) { paginated_collection(collection, download_links: false) }
 
       it "should not render download links" do
-        expect(pagination.find_by_tag('div').last.content).to_not match(/Download:/)
+        expect(pagination.find_by_tag("div").last.content).to_not match(/Download:/)
       end
     end
 
@@ -98,7 +98,7 @@ RSpec.describe ActiveAdmin::Views::PaginatedCollection do
       let(:pagination) { paginated_collection(collection, entry_name: "message") }
 
       it "should use :entry_name as the collection name" do
-        expect(pagination.find_by_class('pagination_information').first.content).to eq "Displaying <b>1</b> message"
+        expect(pagination.find_by_class("pagination_information").first.content).to eq "Displaying <b>1</b> message"
       end
     end
 
@@ -106,7 +106,7 @@ RSpec.describe ActiveAdmin::Views::PaginatedCollection do
       let(:pagination) { paginated_collection(collection, entry_name: "message") }
 
       it "should use :entry_name as the collection name" do
-        expect(pagination.find_by_class('pagination_information').first.content).to eq "Displaying <b>all 3</b> messages"
+        expect(pagination.find_by_class("pagination_information").first.content).to eq "Displaying <b>all 3</b> messages"
       end
     end
 
@@ -119,7 +119,7 @@ RSpec.describe ActiveAdmin::Views::PaginatedCollection do
       let(:pagination) { paginated_collection(collection, entry_name: "singular", entries_name: "plural") }
 
       it "should use :entry_name as the collection name" do
-        expect(pagination.find_by_class('pagination_information').first.content).to eq "Displaying <b>1</b> singular"
+        expect(pagination.find_by_class("pagination_information").first.content).to eq "Displaying <b>1</b> singular"
       end
     end
 
@@ -127,7 +127,7 @@ RSpec.describe ActiveAdmin::Views::PaginatedCollection do
       let(:pagination) { paginated_collection(collection, entry_name: "singular", entries_name: "plural") }
 
       it "should use :entries_name as the collection name" do
-        expect(pagination.find_by_class('pagination_information').first.content).to eq "Displaying <b>all 3</b> plural"
+        expect(pagination.find_by_class("pagination_information").first.content).to eq "Displaying <b>all 3</b> plural"
       end
     end
 
@@ -138,23 +138,23 @@ RSpec.describe ActiveAdmin::Views::PaginatedCollection do
       end
 
       it "should use 'post' as the collection name when there is no I18n translation" do
-        expect(pagination.find_by_class('pagination_information').first.content).to eq "Displaying <b>1</b> post"
+        expect(pagination.find_by_class("pagination_information").first.content).to eq "Displaying <b>1</b> post"
       end
 
       it "should use 'Singular' as the collection name when there is an I18n translation" do
         allow(I18n).to receive(:translate) { "Singular" }
-        expect(pagination.find_by_class('pagination_information').first.content).to eq "Displaying <b>1</b> Singular"
+        expect(pagination.find_by_class("pagination_information").first.content).to eq "Displaying <b>1</b> Singular"
       end
     end
 
     context "when omitting :entry_name with multiple items" do
       it "should use 'posts' as the collection name when there is no I18n translation" do
-        expect(pagination.find_by_class('pagination_information').first.content).to eq "Displaying <b>all 3</b> posts"
+        expect(pagination.find_by_class("pagination_information").first.content).to eq "Displaying <b>all 3</b> posts"
       end
 
       it "should use 'Plural' as the collection name when there is an I18n translation" do
         allow(I18n).to receive(:translate) { "Plural" }
-        expect(pagination.find_by_class('pagination_information').first.content).to eq "Displaying <b>all 3</b> Plural"
+        expect(pagination.find_by_class("pagination_information").first.content).to eq "Displaying <b>all 3</b> Plural"
       end
     end
 
@@ -165,7 +165,7 @@ RSpec.describe ActiveAdmin::Views::PaginatedCollection do
       end
 
       it "should display 'No entries found'" do
-        expect(pagination.find_by_class('pagination_information').first.content).to eq "No entries found"
+        expect(pagination.find_by_class("pagination_information").first.content).to eq "No entries found"
       end
     end
 
@@ -176,7 +176,7 @@ RSpec.describe ActiveAdmin::Views::PaginatedCollection do
       end
 
       it "should display proper message (including number and not hash)" do
-        expect(pagination.find_by_class('pagination_information').first.content).to eq "Displaying <b>all 2</b> posts"
+        expect(pagination.find_by_class("pagination_information").first.content).to eq "Displaying <b>all 2</b> posts"
       end
     end
 
@@ -187,7 +187,7 @@ RSpec.describe ActiveAdmin::Views::PaginatedCollection do
       end
 
       it "should display proper message (including number and not hash)" do
-        expect(pagination.find_by_class('pagination_information').first.content.gsub('&nbsp;', ' ')).
+        expect(pagination.find_by_class("pagination_information").first.content.gsub("&nbsp;", " ")).
           to eq "Displaying posts <b>1 - 2</b> of <b>3</b> in total"
       end
     end
@@ -198,7 +198,7 @@ RSpec.describe ActiveAdmin::Views::PaginatedCollection do
       end
 
       it "should show the proper item counts" do
-        expect(pagination.find_by_class('pagination_information').first.content.gsub('&nbsp;', ' ')).
+        expect(pagination.find_by_class("pagination_information").first.content.gsub("&nbsp;", " ")).
           to eq "Displaying posts <b>61 - 81</b> of <b>81</b> in total"
       end
     end
@@ -212,7 +212,7 @@ RSpec.describe ActiveAdmin::Views::PaginatedCollection do
         it "should not show the total item counts" do
           expect(collection).not_to receive(:total_pages)
           pagination = paginated_collection(collection, pagination_total: false)
-          info = pagination.find_by_class('pagination_information').first.content.gsub('&nbsp;', ' ')
+          info = pagination.find_by_class("pagination_information").first.content.gsub("&nbsp;", " ")
           expect(info).to eq "Displaying posts <b>1 - 30</b>"
         end
       end
@@ -221,14 +221,14 @@ RSpec.describe ActiveAdmin::Views::PaginatedCollection do
         let(:pagination) { paginated_collection(collection, pagination_total: true) }
 
         it "should show the total item counts" do
-          info = pagination.find_by_class('pagination_information').first.content.gsub('&nbsp;', ' ')
+          info = pagination.find_by_class("pagination_information").first.content.gsub("&nbsp;", " ")
           expect(info).to eq "Displaying posts <b>1 - 30</b> of <b>256</b> in total"
         end
       end
     end
 
     it "makes no expensive COUNT queries when pagination_total is false" do
-      require 'db-query-matchers'
+      require "db-query-matchers"
 
       undecorated_collection = Post.all.page(1).per(30)
 
@@ -260,7 +260,7 @@ RSpec.describe ActiveAdmin::Views::PaginatedCollection do
         let(:pagination) { paginated_collection(collection, per_page: [1, 2, 3], pagination_total: false) }
 
         it "should render per_page select tag" do
-          info = pagination.find_by_class('pagination_information').first.content.gsub('&nbsp;', ' ')
+          info = pagination.find_by_class("pagination_information").first.content.gsub("&nbsp;", " ")
           expect(info).to eq "Displaying posts <b>1 - 5</b>"
         end
       end

--- a/spec/unit/views/components/panel_spec.rb
+++ b/spec/unit/views/components/panel_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::Panel do
   let(:arbre_panel) do
@@ -13,21 +13,21 @@ RSpec.describe ActiveAdmin::Views::Panel do
   let(:panel_html) { Capybara.string(arbre_panel.to_s) }
 
   it "should have a title h3" do
-    expect(panel_html).to have_css 'h3', text: "My Title"
+    expect(panel_html).to have_css "h3", text: "My Title"
   end
 
   it "should add panel actions to the panel header" do
-    link = panel_html.find('h3 > div.header_action a')
-    expect(link.text).to eq('My Link')
+    link = panel_html.find("h3 > div.header_action a")
+    expect(link.text).to eq("My Link")
     expect(link[:href]).to eq("https://www.github.com/activeadmin/activeadmin")
   end
 
   it "should have a contents div" do
-    expect(panel_html).to have_css 'div.panel_contents'
+    expect(panel_html).to have_css "div.panel_contents"
   end
 
   it "should add children to the contents div" do
-    expect(panel_html).to have_css 'div.panel_contents > span', text: "Hello World"
+    expect(panel_html).to have_css "div.panel_contents > span", text: "Hello World"
   end
 
   context "with html-safe title" do

--- a/spec/unit/views/components/sidebar_section_spec.rb
+++ b/spec/unit/views/components/sidebar_section_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::SidebarSection do
   let(:options) { {} }
@@ -35,8 +35,8 @@ RSpec.describe ActiveAdmin::Views::SidebarSection do
     expect(html.find_by_tag("span").first.parent).to eq html.find_by_tag("div").first
   end
 
-  context 'with a custom class attribute' do
-    let(:options) { { class: 'custom_class' } }
+  context "with a custom class attribute" do
+    let(:options) { { class: "custom_class" } }
 
     it "should have 'custom_class' class" do
       expect(html.class_list).to include("custom_class")

--- a/spec/unit/views/components/sidebar_spec.rb
+++ b/spec/unit/views/components/sidebar_spec.rb
@@ -1,23 +1,23 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::Sidebar do
   let(:section) do
     ActiveAdmin::SidebarSection.new("Section") do
-      para 'Section content.'
+      para "Section content."
     end
   end
 
   let(:html) do
     render_arbre_component sections: [section] do
-      sidebar assigns[:sections], id: 'sidebar'
+      sidebar assigns[:sections], id: "sidebar"
     end
   end
 
   it "should have an id of 'sidebar'" do
-    expect(html.id).to eq 'sidebar'
+    expect(html.id).to eq "sidebar"
   end
 
   it "renders the section" do
-    expect(html.find_by_tag('p').first.content).to eq 'Section content.'
+    expect(html.find_by_tag("p").first.content).to eq "Section content."
   end
 end

--- a/spec/unit/views/components/site_title_spec.rb
+++ b/spec/unit/views/components/site_title_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::SiteTitle do
   let(:helpers) { mock_action_view }

--- a/spec/unit/views/components/status_tag_spec.rb
+++ b/spec/unit/views/components/status_tag_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::StatusTag do
   describe "#status_tag" do
@@ -11,220 +11,220 @@ RSpec.describe ActiveAdmin::Views::StatusTag do
 
     subject { status_tag(nil) }
 
-    describe '#tag_name' do
+    describe "#tag_name" do
       subject { super().tag_name }
-      it { is_expected.to eq 'span' }
+      it { is_expected.to eq "span" }
     end
 
-    describe '#class_list' do
+    describe "#class_list" do
       subject { super().class_list }
-      it { is_expected.to include('status_tag') }
+      it { is_expected.to include("status_tag") }
     end
 
     context "when status is 'completed'" do
-      subject { status_tag('completed') }
+      subject { status_tag("completed") }
 
-      describe '#tag_name' do
+      describe "#tag_name" do
         subject { super().tag_name }
-        it { is_expected.to eq 'span' }
+        it { is_expected.to eq "span" }
       end
 
-      describe '#class_list' do
+      describe "#class_list" do
         subject { super().class_list }
-        it { is_expected.to include('status_tag') }
+        it { is_expected.to include("status_tag") }
       end
 
-      describe '#class_list' do
+      describe "#class_list" do
         subject { super().class_list }
-        it { is_expected.to include('completed') }
+        it { is_expected.to include("completed") }
       end
 
-      describe '#content' do
+      describe "#content" do
         subject { super().content }
-        it { is_expected.to eq 'Completed' }
+        it { is_expected.to eq "Completed" }
       end
     end
 
     context "when status is 'in_progress'" do
-      subject { status_tag('in_progress') }
+      subject { status_tag("in_progress") }
 
-      describe '#class_list' do
+      describe "#class_list" do
         subject { super().class_list }
-        it { is_expected.to include('in_progress') }
+        it { is_expected.to include("in_progress") }
       end
 
-      describe '#content' do
+      describe "#content" do
         subject { super().content }
-        it { is_expected.to eq 'In Progress' }
+        it { is_expected.to eq "In Progress" }
       end
     end
 
     context "when status is 'In progress'" do
-      subject { status_tag('In progress') }
+      subject { status_tag("In progress") }
 
-      describe '#class_list' do
+      describe "#class_list" do
         subject { super().class_list }
-        it { is_expected.to include('in_progress') }
+        it { is_expected.to include("in_progress") }
       end
 
-      describe '#content' do
+      describe "#content" do
         subject { super().content }
-        it { is_expected.to eq 'In Progress' }
+        it { is_expected.to eq "In Progress" }
       end
     end
 
     context "when status is an empty string" do
-      subject { status_tag('') }
+      subject { status_tag("") }
 
-      describe '#class_list' do
+      describe "#class_list" do
         subject { super().class_list }
-        it { is_expected.to include('status_tag') }
+        it { is_expected.to include("status_tag") }
       end
 
-      describe '#content' do
+      describe "#content" do
         subject { super().content }
-        it { is_expected.to eq '' }
+        it { is_expected.to eq "" }
       end
     end
 
     context "when status is 'false'" do
-      subject { status_tag('false') }
+      subject { status_tag("false") }
 
-      describe '#class_list' do
+      describe "#class_list" do
         subject { super().class_list }
-        it { is_expected.to include('status_tag') }
+        it { is_expected.to include("status_tag") }
       end
 
-      describe '#content' do
+      describe "#content" do
         subject { super().content }
-        it { is_expected.to eq('No') }
+        it { is_expected.to eq("No") }
       end
     end
 
     context "when status is false" do
       subject { status_tag(false) }
 
-      describe '#class_list' do
+      describe "#class_list" do
         subject { super().class_list }
-        it { is_expected.to include('status_tag') }
+        it { is_expected.to include("status_tag") }
       end
 
-      describe '#content' do
+      describe "#content" do
         subject { super().content }
-        it { is_expected.to eq('No') }
+        it { is_expected.to eq("No") }
       end
     end
 
     context "when status is nil" do
       subject { status_tag(nil) }
 
-      describe '#class_list' do
+      describe "#class_list" do
         subject { super().class_list }
-        it { is_expected.to include('status_tag') }
-        it { is_expected.to include('no') }
-        it { is_expected.to include('unset') }
+        it { is_expected.to include("status_tag") }
+        it { is_expected.to include("no") }
+        it { is_expected.to include("unset") }
       end
 
-      describe '#content' do
+      describe "#content" do
         subject { super().content }
-        it { is_expected.to eq('No') }
+        it { is_expected.to eq("No") }
 
-        it 'uses the unset locale key to customize the label for the `nil` case' do
-          with_translation active_admin: { status_tag: { unset: 'Unknown' } } do
-            expect(subject).to eq('Unknown')
+        it "uses the unset locale key to customize the label for the `nil` case" do
+          with_translation active_admin: { status_tag: { unset: "Unknown" } } do
+            expect(subject).to eq("Unknown")
           end
         end
       end
     end
 
     context "when status is 'Active' and class is 'ok'" do
-      subject { status_tag('Active', class: 'ok') }
+      subject { status_tag("Active", class: "ok") }
 
-      describe '#class_list' do
+      describe "#class_list" do
         subject { super().class_list }
-        it { is_expected.to include('status_tag') }
+        it { is_expected.to include("status_tag") }
       end
 
-      describe '#class_list' do
+      describe "#class_list" do
         subject { super().class_list }
-        it { is_expected.to include('active') }
+        it { is_expected.to include("active") }
       end
 
-      describe '#class_list' do
+      describe "#class_list" do
         subject { super().class_list }
-        it { is_expected.to include('ok') }
+        it { is_expected.to include("ok") }
       end
     end
 
     context "when status is 'Active' and label is 'on'" do
-      subject { status_tag('Active', label: 'on') }
+      subject { status_tag("Active", label: "on") }
 
-      describe '#content' do
+      describe "#content" do
         subject { super().content }
-        it { is_expected.to eq 'on' }
+        it { is_expected.to eq "on" }
       end
 
-      describe '#class_list' do
+      describe "#class_list" do
         subject { super().class_list }
-        it { is_expected.to include('status_tag') }
+        it { is_expected.to include("status_tag") }
       end
 
-      describe '#class_list' do
+      describe "#class_list" do
         subject { super().class_list }
-        it { is_expected.to include('active') }
+        it { is_expected.to include("active") }
       end
 
-      describe '#class_list' do
+      describe "#class_list" do
         subject { super().class_list }
-        it { is_expected.not_to include('on') }
+        it { is_expected.not_to include("on") }
       end
     end
 
     context "when status is 'So useless', class is 'woot awesome' and id is 'useless'" do
-      subject { status_tag('So useless', class: 'woot awesome', id: 'useless') }
+      subject { status_tag("So useless", class: "woot awesome", id: "useless") }
 
-      describe '#content' do
+      describe "#content" do
         subject { super().content }
-        it { is_expected.to eq 'So Useless' }
+        it { is_expected.to eq "So Useless" }
       end
 
-      describe '#class_list' do
+      describe "#class_list" do
         subject { super().class_list }
-        it { is_expected.to include('status_tag') }
+        it { is_expected.to include("status_tag") }
       end
 
-      describe '#class_list' do
+      describe "#class_list" do
         subject { super().class_list }
-        it { is_expected.to include('so_useless') }
+        it { is_expected.to include("so_useless") }
       end
 
-      describe '#class_list' do
+      describe "#class_list" do
         subject { super().class_list }
-        it { is_expected.to include('woot') }
+        it { is_expected.to include("woot") }
       end
 
-      describe '#class_list' do
+      describe "#class_list" do
         subject { super().class_list }
-        it { is_expected.to include('awesome') }
+        it { is_expected.to include("awesome") }
       end
 
-      describe '#id' do
+      describe "#id" do
         subject { super().id }
-        it { is_expected.to eq 'useless' }
+        it { is_expected.to eq "useless" }
       end
     end
 
     context "when status is set to a Fixnum" do
       subject { status_tag(42) }
 
-      describe '#content' do
+      describe "#content" do
         subject { super().content }
-        it { is_expected.to eq '42' }
+        it { is_expected.to eq "42" }
       end
 
-      describe '#class_list' do
+      describe "#class_list" do
         subject { super().class_list }
-        it { is_expected.not_to include('42') }
+        it { is_expected.not_to include("42") }
       end
     end
   end

--- a/spec/unit/views/components/table_for_spec.rb
+++ b/spec/unit/views/components/table_for_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::TableFor do
   describe "creating with the dsl" do
@@ -48,8 +48,8 @@ RSpec.describe ActiveAdmin::Views::TableFor do
       end
 
       it "should add a class to each table header based on the col name" do
-        expect(table.find_by_tag("th").first.class_list.to_a.join(' ')).to eq "col col-title"
-        expect(table.find_by_tag("th").last.class_list.to_a.join(' ')).to eq "col col-created_at"
+        expect(table.find_by_tag("th").first.class_list.to_a.join(" ")).to eq "col col-title"
+        expect(table.find_by_tag("th").last.class_list.to_a.join(" ")).to eq "col col-created_at"
       end
 
       it "should create a table row for each element in the collection" do
@@ -61,8 +61,8 @@ RSpec.describe ActiveAdmin::Views::TableFor do
       end
 
       it "should add a class for each cell based on the col name" do
-        expect(table.find_by_tag("td").first.class_list.to_a.join(' ')).to eq "col col-title"
-        expect(table.find_by_tag("td").last.class_list.to_a.join(' ')).to eq "col col-created_at"
+        expect(table.find_by_tag("td").first.class_list.to_a.join(" ")).to eq "col col-title"
+        expect(table.find_by_tag("td").last.class_list.to_a.join(" ")).to eq "col col-created_at"
       end
     end
 
@@ -81,8 +81,8 @@ RSpec.describe ActiveAdmin::Views::TableFor do
       end
 
       it "should add a class to each table header based on the col name" do
-        expect(table.find_by_tag("th").first.class_list.to_a.join(' ')).to eq "col col-title"
-        expect(table.find_by_tag("th").last.class_list.to_a.join(' ')).to eq "col col-created_at"
+        expect(table.find_by_tag("th").first.class_list.to_a.join(" ")).to eq "col col-title"
+        expect(table.find_by_tag("th").last.class_list.to_a.join(" ")).to eq "col col-created_at"
       end
 
       it "should create a table row for each element in the collection" do
@@ -94,8 +94,8 @@ RSpec.describe ActiveAdmin::Views::TableFor do
       end
 
       it "should add a class for each cell based on the col name" do
-        expect(table.find_by_tag("td").first.class_list.to_a.join(' ')).to eq "col col-title"
-        expect(table.find_by_tag("td").last.class_list.to_a.join(' ')).to eq "col col-created_at"
+        expect(table.find_by_tag("td").first.class_list.to_a.join(" ")).to eq "col col-title"
+        expect(table.find_by_tag("td").last.class_list.to_a.join(" ")).to eq "col col-created_at"
       end
     end
 
@@ -139,8 +139,8 @@ RSpec.describe ActiveAdmin::Views::TableFor do
       end
 
       it "should add a class to each table header based on the col name" do
-        expect(table.find_by_tag("th").first.class_list.to_a.join(' ')).to eq "col col-title"
-        expect(table.find_by_tag("th").last.class_list.to_a.join(' ')).to eq "col col-created_at"
+        expect(table.find_by_tag("th").first.class_list.to_a.join(" ")).to eq "col col-title"
+        expect(table.find_by_tag("th").last.class_list.to_a.join(" ")).to eq "col col-created_at"
       end
 
       it "should create a table row for each element in the collection" do
@@ -152,8 +152,8 @@ RSpec.describe ActiveAdmin::Views::TableFor do
       end
 
       it "should add a class for each cell based on the col name" do
-        expect(table.find_by_tag("td").first.class_list.to_a.join(' ')).to eq "col col-title"
-        expect(table.find_by_tag("td").last.class_list.to_a.join(' ')).to eq "col col-created_at"
+        expect(table.find_by_tag("td").first.class_list.to_a.join(" ")).to eq "col col-title"
+        expect(table.find_by_tag("td").last.class_list.to_a.join(" ")).to eq "col col-created_at"
       end
     end
 
@@ -212,13 +212,13 @@ RSpec.describe ActiveAdmin::Views::TableFor do
       end
 
       it "should add a class to each header based on class option or the col name" do
-        expect(table.find_by_tag("th").first.class_list.to_a.join(' ')).to eq "col col-my_custom_title"
-        expect(table.find_by_tag("th").last.class_list.to_a.join(' ')).to eq "col datetime"
+        expect(table.find_by_tag("th").first.class_list.to_a.join(" ")).to eq "col col-my_custom_title"
+        expect(table.find_by_tag("th").last.class_list.to_a.join(" ")).to eq "col datetime"
       end
 
       it "should add a class to each cell based on class option or the col name" do
-        expect(table.find_by_tag("td").first.class_list.to_a.join(' ')).to eq "col col-my_custom_title"
-        expect(table.find_by_tag("td").last.class_list.to_a.join(' ')).to eq "col datetime"
+        expect(table.find_by_tag("td").first.class_list.to_a.join(" ")).to eq "col col-my_custom_title"
+        expect(table.find_by_tag("td").last.class_list.to_a.join(" ")).to eq "col datetime"
       end
     end
 
@@ -280,29 +280,29 @@ RSpec.describe ActiveAdmin::Views::TableFor do
       end
 
       it "should render boolean attribute within status tag" do
-        expect(table.find_by_tag("span").first.class_list.to_a.join(' ')).to eq "status_tag yes"
+        expect(table.find_by_tag("span").first.class_list.to_a.join(" ")).to eq "status_tag yes"
         expect(table.find_by_tag("span").first.content).to eq "Yes"
-        expect(table.find_by_tag("span").last.class_list.to_a.join(' ')).to eq "status_tag no"
+        expect(table.find_by_tag("span").last.class_list.to_a.join(" ")).to eq "status_tag no"
         expect(table.find_by_tag("span").last.content).to eq "No"
       end
     end
 
-    context 'when row_class' do
+    context "when row_class" do
       let(:table) do
         render_arbre_component assigns, helpers do
-          table_for(collection, row_class: -> e { 'starred' if e.starred }) do
+          table_for(collection, row_class: -> e { "starred" if e.starred }) do
             column :starred
           end
         end
       end
 
-      it 'should render boolean attribute within status tag' do
-        trs = table.find_by_tag('tr')
+      it "should render boolean attribute within status tag" do
+        trs = table.find_by_tag("tr")
         expect(trs.size).to eq 4
-        expect(trs.first.class_list.to_a.join(' ')).to eq ''
-        expect(trs.second.class_list.to_a.join(' ')).to eq 'odd starred'
-        expect(trs.third.class_list.to_a.join(' ')).to eq 'even'
-        expect(trs.fourth.class_list.to_a.join(' ')).to eq 'odd'
+        expect(trs.first.class_list.to_a.join(" ")).to eq ""
+        expect(trs.second.class_list.to_a.join(" ")).to eq "odd starred"
+        expect(trs.third.class_list.to_a.join(" ")).to eq "even"
+        expect(trs.fourth.class_list.to_a.join(" ")).to eq "odd"
       end
     end
 
@@ -366,7 +366,7 @@ RSpec.describe ActiveAdmin::Views::TableFor do
       let(:table_column) { build_column(:username) }
       it { is_expected.to be_sortable }
 
-      describe '#sort_key' do
+      describe "#sort_key" do
         subject { super().sort_key }
         it { is_expected.to eq("username") }
       end
@@ -376,7 +376,7 @@ RSpec.describe ActiveAdmin::Views::TableFor do
       let(:table_column) { build_column("Username") {} }
       it { is_expected.to be_sortable }
 
-      describe '#sort_key' do
+      describe "#sort_key" do
         subject { super().sort_key }
         it { is_expected.to eq("Username") }
       end
@@ -386,34 +386,34 @@ RSpec.describe ActiveAdmin::Views::TableFor do
       let(:table_column) { build_column("Username", sortable: :username) {} }
       it { is_expected.to be_sortable }
 
-      describe '#sort_key' do
+      describe "#sort_key" do
         subject { super().sort_key }
         it { is_expected.to eq("username") }
       end
     end
 
-    context 'when a block given with virtual attribute and no sort key' do
+    context "when a block given with virtual attribute and no sort key" do
       let(:table_column) { build_column(:virtual, nil, Post) {} }
       it { is_expected.not_to be_sortable }
     end
 
-    context 'when symbol given as a data column should be sortable' do
-      let(:table_column) { build_column('Username column', :username) }
+    context "when symbol given as a data column should be sortable" do
+      let(:table_column) { build_column("Username column", :username) }
       it { is_expected.to be_sortable }
 
-      describe '#sort_key' do
+      describe "#sort_key" do
         subject { super().sort_key }
-        it { is_expected.to eq 'username' }
+        it { is_expected.to eq "username" }
       end
     end
 
-    context 'when sortable: true with a symbol and string' do
-      let(:table_column) { build_column('Username column', :username, sortable: true) }
+    context "when sortable: true with a symbol and string" do
+      let(:table_column) { build_column("Username column", :username, sortable: true) }
       it { is_expected.to be_sortable }
 
-      describe '#sort_key' do
+      describe "#sort_key" do
         subject { super().sort_key }
-        it { is_expected.to eq 'username' }
+        it { is_expected.to eq "username" }
       end
     end
 
@@ -432,8 +432,8 @@ RSpec.describe ActiveAdmin::Views::TableFor do
       it { is_expected.not_to be_sortable }
     end
 
-    context 'when :sortable column is an association and block given' do
-      let(:table_column) { build_column('Category', :category, Post) {} }
+    context "when :sortable column is an association and block given" do
+      let(:table_column) { build_column("Category", :category, Post) {} }
       it { is_expected.not_to be_sortable }
     end
   end

--- a/spec/unit/views/components/tabs_spec.rb
+++ b/spec/unit/views/components/tabs_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::Tabs do
   describe "creating with the dsl" do
@@ -19,11 +19,11 @@ RSpec.describe ActiveAdmin::Views::Tabs do
       let(:subject) { Capybara.string(tabs.to_s) }
 
       it "should create a tab navigation bar based on the symbol" do
-        expect(subject).to have_content('Overview')
+        expect(subject).to have_content("Overview")
       end
 
       it "should have tab with id based on symbol" do
-        expect(subject).to have_selector('div#overview')
+        expect(subject).to have_selector("div#overview")
       end
 
       it "should have link with fragment based on symbol" do
@@ -31,11 +31,11 @@ RSpec.describe ActiveAdmin::Views::Tabs do
       end
 
       it "should handle translation" do
-        expect(subject).to have_content('テスト')
+        expect(subject).to have_content("テスト")
       end
 
       it "should have tab with id based on options" do
-        expect(subject).to have_selector('div#something_unique')
+        expect(subject).to have_selector("div#something_unique")
       end
 
       it "should have link with fragment based on options" do
@@ -43,7 +43,7 @@ RSpec.describe ActiveAdmin::Views::Tabs do
       end
 
       it "should have li with specific css class" do
-        expect(subject).to have_selector('li.some_css_class')
+        expect(subject).to have_selector("li.some_css_class")
       end
     end
 
@@ -52,18 +52,18 @@ RSpec.describe ActiveAdmin::Views::Tabs do
         render_arbre_component do
           tabs do
             tab :overview do
-              span 'tab 1'
+              span "tab 1"
             end
           end
         end
       end
 
       it "should create a tab navigation bar based on the symbol" do
-        expect(tabs.find_by_tag('li').first.content).to include("Overview")
+        expect(tabs.find_by_tag("li").first.content).to include("Overview")
       end
 
       it "should create a tab with a span inside of it" do
-        expect(tabs.find_by_tag('span').first.content).to eq('tab 1')
+        expect(tabs.find_by_tag("span").first.content).to eq("tab 1")
       end
     end
 
@@ -71,8 +71,8 @@ RSpec.describe ActiveAdmin::Views::Tabs do
       let(:tabs) do
         render_arbre_component do
           tabs do
-            tab '🤗' do
-              'content'
+            tab "🤗" do
+              "content"
             end
           end
         end
@@ -81,16 +81,16 @@ RSpec.describe ActiveAdmin::Views::Tabs do
       let(:subject) { Capybara.string(tabs.to_s) }
 
       it "should create a tab navigation bar based on the string" do
-        expect(subject).to have_content('🤗')
+        expect(subject).to have_content("🤗")
       end
 
       it "should have tab with id based on URL-encoded string" do
-        tab_content = subject.find('.tabs .tab-content div', text: 'content')
-        expect(tab_content['id']).to eq(CGI.escape('🤗'))
+        tab_content = subject.find(".tabs .tab-content div", text: "content")
+        expect(tab_content["id"]).to eq(CGI.escape("🤗"))
       end
 
       it "should have link with fragment based on URL-encoded string" do
-        expect(subject).to have_link('🤗', href: "##{CGI.escape('🤗')}")
+        expect(subject).to have_link("🤗", href: "##{CGI.escape('🤗')}")
       end
     end
   end

--- a/spec/unit/views/components/unsupported_browser_spec.rb
+++ b/spec/unit/views/components/unsupported_browser_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::UnsupportedBrowser do
   let(:helpers) { mock_action_view }

--- a/spec/unit/views/index_as_blog_spec.rb
+++ b/spec/unit/views/index_as_blog_spec.rb
@@ -1,19 +1,19 @@
-require 'rails_helper'
+require "rails_helper"
 
 include ActiveAdmin
 RSpec.describe ActiveAdmin::Views::IndexAsBlog do
   subject { described_class.new }
 
-  describe '#build' do
-    let(:page_presenter) { double('page_presenter', block: nil) }
-    let(:collection) { double('collection') }
+  describe "#build" do
+    let(:page_presenter) { double("page_presenter", block: nil) }
+    let(:collection) { double("collection") }
 
     before do
-      expect(subject).to receive('build_posts')
-      expect(subject).to receive('add_class').with('index')
+      expect(subject).to receive("build_posts")
+      expect(subject).to receive("add_class").with("index")
     end
 
-    context 'when page_presenter has no block' do
+    context "when page_presenter has no block" do
       before do
         subject.build(page_presenter, collection)
       end
@@ -25,25 +25,25 @@ RSpec.describe ActiveAdmin::Views::IndexAsBlog do
       end
     end
 
-    context 'when page_presenter has block' do
-      let(:block) { Proc.new { double('proc_method') } }
+    context "when page_presenter has block" do
+      let(:block) { Proc.new { double("proc_method") } }
 
       before do
         allow(page_presenter).to receive(:block).and_return(block)
-        allow(subject).to receive('instance_exec')
+        allow(subject).to receive("instance_exec")
         subject.build(page_presenter, collection)
       end
 
       it do
-        expect(subject).to have_received('instance_exec')
+        expect(subject).to have_received("instance_exec")
       end
     end
   end
 
   %w(title body).each do |method|
     describe "#{method}" do
-      context 'when block given' do
-        let(:block_result) { double('block_result') }
+      context "when block given" do
+        let(:block_result) { double("block_result") }
 
         it "should use the block to set the #{method}" do
           expect(
@@ -54,23 +54,23 @@ RSpec.describe ActiveAdmin::Views::IndexAsBlog do
         end
       end
 
-      context 'when no block and method given' do
-        let(:method) { double('method') }
+      context "when no block and method given" do
+        let(:method) { double("method") }
 
         it "should use method to set the #{method}" do
           expect(subject.public_send("#{method}", method)).to eq(method)
         end
       end
 
-      context 'when no block and no method given' do
-        it 'should be nil' do
+      context "when no block and no method given" do
+        it "should be nil" do
           expect(subject.public_send("#{method}")).to eq(nil)
         end
       end
     end
   end
 
-  describe '.index_name' do
-    it { expect(described_class.index_name).to eq('blog') }
+  describe ".index_name" do
+    it { expect(described_class.index_name).to eq("blog") }
   end
 end

--- a/spec/unit/views/pages/base_spec.rb
+++ b/spec/unit/views/pages/base_spec.rb
@@ -1,27 +1,27 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::Pages::Base do
   class NewPage < ActiveAdmin::Views::Pages::Base
   end
 
   it "defines a default title" do
-    expect(NewPage.new.title).to eq 'NewPage'
+    expect(NewPage.new.title).to eq "NewPage"
   end
 
   it "defines default main content" do
-    expect(NewPage.new.main_content).to eq 'Please implement NewPage#main_content to display content.'
+    expect(NewPage.new.main_content).to eq "Please implement NewPage#main_content to display content."
   end
 
   describe "build_flash_messages" do
     class PageWithFlashMessages < ActiveAdmin::Views::Pages::Base
       def flash_messages
-        { alert: 'Alert message', notice: ['First notice message', 'Second notice message'] }
+        { alert: "Alert message", notice: ["First notice message", "Second notice message"] }
       end
     end
 
     it "shows all flash messages" do
       div = PageWithFlashMessages.new.send :build_flash_messages
-      expect(div.get_elements_by_tag_name('div').map(&:content)).to contain_exactly('Alert message', 'First notice message', 'Second notice message')
+      expect(div.get_elements_by_tag_name("div").map(&:content)).to contain_exactly("Alert message", "First notice message", "Second notice message")
     end
   end
 end

--- a/spec/unit/views/pages/form_spec.rb
+++ b/spec/unit/views/pages/form_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::Pages::Form do
   describe "#title" do

--- a/spec/unit/views/pages/index_spec.rb
+++ b/spec/unit/views/pages/index_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::Pages::Index do
   describe "#title" do

--- a/spec/unit/views/pages/layout_spec.rb
+++ b/spec/unit/views/pages/layout_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::Pages::Layout do
   let(:assigns) { {} }
@@ -6,13 +6,13 @@ RSpec.describe ActiveAdmin::Views::Pages::Layout do
     helpers = mock_action_view
 
     { active_admin_application: active_admin_application,
-      active_admin_config: double('Config', action_items?: nil, breadcrumb: nil, sidebar_sections?: nil),
+      active_admin_config: double("Config", action_items?: nil, breadcrumb: nil, sidebar_sections?: nil),
       active_admin_namespace: active_admin_namespace,
-      csrf_meta_tag: '',
+      csrf_meta_tag: "",
       current_active_admin_user: nil,
       current_active_admin_user?: false,
-      current_menu: double('Menu', items: []),
-      params: { controller: 'UsersController', action: 'edit' },
+      current_menu: double("Menu", items: []),
+      params: { controller: "UsersController", action: "edit" },
       env: {}
     }.each do |method, returns|
       allow(helpers).to receive(method).and_return returns
@@ -53,7 +53,7 @@ RSpec.describe ActiveAdmin::Views::Pages::Layout do
 
   describe "the body" do
     it "should have class 'active_admin'" do
-      expect(layout.build.class_list).to include 'active_admin'
+      expect(layout.build.class_list).to include "active_admin"
     end
 
     it "should have namespace class" do

--- a/spec/unit/views/pages/show_spec.rb
+++ b/spec/unit/views/pages/show_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::Pages::Show do
   describe "the resource" do
@@ -6,21 +6,21 @@ RSpec.describe ActiveAdmin::Views::Pages::Show do
     let(:arbre_context) { Arbre::Context.new({}, helpers) }
     subject(:page) { ActiveAdmin::Views::Pages::Show.new(arbre_context) }
 
-    context 'when the resource does not respond to #decorator' do
-      let(:resource) { 'Test Resource' }
+    context "when the resource does not respond to #decorator" do
+      let(:resource) { "Test Resource" }
 
       it "normally returns the resource" do
-        expect(page.resource).to eq 'Test Resource'
+        expect(page.resource).to eq "Test Resource"
       end
     end
 
-    context 'when you pass a block to main content' do
+    context "when you pass a block to main content" do
       let(:block) { lambda {} }
-      let(:resource) { double('resource') }
+      let(:resource) { double("resource") }
 
       before { allow(page).to receive(:active_admin_config).and_return(double(comments?: false, resource_columns: [:field])) }
 
-      it 'appends it to the output' do
+      it "appends it to the output" do
         expect(page).to receive(:attributes_table).with(:field).and_yield
         page.default_main_content(&block)
       end

--- a/tasks/bug_report_template.rb
+++ b/tasks/bug_report_template.rb
@@ -1,28 +1,28 @@
-require 'bundler/inline'
+require "bundler/inline"
 
 gemfile(true) do
-  source 'https://rubygems.org'
+  source "https://rubygems.org"
 
   # Use local changes or ActiveAdmin master.
-  if ENV['ACTIVE_ADMIN_PATH']
-    gem 'activeadmin', path: ENV['ACTIVE_ADMIN_PATH'], require: false
+  if ENV["ACTIVE_ADMIN_PATH"]
+    gem "activeadmin", path: ENV["ACTIVE_ADMIN_PATH"], require: false
   else
-    gem 'activeadmin', github: 'activeadmin/activeadmin', require: false
+    gem "activeadmin", github: "activeadmin/activeadmin", require: false
   end
 
   # Change Rails version if necessary.
-  gem 'rails', '6.0.0'
+  gem "rails", "6.0.0"
 
-  gem 'sprockets', '3.7.2'
-  gem 'sassc-rails', '2.1.2'
-  gem 'sqlite3', '1.4.1', platform: :mri
-  gem 'activerecord-jdbcsqlite3-adapter', "52.0", platform: :jruby
-  gem 'jruby-openssl', '0.10.1', platform: :jruby
+  gem "sprockets", "3.7.2"
+  gem "sassc-rails", "2.1.2"
+  gem "sqlite3", "1.4.1", platform: :mri
+  gem "activerecord-jdbcsqlite3-adapter", "52.0", platform: :jruby
+  gem "jruby-openssl", "0.10.1", platform: :jruby
 end
 
-require 'active_record'
+require "active_record"
 
-ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
+ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
 ActiveRecord::Base.logger = Logger.new(STDOUT)
 
 ActiveRecord::Schema.define do
@@ -34,15 +34,15 @@ ActiveRecord::Schema.define do
   end
 end
 
-require 'action_controller/railtie'
-require 'action_view/railtie'
-require 'active_admin'
+require "action_controller/railtie"
+require "action_view/railtie"
+require "active_admin"
 
 class TestApp < Rails::Application
   config.root = __dir__
   config.session_store :cookie_store, key: "cookie_store_key"
-  secrets.secret_token = 'secret_token'
-  secrets.secret_key_base = 'secret_key_base'
+  secrets.secret_token = "secret_token"
+  secrets.secret_key_base = "secret_key_base"
 
   config.eager_load = false
   config.logger = Logger.new($stdout)
@@ -65,10 +65,10 @@ end
 
 Rails.application.initialize!
 
-ActiveAdmin.register_page 'Dashboard' do
-  menu priority: 1, label: proc { I18n.t('active_admin.dashboard') }
+ActiveAdmin.register_page "Dashboard" do
+  menu priority: 1, label: proc { I18n.t("active_admin.dashboard") }
   content do
-    'Test Me'
+    "Test Me"
   end
 end
 
@@ -79,24 +79,24 @@ Rails.application.routes.draw do
   ActiveAdmin.routes(self)
 end
 
-require 'minitest/autorun'
-require 'rack/test'
-require 'rails/test_help'
+require "minitest/autorun"
+require "rack/test"
+require "rails/test_help"
 
 # Replace this with the code necessary to make your test fail.
 class BugTest < ActionDispatch::IntegrationTest
 
   def test_admin_root_success?
     get admin_root_url
-    assert_match 'Test Me', response.body # has content
-    assert_match 'Users', response.body # has 'Your Models' in menu
+    assert_match "Test Me", response.body # has content
+    assert_match "Users", response.body # has 'Your Models' in menu
     assert_response :success
   end
 
   def test_admin_users
-    User.create! full_name: 'John Doe'
+    User.create! full_name: "John Doe"
     get admin_users_url
-    assert_match 'John Doe', response.body # has created row
+    assert_match "John Doe", response.body # has created row
     assert_response :success
   end
 

--- a/tasks/changelog.rake
+++ b/tasks/changelog.rake
@@ -1,7 +1,7 @@
 require_relative "changelog"
 
 namespace :changelog do
-  desc 'Syncronize latest release changelog with latest PR information'
+  desc "Syncronize latest release changelog with latest PR information"
   task :resync do
     Changelog.new.resync!
   end

--- a/tasks/docs.rake
+++ b/tasks/docs.rake
@@ -1,10 +1,10 @@
-require 'yard'
-require 'yard/rake/yardoc_task'
+require "yard"
+require "yard/rake/yardoc_task"
 
 namespace :docs do
   YARD::Rake::YardocTask.new do |t|
-    t.files = ['lib/**/*.rb']
-    t.options = ['--no-output']
+    t.files = ["lib/**/*.rb"]
+    t.options = ["--no-output"]
   end
 
   def jekyll_redirect_string(filename)
@@ -17,14 +17,14 @@ namespace :docs do
   end
 
   def filename_from_module(mod)
-    mod.name.to_s.underscore.tr('_', '-')
+    mod.name.to_s.underscore.tr("_", "-")
   end
 
   def write_docstrings_to(path, mods)
     mods.each do |mod|
       filename = filename_from_module(mod)
 
-      File.open("#{path}/#{filename}.md", 'w+') do |f|
+      File.open("#{path}/#{filename}.md", "w+") do |f|
         f << jekyll_redirect_string("#{filename}.html") + mod.docstring + "\n"
       end
     end
@@ -32,11 +32,11 @@ namespace :docs do
 
   def docs_synchronized?
     # Do not print diff and yield whether exit code was zero
-    sh('git diff --quiet docs/3-index-pages') do |outcome, _|
+    sh("git diff --quiet docs/3-index-pages") do |outcome, _|
       return if outcome
 
       # Output diff before raising error
-      sh('git diff docs/3-index-pages')
+      sh("git diff docs/3-index-pages")
 
       raise <<-MSG.strip_heredoc
         The docs/3-index-pages directory is out of sync.
@@ -47,8 +47,8 @@ namespace :docs do
 
   desc "Update docs in the docs folder"
   task build: :yard do
-    require 'yard'
-    require 'active_support/all'
+    require "yard"
+    require "active_support/all"
 
     YARD::Registry.load!
     views = YARD::Registry.at("ActiveAdmin::Views")

--- a/tasks/local.rake
+++ b/tasks/local.rake
@@ -1,10 +1,10 @@
-desc 'Run a command against the local sample application'
+desc "Run a command against the local sample application"
 task :local do
   require_relative "test_application"
 
   test_application = ActiveAdmin::TestApplication.new(
-    rails_env: 'development',
-    template: 'rails_template_with_data'
+    rails_env: "development",
+    template: "rails_template_with_data"
   )
 
   test_application.soft_generate
@@ -15,11 +15,11 @@ task :local do
   if argv.any?
     # If it's a rails command, auto add the rails script
     if %w(generate console server dbconsole g c s runner).include?(argv[0]) || argv[0] =~ /db:/
-      argv.unshift('rails')
+      argv.unshift("rails")
     end
 
-    command = ['bundle', 'exec', *argv].join(' ')
-    env = { 'BUNDLE_GEMFILE' => test_application.expanded_gemfile }
+    command = ["bundle", "exec", *argv].join(" ")
+    env = { "BUNDLE_GEMFILE" => test_application.expanded_gemfile }
 
     Dir.chdir(test_application.app_dir) do
       Bundler.with_original_env { Kernel.exec(env, command) }

--- a/tasks/release.rake
+++ b/tasks/release.rake
@@ -2,7 +2,7 @@ require "chandler/tasks"
 require_relative "release_manager"
 
 namespace :release do
-  desc 'Publish npm package'
+  desc "Publish npm package"
   task :npm_push do
     ReleaseManager.new.npm_push
   end

--- a/tasks/release_manager.rb
+++ b/tasks/release_manager.rb
@@ -193,11 +193,11 @@ class ReleaseManager
   end
 
   def gem_version_file
-    'lib/active_admin/version.rb'
+    "lib/active_admin/version.rb"
   end
 
   def npm_version_file
-    'package.json'
+    "package.json"
   end
 
   def changelog_file

--- a/tasks/test_application.rb
+++ b/tasks/test_application.rb
@@ -1,12 +1,12 @@
-require 'fileutils'
+require "fileutils"
 
 module ActiveAdmin
   class TestApplication
     attr_reader :rails_env, :template
 
     def initialize(opts = {})
-      @rails_env = opts[:rails_env] || 'test'
-      @template = opts[:template] || 'rails_template'
+      @rails_env = opts[:rails_env] || "test"
+      @template = opts[:template] || "rails_template"
     end
 
     def soft_generate
@@ -34,9 +34,9 @@ module ActiveAdmin
 
       args << "--skip-turbolinks" unless turbolinks_app?
 
-      command = ['bundle', 'exec', 'rails', 'new', app_dir, *args].join(' ')
+      command = ["bundle", "exec", "rails", "new", app_dir, *args].join(" ")
 
-      env = { 'BUNDLE_GEMFILE' => expanded_gemfile, 'RAILS_ENV' => rails_env }
+      env = { "BUNDLE_GEMFILE" => expanded_gemfile, "RAILS_ENV" => rails_env }
 
       Bundler.with_original_env { abort unless Kernel.system(env, command) }
     end
@@ -68,11 +68,11 @@ module ActiveAdmin
     end
 
     def main_app?
-      expanded_gemfile == File.expand_path('Gemfile')
+      expanded_gemfile == File.expand_path("Gemfile")
     end
 
     def turbolinks_app?
-      expanded_gemfile == File.expand_path('gemfiles/rails_60_turbolinks/Gemfile')
+      expanded_gemfile == File.expand_path("gemfiles/rails_60_turbolinks/Gemfile")
     end
 
     def gemfile


### PR DESCRIPTION
To avoid fighting over a preferred style, to have it consistent by default, and to avoid unrelated quoting style changes in PRs that can make diffs harder to read. 