### PR TITLE
Stop persisting test app between jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ version: 2.1
 .create_test_app: &create_test_app
   run:
     name: Create test app
-    command: COVERAGE=true PARALLEL_TEST_PROCESSORS=4 bin/rake setup
+    command: COVERAGE=true bin/rake setup
 
 .restore_test_reporter: &restore_test_reporter
   attach_workspace:
@@ -83,14 +83,14 @@ version: 2.1
   run:
     name: Run RSpec tests
     command: |
-      COVERAGE=true PARALLEL_TEST_PROCESSORS=4 PARALLEL_TEST_HEARTBEAT_INTERVAL=3600 bin/parallel_rspec spec/
+      COVERAGE=true PARALLEL_TEST_HEARTBEAT_INTERVAL=3600 bin/parallel_rspec spec/
       COVERAGE=true RSPEC_FILESYSTEM_CHANGES=true bin/rspec
 
 .run_features: &run_features
   run:
     name: Run Cucumber features
     command: |
-      COVERAGE=true PARALLEL_TEST_PROCESSORS=4 PARALLEL_TEST_HEARTBEAT_INTERVAL=3600 bin/parallel_cucumber features/
+      COVERAGE=true PARALLEL_TEST_HEARTBEAT_INTERVAL=3600 bin/parallel_cucumber features/
       COVERAGE=true bin/cucumber --profile sequential
       COVERAGE=true bin/cucumber --profile class-reloading
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,16 +73,6 @@ version: 2.1
       bin/test-reporter sum-coverage coverage/codeclimate.*.json
       bin/test-reporter upload-coverage
 
-.save_test_app: &save_test_app
-  persist_to_workspace:
-    root: tmp/test_apps
-    paths:
-      - rails_*
-
-.restore_test_app_from_workspace: &restore_test_app_from_workspace
-  attach_workspace:
-    at: tmp/test_apps
-
 .restore_test_times: &restore_test_times
   restore_cache:
     keys:
@@ -135,7 +125,7 @@ version: 2.1
   - *restore_gems
   - *install_dependencies
   - *save_gems
-  - *restore_test_app_from_workspace
+  - *create_test_app
   - *restore_test_times
   - *restore_test_reporter
   - *run_tests
@@ -143,20 +133,6 @@ version: 2.1
   - *format_coverage
   - *save_coverage
   - *save_test_times
-
-.test_app_steps: &test_app_steps
-  - checkout
-  - *install_rubygems
-  - *install_bundler
-  - *copy_current_gemfile
-  - *restore_gems
-  - *install_dependencies
-  - *restore_test_reporter
-  - *save_gems
-  - *create_test_app
-  - *format_coverage
-  - *save_coverage
-  - *save_test_app
 
 jobs:
   setup_coverage:
@@ -186,50 +162,6 @@ jobs:
       - *restore_test_reporter
       - *restore_coverage
       - *submit_coverage
-
-  testapp52:
-    docker:
-      - image: circleci/ruby:2.7.1-node
-        user: root
-
-    environment:
-      BUNDLE_GEMFILE: gemfiles/rails_52/Gemfile
-
-    steps:
-      *test_app_steps
-
-  testapp60:
-    docker:
-      - image: circleci/ruby:2.7.1-node
-        user: root
-
-    environment:
-      BUNDLE_GEMFILE: Gemfile
-
-    steps:
-      *test_app_steps
-
-  testapp60turbolinks:
-    docker:
-      - image: circleci/ruby:2.7.1-node
-        user: root
-
-    environment:
-      BUNDLE_GEMFILE: gemfiles/rails_60_turbolinks/Gemfile
-
-    steps:
-      *test_app_steps
-
-  testapp60webpacker:
-    docker:
-      - image: circleci/ruby:2.7.1-node
-        user: root
-
-    environment:
-      BUNDLE_GEMFILE: gemfiles/rails_60_webpacker/Gemfile
-
-    steps:
-      *test_app_steps
 
   lint_and_docs:
     docker:
@@ -408,78 +340,57 @@ workflows:
           requires:
             - setup_coverage
 
-      - testapp52:
-          requires:
-            - setup_coverage
-
-      - testapp60:
-          requires:
-            - setup_coverage
-
-      - testapp60turbolinks:
-          requires:
-            - setup_coverage
-
-      - testapp60webpacker:
-          requires:
-            - setup_coverage
-
       - ruby25rails52:
           requires:
-            - testapp52
+            - setup_coverage
 
       - ruby25rails60:
           requires:
-            - testapp60
+            - setup_coverage
 
       - ruby26rails52:
           requires:
-            - testapp52
+            - setup_coverage
 
       - ruby26rails60:
           requires:
-            - testapp60
+            - setup_coverage
 
       - ruby26rails60turbolinks:
           requires:
-            - testapp60turbolinks
+            - setup_coverage
 
       - ruby26rails60webpacker:
           requires:
-            - testapp60webpacker
+            - setup_coverage
 
       - ruby27rails52:
           requires:
-            - testapp52
+            - setup_coverage
 
       - ruby27rails60:
           requires:
-            - testapp60
+            - setup_coverage
 
       - ruby27rails60turbolinks:
           requires:
-            - testapp60turbolinks
+            - setup_coverage
 
       - ruby27rails60webpacker:
           requires:
-            - testapp60webpacker
+            - setup_coverage
 
       - jruby92rails52:
           requires:
-            - testapp52
+            - setup_coverage
 
       - jruby92rails60:
           requires:
-            - testapp60
+            - setup_coverage
 
       - upload_coverage:
           requires:
             - lint_and_docs
-
-            - testapp52
-            - testapp60
-            - testapp60turbolinks
-            - testapp60webpacker
 
             - ruby25rails52
             - ruby25rails60

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -12,43 +12,40 @@ end
 
 create_file "app/assets/images/a/favicon.ico"
 
-require "active_admin/dependency"
+initial_timestamp = Time.now.strftime("%Y%M%d%H%M%S").to_i
 
-timestamps = ActiveAdmin::Dependency.rails?(">= 6.1.0.a") ? "--timestamps" : "created_at:datetime updated_at:datetime"
-
-generate :migration, "create_posts title:string body:text published_date:date author_id:integer " +
-  "position:integer custom_category_id:integer starred:boolean foo_id:integer #{timestamps}"
+template File.expand_path("templates/migrations/create_posts.tt", __dir__), "db/migrate/#{initial_timestamp}_create_posts.rb"
 
 copy_file File.expand_path("templates/models/post.rb", __dir__), "app/models/post.rb"
 copy_file File.expand_path("templates/post_decorator.rb", __dir__), "app/models/post_decorator.rb"
 copy_file File.expand_path("templates/post_poro_decorator.rb", __dir__), "app/models/post_poro_decorator.rb"
 
-generate :migration, "create_blog_posts title:string body:text published_date:date author_id:integer " +
-  "position:integer custom_category_id:integer starred:boolean foo_id:integer #{timestamps}"
+template File.expand_path("templates/migrations/create_blog_posts.tt", __dir__), "db/migrate/#{initial_timestamp + 1}_create_blog_posts.rb"
 
 copy_file File.expand_path("templates/models/blog/post.rb", __dir__), "app/models/blog/post.rb"
 
-generate :migration, "create_profiles user_id:integer bio:text #{timestamps}"
+template File.expand_path("templates/migrations/create_profiles.tt", __dir__), "db/migrate/#{initial_timestamp + 2}_create_profiles.rb"
 
 copy_file File.expand_path("templates/models/user.rb", __dir__), "app/models/user.rb"
 
-generate :migration, "create_users type:string first_name:string last_name:string username:string age:integer encrypted_password:string reason_of_sign_in:string #{timestamps}"
+template File.expand_path("templates/migrations/create_users.tt", __dir__), "db/migrate/#{initial_timestamp + 3}_create_users.rb"
 
 copy_file File.expand_path("templates/models/profile.rb", __dir__), "app/models/profile.rb"
 
-generate :model, "publisher --migration=false --parent=User"
+copy_file File.expand_path("templates/models/publisher.rb", __dir__), "app/models/publisher.rb"
 
-generate :migration, "create_categories name:string description:text #{timestamps}"
+template File.expand_path("templates/migrations/create_categories.tt", __dir__), "db/migrate/#{initial_timestamp + 4}_create_categories.rb"
 
 copy_file File.expand_path("templates/models/category.rb", __dir__), "app/models/category.rb"
 
-generate :model, "store name:string user_id:integer"
+copy_file File.expand_path("templates/models/store.rb", __dir__), "app/models/store.rb"
+template File.expand_path("templates/migrations/create_stores.tt", __dir__), "db/migrate/#{initial_timestamp + 5}_create_stores.rb"
 
-generate :migration, "create_tags name:string #{timestamps}"
+template File.expand_path("templates/migrations/create_tags.tt", __dir__), "db/migrate/#{initial_timestamp + 6}_create_tags.rb"
 
 copy_file File.expand_path("templates/models/tag.rb", __dir__), "app/models/tag.rb"
 
-generate :migration, "create_taggings post_id:integer tag_id:integer position:integer #{timestamps}"
+template File.expand_path("templates/migrations/create_taggings.tt", __dir__), "db/migrate/#{initial_timestamp + 7}_create_taggings.rb"
 
 copy_file File.expand_path("templates/models/tagging.rb", __dir__), "app/models/tagging.rb"
 

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -100,7 +100,10 @@ rails_command "db:drop db:create db:migrate", env: ENV["RAILS_ENV"]
 if ENV["RAILS_ENV"] == "test"
   inject_into_file "config/database.yml", "<%= ENV['TEST_ENV_NUMBER'] %>", after: "test.sqlite3"
 
-  rails_command "parallel:drop parallel:create parallel:load_schema", env: ENV["RAILS_ENV"]
+  require "parallel_tests"
+  ParallelTests.determine_number_of_processes(nil).times do |n|
+    copy_file File.expand_path("db/test.sqlite3", destination_root), "db/test.sqlite3#{n + 1}"
+  end
 end
 
 git add: "."

--- a/spec/support/templates/migrations/create_blog_posts.tt
+++ b/spec/support/templates/migrations/create_blog_posts.tt
@@ -1,0 +1,16 @@
+class CreateBlogPosts < ActiveRecord::Migration[<%= Rails::VERSION::MAJOR %>.<%= Rails::VERSION::MINOR %>]
+  def change
+    create_table :blog_posts do |t|
+      t.string :title
+      t.text :body
+      t.date :published_date
+      t.integer :author_id
+      t.integer :position
+      t.integer :custom_category_id
+      t.boolean :starred
+      t.integer :foo_id
+      t.datetime :created_at
+      t.datetime :updated_at
+    end
+  end
+end

--- a/spec/support/templates/migrations/create_categories.tt
+++ b/spec/support/templates/migrations/create_categories.tt
@@ -1,0 +1,10 @@
+class CreateCategories < ActiveRecord::Migration[<%= Rails::VERSION::MAJOR %>.<%= Rails::VERSION::MINOR %>]
+  def change
+    create_table :categories do |t|
+      t.string :name
+      t.text :description
+      t.datetime :created_at
+      t.datetime :updated_at
+    end
+  end
+end

--- a/spec/support/templates/migrations/create_posts.tt
+++ b/spec/support/templates/migrations/create_posts.tt
@@ -1,0 +1,16 @@
+class CreatePosts < ActiveRecord::Migration[<%= Rails::VERSION::MAJOR %>.<%= Rails::VERSION::MINOR %>]
+  def change
+    create_table :posts do |t|
+      t.string :title
+      t.text :body
+      t.date :published_date
+      t.integer :author_id
+      t.integer :position
+      t.integer :custom_category_id
+      t.boolean :starred
+      t.integer :foo_id
+      t.datetime :created_at
+      t.datetime :updated_at
+    end
+  end
+end

--- a/spec/support/templates/migrations/create_profiles.tt
+++ b/spec/support/templates/migrations/create_profiles.tt
@@ -1,0 +1,10 @@
+class CreateProfiles < ActiveRecord::Migration[<%= Rails::VERSION::MAJOR %>.<%= Rails::VERSION::MINOR %>]
+  def change
+    create_table :profiles do |t|
+      t.integer :user_id
+      t.text :bio
+      t.datetime :created_at
+      t.datetime :updated_at
+    end
+  end
+end

--- a/spec/support/templates/migrations/create_stores.tt
+++ b/spec/support/templates/migrations/create_stores.tt
@@ -1,0 +1,10 @@
+class CreateStores < ActiveRecord::Migration[<%= Rails::VERSION::MAJOR %>.<%= Rails::VERSION::MINOR %>]
+  def change
+    create_table :stores do |t|
+      t.string :name
+      t.integer :user_id
+      t.datetime :created_at
+      t.datetime :updated_at
+    end
+  end
+end

--- a/spec/support/templates/migrations/create_taggings.tt
+++ b/spec/support/templates/migrations/create_taggings.tt
@@ -1,0 +1,11 @@
+class CreateTaggings < ActiveRecord::Migration[<%= Rails::VERSION::MAJOR %>.<%= Rails::VERSION::MINOR %>]
+  def change
+    create_table :taggings do |t|
+      t.integer :post_id
+      t.integer :tag_id
+      t.integer :position
+      t.datetime :created_at
+      t.datetime :updated_at
+    end
+  end
+end

--- a/spec/support/templates/migrations/create_tags.tt
+++ b/spec/support/templates/migrations/create_tags.tt
@@ -1,0 +1,9 @@
+class CreateTags < ActiveRecord::Migration[<%= Rails::VERSION::MAJOR %>.<%= Rails::VERSION::MINOR %>]
+  def change
+    create_table :tags do |t|
+      t.string :name
+      t.datetime :created_at
+      t.datetime :updated_at
+    end
+  end
+end

--- a/spec/support/templates/migrations/create_users.tt
+++ b/spec/support/templates/migrations/create_users.tt
@@ -1,0 +1,15 @@
+class CreateUsers < ActiveRecord::Migration[<%= Rails::VERSION::MAJOR %>.<%= Rails::VERSION::MINOR %>]
+  def change
+    create_table :users do |t|
+      t.string :type
+      t.string :first_name
+      t.string :last_name
+      t.string :username
+      t.integer :age
+      t.string :encrypted_password
+      t.string :reason_of_sign_in
+      t.datetime :created_at
+      t.datetime :updated_at
+    end
+  end
+end

--- a/spec/support/templates/models/publisher.rb
+++ b/spec/support/templates/models/publisher.rb
@@ -1,0 +1,2 @@
+class Publisher < User
+end

--- a/spec/support/templates/models/store.rb
+++ b/spec/support/templates/models/store.rb
@@ -1,0 +1,2 @@
+class Store < ApplicationRecord
+end


### PR DESCRIPTION
In Github Actions, persisting data between jobs isn't as easy/efficient as it is on CircleCI. The main reason we did this was because generating a test application was very slow under jruby, so by generating it only once per Rails version on a "fast ruby", we can skip that.

In this PR I'm speeding up test application generation under jruby. With this speed up, I think we can generate the test application for every matrix combination.

This should make migrating to Github Actions more straightforward.

This has the extra advantage of potentially detecting issues with generating the test app under jruby, which is something we didn't test before, and could potentially help a contributor working under jruby.