### PR TITLE
Append DSL for print footer in index_as_table.

### DIFF
--- a/features/index/index_as_table.feature
+++ b/features/index/index_as_table.feature
@@ -289,3 +289,24 @@ Feature: Index as Table
       | Id | Title        | Title Length |
       | 1 | Hello World   | 11 |
       | 2 | Bye bye world | 13 |
+
+  Scenario: Show footer row
+    Given a post with the title "Hello World" exists
+    And a post with the title "Bye bye world" exists
+    And an index configuration of:
+      """
+        ActiveAdmin.register Post do
+
+          index has_footer: true do
+            column :id, footer: 'Total:'
+            column :category, footer: ->(collection) { collection.pluck(:id).sum }
+            column :title, footer: :count
+          end
+        end
+      """
+    When I am on the index page for posts
+    Then I should see the "index_table_posts" table:
+      | Id     | Category | Title         |
+      | 2      |          | Bye bye world |
+      | 1      |          | Hello World   |
+      | Total: | 3        | 2             |

--- a/lib/active_admin/views/components/table_for.rb
+++ b/lib/active_admin/views/components/table_for.rb
@@ -10,6 +10,7 @@ module ActiveAdmin
       def build(obj, *attrs)
         options = attrs.extract_options!
         @sortable = options.delete(:sortable)
+        @has_footer = options.delete(:has_footer)
         @collection = obj.respond_to?(:each) && !obj.is_a?(Hash) ? obj : [obj]
         @resource_class = options.delete(:i18n)
         @resource_class ||= @collection.klass if @collection.respond_to? :klass
@@ -39,6 +40,11 @@ module ActiveAdmin
           build_table_header(col)
         end
 
+        # Build our footer item
+        within @footer_row do
+          build_table_footer(col)
+        end if @has_footer
+
         # Add a table cell for each item
         @collection.each_with_index do |resource, index|
           within @tbody.children[index] do
@@ -56,12 +62,26 @@ module ActiveAdmin
       def build_table
         build_table_head
         build_table_body
+        build_table_foot if @has_footer
+      end
+
+      def build_table_foot
+        @tfoot = tfoot do
+          @footer_row = tr
+        end
       end
 
       def build_table_head
         @thead = thead do
           @header_row = tr
         end
+      end
+
+      def build_table_footer(col)
+        th class: col.html_class do
+          col.footer_proc(@collection)
+        end
+
       end
 
       def build_table_header(col)
@@ -163,6 +183,22 @@ module ActiveAdmin
             @resource_class.column_names.include?(sort_column_name)
           else
             @title.present?
+          end
+        end
+
+        def footer_proc(collection)
+          if (footer = @options[:footer])
+            case footer
+            when Symbol
+              # For example: collection.send(:sum, :amount)
+              collection.send(footer, self.data)
+            when Proc
+              # Use Proc for calculating
+              instance_exec(collection, &@options[:footer])
+            else
+              # String or number will be print out as is
+              footer.to_s
+            end
           end
         end
 

--- a/lib/active_admin/views/index_as_table.rb
+++ b/lib/active_admin/views/index_as_table.rb
@@ -241,7 +241,8 @@ module ActiveAdmin
           class: "index_table index",
           i18n: active_admin_config.resource_class,
           paginator: page_presenter[:paginator] != false,
-          row_class: page_presenter[:row_class]
+          row_class: page_presenter[:row_class],
+          has_footer: page_presenter[:has_footer]
         }
 
         table_for collection, table_options do |t|

--- a/spec/support/templates_with_data/admin/tags.rb
+++ b/spec/support/templates_with_data/admin/tags.rb
@@ -3,11 +3,11 @@ ActiveAdmin.register Tag do
 
   permit_params :name
 
-  index do
+  index has_footer: true do
     selectable_column
     id_column
-    column :name
-    column :created_at
+    column :name, footer: "Total:"
+    column :created_at, footer: :count
     actions dropdown: true do |tag|
       item "Preview", admin_tag_path(tag)
     end


### PR DESCRIPTION
This PR addressed to https://github.com/activeadmin/activeadmin/issues/3797
I use https://gist.github.com/Fivell/d45653841cee22a890f5 as start point, but made some refactor.

New DSL can be used as:

```ruby
index has_footer: true do
  column :title,         footer: 'Total:'
  column :simple_amount, footer: :sum
  column :complex_total, footer: ->(collection) do
    collection.pluck(:amount).sum
  end                       
end
```
