### PR TITLE
Bundler 2.2 locks the specific platform in the lockfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -441,6 +441,7 @@ GEM
 PLATFORMS
   java
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   activeadmin!

--- a/gemfiles/rails_52/Gemfile.lock
+++ b/gemfiles/rails_52/Gemfile.lock
@@ -349,6 +349,7 @@ GEM
 PLATFORMS
   java
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   activeadmin!

--- a/gemfiles/rails_60_turbolinks/Gemfile.lock
+++ b/gemfiles/rails_60_turbolinks/Gemfile.lock
@@ -368,6 +368,7 @@ GEM
 PLATFORMS
   java
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   activeadmin!

--- a/gemfiles/rails_60_webpacker/Gemfile.lock
+++ b/gemfiles/rails_60_webpacker/Gemfile.lock
@@ -373,6 +373,7 @@ GEM
 PLATFORMS
   java
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   activeadmin!


### PR DESCRIPTION
I forgot to commit this part when I upgraded to the latest bundler prerelease.