### PR TITLE
Fix regexp for parsing version in release tasks

### DIFF
--- a/tasks/release_manager.rb
+++ b/tasks/release_manager.rb
@@ -213,7 +213,7 @@ class ReleaseManager
   end
 
   def gem_version
-    @gem_version ||= File.read(gem_version_file).match(/^  VERSION = '(.*)'$/)[1]
+    @gem_version ||= File.read(gem_version_file).match(/^  VERSION = "(.*)"$/)[1]
   end
 
   def prerelease?(version)


### PR DESCRIPTION
It broke since we use double quotes now.