### PR TITLE
Drop git in gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ inherit_mode:
     - Include
 
 require:
+  - rubocop-packaging
   - rubocop-rails
   - rubocop-rspec
 
@@ -87,6 +88,18 @@ Layout/ParameterAlignment:
 Layout/IndentationStyle:
   Enabled: true
   EnforcedStyle: spaces
+
+Packaging/BundlerSetupInTests:
+  Enabled: true
+
+Packaging/GemspecGit:
+  Enabled: true
+
+Packaging/RequireHardcodingLib:
+  Enabled: true
+
+Packaging/RequireRelativeHardcodingLib:
+  Enabled: true
 
 Rails/FilePath:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ end
 group :lint do
   # Code style
   gem "rubocop", "0.92.0"
+  gem "rubocop-packaging", "~> 0.5"
   gem "rubocop-rspec", "~> 1.30"
   gem "rubocop-rails", "~> 2.3"
   gem "mdl", "0.11.0"

--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ end
 group :lint do
   # Code style
   gem "rubocop", "0.92.0"
-  gem "rubocop-packaging", "~> 0.5"
+  gem "rubocop-packaging", "0.5.0"
   gem "rubocop-rspec", "~> 1.30"
   gem "rubocop-rails", "~> 2.3"
   gem "mdl", "0.11.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -417,6 +417,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-ast (0.5.0)
       parser (>= 2.7.1.5)
+    rubocop-packaging (0.5.0)
+      rubocop (~> 0.89)
     rubocop-rails (2.8.1)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
@@ -512,6 +514,7 @@ DEPENDENCIES
   rspec-rails
   rspec-support!
   rubocop (= 0.92.0)
+  rubocop-packaging (= 0.5.0)
   rubocop-rails (~> 2.3)
   rubocop-rspec (~> 1.30)
   simplecov (= 0.19.0)

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
     "application patterns to make it simple for developers to implement " \
     "beautiful and elegant interfaces with very little effort."
 
-  s.files = `git ls-files LICENSE app config/locales docs lib vendor -z`.split("\x0")
+  s.files = Dir["LICENSE", "{app,config/locales,docs,lib,vendor/assets}/**/{.*,*}"].reject { |f| File.directory?(f) }
 
   s.extra_rdoc_files = %w[CHANGELOG.md CODE_OF_CONDUCT.md CONTRIBUTING.md README.md]
 


### PR DESCRIPTION
Hello 👋🏻,

Thanks for your work on this! ❤️ 

We found that `activeadmin` relies on `git ls-files` to produce a list of files, which could also be achieved using a pure Ruby alternative. Using `git` in gemspec, in general, is a bit problematic.
The rationale behind that can be found here: https://docs.rubocop.org/rubocop-packaging/cops_packaging.html#gemspec-git-rationale

This PR drops the usage of `git` and uses `Dir` instead w/o changing the output:
```
irb(main):001:0> Dir["LICENSE", "{app,config/locales,docs,lib,vendor}/**/{.*,*}"].reject { |f| File.directory?(f) }.sort == `git ls-files LICENSE app config/locales docs lib vendor -z`.split("\x0").sort
=> true
irb(main):002:0> 
```

Also adds the `Packaging` extension to help the downstream maintainers as well! 😄 

Let me know what you think? 💫