### PR TITLE
Add ability to override "Remove" button text on has_many forms

### DIFF
--- a/docs/5-forms.md
+++ b/docs/5-forms.md
@@ -112,6 +112,7 @@ ActiveAdmin.register Post do
     f.inputs do
       f.has_many :comment,
                  new_record: 'Leave Comment',
+                 remove_record: 'Remove Comment',
                  allow_destroy: -> (c) { c.author?(current_admin_user) } do |b|
         b.input :body
       end
@@ -138,6 +139,10 @@ The `:heading` option adds a custom heading. You can hide it entirely by passing
 The `:new_record` option controls the visibility of the new record button (shown
 by default).  If you pass a string, it will be used as the text for the new
 record button.
+
+The `:remove_record` option controls the text of the remove button (shown after
+the new record button is pressed). If you pass a string, it will be used as the
+text for the remove button.
 
 The `:sortable` option adds a hidden field and will enable drag & drop sorting
 of the children. It expects the name of the column that will store the index of

--- a/features/has_many.feature
+++ b/features/has_many.feature
@@ -1,0 +1,54 @@
+@javascript
+Feature: Has Many
+
+  A resource has many other resources
+
+  Background:
+    Given I am logged in
+    And a post with the title "Hello World" written by "John Doe" exists
+
+  Scenario: Updating the parent resource page with default text for Remove button
+    Given a configuration of:
+    """
+      ActiveAdmin.register User do
+        form do |f|
+          f.inputs do
+            f.has_many :posts do |ff|
+              ff.input :title
+              ff.input :body
+            end
+          end
+          f.actions
+        end
+      end
+      ActiveAdmin.register Post
+    """
+    When I go to the last author's show page
+    And I follow "Edit User"
+    Then I should see a link to "Add New Post"
+
+    When I click "Add New Post"
+    Then I should see a link to "Remove"
+
+  Scenario: Updating the parent resource page with custom text for Remove button
+    Given a configuration of:
+    """
+      ActiveAdmin.register User do
+        form do |f|
+          f.inputs do
+            f.has_many :posts, remove_record: "Hide" do |ff|
+              ff.input :title
+              ff.input :body
+            end
+          end
+          f.actions
+        end
+      end
+      ActiveAdmin.register Post
+    """
+    When I go to the last author's show page
+    And I follow "Edit User"
+    Then I should see a link to "Add New Post"
+
+    When I click "Add New Post"
+    Then I should see a link to "Hide"

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -47,6 +47,9 @@ module NavigationHelpers
     when /^the last post's edit page$/
       edit_admin_post_path(Post.last)
 
+    when /^the last author's show page$/
+      admin_user_path(User.last)
+
     # Add more mappings here.
     # Here is an example that pulls values out of the Regexp:
     #

--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -40,7 +40,7 @@ module ActiveAdmin
     attr_reader :assoc
     attr_reader :options
     attr_reader :heading, :sortable_column, :sortable_start
-    attr_reader :new_record, :destroy_option
+    attr_reader :new_record, :destroy_option, :remove_record
 
     def initialize(has_many_form, assoc, options)
       super has_many_form
@@ -72,6 +72,7 @@ module ActiveAdmin
       @sortable_start = options.delete(:sortable_start) || 0
       @new_record = options.key?(:new_record) ? options.delete(:new_record) : true
       @destroy_option = options.delete(:allow_destroy)
+      @remove_record = options.delete(:remove_record)
       options
     end
 
@@ -107,7 +108,8 @@ module ActiveAdmin
     def has_many_actions(form_builder, contents)
       if form_builder.object.new_record?
         contents << template.content_tag(:li) do
-          template.link_to I18n.t("active_admin.has_many_remove"), "#", class: "button has_many_remove"
+          remove_text = remove_record.is_a?(String) ? remove_record : I18n.t("active_admin.has_many_remove")
+          template.link_to remove_text, "#", class: "button has_many_remove"
         end
       elsif allow_destroy?(form_builder.object)
         form_builder.input(


### PR DESCRIPTION
<!--

Thanks for contributing to ActiveAdmin!

You can find all the instructions for contributing at the [CONTRIBUTING file].

Before submitting your PR make sure that:

* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are splitted apart.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all github checks are passing, but feel free to ask for early feedback if you need guidance.

[CONTRIBUTING file]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->

Closes #5283 

* Adds new option on a has_many form to override the "Remove" button text
* Adds a new feature spec to test this functionality
* Updates documentation

