### PR TITLE
Bump jruby in CI to 9.2.16.0

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        ruby: [jruby-9.2.13.0]
+        ruby: [jruby-9.2.16.0]
         deps: ["rails_52", "rails_60"]
 
     env:


### PR DESCRIPTION
Our daily JRuby CI is currently broken, I think due to an issue fixed in recent versions. This PR bumps the jruby version to verify that.