### PR TITLE
Make `permit_params` and `belongs_to` order independent

### DIFF
--- a/features/belongs_to.feature
+++ b/features/belongs_to.feature
@@ -103,6 +103,23 @@ Feature: Belongs To
     And I should see the attribute "Body" with "This is the body"
     And I should see the attribute "Author" with "Jane Doe"
 
+  Scenario: Creating a child resource page when belongs to defined after permitted params
+    Given a configuration of:
+    """
+      ActiveAdmin.register User
+      ActiveAdmin.register Post do
+        permit_params :title, :body, :published_date
+        belongs_to :user
+
+        form do |f|
+          f.actions
+        end
+      end
+    """
+    When I go to the last author's posts
+    And I follow "New Post"
+    Then I should see the element "form[action='/admin/users/2/posts']"
+
   Scenario: Viewing a child resource page
     Given a configuration of:
     """

--- a/lib/active_admin/resource_dsl.rb
+++ b/lib/active_admin/resource_dsl.rb
@@ -62,11 +62,12 @@ module ActiveAdmin
     #
     def permit_params(*args, &block)
       param_key = config.param_key.to_sym
-      belongs_to_param = config.belongs_to_param
-      create_another_param = :create_another if config.create_another
 
       controller do
         define_method :permitted_params do
+          belongs_to_param = active_admin_config.belongs_to_param
+          create_another_param = :create_another if active_admin_config.create_another
+
           permitted_params =
             active_admin_namespace.permitted_params +
               Array.wrap(belongs_to_param) +


### PR DESCRIPTION
Currently `belongs_to` needs to be defined before `permit_params` or otherwise belongs to params will fail to be allowed and forms on belongs to resources will fail to render with errors like:

```
found unpermitted parameter: :user_id (ActionController::UnpermittedParameters)
./lib/active_admin/resource_dsl.rb:75:in `block (2 levels) in permit_params'
./lib/active_admin/resource_controller/data_access.rb:133:in `build_new_resource'
./lib/active_admin/resource_controller/data_access.rb:116:in `build_resource'
```

I feel this mistake is quite common, given it was happening on our own demo application. I think we can fix it by lazily loading params without causing any issues.