### PR TITLE
Added support for splitChunks

### DIFF
--- a/app/views/layouts/active_admin_logged_out.html.erb
+++ b/app/views/layouts/active_admin_logged_out.html.erb
@@ -14,7 +14,11 @@
   <% end %>
   <% ActiveAdmin.application.javascripts.each do |path| %>
     <% if ActiveAdmin.application.use_webpacker %>
-      <%= javascript_pack_tag path %>
+      <% if ActiveAdmin.application.use_webpacker_chunks %>
+        <%= javascript_packs_with_chunks_tag path.chomp(".js") %>
+      <% else %>
+        <%= javascript_pack_tag path %>
+      <% end %>
     <% else %>
       <%= javascript_include_tag path %>
     <% end %>

--- a/lib/active_admin/namespace_settings.rb
+++ b/lib/active_admin/namespace_settings.rb
@@ -122,5 +122,8 @@ module ActiveAdmin
 
     # Switch between asset pipeline and webpacker assets
     register :use_webpacker, false
+
+    # Allow webpacker to split js into chunks
+    register :use_webpacker_chunks, false
   end
 end

--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -38,7 +38,15 @@ module ActiveAdmin
             end
 
             active_admin_application.javascripts.each do |path|
-              javascript_tag = active_admin_namespace.use_webpacker ? javascript_pack_tag(path) : javascript_include_tag(path)
+              if active_admin_namespace.use_webpacker
+                if active_admin_namespace.use_webpacker_chunks
+                  javascript_tag = javascript_packs_with_chunks_tag path.chomp(".js")
+                else
+                  javascript_tag = javascript_pack_tag path
+                end
+              else
+                javascript_tag = javascript_include_tag path
+              end
               text_node(javascript_tag)
             end
 

--- a/lib/generators/active_admin/install/templates/active_admin.rb.erb
+++ b/lib/generators/active_admin/install/templates/active_admin.rb.erb
@@ -332,4 +332,9 @@ ActiveAdmin.setup do |config|
   # You can switch to using Webpacker here.
   #
   <% unless @use_webpacker %># <% end %>config.use_webpacker = true
+  #
+  # Webpack allows you to divide your javascript code in chunks.
+  # When doing so, enable this to load the js code correctly.
+  #
+  # config.use_webpacker_chunks = true
 end


### PR DESCRIPTION
If webpack is configured to split the javascript code into chunks, the js is not loaded properly.
Added a setting to solve this. When `use_webpacker_chunks` is set to `true`, it uses webpacker's [javascript_packs_with_chunks_tag](https://www.rubydoc.info/gems/webpacker/Webpacker/Helper#javascript_packs_with_chunks_tag-instance_method) to load the js chunks properly.

Fixes #6429.