### PR TITLE
Bump jruby-openssl version everywhere

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ group :development, :test do
 
   gem "cancancan"
   gem "pundit"
-  gem "jruby-openssl", "~> 0.10.1", platform: :jruby
+  gem "jruby-openssl", "~> 0.10.5", platform: :jruby
 
   gem "draper", "~> 4.0"
   gem "devise"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,7 +217,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    jruby-openssl (0.10.2-java)
+    jruby-openssl (0.10.5-java)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.1)
@@ -460,7 +460,7 @@ DEPENDENCIES
   i18n-tasks
   jasmine
   jasmine-core (= 2.99.2)
-  jruby-openssl (~> 0.10.1)
+  jruby-openssl (~> 0.10.5)
   kramdown
   launchy
   mdl (= 0.11.0)

--- a/gemfiles/rails_52/Gemfile
+++ b/gemfiles/rails_52/Gemfile
@@ -7,7 +7,7 @@ group :development, :test do
 
   gem "cancancan"
   gem "pundit"
-  gem "jruby-openssl", "~> 0.10.1", platform: :jruby
+  gem "jruby-openssl", "~> 0.10.5", platform: :jruby
 
   gem "draper", "~> 4.0"
   gem "devise"

--- a/gemfiles/rails_52/Gemfile.lock
+++ b/gemfiles/rails_52/Gemfile.lock
@@ -181,7 +181,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    jruby-openssl (0.10.2-java)
+    jruby-openssl (0.10.5-java)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.1)
@@ -365,7 +365,7 @@ DEPENDENCIES
   formtastic (~> 4.0.rc1)
   jasmine
   jasmine-core (= 2.99.2)
-  jruby-openssl (~> 0.10.1)
+  jruby-openssl (~> 0.10.5)
   launchy
   parallel_tests (~> 3.0)
   pry

--- a/gemfiles/rails_60_turbolinks/Gemfile
+++ b/gemfiles/rails_60_turbolinks/Gemfile
@@ -7,7 +7,7 @@ group :development, :test do
 
   gem "cancancan"
   gem "pundit"
-  gem "jruby-openssl", "~> 0.10.1", platform: :jruby
+  gem "jruby-openssl", "~> 0.10.5", platform: :jruby
 
   gem "draper", "~> 4.0"
   gem "devise"

--- a/gemfiles/rails_60_turbolinks/Gemfile.lock
+++ b/gemfiles/rails_60_turbolinks/Gemfile.lock
@@ -194,7 +194,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    jruby-openssl (0.10.2-java)
+    jruby-openssl (0.10.5-java)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.1)
@@ -384,7 +384,7 @@ DEPENDENCIES
   formtastic (~> 4.0.rc1)
   jasmine
   jasmine-core (= 2.99.2)
-  jruby-openssl (~> 0.10.1)
+  jruby-openssl (~> 0.10.5)
   launchy
   parallel_tests (~> 3.0)
   pry

--- a/gemfiles/rails_60_webpacker/Gemfile
+++ b/gemfiles/rails_60_webpacker/Gemfile
@@ -7,7 +7,7 @@ group :development, :test do
 
   gem "cancancan"
   gem "pundit"
-  gem "jruby-openssl", "~> 0.10.1", platform: :jruby
+  gem "jruby-openssl", "~> 0.10.5", platform: :jruby
 
   gem "draper", "~> 4.0"
   gem "devise"

--- a/gemfiles/rails_60_webpacker/Gemfile.lock
+++ b/gemfiles/rails_60_webpacker/Gemfile.lock
@@ -194,7 +194,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    jruby-openssl (0.10.4-java)
+    jruby-openssl (0.10.5-java)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.1)
@@ -389,7 +389,7 @@ DEPENDENCIES
   formtastic (~> 4.0.rc1)
   jasmine
   jasmine-core (= 2.99.2)
-  jruby-openssl (~> 0.10.1)
+  jruby-openssl (~> 0.10.5)
   launchy
   parallel_tests (~> 3.0)
   pry

--- a/tasks/bug_report_template.rb
+++ b/tasks/bug_report_template.rb
@@ -17,7 +17,7 @@ gemfile(true) do
   gem "sassc-rails", "2.1.2"
   gem "sqlite3", "1.4.1", platform: :mri
   gem "activerecord-jdbcsqlite3-adapter", "60.0", platform: :jruby
-  gem "jruby-openssl", "0.10.1", platform: :jruby
+  gem "jruby-openssl", "0.10.5", platform: :jruby
 end
 
 require "active_record"


### PR DESCRIPTION
Previous versions show verbose and annoying warnings on every jruby invocation.