### PR TITLE
Workaround flaky CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,10 +35,10 @@ jobs:
           bundler: none
 
       - name: Install a specific rubygems version
-        run: gem update --system 3.2.14
+        run: gem update --system 3.2.15
 
       - name: Install a specific bundler version
-        run: gem install bundler -v 2.2.14
+        run: gem install bundler -v 2.2.15
 
       - name: Cat current Gemfile to a specific file so caching works
         run: cat "$BUNDLE_GEMFILE.lock" > current_gemfile.lock
@@ -124,10 +124,10 @@ jobs:
           bundler: none
 
       - name: Install a specific rubygems version
-        run: gem update --system 3.2.14
+        run: gem update --system 3.2.15
 
       - name: Install a specific bundler version
-        run: gem install bundler -v 2.2.14
+        run: gem install bundler -v 2.2.15
 
       - name: Cat current Gemfile to a specific file so caching works
         run: cat "$BUNDLE_GEMFILE.lock" > current_gemfile.lock

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
           key: gems-2.7.2-rails_61-${{ hashFiles('current_gemfile.lock') }}
 
       - name: Install dependencies
-        run: bundle install --jobs 3
+        run: bundle install
 
       - name: Generate docs
         run: bin/rake docs:build
@@ -139,7 +139,7 @@ jobs:
           key: gems-${{ matrix.ruby }}-${{ matrix.deps }}-${{ hashFiles('current_gemfile.lock') }}
 
       - name: Install dependencies
-        run: bundle install --jobs 3
+        run: bundle install
 
       - name: Setup git
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -157,7 +157,7 @@ jobs:
 
       - name: Run RSpec tests
         run: |
-          bin/parallel_rspec spec/
+          bin/parallel_rspec
           RSPEC_FILESYSTEM_CHANGES=true bin/rspec
 
       - name: Restore cached cucumber runtimes
@@ -168,7 +168,7 @@ jobs:
 
       - name: Run Cucumber features
         run: |
-          bin/parallel_cucumber features/
+          bin/parallel_cucumber
           bin/cucumber --profile filesystem-changes
           bin/cucumber --profile class-reloading
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -168,7 +168,7 @@ jobs:
 
       - name: Run Cucumber features
         run: |
-          bin/parallel_cucumber
+          bin/parallel_cucumber --fail-fast
           bin/cucumber --profile filesystem-changes
           bin/cucumber --profile class-reloading
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -157,7 +157,7 @@ jobs:
 
       - name: Run RSpec tests
         run: |
-          PARALLEL_TEST_HEARTBEAT_INTERVAL=3600 bin/parallel_rspec spec/
+          bin/parallel_rspec spec/
           RSPEC_FILESYSTEM_CHANGES=true bin/rspec
 
       - name: Restore cached cucumber runtimes
@@ -168,7 +168,7 @@ jobs:
 
       - name: Run Cucumber features
         run: |
-          PARALLEL_TEST_HEARTBEAT_INTERVAL=3600 bin/parallel_cucumber features/
+          bin/parallel_cucumber features/
           bin/cucumber --profile filesystem-changes
           bin/cucumber --profile class-reloading
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,7 +95,7 @@ jobs:
         ruby: [2.7.2, 2.6.6]
         os: [ubuntu-20.04]
 
-        deps: ["rails_52", "rails_60", "rails_61", "rails_61_turbolinks", "rails_61_webpacker"]
+        deps: [rails_52, rails_60, rails_61, rails_61_turbolinks, rails_61_webpacker]
 
         include:
           - ruby: 2.5.8

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   lint:
     name: lint
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
 
     timeout-minutes: 15
 
@@ -21,6 +21,7 @@ jobs:
 
       matrix:
         ruby: [2.7.2]
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v2
@@ -51,7 +52,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.BUNDLE_PATH }}
-          key: gems-${{ matrix.ruby }}-rails_61-${{ hashFiles('current_gemfile.lock') }}
+          key: gems-${{ matrix.os }}-${{ matrix.ruby }}-rails_61-${{ hashFiles('current_gemfile.lock') }}
 
       - name: Install dependencies
         run: bundle install
@@ -82,7 +83,8 @@ jobs:
           path: coverage/raw.lint.json
 
   test:
-    runs-on: ubuntu-20.04
+    name: test (${{ matrix.ruby }}, ${{ matrix.deps }})
+    runs-on: ${{ matrix.os }}
 
     timeout-minutes: 15
 
@@ -91,17 +93,21 @@ jobs:
 
       matrix:
         ruby: [2.7.2, 2.6.6]
+        os: [ubuntu-20.04]
 
         deps: ["rails_52", "rails_60", "rails_61", "rails_61_turbolinks", "rails_61_webpacker"]
 
         include:
           - ruby: 2.5.8
+            os: ubuntu-20.04
             deps: rails_52
 
           - ruby: 2.5.8
+            os: ubuntu-20.04
             deps: rails_60
 
           - ruby: 2.5.8
+            os: ubuntu-20.04
             deps: rails_61
 
     env:
@@ -140,7 +146,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.BUNDLE_PATH }}
-          key: gems-${{ matrix.ruby }}-${{ matrix.deps }}-${{ hashFiles('current_gemfile.lock') }}
+          key: gems-${{ matrix.os }}-${{ matrix.ruby }}-${{ matrix.deps }}-${{ hashFiles('current_gemfile.lock') }}
 
       - name: Install dependencies
         run: bundle install

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
 
       matrix:
         ruby: [2.7.2]
-        os: [ubuntu-20.04]
+        os: [ubuntu-18.04]
 
     steps:
       - uses: actions/checkout@v2
@@ -93,21 +93,21 @@ jobs:
 
       matrix:
         ruby: [2.7.2, 2.6.6]
-        os: [ubuntu-20.04]
+        os: [ubuntu-18.04]
 
         deps: [rails_52, rails_60, rails_61, rails_61_turbolinks, rails_61_webpacker]
 
         include:
           - ruby: 2.5.8
-            os: ubuntu-20.04
+            os: ubuntu-18.04
             deps: rails_52
 
           - ruby: 2.5.8
-            os: ubuntu-20.04
+            os: ubuntu-18.04
             deps: rails_60
 
           - ruby: 2.5.8
-            os: ubuntu-20.04
+            os: ubuntu-18.04
             deps: rails_61
 
     env:
@@ -194,7 +194,7 @@ jobs:
           path: coverage/raw.${{ matrix.ruby }}.${{ matrix.deps }}.json
 
   upload_coverage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
 
     needs:
       - lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,12 +11,16 @@ on:
 
 jobs:
   lint:
+    name: lint
     runs-on: ubuntu-20.04
 
     timeout-minutes: 15
 
     strategy:
       fail-fast: false
+
+      matrix:
+        ruby: [2.7.2]
 
     steps:
       - uses: actions/checkout@v2
@@ -31,7 +35,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.2
+          ruby-version: ${{ matrix.ruby }}
           bundler: none
 
       - name: Install a specific rubygems version
@@ -47,7 +51,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.BUNDLE_PATH }}
-          key: gems-2.7.2-rails_61-${{ hashFiles('current_gemfile.lock') }}
+          key: gems-${{ matrix.ruby }}-rails_61-${{ hashFiles('current_gemfile.lock') }}
 
       - name: Install dependencies
         run: bundle install

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   lint:
-    name: lint
+    name: lint (${{ matrix.ruby }})
     runs-on: ${{ matrix.os }}
 
     timeout-minutes: 15

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -58,7 +58,7 @@ jobs:
           key: gems-jruby-${{ matrix.ruby }}-${{ matrix.deps }}-${{ hashFiles('current_gemfile.lock') }}
 
       - name: Install dependencies
-        run: bundle install --jobs 3
+        run: bundle install
 
       - name: Setup git
         run: |

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -43,10 +43,10 @@ jobs:
           bundler: none
 
       - name: Install a specific rubygems version
-        run: gem update --system 3.2.14
+        run: gem update --system 3.2.15
 
       - name: Install a specific bundler version
-        run: gem install bundler -v 2.2.14
+        run: gem install bundler -v 2.2.15
 
       - name: Cat current Gemfile to a specific file so caching works
         run: cat "$BUNDLE_GEMFILE.lock" > current_gemfile.lock

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-18.04]
         ruby: [jruby-9.2.16.0]
         deps: ["rails_52", "rails_60"]
 

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -87,6 +87,6 @@ jobs:
 
       - name: Run Cucumber features
         run: |
-          bin/parallel_cucumber
+          bin/parallel_cucumber --fail-fast
           bin/cucumber --profile filesystem-changes
           bin/cucumber --profile class-reloading

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -8,7 +8,8 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    name: test (${{ matrix.ruby }}, ${{ matrix.deps }})
+    runs-on: ${{ matrix.os }}
 
     timeout-minutes: 15
 
@@ -16,6 +17,7 @@ jobs:
       fail-fast: false
 
       matrix:
+        os: [ubuntu-20.04]
         ruby: [jruby-9.2.16.0]
         deps: ["rails_52", "rails_60"]
 
@@ -55,7 +57,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.BUNDLE_PATH }}
-          key: gems-${{ matrix.ruby }}-${{ matrix.deps }}-${{ hashFiles('current_gemfile.lock') }}
+          key: gems-${{ matrix.os }}-${{ matrix.ruby }}-${{ matrix.deps }}-${{ hashFiles('current_gemfile.lock') }}
 
       - name: Install dependencies
         run: bundle install

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.BUNDLE_PATH }}
-          key: gems-jruby-${{ matrix.ruby }}-${{ matrix.deps }}-${{ hashFiles('current_gemfile.lock') }}
+          key: gems-${{ matrix.ruby }}-${{ matrix.deps }}-${{ hashFiles('current_gemfile.lock') }}
 
       - name: Install dependencies
         run: bundle install

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Run RSpec tests
         run: |
-          PARALLEL_TEST_HEARTBEAT_INTERVAL=3600 bin/parallel_rspec spec/
+          bin/parallel_rspec spec/
           RSPEC_FILESYSTEM_CHANGES=true bin/rspec
 
       - name: Restore cached cucumber runtimes
@@ -87,6 +87,6 @@ jobs:
 
       - name: Run Cucumber features
         run: |
-          PARALLEL_TEST_HEARTBEAT_INTERVAL=3600 bin/parallel_cucumber features/
+          bin/parallel_cucumber features/
           bin/cucumber --profile filesystem-changes
           bin/cucumber --profile class-reloading

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -87,6 +87,6 @@ jobs:
 
       - name: Run Cucumber features
         run: |
-          bin/parallel_cucumber features/
+          bin/parallel_cucumber
           bin/cucumber --profile filesystem-changes
           bin/cucumber --profile class-reloading

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -502,4 +502,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.2.14
+   2.2.15

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -7,7 +7,7 @@ Given /^(?:I am logged|log) out$/ do
 end
 
 Given /^I am logged in$/ do
-  step "log out"
+  logout(:user)
   login_as ensure_user_created "admin@example.com"
 end
 

--- a/gemfiles/rails_52/Gemfile.lock
+++ b/gemfiles/rails_52/Gemfile.lock
@@ -391,4 +391,4 @@ DEPENDENCIES
   webrick (~> 1.7)
 
 BUNDLED WITH
-   2.2.14
+   2.2.15

--- a/gemfiles/rails_60/Gemfile.lock
+++ b/gemfiles/rails_60/Gemfile.lock
@@ -407,4 +407,4 @@ DEPENDENCIES
   webrick (~> 1.7)
 
 BUNDLED WITH
-   2.2.14
+   2.2.15

--- a/gemfiles/rails_61_turbolinks/Gemfile.lock
+++ b/gemfiles/rails_61_turbolinks/Gemfile.lock
@@ -418,4 +418,4 @@ DEPENDENCIES
   webrick (~> 1.7)
 
 BUNDLED WITH
-   2.2.14
+   2.2.15

--- a/gemfiles/rails_61_webpacker/Gemfile.lock
+++ b/gemfiles/rails_61_webpacker/Gemfile.lock
@@ -409,4 +409,4 @@ DEPENDENCIES
   webrick (~> 1.7)
 
 BUNDLED WITH
-   2.2.14
+   2.2.15

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -42,7 +42,7 @@ namespace :spec do
 
   desc "Run the standard specs in parallel"
   task :regular do
-    sh("bin/parallel_rspec spec/")
+    sh("bin/parallel_rspec")
   end
 
   desc "Run the specs that change the filesystem sequentially"
@@ -60,7 +60,7 @@ namespace :cucumber do
 
   desc "Run the standard cucumber scenarios in parallel"
   task :regular do
-    sh("bin/parallel_cucumber features/")
+    sh("bin/parallel_cucumber")
   end
 
   desc "Run the cucumber scenarios that change the filesystem sequentially"


### PR DESCRIPTION
The [latest Github Actions environment update](https://github.com/actions/virtual-environments/releases/tag/ubuntu20%2F20210318.0) made our CI flaky. I don't know the specific change that caused it but seems definitely tied to the upgrade. Even if there's no public report, I think it's due to the new image installing chromium from apt/snap sources which seems problematic (it should be installed from source). This suspicion is based on the work being done in this regard since the release: https://github.com/actions/virtual-environments/pull/3029.

I checked that downgrading to ubuntu-18.04 fixes the issue by rerunning things a few times there.

This PR also includes a few other CI changes that I made while investigating this.