### PR TITLE
Use bundler 2.2.0.rc.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ version: 2.1
 .install_bundler: &install_bundler
   run:
     name: Install a specific bundler version
-    command: gem install bundler -v 2.1.4
+    command: gem install bundler -v 2.2.0.rc.1
 
 .install_build_deps: &install_build_deps
   run:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -521,4 +521,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.1.4
+   2.2.0.rc.1

--- a/gemfiles/rails_52/Gemfile.lock
+++ b/gemfiles/rails_52/Gemfile.lock
@@ -423,4 +423,4 @@ DEPENDENCIES
   sqlite3 (~> 1.4)
 
 BUNDLED WITH
-   2.1.4
+   2.2.0.rc.1

--- a/gemfiles/rails_60_turbolinks/Gemfile.lock
+++ b/gemfiles/rails_60_turbolinks/Gemfile.lock
@@ -443,4 +443,4 @@ DEPENDENCIES
   turbolinks (~> 5.2)
 
 BUNDLED WITH
-   2.1.4
+   2.2.0.rc.1

--- a/gemfiles/rails_60_webpacker/Gemfile.lock
+++ b/gemfiles/rails_60_webpacker/Gemfile.lock
@@ -448,4 +448,4 @@ DEPENDENCIES
   webpacker (~> 5.1)
 
 BUNDLED WITH
-   2.1.4
+   2.2.0.rc.1

--- a/tasks/bug_report_template.rb
+++ b/tasks/bug_report_template.rb
@@ -16,7 +16,7 @@ gemfile(true) do
   gem "sprockets", "3.7.2"
   gem "sassc-rails", "2.1.2"
   gem "sqlite3", "1.4.1", platform: :mri
-  gem "activerecord-jdbcsqlite3-adapter", "52.0", platform: :jruby
+  gem "activerecord-jdbcsqlite3-adapter", "60.0", platform: :jruby
   gem "jruby-openssl", "0.10.1", platform: :jruby
 end
 


### PR DESCRIPTION
There's a bug in the `rake release` task that's [fixed in the latest bundler rc release](https://github.com/rubygems/rubygems/pull/3785) and it's preventing me from releasing. I get this:

```
$ bin/rake release
activeadmin 2.8.1 built to pkg/activeadmin-2.8.1.gem.
Tagged v2.8.1.
Untagging v2.8.1 due to error.
rake aborted!
Couldn't git push. `git push  --tags' failed with the following output:

To https://github.com/activeadmin/activeadmin
 * [new tag]             v2.8.1 -> v2.8.1
 ! [rejected]            v2.7.0 -> v2.7.0 (already exists)
error: failed to push some refs to 'https://github.com/activeadmin/activeadmin'
hint: Updates were rejected because the tag already exists in the remote.
```

I think I could also fix it by messing with my local tags, but I'd like to try the bundler rc release too.