### PR TITLE
The `env` helper method is dead and not working

### DIFF
--- a/lib/active_admin/base_controller.rb
+++ b/lib/active_admin/base_controller.rb
@@ -6,7 +6,6 @@ module ActiveAdmin
   # It implements ActiveAdmin controllers core features.
   class BaseController < ::InheritedResources::Base
     helper ::ActiveAdmin::ViewHelpers
-    helper_method :env
 
     layout :determine_active_admin_layout
 


### PR DESCRIPTION
Based on [this bug report](https://github.com/Shopify/tapioca/issues/280) in Tapioca (which generates interface files for dynamically generated methods for various DSLs), I was able to figure out that this `env` helper method is dead-code in ActiveAdmin. Moreover, if the `env` helper method is ever called, it will fail since there is no actual method to proxy to anymore.

For more details, see my analysis here: https://github.com/Shopify/tapioca/issues/280#issuecomment-815070624

<!--

Thanks for contributing to ActiveAdmin!

You can find all the instructions for contributing at the [CONTRIBUTING file].

Before submitting your PR make sure that:

* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are splitted apart.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all github checks are passing, but feel free to ask for early feedback if you need guidance.

[CONTRIBUTING file]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->
