### PR TITLE
Really fix parsing version during release scripts

### DIFF
--- a/tasks/release_manager.rb
+++ b/tasks/release_manager.rb
@@ -160,7 +160,7 @@ class ReleaseManager
 
   def bump_version_file(version)
     old_content = File.read(gem_version_file)
-    new_content = old_content.gsub!(/^  VERSION = '.*'$/, "  VERSION = '#{version}'")
+    new_content = old_content.gsub!(/^  VERSION = ".*"$/, "  VERSION = \"#{version}\"")
 
     File.open(gem_version_file, "w") { |f| f.puts new_content }
   end


### PR DESCRIPTION
Also broken due to changing to double quotes.

This is a follow up PR to https://github.com/activeadmin/activeadmin/pull/6475, but this time I actually made sure the code fully works.