### PR TITLE
Ignore any blank flash messages 

### DIFF
--- a/app/views/layouts/active_admin_logged_out.html.erb
+++ b/app/views/layouts/active_admin_logged_out.html.erb
@@ -34,7 +34,7 @@
   <div id="content_wrapper">
     <div class="flashes">
       <% flash_messages.each do |type, message| %>
-        <%= content_tag :div, message, class: "flash flash_#{type}" %>
+        <%= content_tag(:div, message, class: "flash flash_#{type}") if message.present? %>
       <% end %>
     </div>
     <div id="active_admin_content">

--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -88,10 +88,11 @@ module ActiveAdmin
         def build_flash_messages
           div class: "flashes" do
             flash_messages.each do |type, messages|
-              [*messages].each do |message|
+              [*messages].reject(&:blank?).each do |message|
                 div message, class: "flash flash_#{type}"
               end
             end
+            nil
           end
         end
 


### PR DESCRIPTION
Hello! I have a very small annoyance that I would like to fix in ActiveAdmin. This is also related to using the Devise gem for authentication.

I don't like the default `already_authenticated` error for Devise, which shows the flash alert: "You are already signed in."
I wanted to turn this off so that people would just get silently redirected to the dashboard, and I think most people would quickly figure out what happened without the need to show an error. This is also what GitHub is doing when you visit: https://github.com/login

I was looking for a way to disable these messages, and it's surprisingly difficult. There are a lot of solutions posted on StackOverflow, involving various overrides, but [the most common and straightforward solution](https://stackoverflow.com/a/5762835/304706) is to replace the error translation with an empty string. (I also tried changing this to `null`, but that gives an i18n "missing translation" error.) 

This works fine in my app, since I change my view to check for `present?`. But in ActiveAdmin, this shows an empty flash message with an empty red bar at the top of the screen:
 
<img width="1063" alt="Screen Shot 2020-09-27 at 2 39 41 PM" src="https://user-images.githubusercontent.com/139536/94357998-3a862700-00d0-11eb-8518-73109f775a94.png">

<img width="450" alt="Screen Shot 2020-09-27 at 2 39 47 PM" src="https://user-images.githubusercontent.com/139536/94358020-6b665c00-00d0-11eb-9a76-eaf6a8ddea6d.png">

(The `nil` is needed at the end of the block is to prevent the hash from getting rendered by default when there are no messages.)