### PR TITLE
Use latest rubygems & bundler in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
         run: gem update --system 3.1.4
 
       - name: Install a specific bundler version
-        run: gem install bundler -v 2.2.0.rc.2
+        run: gem install bundler -v 2.2.0
 
       - name: Cat current Gemfile to a specific file so caching works
         run: cat "$BUNDLE_GEMFILE.lock" > current_gemfile.lock
@@ -127,7 +127,7 @@ jobs:
         run: gem update --system 3.1.4
 
       - name: Install a specific bundler version
-        run: gem install bundler -v 2.2.0.rc.2
+        run: gem install bundler -v 2.2.0
 
       - name: Cat current Gemfile to a specific file so caching works
         run: cat "$BUNDLE_GEMFILE.lock" > current_gemfile.lock

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
           bundler: none
 
       - name: Install a specific rubygems version
-        run: gem update --system 3.1.4
+        run: gem update --system 3.2.0
 
       - name: Install a specific bundler version
         run: gem install bundler -v 2.2.0
@@ -124,7 +124,7 @@ jobs:
           bundler: none
 
       - name: Install a specific rubygems version
-        run: gem update --system 3.1.4
+        run: gem update --system 3.2.0
 
       - name: Install a specific bundler version
         run: gem install bundler -v 2.2.0

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -46,7 +46,7 @@ jobs:
         run: gem update --system 3.1.4
 
       - name: Install a specific bundler version
-        run: gem install bundler -v 2.2.0.rc.2
+        run: gem install bundler -v 2.2.0
 
       - name: Cat current Gemfile to a specific file so caching works
         run: cat "$BUNDLE_GEMFILE.lock" > current_gemfile.lock

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -43,7 +43,7 @@ jobs:
           bundler: none
 
       - name: Install a specific rubygems version
-        run: gem update --system 3.1.4
+        run: gem update --system 3.2.0
 
       - name: Install a specific bundler version
         run: gem install bundler -v 2.2.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -492,4 +492,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.2.0.rc.2
+   2.2.0

--- a/gemfiles/rails_52/Gemfile.lock
+++ b/gemfiles/rails_52/Gemfile.lock
@@ -380,4 +380,4 @@ DEPENDENCIES
   sqlite3 (~> 1.4)
 
 BUNDLED WITH
-   2.2.0.rc.2
+   2.2.0

--- a/gemfiles/rails_60/Gemfile.lock
+++ b/gemfiles/rails_60/Gemfile.lock
@@ -396,4 +396,4 @@ DEPENDENCIES
   sqlite3 (~> 1.4)
 
 BUNDLED WITH
-   2.2.0.rc.2
+   2.2.0

--- a/gemfiles/rails_61_turbolinks/Gemfile.lock
+++ b/gemfiles/rails_61_turbolinks/Gemfile.lock
@@ -375,6 +375,7 @@ GEM
 PLATFORMS
   java
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   activeadmin!
@@ -408,4 +409,4 @@ DEPENDENCIES
   turbolinks (~> 5.2)
 
 BUNDLED WITH
-   2.2.0.rc.2
+   2.2.0

--- a/gemfiles/rails_61_webpacker/Gemfile.lock
+++ b/gemfiles/rails_61_webpacker/Gemfile.lock
@@ -403,4 +403,4 @@ DEPENDENCIES
   webpacker (~> 5.1)
 
 BUNDLED WITH
-   2.2.0.rc.2
+   2.2.0


### PR DESCRIPTION
We released rubygems 3.2.0 and bundler 2.2.0.

Just checking everything is good since we're having a few issues with the final
versions.