### PR TITLE
Try to fix stuck codeclimate coverage checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -181,16 +181,8 @@ jobs:
       - lint
       - test
 
-    env:
-      CC_TEST_REPORTER_ID: 8d5fcf7abea6d56c625104a9d1a81140a588a7f546f4fa9de9bc6ffc8feaaf70
-
     steps:
       - uses: actions/checkout@v2
-
-      - name: Download Code Climate test-reporter
-        run: |
-          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-0.8.0-linux-amd64 > bin/test-reporter
-          chmod +x bin/test-reporter
 
       - name: Download partial coverages
         uses: actions/download-artifact@v2
@@ -198,8 +190,10 @@ jobs:
           name: coverage
           path: coverage
 
-      - name: Upload coverage results to Code Climate
-        run: |
-          bin/format_coverage
-          bin/test-reporter --debug sum-coverage coverage/codeclimate.*.json
-          bin/test-reporter --debug upload-coverage
+      - name: Format, sum & upload results to Code Climate
+        uses: paambaati/codeclimate-action@v2.7.4
+        env:
+          CC_TEST_REPORTER_ID: 8d5fcf7abea6d56c625104a9d1a81140a588a7f546f4fa9de9bc6ffc8feaaf70
+        with:
+          debug: true
+          coverageLocations: coverage/raw.*.json:simplecov

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Format coverage
         run: |
           bin/prepare_coverage
-          bin/test-reporter format-coverage --output coverage/codeclimate.lint.json
+          bin/test-reporter --debug format-coverage --output coverage/codeclimate.lint.json
 
       - name: Save partial coverage as an artifact
         uses: actions/upload-artifact@v2
@@ -176,7 +176,7 @@ jobs:
       - name: Format coverage
         run: |
           bin/prepare_coverage
-          bin/test-reporter format-coverage --output coverage/codeclimate.${{ matrix.ruby }}.${{ matrix.deps }}.json
+          bin/test-reporter --debug format-coverage --output coverage/codeclimate.${{ matrix.ruby }}.${{ matrix.deps }}.json
 
       - name: Save partial coverage as an artifact
         uses: actions/upload-artifact@v2
@@ -209,5 +209,5 @@ jobs:
 
       - name: Upload coverage results to Code Climate
         run: |
-          bin/test-reporter sum-coverage coverage/codeclimate.*.json
-          bin/test-reporter upload-coverage
+          bin/test-reporter --debug sum-coverage coverage/codeclimate.*.json
+          bin/test-reporter --debug upload-coverage

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,11 +21,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Download Code Climate test-reporter
-        run: |
-          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-0.8.0-linux-amd64 > bin/test-reporter
-          chmod +x bin/test-reporter
-
       - name: Configure bundler
         run: |
           echo "BUNDLE_GEMFILE=Gemfile" >> $GITHUB_ENV
@@ -68,13 +63,13 @@ jobs:
       - name: Format coverage
         run: |
           bin/prepare_coverage
-          bin/test-reporter --debug format-coverage --output coverage/codeclimate.lint.json
+          mv coverage/.resultset.json coverage/raw.lint.json
 
       - name: Save partial coverage as an artifact
         uses: actions/upload-artifact@v2
         with:
           name: coverage
-          path: coverage/codeclimate.lint.json
+          path: coverage/raw.lint.json
 
   test:
     runs-on: ubuntu-20.04
@@ -101,11 +96,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
-      - name: Download Code Climate test-reporter
-        run: |
-          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-0.8.0-linux-amd64 > bin/test-reporter
-          chmod +x bin/test-reporter
 
       - name: Configure bundler (default)
         run: |
@@ -176,13 +166,13 @@ jobs:
       - name: Format coverage
         run: |
           bin/prepare_coverage
-          bin/test-reporter --debug format-coverage --output coverage/codeclimate.${{ matrix.ruby }}.${{ matrix.deps }}.json
+          mv coverage/.resultset.json coverage/raw.${{ matrix.ruby }}.${{ matrix.deps }}.json
 
       - name: Save partial coverage as an artifact
         uses: actions/upload-artifact@v2
         with:
           name: coverage
-          path: coverage/codeclimate.${{ matrix.ruby }}.${{ matrix.deps }}.json
+          path: coverage/raw.${{ matrix.ruby }}.${{ matrix.deps }}.json
 
   upload_coverage:
     runs-on: ubuntu-20.04
@@ -195,9 +185,10 @@ jobs:
       CC_TEST_REPORTER_ID: 8d5fcf7abea6d56c625104a9d1a81140a588a7f546f4fa9de9bc6ffc8feaaf70
 
     steps:
+      - uses: actions/checkout@v2
+
       - name: Download Code Climate test-reporter
         run: |
-          mkdir bin
           curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-0.8.0-linux-amd64 > bin/test-reporter
           chmod +x bin/test-reporter
 
@@ -209,5 +200,6 @@ jobs:
 
       - name: Upload coverage results to Code Climate
         run: |
+          bin/format_coverage
           bin/test-reporter --debug sum-coverage coverage/codeclimate.*.json
           bin/test-reporter --debug upload-coverage

--- a/bin/format_coverage
+++ b/bin/format_coverage
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+Dir.glob("coverage/raw.*.json").each do |part|
+  output = part.gsub(/raw/, "codeclimate")
+
+  abort unless system("bin/test-reporter", "--debug", "--format-coverage", part, "-t", "simplecov", "--output", output)
+end

--- a/bin/format_coverage
+++ b/bin/format_coverage
@@ -1,7 +1,0 @@
-#!/usr/bin/env ruby
-
-Dir.glob("coverage/raw.*.json").each do |part|
-  output = part.gsub(/raw/, "codeclimate")
-
-  abort unless system("bin/test-reporter", "--debug", "--format-coverage", part, "-t", "simplecov", "--output", output)
-end


### PR DESCRIPTION
The problem seems to be that codeclimate's test-reporter doesn't support Github Actions. See https://github.com/codeclimate/test-reporter/issues/406.

However, there's this action that claims to set the proper environment variables needed for codeclimate to calculate diff coverage.

So let's try it!