### PR TITLE
Scope new record instantiation by authorization scope

### DIFF
--- a/lib/active_admin/resource_controller/data_access.rb
+++ b/lib/active_admin/resource_controller/data_access.rb
@@ -128,7 +128,7 @@ module ActiveAdmin
       #
       # @return [ActiveRecord::Base] An un-saved active record base object
       def build_new_resource
-        scoped_collection.send(
+        apply_authorization_scope(scoped_collection).send(
           method_for_build,
           *resource_params.map { |params| params.slice(active_admin_config.resource_class.inheritance_column) }
         )

--- a/spec/unit/resource_controller/data_access_spec.rb
+++ b/spec/unit/resource_controller/data_access_spec.rb
@@ -225,5 +225,16 @@ RSpec.describe ActiveAdmin::ResourceController::DataAccess do
     it "should assign nested attributes once" do
       expect(subject.posts.size).to eq(1)
     end
+
+    context "given authorization scope" do
+      let(:authorization) { controller.send(:active_admin_authorization) }
+
+      it "should apply authorization scope" do
+        expect(authorization).to receive(:scope_collection) do |collection|
+          collection.where(age: "42")
+        end
+        expect(subject.age).to eq(42)
+      end
+    end
   end
 end


### PR DESCRIPTION
Lets have a basic structure :
`asset belongs to company`
`company have_many admin_users`
`an admin_user can manage (see/create/update) assets of the company`

this last assertion is be described/implemented into the `AssetPolicy::Scope#resolve` (using pundit)

When we have policy scopes (such as pundit), we are not leveraging them for instantiating (building) new resources (in `#new` and `#create` controller methods)

I face 2 issues because of this:
- issue with my `:create` policy raises me an error when hitting the assets/new URL, as my `create` policy is checking that the asset#company matches the admin_user#company. But company is blank (because we are not leveraging the policy scope).
- I have to overwrite the controller "create" method just to add the scope that I already set (in this case, adding the company_id to the asset).