### PR TITLE
Include print styles in main stylesheet

### DIFF
--- a/app/assets/stylesheets/active_admin/_base.scss
+++ b/app/assets/stylesheets/active_admin/_base.scss
@@ -4,38 +4,45 @@
 
 // Partials
 @import "./typography";
-@import "./header";
-@import "./forms";
-@import "./components/comments";
-@import "./components/flash_messages";
-@import "./components/date_picker";
-@import "./components/tables";
-@import "./components/batch_actions";
-@import "./components/modal_dialog";
-@import "./components/blank_slates";
-@import "./components/breadcrumbs";
-@import "./components/dropdown_menu";
-@import "./components/buttons";
-@import "./components/grid";
-@import "./components/links";
-@import "./components/pagination";
-@import "./components/panels";
-@import "./components/columns";
-@import "./components/scopes";
-@import "./components/status_tags";
-@import "./components/table_tools";
-@import "./components/index_list";
-@import "./components/unsupported_browser";
-@import "./components/tabs";
-@import "./pages/logged_out";
-@import "./structure/footer";
-@import "./structure/main_structure";
-@import "./structure/title_bar";
 
-body {
-  @include sans-family;
-  line-height: 1.5;
-  font-size: 72%;
-  background: $body-background-color;
-  color: $text-color;
+@media screen {
+  @import "./header";
+  @import "./forms";
+  @import "./components/comments";
+  @import "./components/flash_messages";
+  @import "./components/date_picker";
+  @import "./components/tables";
+  @import "./components/batch_actions";
+  @import "./components/modal_dialog";
+  @import "./components/blank_slates";
+  @import "./components/breadcrumbs";
+  @import "./components/dropdown_menu";
+  @import "./components/buttons";
+  @import "./components/grid";
+  @import "./components/links";
+  @import "./components/pagination";
+  @import "./components/panels";
+  @import "./components/columns";
+  @import "./components/scopes";
+  @import "./components/status_tags";
+  @import "./components/table_tools";
+  @import "./components/index_list";
+  @import "./components/unsupported_browser";
+  @import "./components/tabs";
+  @import "./pages/logged_out";
+  @import "./structure/footer";
+  @import "./structure/main_structure";
+  @import "./structure/title_bar";
+
+  body {
+    @include sans-family;
+    line-height: 1.5;
+    font-size: 72%;
+    background: $body-background-color;
+    color: $text-color;
+  }
+}
+
+@media print {
+  @import "./print";
 }

--- a/app/assets/stylesheets/active_admin/_print.scss
+++ b/app/assets/stylesheets/active_admin/_print.scss
@@ -4,12 +4,6 @@
 $primary-color: black;
 $text-color: black;
 
-// Normalize
-@import "./normalize";
-
-// Partials
-@import "./typography";
-
 body {
   font-family: Helvetica, Arial, sans-serif;
   line-height: 150%;

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -164,8 +164,7 @@ module ActiveAdmin
     private
 
     def register_default_assets
-      register_stylesheet "active_admin.css", media: "screen"
-      register_stylesheet "active_admin/print.css", media: "print"
+      register_stylesheet "active_admin.css"
       register_javascript "active_admin.js"
     end
 


### PR DESCRIPTION
No need to do this separately which makes an extra http request, plus this has the benefit of delaying print styles until needed. I’ve been doing this for a long time now and as its been well supported to include print styles using a media block. The HTML5 Boilerplate has stressed this as a good default approach for many years now. https://github.com/h5bp/html5-boilerplate/blob/master/src/css/main.css#L205-L209

Extracted from #3862.

Closes #6908.