### PR TITLE
Sprockets 4.0.2 was released

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ group :development, :test do
   gem "activerecord-jdbcsqlite3-adapter", "~> 60.0", platform: :jruby
 
   gem "sprockets-rails"
-  gem "sprockets", github: "rails/sprockets", ref: "2d6b1a8bde0cf870c14a2d193fa9a9be09ef99fc"
 
   gem "formtastic", "~> 4.0.rc1"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: https://github.com/rails/sprockets.git
-  revision: 2d6b1a8bde0cf870c14a2d193fa9a9be09ef99fc
-  ref: 2d6b1a8bde0cf870c14a2d193fa9a9be09ef99fc
-  specs:
-    sprockets (4.0.0)
-      concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
-
 PATH
   remote: .
   specs:
@@ -416,6 +407,9 @@ GEM
     simplecov-html (0.12.3)
     spoon (0.0.6)
       ffi
+    sprockets (4.0.2)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
     sprockets-rails (3.2.2)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
@@ -485,7 +479,6 @@ DEPENDENCIES
   rubocop-rails (~> 2.3)
   rubocop-rspec (~> 1.30)
   simplecov (= 0.19.1)
-  sprockets!
   sprockets-rails
   sqlite3 (~> 1.4)
   yard

--- a/gemfiles/rails_52/Gemfile
+++ b/gemfiles/rails_52/Gemfile
@@ -16,7 +16,6 @@ group :development, :test do
   gem "activerecord-jdbcsqlite3-adapter", "~> 52.0", platform: :jruby
 
   gem "sprockets-rails"
-  gem "sprockets", github: "rails/sprockets", ref: "2d6b1a8bde0cf870c14a2d193fa9a9be09ef99fc"
 
   gem "formtastic", "~> 4.0.rc1"
 end

--- a/gemfiles/rails_52/Gemfile.lock
+++ b/gemfiles/rails_52/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: https://github.com/rails/sprockets.git
-  revision: 2d6b1a8bde0cf870c14a2d193fa9a9be09ef99fc
-  ref: 2d6b1a8bde0cf870c14a2d193fa9a9be09ef99fc
-  specs:
-    sprockets (4.0.0)
-      concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
-
 PATH
   remote: ../..
   specs:
@@ -330,6 +321,9 @@ GEM
     simplecov-html (0.12.3)
     spoon (0.0.6)
       ffi
+    sprockets (4.0.2)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
     sprockets-rails (3.2.2)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
@@ -383,7 +377,6 @@ DEPENDENCIES
   rake
   rspec-rails
   simplecov (= 0.19.1)
-  sprockets!
   sprockets-rails
   sqlite3 (~> 1.4)
 

--- a/gemfiles/rails_60_turbolinks/Gemfile
+++ b/gemfiles/rails_60_turbolinks/Gemfile
@@ -16,7 +16,6 @@ group :development, :test do
   gem "activerecord-jdbcsqlite3-adapter", "~> 60.0", platform: :jruby
 
   gem "sprockets-rails"
-  gem "sprockets", github: "rails/sprockets", ref: "2d6b1a8bde0cf870c14a2d193fa9a9be09ef99fc"
 
   gem "turbolinks", "~> 5.2"
 

--- a/gemfiles/rails_60_turbolinks/Gemfile.lock
+++ b/gemfiles/rails_60_turbolinks/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: https://github.com/rails/sprockets.git
-  revision: 2d6b1a8bde0cf870c14a2d193fa9a9be09ef99fc
-  ref: 2d6b1a8bde0cf870c14a2d193fa9a9be09ef99fc
-  specs:
-    sprockets (4.0.0)
-      concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
-
 PATH
   remote: ../..
   specs:
@@ -345,6 +336,9 @@ GEM
     simplecov-html (0.12.3)
     spoon (0.0.6)
       ffi
+    sprockets (4.0.2)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
     sprockets-rails (3.2.2)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
@@ -402,7 +396,6 @@ DEPENDENCIES
   rake
   rspec-rails
   simplecov (= 0.19.1)
-  sprockets!
   sprockets-rails
   sqlite3 (~> 1.4)
   turbolinks (~> 5.2)

--- a/gemfiles/rails_60_webpacker/Gemfile
+++ b/gemfiles/rails_60_webpacker/Gemfile
@@ -16,7 +16,6 @@ group :development, :test do
   gem "activerecord-jdbcsqlite3-adapter", "~> 60.0", platform: :jruby
 
   gem "sprockets-rails"
-  gem "sprockets", github: "rails/sprockets", ref: "2d6b1a8bde0cf870c14a2d193fa9a9be09ef99fc"
 
   gem "webpacker", "~> 5.1"
 

--- a/gemfiles/rails_60_webpacker/Gemfile.lock
+++ b/gemfiles/rails_60_webpacker/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: https://github.com/rails/sprockets.git
-  revision: 2d6b1a8bde0cf870c14a2d193fa9a9be09ef99fc
-  ref: 2d6b1a8bde0cf870c14a2d193fa9a9be09ef99fc
-  specs:
-    sprockets (4.0.0)
-      concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
-
 PATH
   remote: ../..
   specs:
@@ -348,6 +339,9 @@ GEM
     simplecov-html (0.12.3)
     spoon (0.0.6)
       ffi
+    sprockets (4.0.2)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
     sprockets-rails (3.2.2)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
@@ -407,7 +401,6 @@ DEPENDENCIES
   rake
   rspec-rails
   simplecov (= 0.19.1)
-  sprockets!
   sprockets-rails
   sqlite3 (~> 1.4)
   webpacker (~> 5.1)


### PR DESCRIPTION
We can lock to the final release now.

The reason we were testing using a (previously unreleased) ref is that it included fixes the keyword parameter warnings.