### PR TITLE
Remove sassc and sprockets runtime dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ group :development, :test do
   gem "activerecord-jdbcsqlite3-adapter", "~> 60.0", platform: :jruby
 
   gem "sprockets-rails"
+  gem "sassc-rails", "~> 2.1"
 
   gem "formtastic", "~> 4.0.rc1"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,6 @@ PATH
       kaminari (~> 1.0, >= 1.2.1)
       railties (>= 5.2, < 6.1)
       ransack (~> 2.1, >= 2.1.1)
-      sprockets (>= 3.0, < 4.1)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,6 @@ PATH
       kaminari (~> 1.0, >= 1.2.1)
       railties (>= 5.2, < 6.1)
       ransack (~> 2.1, >= 2.1.1)
-      sassc-rails (~> 2.1)
       sprockets (>= 3.0, < 4.1)
 
 GEM
@@ -478,6 +477,7 @@ DEPENDENCIES
   rubocop-packaging (= 0.5.1)
   rubocop-rails (~> 2.3)
   rubocop-rspec (~> 1.30)
+  sassc-rails (~> 2.1)
   simplecov (= 0.20.0)
   sprockets-rails
   sqlite3 (~> 1.4)

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -27,6 +27,5 @@ Gem::Specification.new do |s|
   s.add_dependency "kaminari", "~> 1.0", ">= 1.2.1"
   s.add_dependency "railties", ">= 5.2", "< 6.1"
   s.add_dependency "ransack", "~> 2.1", ">= 2.1.1"
-  s.add_dependency "sassc-rails", "~> 2.1"
   s.add_dependency "sprockets", ">= 3.0", "< 4.1"
 end

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -27,5 +27,4 @@ Gem::Specification.new do |s|
   s.add_dependency "kaminari", "~> 1.0", ">= 1.2.1"
   s.add_dependency "railties", ">= 5.2", "< 6.1"
   s.add_dependency "ransack", "~> 2.1", ">= 2.1.1"
-  s.add_dependency "sprockets", ">= 3.0", "< 4.1"
 end

--- a/gemfiles/rails_52/Gemfile
+++ b/gemfiles/rails_52/Gemfile
@@ -16,6 +16,7 @@ group :development, :test do
   gem "activerecord-jdbcsqlite3-adapter", "~> 52.0", platform: :jruby
 
   gem "sprockets-rails"
+  gem "sassc-rails", "~> 2.1"
 
   gem "formtastic", "~> 4.0.rc1"
 end

--- a/gemfiles/rails_52/Gemfile.lock
+++ b/gemfiles/rails_52/Gemfile.lock
@@ -10,7 +10,6 @@ PATH
       kaminari (~> 1.0, >= 1.2.1)
       railties (>= 5.2, < 6.1)
       ransack (~> 2.1, >= 2.1.1)
-      sprockets (>= 3.0, < 4.1)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails_52/Gemfile.lock
+++ b/gemfiles/rails_52/Gemfile.lock
@@ -10,7 +10,6 @@ PATH
       kaminari (~> 1.0, >= 1.2.1)
       railties (>= 5.2, < 6.1)
       ransack (~> 2.1, >= 2.1.1)
-      sassc-rails (~> 2.1)
       sprockets (>= 3.0, < 4.1)
 
 GEM
@@ -376,6 +375,7 @@ DEPENDENCIES
   rails-i18n
   rake
   rspec-rails
+  sassc-rails (~> 2.1)
   simplecov (= 0.20.0)
   sprockets-rails
   sqlite3 (~> 1.4)

--- a/gemfiles/rails_60_turbolinks/Gemfile
+++ b/gemfiles/rails_60_turbolinks/Gemfile
@@ -16,6 +16,7 @@ group :development, :test do
   gem "activerecord-jdbcsqlite3-adapter", "~> 60.0", platform: :jruby
 
   gem "sprockets-rails"
+  gem "sassc-rails", "~> 2.1"
 
   gem "turbolinks", "~> 5.2"
 

--- a/gemfiles/rails_60_turbolinks/Gemfile.lock
+++ b/gemfiles/rails_60_turbolinks/Gemfile.lock
@@ -10,7 +10,6 @@ PATH
       kaminari (~> 1.0, >= 1.2.1)
       railties (>= 5.2, < 6.1)
       ransack (~> 2.1, >= 2.1.1)
-      sprockets (>= 3.0, < 4.1)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails_60_turbolinks/Gemfile.lock
+++ b/gemfiles/rails_60_turbolinks/Gemfile.lock
@@ -10,7 +10,6 @@ PATH
       kaminari (~> 1.0, >= 1.2.1)
       railties (>= 5.2, < 6.1)
       ransack (~> 2.1, >= 2.1.1)
-      sassc-rails (~> 2.1)
       sprockets (>= 3.0, < 4.1)
 
 GEM
@@ -395,6 +394,7 @@ DEPENDENCIES
   rails-i18n
   rake
   rspec-rails
+  sassc-rails (~> 2.1)
   simplecov (= 0.20.0)
   sprockets-rails
   sqlite3 (~> 1.4)

--- a/gemfiles/rails_60_webpacker/Gemfile
+++ b/gemfiles/rails_60_webpacker/Gemfile
@@ -15,8 +15,6 @@ group :development, :test do
   gem "rails", "~> 6.0.0"
   gem "activerecord-jdbcsqlite3-adapter", "~> 60.0", platform: :jruby
 
-  gem "sprockets-rails"
-
   gem "webpacker", "~> 5.1"
 
   gem "formtastic", "~> 4.0.rc1"

--- a/gemfiles/rails_60_webpacker/Gemfile.lock
+++ b/gemfiles/rails_60_webpacker/Gemfile.lock
@@ -10,7 +10,6 @@ PATH
       kaminari (~> 1.0, >= 1.2.1)
       railties (>= 5.2, < 6.1)
       ransack (~> 2.1, >= 2.1.1)
-      sassc-rails (~> 2.1)
       sprockets (>= 3.0, < 4.1)
 
 GEM
@@ -321,14 +320,6 @@ GEM
       rspec-support (~> 3.9)
     rspec-support (3.10.0)
     ruby2_keywords (0.0.2)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
     semantic_range (2.3.0)
     simplecov (0.20.0)
       docile (~> 1.1)
@@ -351,7 +342,6 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     thread_safe (0.3.6-java)
-    tilt (2.0.10)
     tzinfo (1.2.8)
       thread_safe (~> 0.1)
     warden (1.2.9)

--- a/gemfiles/rails_60_webpacker/Gemfile.lock
+++ b/gemfiles/rails_60_webpacker/Gemfile.lock
@@ -10,7 +10,6 @@ PATH
       kaminari (~> 1.0, >= 1.2.1)
       railties (>= 5.2, < 6.1)
       ransack (~> 2.1, >= 2.1.1)
-      sprockets (>= 3.0, < 4.1)
 
 GEM
   remote: https://rubygems.org/
@@ -391,7 +390,6 @@ DEPENDENCIES
   rake
   rspec-rails
   simplecov (= 0.20.0)
-  sprockets-rails
   sqlite3 (~> 1.4)
   webpacker (~> 5.1)
 

--- a/lib/active_admin.rb
+++ b/lib/active_admin.rb
@@ -8,7 +8,6 @@ require "formtastic"
 require "formtastic_i18n"
 require "inherited_resources"
 require "jquery-rails"
-require "sassc-rails"
 require "arbre"
 
 require "active_admin/helpers/i18n"

--- a/lib/active_admin/engine.rb
+++ b/lib/active_admin/engine.rb
@@ -6,11 +6,13 @@ module ActiveAdmin
     end
 
     initializer "active_admin.precompile", group: :all do |app|
-      ActiveAdmin.application.stylesheets.each do |path, _|
-        app.config.assets.precompile << path
-      end
-      ActiveAdmin.application.javascripts.each do |path|
-        app.config.assets.precompile << path
+      unless ActiveAdmin.application.use_webpacker
+        ActiveAdmin.application.stylesheets.each do |path, _|
+          app.config.assets.precompile << path
+        end
+        ActiveAdmin.application.javascripts.each do |path|
+          app.config.assets.precompile << path
+        end
       end
     end
 

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -53,11 +53,16 @@ gsub_file "config/environments/test.rb", /  config.cache_classes = true/, <<-RUB
 
   config.cache_classes = !ENV['CLASS_RELOADING']
   config.action_mailer.default_url_options = {host: 'example.com'}
-  config.assets.precompile += %w( some-random-css.css some-random-js.js a/favicon.ico )
 
   config.active_record.maintain_test_schema = false
 
 RUBY
+
+unless webpacker_app
+  inject_into_file "config/environments/test.rb", after: "  config.action_mailer.default_url_options = {host: 'example.com'}" do
+    "\n  config.assets.precompile += %w( some-random-css.css some-random-js.js a/favicon.ico )\n"
+  end
+end
 
 gsub_file "config/boot.rb", /^.*BUNDLE_GEMFILE.*$/, <<-RUBY
   ENV['BUNDLE_GEMFILE'] = "#{File.expand_path(ENV['BUNDLE_GEMFILE'])}"

--- a/tasks/test_application.rb
+++ b/tasks/test_application.rb
@@ -33,6 +33,7 @@ module ActiveAdmin
       )
 
       args << "--skip-turbolinks" unless turbolinks_app?
+      args << "--skip-sprockets" if webpacker_app?
 
       command = ["bundle", "exec", "rails", "new", app_dir, *args].join(" ")
 
@@ -73,6 +74,10 @@ module ActiveAdmin
 
     def turbolinks_app?
       expanded_gemfile == File.expand_path("gemfiles/rails_60_turbolinks/Gemfile")
+    end
+
+    def webpacker_app?
+      expanded_gemfile == File.expand_path("gemfiles/rails_60_webpacker/Gemfile")
     end
 
     def gemfile


### PR DESCRIPTION
I think now that we support apps using webpacker for assets and js, it makes
sense to remove these dependencies, since these apps don't need them.

This could break people's apps that do need this but are relying on activeadmin
for providing this dependency, so I think we could do it for ActiveAdmin 3.

Thoughts?

Closes #6201.
Closes #6222.
Closes #6206.