### PR TITLE
Check if cuprite works well with latest chrome

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,7 +256,7 @@ jobs:
 
   ruby25rails52:
     docker:
-      - image: circleci/ruby:2.5.8-node-browsers@sha256:8ec7685a1b699535b79bc41717d122162a4d018210782cdc46fcec5c3fac6c50
+      - image: circleci/ruby:2.5.8-node-browsers@sha256:772449521f5bdc456b3da1226d4070c46b53868a7b7b41f4de2318f1358c8fe6
         user: root
 
     environment:
@@ -267,7 +267,7 @@ jobs:
 
   ruby25rails60:
     docker:
-      - image: circleci/ruby:2.5.8-node-browsers@sha256:8ec7685a1b699535b79bc41717d122162a4d018210782cdc46fcec5c3fac6c50
+      - image: circleci/ruby:2.5.8-node-browsers@sha256:772449521f5bdc456b3da1226d4070c46b53868a7b7b41f4de2318f1358c8fe6
         user: root
 
     environment:
@@ -278,7 +278,7 @@ jobs:
 
   ruby26rails52:
     docker:
-      - image: circleci/ruby:2.6.6-node-browsers@sha256:8d362341980cd7fe89d716ec00061d9669c13e9a75f3e99c835b2e1557e61291
+      - image: circleci/ruby:2.6.6-node-browsers@sha256:6fecbb049a4a8a561566a0dd976a617443d14346a17e6d12d83db882684273e1
         user: root
 
     environment:
@@ -289,7 +289,7 @@ jobs:
 
   ruby26rails60:
     docker:
-      - image: circleci/ruby:2.6.6-node-browsers@sha256:8d362341980cd7fe89d716ec00061d9669c13e9a75f3e99c835b2e1557e61291
+      - image: circleci/ruby:2.6.6-node-browsers@sha256:6fecbb049a4a8a561566a0dd976a617443d14346a17e6d12d83db882684273e1
         user: root
 
     environment:
@@ -300,7 +300,7 @@ jobs:
 
   ruby26rails60turbolinks:
     docker:
-      - image: circleci/ruby:2.6.6-node-browsers@sha256:8d362341980cd7fe89d716ec00061d9669c13e9a75f3e99c835b2e1557e61291
+      - image: circleci/ruby:2.6.6-node-browsers@sha256:6fecbb049a4a8a561566a0dd976a617443d14346a17e6d12d83db882684273e1
         user: root
 
     environment:
@@ -311,7 +311,7 @@ jobs:
 
   ruby26rails60webpacker:
     docker:
-      - image: circleci/ruby:2.6.6-node-browsers@sha256:8d362341980cd7fe89d716ec00061d9669c13e9a75f3e99c835b2e1557e61291
+      - image: circleci/ruby:2.6.6-node-browsers@sha256:6fecbb049a4a8a561566a0dd976a617443d14346a17e6d12d83db882684273e1
         user: root
 
     environment:
@@ -322,7 +322,7 @@ jobs:
 
   ruby27rails52:
     docker:
-      - image: circleci/ruby:2.7.1-node-browsers@sha256:919028ba2abddd4a00228549bfc3d4bc9a0a19d48bb9246be5a8503a4afa9416
+      - image: circleci/ruby:2.7.1-node-browsers@sha256:94789a1524fa16521f6397f05ff9d4569c102ae4479135ee3f78e3b4d25c1b0e
         user: root
 
     environment:
@@ -333,7 +333,7 @@ jobs:
 
   ruby27rails60:
     docker:
-      - image: circleci/ruby:2.7.1-node-browsers@sha256:919028ba2abddd4a00228549bfc3d4bc9a0a19d48bb9246be5a8503a4afa9416
+      - image: circleci/ruby:2.7.1-node-browsers@sha256:94789a1524fa16521f6397f05ff9d4569c102ae4479135ee3f78e3b4d25c1b0e
         user: root
 
     environment:
@@ -344,7 +344,7 @@ jobs:
 
   ruby27rails60turbolinks:
     docker:
-      - image: circleci/ruby:2.7.1-node-browsers@sha256:919028ba2abddd4a00228549bfc3d4bc9a0a19d48bb9246be5a8503a4afa9416
+      - image: circleci/ruby:2.7.1-node-browsers@sha256:94789a1524fa16521f6397f05ff9d4569c102ae4479135ee3f78e3b4d25c1b0e
         user: root
 
     environment:
@@ -355,7 +355,7 @@ jobs:
 
   ruby27rails60webpacker:
     docker:
-      - image: circleci/ruby:2.7.1-node-browsers@sha256:919028ba2abddd4a00228549bfc3d4bc9a0a19d48bb9246be5a8503a4afa9416
+      - image: circleci/ruby:2.7.1-node-browsers@sha256:94789a1524fa16521f6397f05ff9d4569c102ae4479135ee3f78e3b4d25c1b0e
         user: root
 
     environment:

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ group :development, :test do
 end
 
 group :test do
-  gem "apparition"
+  gem "cuprite", "0.11"
   gem "capybara", "~> 3.14"
   gem "db-query-matchers", "0.10.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,9 +144,6 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    apparition (0.6.0)
-      capybara (~> 3.13, < 4)
-      websocket-driver (>= 0.6.5)
     arbre (1.3.0)
       activesupport (>= 3.0.0, < 6.1)
       ruby2_keywords (>= 0.0.2, < 1.0)
@@ -168,6 +165,7 @@ GEM
       netrc
       octokit (>= 2.2.0)
     chef-utils (16.4.41)
+    cliver (0.3.2)
     coderay (1.1.2)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
@@ -208,6 +206,9 @@ GEM
       cucumber-core (~> 7.1, >= 7.1.0)
       cucumber-cucumber-expressions (~> 10.1, >= 10.1.0)
       cucumber-messages (~> 12.2, >= 12.2.0)
+    cuprite (0.11)
+      capybara (>= 2.1, < 4)
+      ferrum (~> 0.9.0)
     database_cleaner (1.8.5)
     db-query-matchers (0.10.0)
       activesupport (>= 4.0, < 7)
@@ -229,6 +230,11 @@ GEM
     erubi (1.9.0)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
+    ferrum (0.9)
+      addressable (~> 2.5)
+      cliver (~> 0.3)
+      concurrent-ruby (~> 1.1)
+      websocket-driver (>= 0.6, < 0.8)
     ffi (1.13.1)
     ffi (1.13.1-java)
     formtastic (4.0.0.rc1)
@@ -478,12 +484,12 @@ PLATFORMS
 DEPENDENCIES
   activeadmin!
   activerecord-jdbcsqlite3-adapter (~> 60.0)
-  apparition
   cancancan
   capybara (~> 3.14)
   chandler (= 0.9.0)
   cucumber
   cucumber-rails (~> 2.0)
+  cuprite (= 0.11)
   database_cleaner
   db-query-matchers (= 0.10.0)
   devise

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -49,8 +49,8 @@ Before "@javascript" do
   Capybara.current_driver = Capybara.javascript_driver
 end
 
-require "capybara/apparition"
-Capybara.javascript_driver = :apparition
+require "capybara/cuprite"
+Capybara.javascript_driver = :cuprite
 
 Capybara.server = :webrick
 

--- a/gemfiles/rails_52/Gemfile
+++ b/gemfiles/rails_52/Gemfile
@@ -22,7 +22,7 @@ group :development, :test do
 end
 
 group :test do
-  gem "apparition"
+  gem "cuprite", "0.11"
   gem "capybara", "~> 3.14"
   gem "db-query-matchers", "0.10.0"
 

--- a/gemfiles/rails_52/Gemfile.lock
+++ b/gemfiles/rails_52/Gemfile.lock
@@ -130,9 +130,6 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    apparition (0.6.0)
-      capybara (~> 3.13, < 4)
-      websocket-driver (>= 0.6.5)
     arbre (1.3.0)
       activesupport (>= 3.0.0, < 6.1)
       ruby2_keywords (>= 0.0.2, < 1.0)
@@ -150,6 +147,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
+    cliver (0.3.2)
     coderay (1.1.2)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
@@ -190,6 +188,9 @@ GEM
       cucumber-core (~> 7.1, >= 7.1.0)
       cucumber-cucumber-expressions (~> 10.1, >= 10.1.0)
       cucumber-messages (~> 12.2, >= 12.2.0)
+    cuprite (0.11)
+      capybara (>= 2.1, < 4)
+      ferrum (~> 0.9.0)
     database_cleaner (1.8.5)
     db-query-matchers (0.10.0)
       activesupport (>= 4.0, < 7)
@@ -209,6 +210,11 @@ GEM
       activesupport (>= 5.0)
       request_store (>= 1.0)
     erubi (1.9.0)
+    ferrum (0.9)
+      addressable (~> 2.5)
+      cliver (~> 0.3)
+      concurrent-ruby (~> 1.1)
+      websocket-driver (>= 0.6, < 0.8)
     ffi (1.13.1)
     ffi (1.13.1-java)
     formtastic (4.0.0.rc1)
@@ -390,11 +396,11 @@ PLATFORMS
 DEPENDENCIES
   activeadmin!
   activerecord-jdbcsqlite3-adapter (~> 52.0)
-  apparition
   cancancan
   capybara (~> 3.14)
   cucumber
   cucumber-rails (~> 2.0)
+  cuprite (= 0.11)
   database_cleaner
   db-query-matchers (= 0.10.0)
   devise

--- a/gemfiles/rails_60_turbolinks/Gemfile
+++ b/gemfiles/rails_60_turbolinks/Gemfile
@@ -24,7 +24,7 @@ group :development, :test do
 end
 
 group :test do
-  gem "apparition"
+  gem "cuprite", "0.11"
   gem "capybara", "~> 3.14"
   gem "db-query-matchers", "0.10.0"
 

--- a/gemfiles/rails_60_turbolinks/Gemfile.lock
+++ b/gemfiles/rails_60_turbolinks/Gemfile.lock
@@ -144,9 +144,6 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    apparition (0.6.0)
-      capybara (~> 3.13, < 4)
-      websocket-driver (>= 0.6.5)
     arbre (1.3.0)
       activesupport (>= 3.0.0, < 6.1)
       ruby2_keywords (>= 0.0.2, < 1.0)
@@ -163,6 +160,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
+    cliver (0.3.2)
     coderay (1.1.2)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
@@ -203,6 +201,9 @@ GEM
       cucumber-core (~> 7.1, >= 7.1.0)
       cucumber-cucumber-expressions (~> 10.1, >= 10.1.0)
       cucumber-messages (~> 12.2, >= 12.2.0)
+    cuprite (0.11)
+      capybara (>= 2.1, < 4)
+      ferrum (~> 0.9.0)
     database_cleaner (1.8.5)
     db-query-matchers (0.10.0)
       activesupport (>= 4.0, < 7)
@@ -222,6 +223,11 @@ GEM
       activesupport (>= 5.0)
       request_store (>= 1.0)
     erubi (1.9.0)
+    ferrum (0.9)
+      addressable (~> 2.5)
+      cliver (~> 0.3)
+      concurrent-ruby (~> 1.1)
+      websocket-driver (>= 0.6, < 0.8)
     ffi (1.13.1)
     ffi (1.13.1-java)
     formtastic (4.0.0.rc1)
@@ -409,11 +415,11 @@ PLATFORMS
 DEPENDENCIES
   activeadmin!
   activerecord-jdbcsqlite3-adapter (~> 60.0)
-  apparition
   cancancan
   capybara (~> 3.14)
   cucumber
   cucumber-rails (~> 2.0)
+  cuprite (= 0.11)
   database_cleaner
   db-query-matchers (= 0.10.0)
   devise

--- a/gemfiles/rails_60_webpacker/Gemfile
+++ b/gemfiles/rails_60_webpacker/Gemfile
@@ -24,7 +24,7 @@ group :development, :test do
 end
 
 group :test do
-  gem "apparition"
+  gem "cuprite", "0.11"
   gem "capybara", "~> 3.14"
   gem "db-query-matchers", "0.10.0"
 

--- a/gemfiles/rails_60_webpacker/Gemfile.lock
+++ b/gemfiles/rails_60_webpacker/Gemfile.lock
@@ -144,9 +144,6 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    apparition (0.6.0)
-      capybara (~> 3.13, < 4)
-      websocket-driver (>= 0.6.5)
     arbre (1.3.0)
       activesupport (>= 3.0.0, < 6.1)
       ruby2_keywords (>= 0.0.2, < 1.0)
@@ -163,6 +160,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
+    cliver (0.3.2)
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
@@ -203,6 +201,9 @@ GEM
       cucumber-core (~> 7.1, >= 7.1.0)
       cucumber-cucumber-expressions (~> 10.1, >= 10.1.0)
       cucumber-messages (~> 12.2, >= 12.2.0)
+    cuprite (0.11)
+      capybara (>= 2.1, < 4)
+      ferrum (~> 0.9.0)
     database_cleaner (1.8.5)
     db-query-matchers (0.10.0)
       activesupport (>= 4.0, < 7)
@@ -222,6 +223,11 @@ GEM
       activesupport (>= 5.0)
       request_store (>= 1.0)
     erubi (1.9.0)
+    ferrum (0.9)
+      addressable (~> 2.5)
+      cliver (~> 0.3)
+      concurrent-ruby (~> 1.1)
+      websocket-driver (>= 0.6, < 0.8)
     ffi (1.13.1)
     ffi (1.13.1-java)
     formtastic (4.0.0.rc1)
@@ -414,11 +420,11 @@ PLATFORMS
 DEPENDENCIES
   activeadmin!
   activerecord-jdbcsqlite3-adapter (~> 60.0)
-  apparition
   cancancan
   capybara (~> 3.14)
   cucumber
   cucumber-rails (~> 2.0)
+  cuprite (= 0.11)
   database_cleaner
   db-query-matchers (= 0.10.0)
   devise


### PR DESCRIPTION
It seems like [cuprite](https://github.com/rubycdp/cuprite) works well with the latest chrome, so we can keep our docker images up to date. I still kept them locked because I really dislike third party changes breaking our CI. 
