### PR TITLE
Adds warning for users that are using "require_tree ."

### DIFF
--- a/lib/generators/active_admin/install/install_generator.rb
+++ b/lib/generators/active_admin/install/install_generator.rb
@@ -38,6 +38,15 @@ module ActiveAdmin
       end
 
       def create_assets
+        js_file = File.join(destination_root, "app", "assets", "javascript", "application.js")
+        css_file = File.join(destination_root, "app", "assets", "stylesheets", "application.css")
+        if File.foreach(css_file).grep(/\*= require_tree \./).any? || File.foreach(js_file).grep(/\/\/= require_tree \./).any?
+          say_status(
+            :warning, "The code #{set_color("require_tree .", :red)} in either application.css or application.js files
+              makes Active Admin styles or scripts to be included in other parts of your app.
+              If that is not desired you can stub active_admin at the end of those files.")
+        end
+
         if options[:use_webpacker]
           generate "active_admin:webpacker"
         else


### PR DESCRIPTION
Adds warning for users that are using "require_tree ." in their js and css config files

 - This change is being split from PR #6676

<!--

Thanks for contributing to ActiveAdmin!

You can find all the instructions for contributing at the [CONTRIBUTING file].

Before submitting your PR make sure that:

* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are splitted apart.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all github checks are passing, but feel free to ask for early feedback if you need guidance.

[CONTRIBUTING file]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->
