### PR TITLE
Improve release task prerequisites

### DIFF
--- a/tasks/release.rake
+++ b/tasks/release.rake
@@ -43,7 +43,4 @@ namespace :release do
   end
 end
 
-#
-# Add chandler as a prerequisite for `rake release`
-#
-task "release:rubygem_push" => ["chandler:push", "release:npm_push"]
+task "release", [:remote] => ["build", "release:guard_clean", "release:source_control_push", "chandler:push", "release:npm_push", "release:rubygem_push"]


### PR DESCRIPTION
Instead of enhancing `rake release:rubygems_push`, enhance `rake release` directly.

This allows to run `rake release:rubygem_push` and `rake release:npm_push` independently, which helps fixing situations like the current where I already released 2.8.1 to npm, but I can't release it to rubygems due to the current task dependencies (`release:rubygem_push` requires `release:npm_push` and `npm` won't let you "repush" the same release again).

Before:

```
$ bin/rake -P
(...)

rake release
    build
    release:guard_clean
    release:source_control_push
    release:rubygem_push
rake release:guard_clean
rake release:npm_push
rake release:prepare_major
rake release:prepare_minor
rake release:prepare_patch
rake release:prepare_premajor
rake release:prepare_preminor
rake release:prepare_prepatch
rake release:prepare_prerelease
rake release:rubygem_push
    chandler:push
    release:npm_push
rake release:source_control_push

(...)
```

After:

```
$ bin/rake -P
(...)

rake release
    build
    release:guard_clean
    release:source_control_push
    release:rubygem_push
    chandler:push
    release:npm_push
rake release:guard_clean
rake release:npm_push
rake release:prepare_major
rake release:prepare_minor
rake release:prepare_patch
rake release:prepare_premajor
rake release:prepare_preminor
rake release:prepare_prepatch
rake release:prepare_prerelease
rake release:rubygem_push
rake release:source_control_push

(...)
```