### PR TITLE
Load favicon from Webpacker assets when use_webpacker is set to true

### DIFF
--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -44,7 +44,9 @@ module ActiveAdmin
             end
 
             if active_admin_namespace.favicon
-              text_node(favicon_link_tag(active_admin_namespace.favicon))
+              favicon = active_admin_namespace.favicon
+              favicon_tag = active_admin_namespace.use_webpacker ? favicon_pack_tag(favicon) : favicon_link_tag(favicon)
+              text_node(favicon_tag)
             end
 
             text_node csrf_meta_tag

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -6,12 +6,14 @@ webpacker_app = ENV["BUNDLE_GEMFILE"] == File.expand_path("../../gemfiles/rails_
 if webpacker_app
   create_file "app/javascript/packs/some-random-css.css"
   create_file "app/javascript/packs/some-random-js.js"
+  create_file "app/javascript/images/a/favicon.ico"
+  create_file "app/javascript/packs/images.js"
+  append_file "app/javascript/packs/images.js", "import '../images/a/favicon.ico';"
 else
   create_file "app/assets/stylesheets/some-random-css.css"
   create_file "app/assets/javascripts/some-random-js.js"
+  create_file "app/assets/images/a/favicon.ico"
 end
-
-create_file "app/assets/images/a/favicon.ico"
 
 initial_timestamp = Time.now.strftime("%Y%M%d%H%M%S").to_i
 


### PR DESCRIPTION
When config.use_webpacker is true, ActiveAdmin will now generate the favicon tag using Webpacker's `favicon_pack_tag` instead of `favicon_link_tag` (which uses the asset pipeline). This change makes it possible to use Webpacker to provide the favicon asset.

I managed to get both Webpacker and Sprockets tests to work by making the favicon path consistent between the two types of test projects. 

Fixes #6728
