### PR TITLE
Add example of using `default_main_content` in show pages

### DIFF
--- a/docs/6-show-pages.md
+++ b/docs/6-show-pages.md
@@ -79,3 +79,15 @@ ActiveAdmin.register Book do
   end
 end
 ```
+
+If you want to keep the default show data, but add something extra to it:
+
+```ruby
+show do
+  div do
+    h3 'Some custom charts about this object'
+    render partial: 'charts'
+  end
+  default_main_content
+end
+```


### PR DESCRIPTION
See #6486 
Added an example using `default_main_content` function.

Closes #6486 