### PR TITLE
Avoid mutating string literals

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -130,7 +130,7 @@ Style/ExpandPathArguments:
 
 Style/FrozenStringLiteralComment:
   Enabled: true
-  EnforcedStyle: never
+  EnforcedStyle: always
 
 Style/HashSyntax:
   Enabled: true

--- a/.simplecov
+++ b/.simplecov
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 SimpleCov.start do
   add_filter "tmp/development_apps/"
   add_filter "tmp/test_apps/"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source "https://rubygems.org"
 
 group :development, :test do

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "bundler/gem_tasks"
 
 import "tasks/gemfiles.rake"

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require File.join(__dir__, "lib", "active_admin", "version")
 
 Gem::Specification.new do |s|

--- a/app/views/active_admin/page/index.html.arb
+++ b/app/views/active_admin/page/index.html.arb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 insert_tag active_admin_application.view_factory["page"]

--- a/app/views/active_admin/resource/edit.html.arb
+++ b/app/views/active_admin/resource/edit.html.arb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 insert_tag renderer_for(:edit)

--- a/app/views/active_admin/resource/index.html.arb
+++ b/app/views/active_admin/resource/index.html.arb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 insert_tag renderer_for(:index)

--- a/app/views/active_admin/resource/new.html.arb
+++ b/app/views/active_admin/resource/new.html.arb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 insert_tag renderer_for(:new)

--- a/app/views/active_admin/resource/show.html.arb
+++ b/app/views/active_admin/resource/show.html.arb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 insert_tag renderer_for(:show)

--- a/app/views/layouts/active_admin.html.arb
+++ b/app/views/layouts/active_admin.html.arb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 insert_tag view_factory.layout

--- a/bin/cucumber
+++ b/bin/cucumber
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "bundler/setup"
 

--- a/bin/i18n-tasks
+++ b/bin/i18n-tasks
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "bundler/setup"
 

--- a/bin/parallel_cucumber
+++ b/bin/parallel_cucumber
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "bundler/setup"
 

--- a/bin/parallel_rspec
+++ b/bin/parallel_rspec
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "bundler/setup"
 

--- a/bin/prepare_coverage
+++ b/bin/prepare_coverage
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-
+# frozen_string_literal: true
 # Borrowed from https://gist.github.com/qortex/7e7c49f3731391a91ee898336183acef
 
 # Temporary hack to get CodeClimate to work with SimpleCov 0.18 JSON format until issue is fixed

--- a/bin/rake
+++ b/bin/rake
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "bundler/setup"
 

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "bundler/setup"
 

--- a/bin/rubocop
+++ b/bin/rubocop
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "bundler/setup"
 

--- a/bin/yarn
+++ b/bin/yarn
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-
+# frozen_string_literal: true
 begin
   exec "yarnpkg", *ARGV
 rescue Errno::ENOENT

--- a/config/mdl_style.rb
+++ b/config/mdl_style.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 all
 
 exclude_rule "first-header-h1"

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source "https://rubygems.org"
 
 gem "github-pages"

--- a/features/step_definitions/action_item_steps.rb
+++ b/features/step_definitions/action_item_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Then /^I should see an action item link to "([^"]*)"$/ do |link|
   expect(page).to have_css(".action_item a", text: link)
 end

--- a/features/step_definitions/action_link_steps.rb
+++ b/features/step_definitions/action_link_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Then /^I should see a member link to "([^"]*)"$/ do |name|
   expect(page).to have_css("a.member_link", text: name)
 end

--- a/features/step_definitions/additional_web_steps.rb
+++ b/features/step_definitions/additional_web_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Then /^I should see a table header with "([^"]*)"$/ do |content|
   expect(page).to have_xpath "//th", text: content
 end

--- a/features/step_definitions/asset_steps.rb
+++ b/features/step_definitions/asset_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Then /^I should see the css file "([^"]*)"$/ do |path|
   step %{I should see the css file "#{path}" of media "screen"}
 end

--- a/features/step_definitions/attribute_steps.rb
+++ b/features/step_definitions/attribute_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Then /^I should see the attribute "([^"]*)" with "([^"]*)"$/ do |title, value|
   elems = all ".attributes_table th:contains('#{title}') ~ td:contains('#{value}')"
   expect(elems.first).to_not eq(nil), "attribute missing"

--- a/features/step_definitions/attributes_table_title_steps.rb
+++ b/features/step_definitions/attributes_table_title_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Then /^I should see the panel title "([^"]*)"$/ do |title|
   expect(page).to have_css ".panel > h3", text: title
 end

--- a/features/step_definitions/batch_action_steps.rb
+++ b/features/step_definitions/batch_action_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Then /^I (should|should not) see the batch action :([^\s]*) "([^"]*)"$/ do |maybe, sym, title|
   selector = maybe == "should" ? ".batch_actions_selector a.batch_action[href='#'][data-action='#{sym}']" : ".batch_actions_selector a.batch_action"
 

--- a/features/step_definitions/batch_action_steps.rb
+++ b/features/step_definitions/batch_action_steps.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 Then /^I (should|should not) see the batch action :([^\s]*) "([^"]*)"$/ do |maybe, sym, title|
-  selector = maybe == "should" ? ".batch_actions_selector a.batch_action[href='#'][data-action='#{sym}']" : ".batch_actions_selector a.batch_action"
+  selector = ".batch_actions_selector a.batch_action"
+  selector += "[href='#'][data-action='#{sym}']" if maybe == "should"
 
   verb = maybe == "should" ? :to : :to_not
   expect(page).send verb, have_css(selector, text: title)
@@ -20,7 +21,8 @@ Then /^I should see that the batch action button is disabled$/ do
 end
 
 Then /^I (should|should not) see the batch action (button|selector)$/ do |maybe, type|
-  selector = maybe == "should" && type == "button" ? "div.table_tools .batch_actions_selector .dropdown_menu_button" : "div.table_tools .batch_actions_selector"
+  selector = "div.table_tools .batch_actions_selector"
+  selector += " .dropdown_menu_button" if maybe == "should" && type == "button"
 
   verb = maybe == "should" ? :to : :to_not
   expect(page).send verb, have_css(selector)

--- a/features/step_definitions/batch_action_steps.rb
+++ b/features/step_definitions/batch_action_steps.rb
@@ -1,6 +1,5 @@
 Then /^I (should|should not) see the batch action :([^\s]*) "([^"]*)"$/ do |maybe, sym, title|
-  selector = ".batch_actions_selector a.batch_action"
-  selector << "[href='#'][data-action='#{sym}']" if maybe == "should"
+  selector = maybe == "should" ? ".batch_actions_selector a.batch_action[href='#'][data-action='#{sym}']" : ".batch_actions_selector a.batch_action"
 
   verb = maybe == "should" ? :to : :to_not
   expect(page).send verb, have_css(selector, text: title)
@@ -20,8 +19,7 @@ Then /^I should see that the batch action button is disabled$/ do
 end
 
 Then /^I (should|should not) see the batch action (button|selector)$/ do |maybe, type|
-  selector = "div.table_tools .batch_actions_selector"
-  selector << " .dropdown_menu_button" if maybe == "should" && type == "button"
+  selector = maybe == "should" && type == "button" ? "div.table_tools .batch_actions_selector .dropdown_menu_button" : "div.table_tools .batch_actions_selector"
 
   verb = maybe == "should" ? :to : :to_not
   expect(page).send verb, have_css(selector)

--- a/features/step_definitions/blog_steps.rb
+++ b/features/step_definitions/blog_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Then /^I should see a blog header "([^"]*)"$/ do |header_text|
   expect(page).to have_css "h3", text: header_text
 end

--- a/features/step_definitions/breadcrumb_steps.rb
+++ b/features/step_definitions/breadcrumb_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Around "@breadcrumb" do |scenario, block|
   previous_breadcrumb = ActiveAdmin.application.breadcrumb
 

--- a/features/step_definitions/column_steps.rb
+++ b/features/step_definitions/column_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Then /^I should see a columns container$/ do
   expect(page).to have_css ".columns"
 end

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Then /^I should see a comment by "([^"]*)"$/ do |name|
   step %{I should see "#{name}" within ".active_admin_comment_author"}
 end

--- a/features/step_definitions/configuration_steps.rb
+++ b/features/step_definitions/configuration_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdminReloading
   def load_aa_config(config_content)
     ActiveSupport::Notifications.publish ActiveAdmin::Application::BeforeLoadEvent, ActiveAdmin.application

--- a/features/step_definitions/dashboard_steps.rb
+++ b/features/step_definitions/dashboard_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Then /^I should not see the default welcome message$/ do
   step %{I should not see "Welcome to Active Admin"}
 end

--- a/features/step_definitions/factory_steps.rb
+++ b/features/step_definitions/factory_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 def create_user(name, type = "User")
   first_name, last_name = name.split(" ")
   user = type.camelize.constantize.where(first_name: first_name, last_name: last_name).first_or_create(username: name.tr(" ", "").underscore)

--- a/features/step_definitions/filesystem_steps.rb
+++ b/features/step_definitions/filesystem_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdminContentsRollback
   def files
     @files ||= {}

--- a/features/step_definitions/filter_steps.rb
+++ b/features/step_definitions/filter_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Around "@filters" do |scenario, block|
   previous_current_filters = ActiveAdmin.application.current_filters
 

--- a/features/step_definitions/flash_steps.rb
+++ b/features/step_definitions/flash_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Then /^I should see a flash with "([^"]*)"$/ do |text|
   expect(page).to have_content text
 end

--- a/features/step_definitions/footer_steps.rb
+++ b/features/step_definitions/footer_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Around "@footer" do |scenario, block|
   previous_footer = ActiveAdmin.application.footer
 

--- a/features/step_definitions/format_steps.rb
+++ b/features/step_definitions/format_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "csv"
 
 Around "@csv" do |scenario, block|

--- a/features/step_definitions/head_steps.rb
+++ b/features/step_definitions/head_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Around "@head" do |scenario, block|
   previous_head = ActiveAdmin.application.head
 

--- a/features/step_definitions/i18n_steps.rb
+++ b/features/step_definitions/i18n_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Given /^String "([^"]*)" corresponds to "([^"]*)"$/ do |translation, key|
   *seq, last_key = key.split(".")
   result = seq.reverse.inject({ last_key.to_sym => translation }) do |temp_result, nested_key|

--- a/features/step_definitions/index_scope_steps.rb
+++ b/features/step_definitions/index_scope_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Then /^I should( not)? see the scope "([^"]*)"( selected)?$/ do |negate, name, selected|
   should = "I should#{' not' if negate}"
   scope = ".scopes#{' .selected' if selected}"

--- a/features/step_definitions/index_views_steps.rb
+++ b/features/step_definitions/index_views_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 When /^I click "(.*?)"$/ do |link|
   click_link(link)
 end

--- a/features/step_definitions/layout_steps.rb
+++ b/features/step_definitions/layout_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Then /^I should see the Active Admin layout$/ do
   expect(page).to have_css "#active_admin_content #main_content_wrapper"
 end

--- a/features/step_definitions/member_link_steps.rb
+++ b/features/step_definitions/member_link_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Then /^I should see an action item button "([^"]*)"$/ do |content|
   expect(page).to have_css ".action_items a", text: content
 end

--- a/features/step_definitions/menu_steps.rb
+++ b/features/step_definitions/menu_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Then /^I should see a menu item for "([^"]*)"$/ do |name|
   expect(page).to have_css "#tabs > li > a", text: name
 end

--- a/features/step_definitions/meta_tag_steps.rb
+++ b/features/step_definitions/meta_tag_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Then /^the site should contain a meta tag with name "([^"]*)" and content "([^"]*)"$/ do |name, content|
   expect(page).to have_xpath("//meta[@name='#{name}' and @content='#{content}']", visible: false)
 end

--- a/features/step_definitions/pagination_steps.rb
+++ b/features/step_definitions/pagination_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Then /^I should not see pagination$/ do
   expect(page).to_not have_css ".pagination"
 end

--- a/features/step_definitions/root_steps.rb
+++ b/features/step_definitions/root_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Around "@root" do |scenario, block|
   previous_root = ActiveAdmin.application.root_to
 

--- a/features/step_definitions/sidebar_steps.rb
+++ b/features/step_definitions/sidebar_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Then /^I should see a sidebar titled "([^"]*)"$/ do |title|
   expect(page).to have_css ".sidebar_section h3", text: title
 end

--- a/features/step_definitions/site_title_steps.rb
+++ b/features/step_definitions/site_title_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Around "@site_title" do |scenario, block|
   previous_site_title = ActiveAdmin.application.site_title
   previous_site_title_link = ActiveAdmin.application.site_title_link

--- a/features/step_definitions/tab_steps.rb
+++ b/features/step_definitions/tab_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Then(/^the "([^"]*)" tab should be selected$/) do |name|
   step %{I should see "#{name}" within "ul#tabs li.current"}
 end

--- a/features/step_definitions/table_steps.rb
+++ b/features/step_definitions/table_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Then /^I should see (\d+) ([\w]*) in the table$/ do |count, resource_type|
   expect(page).to \
     have_css("table.index_table tr > td:first-child", count: count.to_i)

--- a/features/step_definitions/table_steps.rb
+++ b/features/step_definitions/table_steps.rb
@@ -23,13 +23,14 @@ class HtmlTableToTextHelper
   private
 
   def cell_to_string(td)
+    str = ""
     input = td.css("input").last
 
     if input
-      input_to_string(input) + td.content.strip.gsub("\n", " ")
-    else
-      td.content.strip.gsub("\n", " ")
+      str += input_to_string(input)
     end
+
+    str += td.content.strip.gsub("\n", " ")
   end
 
   def input_to_string(input)

--- a/features/step_definitions/table_steps.rb
+++ b/features/step_definitions/table_steps.rb
@@ -22,14 +22,13 @@ class HtmlTableToTextHelper
   private
 
   def cell_to_string(td)
-    str = ""
     input = td.css("input").last
 
     if input
-      str << input_to_string(input)
+      input_to_string(input) + td.content.strip.gsub("\n", " ")
+    else
+      td.content.strip.gsub("\n", " ")
     end
-
-    str << td.content.strip.gsub("\n", " ")
   end
 
   def input_to_string(input)

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 def ensure_user_created(email)
   AdminUser.create_with(password: "password", password_confirmation: "password").find_or_create_by!(email: email)
 end

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "uri"
 require File.expand_path(File.join(__dir__, "..", "support", "paths"))
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ENV["RAILS_ENV"] = "test"
 
 require "simplecov" if ENV["COVERAGE"] == "true"

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module NavigationHelpers
   # Maps a name to a path. Used by the
   #

--- a/features/support/rails.rb
+++ b/features/support/rails.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "cucumber/rails/application"
 require "cucumber/rails/action_dispatch"
 require "cucumber/rails/world"

--- a/features/support/simplecov_changes_env.rb
+++ b/features/support/simplecov_changes_env.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 if ENV["COVERAGE"] == "true"
   require "simplecov"
 

--- a/features/support/simplecov_regular_env.rb
+++ b/features/support/simplecov_regular_env.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 if ENV["COVERAGE"] == "true"
   require "simplecov"
 

--- a/features/support/simplecov_reload_env.rb
+++ b/features/support/simplecov_reload_env.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 if ENV["COVERAGE"] == "true"
   require "simplecov"
 

--- a/gemfiles/rails_52/Gemfile
+++ b/gemfiles/rails_52/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source "https://rubygems.org"
 
 group :development, :test do

--- a/gemfiles/rails_60/Gemfile
+++ b/gemfiles/rails_60/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source "https://rubygems.org"
 
 group :development, :test do

--- a/gemfiles/rails_61_turbolinks/Gemfile
+++ b/gemfiles/rails_61_turbolinks/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source "https://rubygems.org"
 
 group :development, :test do

--- a/gemfiles/rails_61_webpacker/Gemfile
+++ b/gemfiles/rails_61_webpacker/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source "https://rubygems.org"
 
 group :development, :test do

--- a/lib/active_admin.rb
+++ b/lib/active_admin.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_support/core_ext"
 require "set"
 

--- a/lib/active_admin/abstract_view_factory.rb
+++ b/lib/active_admin/abstract_view_factory.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   class AbstractViewFactory < SettingsNode
 

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_admin/router"
 require "active_admin/application_settings"
 require "active_admin/namespace_settings"

--- a/lib/active_admin/application_settings.rb
+++ b/lib/active_admin/application_settings.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_admin/settings_node"
 
 module ActiveAdmin

--- a/lib/active_admin/asset_registration.rb
+++ b/lib/active_admin/asset_registration.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module AssetRegistration
 

--- a/lib/active_admin/authorization_adapter.rb
+++ b/lib/active_admin/authorization_adapter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
 
   # Default Authorization permissions for Active Admin

--- a/lib/active_admin/base_controller.rb
+++ b/lib/active_admin/base_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_admin/base_controller/authorization"
 require "active_admin/base_controller/menu"
 

--- a/lib/active_admin/base_controller/authorization.rb
+++ b/lib/active_admin/base_controller/authorization.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   class BaseController < ::InheritedResources::Base
     module Authorization

--- a/lib/active_admin/base_controller/menu.rb
+++ b/lib/active_admin/base_controller/menu.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   class BaseController < ::InheritedResources::Base
     module Menu

--- a/lib/active_admin/batch_actions.rb
+++ b/lib/active_admin/batch_actions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ActiveAdmin.before_load do |app|
   require "active_admin/batch_actions/resource_extension"
   require "active_admin/batch_actions/controller"

--- a/lib/active_admin/batch_actions/controller.rb
+++ b/lib/active_admin/batch_actions/controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module BatchActions
     module Controller

--- a/lib/active_admin/batch_actions/resource_extension.rb
+++ b/lib/active_admin/batch_actions/resource_extension.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
 
   module BatchActions

--- a/lib/active_admin/batch_actions/views/batch_action_form.rb
+++ b/lib/active_admin/batch_actions/views/batch_action_form.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_admin/component"
 
 module ActiveAdmin

--- a/lib/active_admin/batch_actions/views/batch_action_selector.rb
+++ b/lib/active_admin/batch_actions/views/batch_action_selector.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_admin/component"
 
 module ActiveAdmin

--- a/lib/active_admin/batch_actions/views/selection_cells.rb
+++ b/lib/active_admin/batch_actions/views/selection_cells.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_admin/component"
 
 module ActiveAdmin

--- a/lib/active_admin/callbacks.rb
+++ b/lib/active_admin/callbacks.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Callbacks
     extend ActiveSupport::Concern

--- a/lib/active_admin/cancan_adapter.rb
+++ b/lib/active_admin/cancan_adapter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 unless ActiveAdmin::Dependency.cancan? || ActiveAdmin::Dependency.cancancan?
   ActiveAdmin::Dependency.cancan!
 end

--- a/lib/active_admin/collection_decorator.rb
+++ b/lib/active_admin/collection_decorator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   # This class decorates a collection of objects delegating
   # mehods to behave like an Array. It's used to decouple ActiveAdmin

--- a/lib/active_admin/component.rb
+++ b/lib/active_admin/component.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   class Component < Arbre::Component
 

--- a/lib/active_admin/controller_action.rb
+++ b/lib/active_admin/controller_action.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   class ControllerAction
     attr_reader :name

--- a/lib/active_admin/csv_builder.rb
+++ b/lib/active_admin/csv_builder.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   # CSVBuilder stores CSV configuration
   #

--- a/lib/active_admin/dependency.rb
+++ b/lib/active_admin/dependency.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Dependency
     module Requirements

--- a/lib/active_admin/deprecation.rb
+++ b/lib/active_admin/deprecation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Deprecation
     module_function

--- a/lib/active_admin/devise.rb
+++ b/lib/active_admin/devise.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ActiveAdmin::Dependency.devise! ActiveAdmin::Dependency::Requirements::DEVISE
 
 require "devise"

--- a/lib/active_admin/dsl.rb
+++ b/lib/active_admin/dsl.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
 
   # The Active Admin DSL. This class is where all the registration blocks

--- a/lib/active_admin/dynamic_setting.rb
+++ b/lib/active_admin/dynamic_setting.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
 
   class DynamicSetting

--- a/lib/active_admin/dynamic_settings_node.rb
+++ b/lib/active_admin/dynamic_settings_node.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_admin/dynamic_setting"
 require "active_admin/settings_node"
 

--- a/lib/active_admin/engine.rb
+++ b/lib/active_admin/engine.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   class Engine < ::Rails::Engine
     initializer "active_admin.load_app_path" do |app|

--- a/lib/active_admin/error.rb
+++ b/lib/active_admin/error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   # Exception class to raise when there is an authorized access
   # exception thrown. The exception has a few goodies that may

--- a/lib/active_admin/filters.rb
+++ b/lib/active_admin/filters.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_admin/filters/dsl"
 require "active_admin/filters/resource_extension"
 require "active_admin/filters/formtastic_addons"

--- a/lib/active_admin/filters/active.rb
+++ b/lib/active_admin/filters/active.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_admin/filters/active_filter"
 
 module ActiveAdmin

--- a/lib/active_admin/filters/active_filter.rb
+++ b/lib/active_admin/filters/active_filter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Filters
 

--- a/lib/active_admin/filters/active_sidebar.rb
+++ b/lib/active_admin/filters/active_sidebar.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_admin/filters/active"
 
 module ActiveAdmin

--- a/lib/active_admin/filters/dsl.rb
+++ b/lib/active_admin/filters/dsl.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Filters
     module DSL

--- a/lib/active_admin/filters/forms.rb
+++ b/lib/active_admin/filters/forms.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Filters
     # This form builder defines methods to build filter forms such

--- a/lib/active_admin/filters/formtastic_addons.rb
+++ b/lib/active_admin/filters/formtastic_addons.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Filters
     module FormtasticAddons

--- a/lib/active_admin/filters/resource_extension.rb
+++ b/lib/active_admin/filters/resource_extension.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Filters
 

--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Provides an intuitive way to build has_many associated records in the same form.
 module Formtastic
   module Inputs

--- a/lib/active_admin/generators/boilerplate.rb
+++ b/lib/active_admin/generators/boilerplate.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Generators
     class Boilerplate

--- a/lib/active_admin/helpers/collection.rb
+++ b/lib/active_admin/helpers/collection.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Helpers
     module Collection

--- a/lib/active_admin/helpers/i18n.rb
+++ b/lib/active_admin/helpers/i18n.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Helpers
     module I18n

--- a/lib/active_admin/helpers/optional_display.rb
+++ b/lib/active_admin/helpers/optional_display.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
 
   # Shareable module to give a #display_on?(action) method

--- a/lib/active_admin/helpers/routes/url_helpers.rb
+++ b/lib/active_admin/helpers/routes/url_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Helpers
     module Routes

--- a/lib/active_admin/helpers/scope_chain.rb
+++ b/lib/active_admin/helpers/scope_chain.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module ScopeChain
     private

--- a/lib/active_admin/inputs.rb
+++ b/lib/active_admin/inputs.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Inputs
     extend ActiveSupport::Autoload

--- a/lib/active_admin/inputs/datepicker_input.rb
+++ b/lib/active_admin/inputs/datepicker_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Inputs
     class DatepickerInput < ::Formtastic::Inputs::StringInput

--- a/lib/active_admin/inputs/filters/base.rb
+++ b/lib/active_admin/inputs/filters/base.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Inputs
     module Filters

--- a/lib/active_admin/inputs/filters/base/search_method_select.rb
+++ b/lib/active_admin/inputs/filters/base/search_method_select.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # This is a common set of Formtastic overrides needed to build a filter form
 # that lets you select from a set of search methods for a given attribute.
 #

--- a/lib/active_admin/inputs/filters/boolean_input.rb
+++ b/lib/active_admin/inputs/filters/boolean_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Inputs
     module Filters

--- a/lib/active_admin/inputs/filters/check_boxes_input.rb
+++ b/lib/active_admin/inputs/filters/check_boxes_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Inputs
     module Filters

--- a/lib/active_admin/inputs/filters/date_picker_input.rb
+++ b/lib/active_admin/inputs/filters/date_picker_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Inputs
     module Filters

--- a/lib/active_admin/inputs/filters/date_range_input.rb
+++ b/lib/active_admin/inputs/filters/date_range_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Inputs
     module Filters

--- a/lib/active_admin/inputs/filters/numeric_input.rb
+++ b/lib/active_admin/inputs/filters/numeric_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Inputs
     module Filters

--- a/lib/active_admin/inputs/filters/select_input.rb
+++ b/lib/active_admin/inputs/filters/select_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Inputs
     module Filters

--- a/lib/active_admin/inputs/filters/string_input.rb
+++ b/lib/active_admin/inputs/filters/string_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Inputs
     module Filters

--- a/lib/active_admin/inputs/filters/text_input.rb
+++ b/lib/active_admin/inputs/filters/text_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Inputs
     module Filters

--- a/lib/active_admin/localizers.rb
+++ b/lib/active_admin/localizers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_admin/localizers/resource_localizer"
 
 module ActiveAdmin

--- a/lib/active_admin/localizers/resource_localizer.rb
+++ b/lib/active_admin/localizers/resource_localizer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Localizers
     class ResourceLocalizer

--- a/lib/active_admin/menu.rb
+++ b/lib/active_admin/menu.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
 
   # Each Namespace builds up it's own menu as the global navigation

--- a/lib/active_admin/menu_collection.rb
+++ b/lib/active_admin/menu_collection.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
 
   DEFAULT_MENU = :default

--- a/lib/active_admin/menu_item.rb
+++ b/lib/active_admin/menu_item.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   class MenuItem
     include Menu::MenuNode

--- a/lib/active_admin/namespace.rb
+++ b/lib/active_admin/namespace.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_admin/resource_collection"
 
 module ActiveAdmin

--- a/lib/active_admin/namespace_settings.rb
+++ b/lib/active_admin/namespace_settings.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_admin/dynamic_settings_node"
 
 module ActiveAdmin

--- a/lib/active_admin/order_clause.rb
+++ b/lib/active_admin/order_clause.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   class OrderClause
     attr_reader :field, :order, :active_admin_config

--- a/lib/active_admin/orm/active_record.rb
+++ b/lib/active_admin/orm/active_record.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # ActiveRecord-specific plugins should be required here
 
 ActiveAdmin::DatabaseHitDuringLoad.database_error_classes << ActiveRecord::StatementInvalid

--- a/lib/active_admin/orm/active_record/comments.rb
+++ b/lib/active_admin/orm/active_record/comments.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_admin/orm/active_record/comments/views"
 require "active_admin/orm/active_record/comments/show_page_helper"
 require "active_admin/orm/active_record/comments/namespace_helper"

--- a/lib/active_admin/orm/active_record/comments/comment.rb
+++ b/lib/active_admin/orm/active_record/comments/comment.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   class Comment < ActiveRecord::Base
 

--- a/lib/active_admin/orm/active_record/comments/namespace_helper.rb
+++ b/lib/active_admin/orm/active_record/comments/namespace_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Comments
 

--- a/lib/active_admin/orm/active_record/comments/resource_helper.rb
+++ b/lib/active_admin/orm/active_record/comments/resource_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Comments
 

--- a/lib/active_admin/orm/active_record/comments/show_page_helper.rb
+++ b/lib/active_admin/orm/active_record/comments/show_page_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Comments
 

--- a/lib/active_admin/orm/active_record/comments/views.rb
+++ b/lib/active_admin/orm/active_record/comments/views.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 require "active_admin/views"
 require "active_admin/orm/active_record/comments/views/active_admin_comments"

--- a/lib/active_admin/orm/active_record/comments/views/active_admin_comments.rb
+++ b/lib/active_admin/orm/active_record/comments/views/active_admin_comments.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_admin/views"
 require "active_admin/views/components/panel"
 

--- a/lib/active_admin/orm/mongoid.rb
+++ b/lib/active_admin/orm/mongoid.rb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 # Mongoid-specific plugins should be required here

--- a/lib/active_admin/page.rb
+++ b/lib/active_admin/page.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   # Page is the primary data storage for page configuration in Active Admin
   #

--- a/lib/active_admin/page_controller.rb
+++ b/lib/active_admin/page_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
 
   # All Pages controllers inherit from this controller.

--- a/lib/active_admin/page_dsl.rb
+++ b/lib/active_admin/page_dsl.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   # This is the class where all the register_page blocks are evaluated.
   class PageDSL < DSL

--- a/lib/active_admin/page_presenter.rb
+++ b/lib/active_admin/page_presenter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
 
   # A simple object that gets used to present different aspects of views

--- a/lib/active_admin/pundit_adapter.rb
+++ b/lib/active_admin/pundit_adapter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ActiveAdmin::Dependency.pundit!
 
 require "pundit"

--- a/lib/active_admin/resource.rb
+++ b/lib/active_admin/resource.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_admin/resource/action_items"
 require "active_admin/resource/attributes"
 require "active_admin/resource/controllers"

--- a/lib/active_admin/resource/action_items.rb
+++ b/lib/active_admin/resource/action_items.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_admin/helpers/optional_display"
 
 module ActiveAdmin

--- a/lib/active_admin/resource/attributes.rb
+++ b/lib/active_admin/resource/attributes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
 
   class Resource

--- a/lib/active_admin/resource/belongs_to.rb
+++ b/lib/active_admin/resource/belongs_to.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_admin/resource"
 
 module ActiveAdmin

--- a/lib/active_admin/resource/controllers.rb
+++ b/lib/active_admin/resource/controllers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   class Resource
     module Controllers

--- a/lib/active_admin/resource/includes.rb
+++ b/lib/active_admin/resource/includes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   class Resource
     module Includes

--- a/lib/active_admin/resource/menu.rb
+++ b/lib/active_admin/resource/menu.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   class Resource
 

--- a/lib/active_admin/resource/model.rb
+++ b/lib/active_admin/resource/model.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   class Model
     def initialize(resource, record)

--- a/lib/active_admin/resource/naming.rb
+++ b/lib/active_admin/resource/naming.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   class Resource
 

--- a/lib/active_admin/resource/ordering.rb
+++ b/lib/active_admin/resource/ordering.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   class Resource
     module Ordering

--- a/lib/active_admin/resource/page_presenters.rb
+++ b/lib/active_admin/resource/page_presenters.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   class Resource
     module PagePresenters

--- a/lib/active_admin/resource/pagination.rb
+++ b/lib/active_admin/resource/pagination.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
 
   class Resource

--- a/lib/active_admin/resource/routes.rb
+++ b/lib/active_admin/resource/routes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   class Resource
     module Routes

--- a/lib/active_admin/resource/scope_to.rb
+++ b/lib/active_admin/resource/scope_to.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   class Resource
     module ScopeTo

--- a/lib/active_admin/resource/scopes.rb
+++ b/lib/active_admin/resource/scopes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   class Resource
     module Scopes

--- a/lib/active_admin/resource/sidebars.rb
+++ b/lib/active_admin/resource/sidebars.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_admin/helpers/optional_display"
 
 module ActiveAdmin

--- a/lib/active_admin/resource_collection.rb
+++ b/lib/active_admin/resource_collection.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   # This is a container for resources, which acts much like a Hash.
   # It's assumed that an added resource responds to `resource_name`.

--- a/lib/active_admin/resource_controller.rb
+++ b/lib/active_admin/resource_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_admin/collection_decorator"
 require "active_admin/resource_controller/action_builder"
 require "active_admin/resource_controller/data_access"

--- a/lib/active_admin/resource_controller/action_builder.rb
+++ b/lib/active_admin/resource_controller/action_builder.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   class ResourceController < BaseController
 

--- a/lib/active_admin/resource_controller/data_access.rb
+++ b/lib/active_admin/resource_controller/data_access.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   class ResourceController < BaseController
 

--- a/lib/active_admin/resource_controller/decorators.rb
+++ b/lib/active_admin/resource_controller/decorators.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   class ResourceController < BaseController
     module Decorators

--- a/lib/active_admin/resource_controller/polymorphic_routes.rb
+++ b/lib/active_admin/resource_controller/polymorphic_routes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_admin/resource"
 require "active_admin/resource/model"
 

--- a/lib/active_admin/resource_controller/resource_class_methods.rb
+++ b/lib/active_admin/resource_controller/resource_class_methods.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   class ResourceController < BaseController
     module ResourceClassMethods

--- a/lib/active_admin/resource_controller/scoping.rb
+++ b/lib/active_admin/resource_controller/scoping.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   class ResourceController < BaseController
 

--- a/lib/active_admin/resource_controller/sidebars.rb
+++ b/lib/active_admin/resource_controller/sidebars.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   class ResourceController < BaseController
 

--- a/lib/active_admin/resource_controller/streaming.rb
+++ b/lib/active_admin/resource_controller/streaming.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "csv"
 
 module ActiveAdmin

--- a/lib/active_admin/resource_dsl.rb
+++ b/lib/active_admin/resource_dsl.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   # This is the class where all the register blocks are evaluated.
   class ResourceDSL < DSL

--- a/lib/active_admin/router.rb
+++ b/lib/active_admin/router.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   # @private
   class Router

--- a/lib/active_admin/scope.rb
+++ b/lib/active_admin/scope.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   class Scope
 

--- a/lib/active_admin/settings_node.rb
+++ b/lib/active_admin/settings_node.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
 
   class SettingsNode

--- a/lib/active_admin/sidebar_section.rb
+++ b/lib/active_admin/sidebar_section.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
 
   class SidebarSection

--- a/lib/active_admin/version.rb
+++ b/lib/active_admin/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   VERSION = "2.9.0"
 end

--- a/lib/active_admin/view_factory.rb
+++ b/lib/active_admin/view_factory.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_admin/abstract_view_factory"
 
 module ActiveAdmin

--- a/lib/active_admin/view_helpers.rb
+++ b/lib/active_admin/view_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module ViewHelpers
 

--- a/lib/active_admin/view_helpers/active_admin_application_helper.rb
+++ b/lib/active_admin/view_helpers/active_admin_application_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module ViewHelpers
     module ActiveAdminApplicationHelper

--- a/lib/active_admin/view_helpers/auto_link_helper.rb
+++ b/lib/active_admin/view_helpers/auto_link_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module ViewHelpers
     module AutoLinkHelper

--- a/lib/active_admin/view_helpers/breadcrumb_helper.rb
+++ b/lib/active_admin/view_helpers/breadcrumb_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module ViewHelpers
     module BreadcrumbHelper

--- a/lib/active_admin/view_helpers/display_helper.rb
+++ b/lib/active_admin/view_helpers/display_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module ViewHelpers
     module DisplayHelper

--- a/lib/active_admin/view_helpers/display_helper.rb
+++ b/lib/active_admin/view_helpers/display_helper.rb
@@ -3,12 +3,19 @@ module ActiveAdmin
     module DisplayHelper
 
       DISPLAY_NAME_FALLBACK = -> {
-        name = ""
         klass = self.class
-        name << klass.model_name.human if klass.respond_to? :model_name
-        name << " ##{send(klass.primary_key)}" if klass.respond_to? :primary_key
+        name = if klass.respond_to?(:model_name)
+                 if klass.respond_to?(:primary_key)
+                   "#{klass.model_name.human} ##{send(klass.primary_key)}"
+                 else
+                   klass.model_name.human
+                 end
+               elsif klass.respond_to?(:primary_key)
+                 " ##{send(klass.primary_key)}"
+               end
         name.present? ? name : to_s
       }
+
       def DISPLAY_NAME_FALLBACK.inspect
         "DISPLAY_NAME_FALLBACK"
       end

--- a/lib/active_admin/view_helpers/download_format_links_helper.rb
+++ b/lib/active_admin/view_helpers/download_format_links_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module ViewHelpers
     module DownloadFormatLinksHelper

--- a/lib/active_admin/view_helpers/fields_for.rb
+++ b/lib/active_admin/view_helpers/fields_for.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module ViewHelpers
     module FormHelper

--- a/lib/active_admin/view_helpers/flash_helper.rb
+++ b/lib/active_admin/view_helpers/flash_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module ViewHelpers
     module FlashHelper

--- a/lib/active_admin/view_helpers/form_helper.rb
+++ b/lib/active_admin/view_helpers/form_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module ViewHelpers
     module FormHelper

--- a/lib/active_admin/view_helpers/method_or_proc_helper.rb
+++ b/lib/active_admin/view_helpers/method_or_proc_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Utility methods for internal use.
 # @private
 module MethodOrProcHelper

--- a/lib/active_admin/view_helpers/scope_name_helper.rb
+++ b/lib/active_admin/view_helpers/scope_name_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module ViewHelpers
     module ScopeNameHelper

--- a/lib/active_admin/view_helpers/sidebar_helper.rb
+++ b/lib/active_admin/view_helpers/sidebar_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module ViewHelpers
     module SidebarHelper

--- a/lib/active_admin/view_helpers/title_helper.rb
+++ b/lib/active_admin/view_helpers/title_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module ViewHelpers
     module TitleHelper

--- a/lib/active_admin/view_helpers/view_factory_helper.rb
+++ b/lib/active_admin/view_helpers/view_factory_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module ViewHelpers
     module ViewFactoryHelper

--- a/lib/active_admin/views.rb
+++ b/lib/active_admin/views.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Views
 

--- a/lib/active_admin/views/action_items.rb
+++ b/lib/active_admin/views/action_items.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Views
 

--- a/lib/active_admin/views/components/active_admin_form.rb
+++ b/lib/active_admin/views/components/active_admin_form.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Views
     class FormtasticProxy < ::Arbre::Rails::Forms::FormBuilderProxy

--- a/lib/active_admin/views/components/active_admin_form.rb
+++ b/lib/active_admin/views/components/active_admin_form.rb
@@ -16,7 +16,7 @@ module ActiveAdmin
       end
 
       def to_s
-        opening_tag << children.to_s << closing_tag
+        opening_tag + children.to_s + closing_tag
       end
     end
 

--- a/lib/active_admin/views/components/attributes_table.rb
+++ b/lib/active_admin/views/components/attributes_table.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Views
 

--- a/lib/active_admin/views/components/blank_slate.rb
+++ b/lib/active_admin/views/components/blank_slate.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Views
     # Build a Blank Slate

--- a/lib/active_admin/views/components/columns.rb
+++ b/lib/active_admin/views/components/columns.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Views
 

--- a/lib/active_admin/views/components/dropdown_menu.rb
+++ b/lib/active_admin/views/components/dropdown_menu.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Views
 

--- a/lib/active_admin/views/components/dropdown_menu.rb
+++ b/lib/active_admin/views/components/dropdown_menu.rb
@@ -45,15 +45,14 @@ module ActiveAdmin
       private
 
       def build_button(name, button_options)
-        button_options[:class] = "#{button_options[:class]} dropdown_menu_button" || "dropdown_menu_button"
-
+        button_options[:class] = "#{button_options[:class]} dropdown_menu_button"
         button_options[:href] = "#"
 
         a name, button_options
       end
 
       def build_menu(options)
-        options[:class] = "#{options[:class]} dropdown_menu_list" || "dropdown_menu_list"
+        options[:class] = "#{options[:class]} dropdown_menu_list"
 
         menu_list = nil
 

--- a/lib/active_admin/views/components/dropdown_menu.rb
+++ b/lib/active_admin/views/components/dropdown_menu.rb
@@ -44,8 +44,7 @@ module ActiveAdmin
       private
 
       def build_button(name, button_options)
-        button_options[:class] ||= ""
-        button_options[:class] << " dropdown_menu_button"
+        button_options[:class] = "#{button_options[:class]} dropdown_menu_button" || "dropdown_menu_button"
 
         button_options[:href] = "#"
 
@@ -53,8 +52,7 @@ module ActiveAdmin
       end
 
       def build_menu(options)
-        options[:class] ||= ""
-        options[:class] << " dropdown_menu_list"
+        options[:class] = "#{options[:class]} dropdown_menu_list" || "dropdown_menu_list"
 
         menu_list = nil
 

--- a/lib/active_admin/views/components/index_list.rb
+++ b/lib/active_admin/views/components/index_list.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_admin/helpers/collection"
 
 module ActiveAdmin

--- a/lib/active_admin/views/components/menu.rb
+++ b/lib/active_admin/views/components/menu.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Views
 

--- a/lib/active_admin/views/components/menu_item.rb
+++ b/lib/active_admin/views/components/menu_item.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Views
 

--- a/lib/active_admin/views/components/paginated_collection.rb
+++ b/lib/active_admin/views/components/paginated_collection.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_admin/helpers/collection"
 require "active_admin/view_helpers/download_format_links_helper"
 

--- a/lib/active_admin/views/components/panel.rb
+++ b/lib/active_admin/views/components/panel.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Views
 

--- a/lib/active_admin/views/components/scopes.rb
+++ b/lib/active_admin/views/components/scopes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_admin/helpers/collection"
 require "active_admin/view_helpers/method_or_proc_helper"
 

--- a/lib/active_admin/views/components/sidebar.rb
+++ b/lib/active_admin/views/components/sidebar.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Views
 

--- a/lib/active_admin/views/components/sidebar_section.rb
+++ b/lib/active_admin/views/components/sidebar_section.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Views
 

--- a/lib/active_admin/views/components/site_title.rb
+++ b/lib/active_admin/views/components/site_title.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Views
 

--- a/lib/active_admin/views/components/status_tag.rb
+++ b/lib/active_admin/views/components/status_tag.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Views
     # Build a StatusTag

--- a/lib/active_admin/views/components/table_for.rb
+++ b/lib/active_admin/views/components/table_for.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Views
     class TableFor < Arbre::HTML::Table

--- a/lib/active_admin/views/components/tabs.rb
+++ b/lib/active_admin/views/components/tabs.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Views
     class Tabs < ActiveAdmin::Component

--- a/lib/active_admin/views/components/unsupported_browser.rb
+++ b/lib/active_admin/views/components/unsupported_browser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Views
     class UnsupportedBrowser < Component

--- a/lib/active_admin/views/footer.rb
+++ b/lib/active_admin/views/footer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Views
     class Footer < Component

--- a/lib/active_admin/views/header.rb
+++ b/lib/active_admin/views/header.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Views
     class Header < Component

--- a/lib/active_admin/views/index_as_block.rb
+++ b/lib/active_admin/views/index_as_block.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Views
 

--- a/lib/active_admin/views/index_as_blog.rb
+++ b/lib/active_admin/views/index_as_blog.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Views
 

--- a/lib/active_admin/views/index_as_grid.rb
+++ b/lib/active_admin/views/index_as_grid.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Views
 

--- a/lib/active_admin/views/index_as_table.rb
+++ b/lib/active_admin/views/index_as_table.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Views
 

--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Views
     module Pages

--- a/lib/active_admin/views/pages/form.rb
+++ b/lib/active_admin/views/pages/form.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Views
     module Pages

--- a/lib/active_admin/views/pages/index.rb
+++ b/lib/active_admin/views/pages/index.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_admin/helpers/collection"
 
 module ActiveAdmin

--- a/lib/active_admin/views/pages/layout.rb
+++ b/lib/active_admin/views/pages/layout.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Views
     module Pages

--- a/lib/active_admin/views/pages/page.rb
+++ b/lib/active_admin/views/pages/page.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Views
     module Pages

--- a/lib/active_admin/views/pages/show.rb
+++ b/lib/active_admin/views/pages/show.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Views
     module Pages

--- a/lib/active_admin/views/tabbed_navigation.rb
+++ b/lib/active_admin/views/tabbed_navigation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "components/menu"
 
 module ActiveAdmin

--- a/lib/active_admin/views/title_bar.rb
+++ b/lib/active_admin/views/title_bar.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Views
     class TitleBar < Component

--- a/lib/activeadmin.rb
+++ b/lib/activeadmin.rb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 require "active_admin"

--- a/lib/generators/active_admin/assets/assets_generator.rb
+++ b/lib/generators/active_admin/assets/assets_generator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Generators
     class AssetsGenerator < Rails::Generators::Base

--- a/lib/generators/active_admin/devise/devise_generator.rb
+++ b/lib/generators/active_admin/devise/devise_generator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_admin/error"
 require "active_admin/dependency"
 

--- a/lib/generators/active_admin/install/install_generator.rb
+++ b/lib/generators/active_admin/install/install_generator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails/generators/active_record"
 
 module ActiveAdmin

--- a/lib/generators/active_admin/install/templates/dashboard.rb
+++ b/lib/generators/active_admin/install/templates/dashboard.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ActiveAdmin.register_page "Dashboard" do
   menu priority: 1, label: proc { I18n.t("active_admin.dashboard") }
 

--- a/lib/generators/active_admin/page/page_generator.rb
+++ b/lib/generators/active_admin/page/page_generator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Generators
     class PageGenerator < Rails::Generators::NamedBase

--- a/lib/generators/active_admin/page/templates/page.rb
+++ b/lib/generators/active_admin/page/templates/page.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ActiveAdmin.register_page "<%= class_name %>" do
   content do
     # your content

--- a/lib/generators/active_admin/resource/resource_generator.rb
+++ b/lib/generators/active_admin/resource/resource_generator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_admin/generators/boilerplate"
 
 module ActiveAdmin

--- a/lib/generators/active_admin/webpacker/webpacker_generator.rb
+++ b/lib/generators/active_admin/webpacker/webpacker_generator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   module Generators
     class WebpackerGenerator < Rails::Generators::Base

--- a/lib/ransack_ext.rb
+++ b/lib/ransack_ext.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # This sets up aliases for old Metasearch query methods so they behave
 # identically to the versions given in Ransack.
 #

--- a/spec/changelog_spec.lint.rb
+++ b/spec/changelog_spec.lint.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 SimpleCov.command_name "lint" if ENV["COVERAGE"] == "true"
 
 require "kramdown"

--- a/spec/gemfiles_spec.lint.rb
+++ b/spec/gemfiles_spec.lint.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 RSpec.describe "Gemfile sanity" do
   shared_examples_for "a sane gemfile" do |gemfile|
     it "is up to date" do

--- a/spec/gemspec_spec.lint.rb
+++ b/spec/gemspec_spec.lint.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "open3"
 require "active_admin/version"
 

--- a/spec/i18n_spec.lint.rb
+++ b/spec/i18n_spec.lint.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "i18n/tasks"
 require "i18n-spec"
 

--- a/spec/javascripts/support/jasmine_runner.rb
+++ b/spec/javascripts/support/jasmine_runner.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 $:.unshift(ENV["JASMINE_GEM_PATH"]) if ENV["JASMINE_GEM_PATH"] # for gem testing purposes
 
 require "jasmine"

--- a/spec/js_bundle_spec.lint.rb
+++ b/spec/js_bundle_spec.lint.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "open3"
 
 RSpec.describe "JS bundle sanity" do

--- a/spec/local_spec.lint.rb
+++ b/spec/local_spec.lint.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "open3"
 
 RSpec.describe "local task" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 ENV["RAILS_ENV"] = "test"

--- a/spec/requests/default_namespace_spec.rb
+++ b/spec/requests/default_namespace_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Application, type: :request do

--- a/spec/requests/memory_spec.rb
+++ b/spec/requests/memory_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe "Memory Leak", type: :request, if: RUBY_ENGINE == "ruby" do

--- a/spec/requests/stylesheets_spec.rb
+++ b/spec/requests/stylesheets_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe "Stylesheets", type: :request, unless: ActiveAdmin.application.use_webpacker do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "simplecov" if ENV["COVERAGE"] == "true"
 
 RSpec.configure do |config|

--- a/spec/support/active_admin_integration_spec_helper.rb
+++ b/spec/support/active_admin_integration_spec_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdminIntegrationSpecHelper
   def with_resources_during(example)
     load_resources { yield }

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Rails template to build the sample app for specs
 
 webpacker_app = ENV["BUNDLE_GEMFILE"] == File.expand_path("../../gemfiles/rails_61_webpacker/Gemfile", __dir__)

--- a/spec/support/rails_template_with_data.rb
+++ b/spec/support/rails_template_with_data.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 apply File.expand_path("rails_template.rb", __dir__)
 
 inject_into_file "config/initializers/active_admin.rb", <<-RUBY, after: "ActiveAdmin.setup do |config|"

--- a/spec/support/simplecov_changes_env.rb
+++ b/spec/support/simplecov_changes_env.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 if ENV["COVERAGE"] == "true"
   require "simplecov"
 

--- a/spec/support/simplecov_regular_env.rb
+++ b/spec/support/simplecov_regular_env.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 if ENV["COVERAGE"] == "true"
   require "simplecov"
 

--- a/spec/support/templates/admin/stores.rb
+++ b/spec/support/templates/admin/stores.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ActiveAdmin.register Store do
   permit_params :name
 

--- a/spec/support/templates/models/blog/post.rb
+++ b/spec/support/templates/models/blog/post.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Blog::Post < ActiveRecord::Base
   belongs_to :category, foreign_key: :custom_category_id
   belongs_to :author, class_name: "User"

--- a/spec/support/templates/models/category.rb
+++ b/spec/support/templates/models/category.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Category < ActiveRecord::Base
   has_many :posts, foreign_key: :custom_category_id
   has_many :authors, through: :posts

--- a/spec/support/templates/models/post.rb
+++ b/spec/support/templates/models/post.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Post < ActiveRecord::Base
   belongs_to :category, foreign_key: :custom_category_id, optional: true
   belongs_to :author, class_name: "User", optional: true

--- a/spec/support/templates/models/profile.rb
+++ b/spec/support/templates/models/profile.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Profile < ActiveRecord::Base
   belongs_to :user
 end

--- a/spec/support/templates/models/publisher.rb
+++ b/spec/support/templates/models/publisher.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 class Publisher < User
 end

--- a/spec/support/templates/models/store.rb
+++ b/spec/support/templates/models/store.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 class Store < ApplicationRecord
 end

--- a/spec/support/templates/models/tag.rb
+++ b/spec/support/templates/models/tag.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Tag < ActiveRecord::Base
   has_many :taggings
   has_many :posts, through: :taggings

--- a/spec/support/templates/models/tagging.rb
+++ b/spec/support/templates/models/tagging.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Tagging < ActiveRecord::Base
   belongs_to :post, optional: true
   belongs_to :tag, optional: true

--- a/spec/support/templates/models/user.rb
+++ b/spec/support/templates/models/user.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class User < ActiveRecord::Base
   class VIP < self
   end

--- a/spec/support/templates/policies/active_admin/comment_policy.rb
+++ b/spec/support/templates/policies/active_admin/comment_policy.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   class CommentPolicy < ApplicationPolicy
     def destroy?

--- a/spec/support/templates/policies/active_admin/page_policy.rb
+++ b/spec/support/templates/policies/active_admin/page_policy.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveAdmin
   class PagePolicy < ApplicationPolicy
     def show?

--- a/spec/support/templates/policies/admin_user_policy.rb
+++ b/spec/support/templates/policies/admin_user_policy.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 class AdminUserPolicy < ApplicationPolicy
 end

--- a/spec/support/templates/policies/application_policy.rb
+++ b/spec/support/templates/policies/application_policy.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ApplicationPolicy
   attr_reader :user, :record
 

--- a/spec/support/templates/policies/category_policy.rb
+++ b/spec/support/templates/policies/category_policy.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 class CategoryPolicy < ApplicationPolicy
 end

--- a/spec/support/templates/policies/post_policy.rb
+++ b/spec/support/templates/policies/post_policy.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class PostPolicy < ApplicationPolicy
   def update?
     record.author == user

--- a/spec/support/templates/policies/store_policy.rb
+++ b/spec/support/templates/policies/store_policy.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 class StorePolicy < ApplicationPolicy
 end

--- a/spec/support/templates/policies/user_policy.rb
+++ b/spec/support/templates/policies/user_policy.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 class UserPolicy < ApplicationPolicy
 end

--- a/spec/support/templates/post_decorator.rb
+++ b/spec/support/templates/post_decorator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "draper"
 
 class PostDecorator < Draper::Decorator

--- a/spec/support/templates/post_poro_decorator.rb
+++ b/spec/support/templates/post_poro_decorator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class PostPoroDecorator
   delegate_missing_to :post
 

--- a/spec/support/templates_with_data/admin/categories.rb
+++ b/spec/support/templates_with_data/admin/categories.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ActiveAdmin.register Category do
   config.create_another = true
 

--- a/spec/support/templates_with_data/admin/kitchen_sink.rb
+++ b/spec/support/templates_with_data/admin/kitchen_sink.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ActiveAdmin.register_page "KitchenSink" do
   sidebar "Sample Sidebar" do
     para "Sidebars can also be used on custom pages."

--- a/spec/support/templates_with_data/admin/posts.rb
+++ b/spec/support/templates_with_data/admin/posts.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ActiveAdmin.register Post do
   permit_params :custom_category_id, :author_id, :title, :body, :published_date, :position, :starred, taggings_attributes: [ :id, :tag_id, :name, :position, :_destroy ]
 

--- a/spec/support/templates_with_data/admin/tags.rb
+++ b/spec/support/templates_with_data/admin/tags.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ActiveAdmin.register Tag do
   config.create_another = true
 

--- a/spec/support/templates_with_data/admin/users.rb
+++ b/spec/support/templates_with_data/admin/users.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ActiveAdmin.register User do
   config.create_another = true
 

--- a/spec/unit/abstract_view_factory_spec.rb
+++ b/spec/unit/abstract_view_factory_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 require "active_admin/abstract_view_factory"

--- a/spec/unit/action_builder_spec.rb
+++ b/spec/unit/action_builder_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe "defining actions from registration blocks", type: :controller do

--- a/spec/unit/active_admin_spec.rb
+++ b/spec/unit/active_admin_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin do

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 require "fileutils"
 

--- a/spec/unit/asset_registration_spec.rb
+++ b/spec/unit/asset_registration_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::AssetRegistration do

--- a/spec/unit/authorization/authorization_adapter_spec.rb
+++ b/spec/unit/authorization/authorization_adapter_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::AuthorizationAdapter do

--- a/spec/unit/authorization/controller_authorization_spec.rb
+++ b/spec/unit/authorization/controller_authorization_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe "Controller Authorization", type: :controller do

--- a/spec/unit/authorization/index_overriding_spec.rb
+++ b/spec/unit/authorization/index_overriding_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe "Index overriding", type: :controller do

--- a/spec/unit/auto_link_spec.rb
+++ b/spec/unit/auto_link_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 require "active_admin/view_helpers/active_admin_application_helper"
 require "active_admin/view_helpers/auto_link_helper"

--- a/spec/unit/batch_actions/resource_spec.rb
+++ b/spec/unit/batch_actions/resource_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::BatchActions::ResourceExtension do

--- a/spec/unit/batch_actions/settings_spec.rb
+++ b/spec/unit/batch_actions/settings_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe "Batch Actions Settings" do

--- a/spec/unit/belongs_to_spec.rb
+++ b/spec/unit/belongs_to_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Resource::BelongsTo do

--- a/spec/unit/cancan_adapter_spec.rb
+++ b/spec/unit/cancan_adapter_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::CanCanAdapter do

--- a/spec/unit/collection_decorator_spec.rb
+++ b/spec/unit/collection_decorator_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 class NumberDecorator

--- a/spec/unit/comments_spec.rb
+++ b/spec/unit/comments_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe "Comments" do

--- a/spec/unit/component_spec.rb
+++ b/spec/unit/component_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 class MockComponentClass < ActiveAdmin::Component; end

--- a/spec/unit/config_shared_examples.rb
+++ b/spec/unit/config_shared_examples.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 RSpec.shared_examples_for "ActiveAdmin::Resource" do
   describe "namespace" do
     it "should return the namespace" do

--- a/spec/unit/controller_filters_spec.rb
+++ b/spec/unit/controller_filters_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Application do

--- a/spec/unit/csv_builder_spec.rb
+++ b/spec/unit/csv_builder_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::CSVBuilder do

--- a/spec/unit/dependency_spec.rb
+++ b/spec/unit/dependency_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Dependency do

--- a/spec/unit/devise_spec.rb
+++ b/spec/unit/devise_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Devise::Controller do

--- a/spec/unit/dsl_spec.rb
+++ b/spec/unit/dsl_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 module MockModuleToInclude

--- a/spec/unit/dynamic_settings_spec.rb
+++ b/spec/unit/dynamic_settings_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::DynamicSettingsNode do

--- a/spec/unit/filters/active_filter_spec.rb
+++ b/spec/unit/filters/active_filter_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Filters::ActiveFilter do

--- a/spec/unit/filters/active_spec.rb
+++ b/spec/unit/filters/active_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Filters::Active do

--- a/spec/unit/filters/filter_form_builder_spec.rb
+++ b/spec/unit/filters/filter_form_builder_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Filters::ViewHelper do

--- a/spec/unit/filters/resource_spec.rb
+++ b/spec/unit/filters/resource_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Filters::ResourceExtension do

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 require "rspec/mocks/standalone"
 

--- a/spec/unit/generators/install_spec.rb
+++ b/spec/unit/generators/install_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe "AA installation" do

--- a/spec/unit/helpers/collection_spec.rb
+++ b/spec/unit/helpers/collection_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Helpers::Collection do

--- a/spec/unit/helpers/scope_chain_spec.rb
+++ b/spec/unit/helpers/scope_chain_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::ScopeChain do

--- a/spec/unit/localizers/resource_localizer_spec.rb
+++ b/spec/unit/localizers/resource_localizer_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.shared_examples_for "ActiveAdmin::Localizers::ResourceLocalizer" do

--- a/spec/unit/menu_collection_spec.rb
+++ b/spec/unit/menu_collection_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::MenuCollection do

--- a/spec/unit/menu_item_spec.rb
+++ b/spec/unit/menu_item_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 require "active_admin/menu"
 require "active_admin/menu_item"

--- a/spec/unit/menu_spec.rb
+++ b/spec/unit/menu_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 require "active_admin/menu"
 require "active_admin/menu_item"

--- a/spec/unit/namespace/authorization_spec.rb
+++ b/spec/unit/namespace/authorization_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Resource, "authorization" do

--- a/spec/unit/namespace/register_page_spec.rb
+++ b/spec/unit/namespace/register_page_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Namespace, "registering a page" do

--- a/spec/unit/namespace/register_resource_spec.rb
+++ b/spec/unit/namespace/register_resource_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Namespace, "registering a resource" do

--- a/spec/unit/namespace_spec.rb
+++ b/spec/unit/namespace_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Namespace do

--- a/spec/unit/order_clause_spec.rb
+++ b/spec/unit/order_clause_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::OrderClause do

--- a/spec/unit/page_controller_spec.rb
+++ b/spec/unit/page_controller_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::PageController do

--- a/spec/unit/page_spec.rb
+++ b/spec/unit/page_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 require File.expand_path("config_shared_examples", __dir__)
 

--- a/spec/unit/pretty_format_spec.rb
+++ b/spec/unit/pretty_format_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 require "active_admin/view_helpers/display_helper"
 

--- a/spec/unit/pundit_adapter_spec.rb
+++ b/spec/unit/pundit_adapter_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 class DefaultPolicy < ApplicationPolicy

--- a/spec/unit/resource/action_items_spec.rb
+++ b/spec/unit/resource/action_items_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Resource::ActionItems do

--- a/spec/unit/resource/attributes_spec.rb
+++ b/spec/unit/resource/attributes_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 module ActiveAdmin

--- a/spec/unit/resource/includes_spec.rb
+++ b/spec/unit/resource/includes_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 module ActiveAdmin

--- a/spec/unit/resource/naming_spec.rb
+++ b/spec/unit/resource/naming_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 module ActiveAdmin

--- a/spec/unit/resource/ordering_spec.rb
+++ b/spec/unit/resource/ordering_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 module ActiveAdmin

--- a/spec/unit/resource/page_presenters_spec.rb
+++ b/spec/unit/resource/page_presenters_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Resource::PagePresenters do

--- a/spec/unit/resource/pagination_spec.rb
+++ b/spec/unit/resource/pagination_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 module ActiveAdmin

--- a/spec/unit/resource/routes_spec.rb
+++ b/spec/unit/resource/routes_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Resource::Routes do

--- a/spec/unit/resource/scopes_spec.rb
+++ b/spec/unit/resource/scopes_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 module ActiveAdmin

--- a/spec/unit/resource/sidebars_spec.rb
+++ b/spec/unit/resource/sidebars_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Resource::Sidebars do

--- a/spec/unit/resource_collection_spec.rb
+++ b/spec/unit/resource_collection_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 require "active_admin/resource_collection"
 

--- a/spec/unit/resource_controller/data_access_spec.rb
+++ b/spec/unit/resource_controller/data_access_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::ResourceController::DataAccess do

--- a/spec/unit/resource_controller/decorators_spec.rb
+++ b/spec/unit/resource_controller/decorators_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::ResourceController::Decorators do

--- a/spec/unit/resource_controller/polymorphic_routes_spec.rb
+++ b/spec/unit/resource_controller/polymorphic_routes_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::ResourceController::PolymorphicRoutes, type: :controller do

--- a/spec/unit/resource_controller/sidebars_spec.rb
+++ b/spec/unit/resource_controller/sidebars_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::ResourceController::Sidebars, type: :controller do

--- a/spec/unit/resource_controller_spec.rb
+++ b/spec/unit/resource_controller_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::ResourceController do

--- a/spec/unit/resource_registration_spec.rb
+++ b/spec/unit/resource_registration_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe "Registering an object to administer" do

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 require File.expand_path("config_shared_examples", __dir__)
 

--- a/spec/unit/routing_spec.rb
+++ b/spec/unit/routing_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe "Routing", type: :routing do

--- a/spec/unit/scope_spec.rb
+++ b/spec/unit/scope_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Scope do

--- a/spec/unit/settings_node_spec.rb
+++ b/spec/unit/settings_node_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::SettingsNode do

--- a/spec/unit/view_factory_spec.rb
+++ b/spec/unit/view_factory_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 def it_should_have_view(key, value)

--- a/spec/unit/view_helpers/breadcrumbs_spec.rb
+++ b/spec/unit/view_helpers/breadcrumbs_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe "Breadcrumbs" do

--- a/spec/unit/view_helpers/display_helper_spec.rb
+++ b/spec/unit/view_helpers/display_helper_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 require "active_admin/view_helpers/active_admin_application_helper"
 require "active_admin/view_helpers/auto_link_helper"

--- a/spec/unit/view_helpers/download_format_links_helper_spec.rb
+++ b/spec/unit/view_helpers/download_format_links_helper_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::ViewHelpers::DownloadFormatLinksHelper do

--- a/spec/unit/view_helpers/fields_for_spec.rb
+++ b/spec/unit/view_helpers/fields_for_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::ViewHelpers::FormHelper, ".fields_for" do

--- a/spec/unit/view_helpers/flash_helper_spec.rb
+++ b/spec/unit/view_helpers/flash_helper_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::ViewHelpers::FlashHelper do

--- a/spec/unit/view_helpers/form_helper_spec.rb
+++ b/spec/unit/view_helpers/form_helper_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::ViewHelpers::FormHelper do

--- a/spec/unit/view_helpers/method_or_proc_helper_spec.rb
+++ b/spec/unit/view_helpers/method_or_proc_helper_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe MethodOrProcHelper do

--- a/spec/unit/views/components/attributes_table_spec.rb
+++ b/spec/unit/views/components/attributes_table_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::AttributesTable do

--- a/spec/unit/views/components/batch_action_selector_spec.rb
+++ b/spec/unit/views/components/batch_action_selector_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 require "active_admin/batch_actions/views/batch_action_selector"
 

--- a/spec/unit/views/components/blank_slate_spec.rb
+++ b/spec/unit/views/components/blank_slate_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::BlankSlate do

--- a/spec/unit/views/components/columns_spec.rb
+++ b/spec/unit/views/components/columns_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::Columns do

--- a/spec/unit/views/components/index_list_spec.rb
+++ b/spec/unit/views/components/index_list_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::IndexList do

--- a/spec/unit/views/components/index_table_for_spec.rb
+++ b/spec/unit/views/components/index_table_for_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::IndexAsTable::IndexTableFor do

--- a/spec/unit/views/components/menu_item_spec.rb
+++ b/spec/unit/views/components/menu_item_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 require "active_admin/menu_item"
 require "active_admin/views/components/menu_item"

--- a/spec/unit/views/components/menu_spec.rb
+++ b/spec/unit/views/components/menu_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::Menu do

--- a/spec/unit/views/components/paginated_collection_spec.rb
+++ b/spec/unit/views/components/paginated_collection_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::PaginatedCollection do

--- a/spec/unit/views/components/panel_spec.rb
+++ b/spec/unit/views/components/panel_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::Panel do

--- a/spec/unit/views/components/sidebar_section_spec.rb
+++ b/spec/unit/views/components/sidebar_section_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::SidebarSection do

--- a/spec/unit/views/components/sidebar_spec.rb
+++ b/spec/unit/views/components/sidebar_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::Sidebar do

--- a/spec/unit/views/components/site_title_spec.rb
+++ b/spec/unit/views/components/site_title_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::SiteTitle do

--- a/spec/unit/views/components/status_tag_spec.rb
+++ b/spec/unit/views/components/status_tag_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::StatusTag do

--- a/spec/unit/views/components/table_for_spec.rb
+++ b/spec/unit/views/components/table_for_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::TableFor do

--- a/spec/unit/views/components/tabs_spec.rb
+++ b/spec/unit/views/components/tabs_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::Tabs do

--- a/spec/unit/views/components/unsupported_browser_spec.rb
+++ b/spec/unit/views/components/unsupported_browser_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::UnsupportedBrowser do

--- a/spec/unit/views/index_as_blog_spec.rb
+++ b/spec/unit/views/index_as_blog_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 include ActiveAdmin

--- a/spec/unit/views/pages/base_spec.rb
+++ b/spec/unit/views/pages/base_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::Pages::Base do

--- a/spec/unit/views/pages/form_spec.rb
+++ b/spec/unit/views/pages/form_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::Pages::Form do

--- a/spec/unit/views/pages/index_spec.rb
+++ b/spec/unit/views/pages/index_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::Pages::Index do

--- a/spec/unit/views/pages/layout_spec.rb
+++ b/spec/unit/views/pages/layout_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::Pages::Layout do

--- a/spec/unit/views/pages/show_spec.rb
+++ b/spec/unit/views/pages/show_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::Pages::Show do

--- a/tasks/bug_report_template.rb
+++ b/tasks/bug_report_template.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "bundler/inline"
 
 gemfile(true) do

--- a/tasks/changelog.rake
+++ b/tasks/changelog.rake
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "changelog"
 
 namespace :changelog do

--- a/tasks/changelog.rb
+++ b/tasks/changelog.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Changelog
   def cut_version(header)
     sync!

--- a/tasks/docs.rake
+++ b/tasks/docs.rake
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "yard"
 require "yard/rake/yardoc_task"
 

--- a/tasks/gemfiles.rake
+++ b/tasks/gemfiles.rake
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 desc "Bundle all Gemfiles"
 task :bundle do |_t, opts|
   ["Gemfile", *Dir.glob("gemfiles/rails_*/Gemfile")].each do |gemfile|

--- a/tasks/lint.rake
+++ b/tasks/lint.rake
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "open3"
 
 #

--- a/tasks/local.rake
+++ b/tasks/local.rake
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 desc "Run a command against the local sample application"
 task :local do
   require_relative "test_application"

--- a/tasks/release.rake
+++ b/tasks/release.rake
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "chandler/tasks"
 require_relative "release_manager"
 

--- a/tasks/release_manager.rb
+++ b/tasks/release_manager.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "changelog"
 
 class ReleaseManager

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 desc "Run the full suite using parallel_tests to run on multiple cores"
 task test: [:setup, :spec, :cucumber]
 

--- a/tasks/test_application.rb
+++ b/tasks/test_application.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "fileutils"
 
 module ActiveAdmin


### PR DESCRIPTION
NB. Adding `# frozen_string_literal: true` enforces frozen string literals for this gem but not its dependencies.
PRs for dependencies:

- activeadmin/arbre#292
- formtastic/formtastic#1339

Just this PR and activeadmin/arbre#292 are sufficient for `RUBYOPT=--enable=frozen-string-literal bundle exec rake` to pass.

Testing against a real world application: this PR, activeadmin/arbre#292 and formtastic/formtastic#1339 are necessary for test suite to pass with `RUBYOPT=--enable=frozen-string-literal`