### PR TITLE
Remove unnecessary conditions

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -5,25 +5,6 @@ pull_request_rules:
 
     conditions:
       - author~=^dependabot(|-preview)\[bot\]$
-      - check-success=lint (2.7)
-      - check-success=test (2.7, rails_52)
-      - check-success=test (2.7, rails_60)
-      - check-success=test (2.7, rails_61)
-      - check-success=test (2.7, rails_61_turbolinks)
-      - check-success=test (2.7, rails_61_webpacker)
-      - check-success=test (2.6, rails_52)
-      - check-success=test (2.6, rails_60)
-      - check-success=test (2.6, rails_61)
-      - check-success=test (2.6, rails_61_turbolinks)
-      - check-success=test (2.6, rails_61_webpacker)
-      - check-success=test (2.5, rails_52)
-      - check-success=test (2.5, rails_60)
-      - check-success=test (2.5, rails_61)
-      - check-success=test (2.5, rails_61_turbolinks)
-      - check-success=test (2.5, rails_61_webpacker)
-      - check-success=upload_coverage
-      - check-success=codeclimate/diff-coverage
-      - check-success=codeclimate/total-coverage
 
     actions:
       merge:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -4,7 +4,7 @@ pull_request_rules:
   - name: Automatic merge for dependabot pull requests
 
     conditions:
-      - author~=^dependabot(|-preview)\[bot\]$
+      - author~=^dependabot\[bot\]$
 
     actions:
       merge:


### PR DESCRIPTION
Mergify respects branch protection settings by default.

Not having to maintain this list reduces the chance of errors, like the one I made that caused #6951 to not be automatically merged (I included two checks that don't exist).