### PR TITLE
Pick up upstream fixes in devise templates

### DIFF
--- a/app/views/active_admin/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/active_admin/devise/mailer/reset_password_instructions.html.erb
@@ -2,7 +2,7 @@
 
 <p>Someone has requested a link to change your password, and you can do this through the link below.</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @resource.reset_password_token) %></p>
+<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
 
 <p>If you didn't request this, please ignore this email.</p>
 <p>Your password won't change until you access the link above and create a new one.</p>

--- a/app/views/active_admin/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/active_admin/devise/mailer/unlock_instructions.html.erb
@@ -1,7 +1,7 @@
 <p>Hello <%= @resource.email %>!</p>
 
-<p>Your account has been locked due to an excessive amount of unsuccessful sign in attempts.</p>
+<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
 
 <p>Click the link below to unlock your account:</p>
 
-<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @resource.unlock_token) %></p>
+<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token) %></p>


### PR DESCRIPTION
Without this fix, the URL to unlock will yield "Unlock token is invalid".

Updated according to the devise upstream view: https://github.com/heartcombo/devise/blob/715192a7709a4c02127afb067e66230061b82cf2/app/views/devise/mailer/unlock_instructions.html.erb
