### PR TITLE
Fix tiny formatting issue in changelog generator

### DIFF
--- a/tasks/changelog.rb
+++ b/tasks/changelog.rb
@@ -29,7 +29,7 @@ class Changelog
       lines << ""
 
       pulls.sort_by(&:merged_at).reverse_each do |pull|
-        lines << "* #{pull.title}. [##{pull.number}] by [@#{pull.user.login}]"
+        lines << "* #{pull.title.strip}. [##{pull.number}] by [@#{pull.user.login}]"
       end
 
       lines << ""


### PR DESCRIPTION
If a PR title include trailing spaces, the generated CHANGELOG entry has an extra space before the final dot:

```
* Fix input string filter no rendering dropdown input when its column name ends with a ransack predicate . [#6422] by [@Fivell]
```

This kind of formatting little issues can be easily corrected by changing the PR title, but in this particular case Github doesn't display this trailing space, so it's hardly impossible to notice. We can fix it when generating the changelog entry instead by striping any trailing whitespace from the title.