### PR TITLE
Update 0-installation.md - Advise not to require_tree, as this will load all activeadmin js on all pages

### DIFF
--- a/docs/0-installation.md
+++ b/docs/0-installation.md
@@ -48,6 +48,9 @@ The generator adds these core files, among others:
 * `app/assets/stylesheets/active_admin.scss`
 * `config/initializers/active_admin.rb`
 
+If you do not want to require the javascript for ActiveAdmin on all pages,
+then make sure that you don't have `require_tree .` in your application.js
+
 Now, migrate and seed your database before starting the server:
 
 ```sh


### PR DESCRIPTION
Added

If you do not want to require the javascript for ActiveAdmin on all pages,
then make sure that you don't have `require_tree .` in your application.js

<!--

Thanks for contributing to ActiveAdmin!

You can find all the instructions for contributing at the [CONTRIBUTING file].

Before submitting your PR make sure that:

* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are splitted apart.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all github checks are passing, but feel free to ask for early feedback if you need guidance.

[CONTRIBUTING file]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->
