### PR TITLE
Allow different new and edit rules in authorization adapters

### DIFF
--- a/features/authorization.feature
+++ b/features/authorization.feature
@@ -15,7 +15,7 @@ Feature: Authorizing Access
 
         when normalized(Post)
           case action
-          when ActiveAdmin::Auth::UPDATE, ActiveAdmin::Auth::DESTROY
+          when :update, :destroy
             false
           else
             true

--- a/features/authorization.feature
+++ b/features/authorization.feature
@@ -15,7 +15,7 @@ Feature: Authorizing Access
 
         when normalized(Post)
           case action
-          when :update, :destroy
+          when :edit, :update, :destroy
             false
           else
             true

--- a/features/comments/commenting.feature
+++ b/features/comments/commenting.feature
@@ -251,7 +251,7 @@ Feature: Commenting
       """
         class NoNewComments < ActiveAdmin::AuthorizationAdapter
           def authorized?(action, subject = nil)
-            if action == :create && subject == ActiveAdmin::Comment
+            if (action == :new || action == :create) && subject == ActiveAdmin::Comment
               false
             else
               true

--- a/lib/active_admin/authorization_adapter.rb
+++ b/lib/active_admin/authorization_adapter.rb
@@ -4,9 +4,9 @@ module ActiveAdmin
   # Default Authorization permissions for Active Admin
   module Authorization
     READ = :read
-    NEW = :create
+    NEW = :new
     CREATE = :create
-    EDIT = :update
+    EDIT = :edit
     UPDATE = :update
     DESTROY = :destroy
   end

--- a/lib/active_admin/authorization_adapter.rb
+++ b/lib/active_admin/authorization_adapter.rb
@@ -4,7 +4,9 @@ module ActiveAdmin
   # Default Authorization permissions for Active Admin
   module Authorization
     READ = :read
+    NEW = :create
     CREATE = :create
+    EDIT = :update
     UPDATE = :update
     DESTROY = :destroy
   end

--- a/lib/active_admin/base_controller/authorization.rb
+++ b/lib/active_admin/base_controller/authorization.rb
@@ -7,9 +7,9 @@ module ActiveAdmin
       ACTIONS_DICTIONARY = {
         index: ActiveAdmin::Authorization::READ,
         show: ActiveAdmin::Authorization::READ,
-        new: ActiveAdmin::Authorization::CREATE,
+        new: ActiveAdmin::Authorization::NEW,
         create: ActiveAdmin::Authorization::CREATE,
-        edit: ActiveAdmin::Authorization::UPDATE,
+        edit: ActiveAdmin::Authorization::EDIT,
         update: ActiveAdmin::Authorization::UPDATE,
         destroy: ActiveAdmin::Authorization::DESTROY
       }

--- a/lib/active_admin/orm/active_record/comments/views/active_admin_comments.rb
+++ b/lib/active_admin/orm/active_record/comments/views/active_admin_comments.rb
@@ -36,7 +36,7 @@ module ActiveAdmin
 
           text_node paginate @comments
 
-          if authorized?(ActiveAdmin::Auth::CREATE, ActiveAdmin::Comment)
+          if authorized?(ActiveAdmin::Auth::NEW, ActiveAdmin::Comment)
             build_comment_form
           end
         end

--- a/lib/active_admin/pundit_adapter.rb
+++ b/lib/active_admin/pundit_adapter.rb
@@ -44,7 +44,9 @@ module ActiveAdmin
     def format_action(action, subject)
       # https://github.com/varvet/pundit/blob/master/lib/generators/pundit/install/templates/application_policy.rb
       case action
+      when Auth::NEW then :new?
       when Auth::CREATE then :create?
+      when Auth::EDIT then :edit?
       when Auth::UPDATE then :update?
       when Auth::READ then subject.is_a?(Class) ? :index? : :show?
       when Auth::DESTROY then subject.is_a?(Class) ? :destroy_all? : :destroy?

--- a/lib/active_admin/pundit_adapter.rb
+++ b/lib/active_admin/pundit_adapter.rb
@@ -44,10 +44,6 @@ module ActiveAdmin
     def format_action(action, subject)
       # https://github.com/varvet/pundit/blob/master/lib/generators/pundit/install/templates/application_policy.rb
       case action
-      when Auth::NEW then :new?
-      when Auth::CREATE then :create?
-      when Auth::EDIT then :edit?
-      when Auth::UPDATE then :update?
       when Auth::READ then subject.is_a?(Class) ? :index? : :show?
       when Auth::DESTROY then subject.is_a?(Class) ? :destroy_all? : :destroy?
       else "#{action}?"

--- a/lib/active_admin/resource/action_items.rb
+++ b/lib/active_admin/resource/action_items.rb
@@ -65,7 +65,7 @@ module ActiveAdmin
       # Adds the default New link on index
       def add_default_new_action_item
         add_action_item :new, only: :index do
-          if controller.action_methods.include?("new") && authorized?(ActiveAdmin::Auth::CREATE, active_admin_config.resource_class)
+          if controller.action_methods.include?("new") && authorized?(ActiveAdmin::Auth::NEW, active_admin_config.resource_class)
             localizer = ActiveAdmin::Localizers.resource(active_admin_config)
             link_to localizer.t(:new_model), new_resource_path
           end
@@ -75,7 +75,7 @@ module ActiveAdmin
       # Adds the default Edit link on show
       def add_default_edit_action_item
         add_action_item :edit, only: :show do
-          if controller.action_methods.include?("edit") && authorized?(ActiveAdmin::Auth::UPDATE, resource)
+          if controller.action_methods.include?("edit") && authorized?(ActiveAdmin::Auth::EDIT, resource)
             localizer = ActiveAdmin::Localizers.resource(active_admin_config)
             link_to localizer.t(:edit_model), edit_resource_path(resource)
           end

--- a/lib/active_admin/view_helpers/auto_link_helper.rb
+++ b/lib/active_admin/view_helpers/auto_link_helper.rb
@@ -29,7 +29,7 @@ module ActiveAdmin
           authorized?(ActiveAdmin::Auth::READ, resource)
           url_for config.route_instance_path resource, url_options
         elsif config.controller.action_methods.include?("edit") &&
-          authorized?(ActiveAdmin::Auth::UPDATE, resource)
+          authorized?(ActiveAdmin::Auth::EDIT, resource)
           url_for config.route_edit_instance_path resource, url_options
         end
       end

--- a/lib/active_admin/views/index_as_table.rb
+++ b/lib/active_admin/views/index_as_table.rb
@@ -377,7 +377,7 @@ module ActiveAdmin
           if controller.action_methods.include?("show") && authorized?(ActiveAdmin::Auth::READ, resource)
             item localizer.t(:view), resource_path(resource), class: "view_link #{options[:css_class]}", title: localizer.t(:view)
           end
-          if controller.action_methods.include?("edit") && authorized?(ActiveAdmin::Auth::UPDATE, resource)
+          if controller.action_methods.include?("edit") && authorized?(ActiveAdmin::Auth::EDIT, resource)
             item localizer.t(:edit), edit_resource_path(resource), class: "edit_link #{options[:css_class]}", title: localizer.t(:edit)
           end
           if controller.action_methods.include?("destroy") && authorized?(ActiveAdmin::Auth::DESTROY, resource)

--- a/lib/active_admin/views/pages/index.rb
+++ b/lib/active_admin/views/pages/index.rb
@@ -112,7 +112,7 @@ module ActiveAdmin
 
         def render_blank_slate
           blank_slate_content = I18n.t("active_admin.blank_slate.content", resource_name: active_admin_config.plural_resource_label)
-          if controller.action_methods.include?("new") && authorized?(ActiveAdmin::Auth::CREATE, active_admin_config.resource_class)
+          if controller.action_methods.include?("new") && authorized?(ActiveAdmin::Auth::NEW, active_admin_config.resource_class)
             blank_slate_content = [blank_slate_content, blank_slate_link].compact.join(" ")
           end
           insert_tag(view_factory.blank_slate, blank_slate_content)

--- a/spec/support/templates/policies/post_policy.rb
+++ b/spec/support/templates/policies/post_policy.rb
@@ -5,7 +5,7 @@ class PostPolicy < ApplicationPolicy
   end
 
   def create?
-    record.category.name != "Announcements" || user.is_a?(User::VIP)
+    record.category.nil? || record.category.name != "Announcements" || user.is_a?(User::VIP)
   end
 
   def update?

--- a/spec/support/templates/policies/post_policy.rb
+++ b/spec/support/templates/policies/post_policy.rb
@@ -1,5 +1,13 @@
 # frozen_string_literal: true
 class PostPolicy < ApplicationPolicy
+  def new?
+    true
+  end
+
+  def create?
+    record.category.name != "Announcements" || user.admin
+  end
+
   def update?
     record.author == user
   end

--- a/spec/support/templates/policies/post_policy.rb
+++ b/spec/support/templates/policies/post_policy.rb
@@ -5,7 +5,7 @@ class PostPolicy < ApplicationPolicy
   end
 
   def create?
-    record.category.name != "Announcements" || user.admin
+    record.category.name != "Announcements" || user.is_a?(User::VIP)
   end
 
   def update?

--- a/spec/unit/authorization/controller_authorization_spec.rb
+++ b/spec/unit/authorization/controller_authorization_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Controller Authorization", type: :controller do
   end
 
   it "should authorize the new action" do
-    expect(authorization).to receive(:authorized?).with(auth::CREATE, an_instance_of(Post)).and_return true
+    expect(authorization).to receive(:authorized?).with(auth::NEW, an_instance_of(Post)).and_return true
     get :new
     expect(response).to be_successful
   end

--- a/spec/unit/cancan_adapter_spec.rb
+++ b/spec/unit/cancan_adapter_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe ActiveAdmin::CanCanAdapter do
 
         def initialize(user)
           can :read, Post
+          can :create, Post
           cannot :update, Post
         end
       end
@@ -28,6 +29,11 @@ RSpec.describe ActiveAdmin::CanCanAdapter do
     it "should initialize the ability stored in the namespace configuration" do
       expect(auth.authorized?(:read, Post)).to eq true
       expect(auth.authorized?(:update, Post)).to eq false
+    end
+
+    it "should treat :new ability the same as :create" do
+      expect(auth.authorized?(:new, Post)).to eq true
+      expect(auth.authorized?(:create, Post)).to eq true
     end
 
     it "should scope the collection with accessible_by" do

--- a/spec/unit/pundit_adapter_spec.rb
+++ b/spec/unit/pundit_adapter_spec.rb
@@ -30,7 +30,8 @@ RSpec.describe ActiveAdmin::PunditAdapter do
     let(:application) { ActiveAdmin::Application.new }
     let(:namespace) { ActiveAdmin::Namespace.new(application, "Admin") }
     let(:resource) { namespace.register(Post) }
-    let(:auth) { namespace.authorization_adapter.new(resource, double) }
+    let(:user) { User.new }
+    let(:auth) { namespace.authorization_adapter.new(resource, user) }
     let(:default_policy_klass) { DefaultPolicy }
     let(:default_policy_klass_name) { "DefaultPolicy" }
 
@@ -45,10 +46,12 @@ RSpec.describe ActiveAdmin::PunditAdapter do
 
     it "should allow differentiating between new and create" do
       expect(auth.authorized?(:new, Post)).to eq true
+      expect(auth.authorized?(ActiveAdmin::Auth::NEW, Post)).to eq true
 
-      announcement_category = Category.create! name: "Announcements"
-      announcement_post = Post.create! title: "Big announcement", category: announcement_category
+      announcement_category = Category.new(name: "Announcements")
+      announcement_post = Post.new(title: "Big announcement", category: announcement_category)
       expect(auth.authorized?(:create, announcement_post)).to eq false
+      expect(auth.authorized?(ActiveAdmin::Auth::CREATE, announcement_post)).to eq false
     end
 
     it "should scope the collection" do

--- a/spec/unit/pundit_adapter_spec.rb
+++ b/spec/unit/pundit_adapter_spec.rb
@@ -43,6 +43,14 @@ RSpec.describe ActiveAdmin::PunditAdapter do
       expect(auth.authorized?(:update, Post)).to eq false
     end
 
+    it "should allow differentiating between new and create" do
+      expect(auth.authorized?(:new, Post)).to eq true
+
+      announcement_category = Category.create! name: "Announcements"
+      announcement_post = Post.create! title: "Big announcement", category: announcement_category
+      expect(auth.authorized?(:create, announcement_post)).to eq false
+    end
+
     it "should scope the collection" do
       class RSpec::Mocks::DoublePolicy < ApplicationPolicy
         class Scope < Struct.new(:user, :scope)


### PR DESCRIPTION
<!--

Thanks for contributing to ActiveAdmin!

You can find all the instructions for contributing at the [CONTRIBUTING file].

Before submitting your PR make sure that:

* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are splitted apart.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all github checks are passing, but feel free to ask for early feedback if you need guidance.

[CONTRIBUTING file]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->
This pull request allows authorisation adapters to specify different logic for `:new` vs `:create` and `:edit` vs `:update`, for the use cases described in #6529, #3802, and #3405, for example:

```ruby
class PostPolicy < ApplicationPolicy
  def new?
    true
  end

  def create?
    record.category.name != "Announcements" || user.admin
  end
end
```

It does so in a (hopefully) backwards-compatible way: prior to this PR, ActiveAdmin checked whether the user was authorised for `Auth::CREATE` before showing the "New Post" button. Now, ActiveAdmin checks whether the user is authorised for `Auth::NEW`. By default, though, `Auth::NEW` maps to the `:create` symbol, just like `Auth::CREATE` does, so any custom authorisation adapters using the `:create` symbol should continue to work fine (as the tests do).

The _Pundit_ adapter, however, _does_ make this differentiation, since pundit specifically lets you specifiy different logic for `new?` vs `create?` (and edit/update). I believe this will be backwards compatible anyway, though, since the [default application policy generated by `pundit:install`](https://github.com/varvet/pundit/blob/master/lib/generators/pundit/install/templates/application_policy.rb) has `new?` simply calling `create?` anyway. Likewise, [ActiveAdmin recommends an application policy](https://activeadmin.info/13-authorization-adapter.html#using-the-pundit-adapter) that does the same.

Therefore the only users for whom this would be breaking are those who use pundit but do not have `new?` or `edit?` methods defined in their policies nor their `ApplicationPolicy`, despite them being defined by default (they will have had to remove them or not use the default `ApplicationPolicy`).

Posting as draft to get feedback. I've still got to get the test to work. I'm under the impression this will be backwards compatible, particularly given that recommended pundit policies have `new?` calling `create?` anyway, but would love to hear if there's any chance this won't be.

Closes #6529