### PR TITLE
to remove large space after first comment

### DIFF
--- a/app/assets/stylesheets/active_admin/components/_comments.scss
+++ b/app/assets/stylesheets/active_admin/components/_comments.scss
@@ -6,6 +6,9 @@
     margin-top: 10px;
     margin-bottom: 40px;
     max-width: 700px;
+    &:after {
+      display: inline-block;
+    }
 
     .active_admin_comment_meta {
       width: 130px;


### PR DESCRIPTION
Fix comment layout

<!--

Thanks for contributing to ActiveAdmin!

You can find all the instructions for contributing at the [CONTRIBUTING file].

Before submitting your PR make sure that:

* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are splitted apart.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all github checks are passing, but feel free to ask for early feedback if you need guidance.

[CONTRIBUTING file]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->
the bug looks like on this git
![22222](https://user-images.githubusercontent.com/10907664/95481686-ef082e80-0995-11eb-9570-44c9046c712d.gif)


fixed  version screen
<img width="1054" alt="Screenshot 2020-10-08 at 18 44 44" src="https://user-images.githubusercontent.com/10907664/95482008-57571000-0996-11eb-800b-648046ae962a.png">
