### PR TITLE
feat: support alias_attribute as valid keys for filter

### DIFF
--- a/lib/active_admin/filters/formtastic_addons.rb
+++ b/lib/active_admin/filters/formtastic_addons.rb
@@ -21,11 +21,17 @@ module ActiveAdmin
       end
 
       def column_for(method)
-        klass.columns_hash[method.to_s] if klass.respond_to? :columns_hash
+        method_name = method_name_for(method)
+
+        klass.columns_hash[method_name.to_s] if klass.respond_to? :columns_hash
       end
 
       def column
         column_for method
+      end
+
+      def method_name_for(method)
+        klass.attribute_alias(method)&.to_sym || method
       end
 
       #

--- a/lib/active_admin/inputs/filters/select_input.rb
+++ b/lib/active_admin/inputs/filters/select_input.rb
@@ -46,7 +46,9 @@ module ActiveAdmin
         end
 
         def pluck_column
-          klass.reorder("#{method} asc").distinct.pluck method
+          method_name = method_name_for(method)
+
+          klass.reorder("#{method_name} asc").distinct.pluck method_name
         end
 
         def reflection_searchable?

--- a/spec/support/templates/models/post.rb
+++ b/spec/support/templates/models/post.rb
@@ -7,6 +7,8 @@ class Post < ActiveRecord::Base
   accepts_nested_attributes_for :author
   accepts_nested_attributes_for :taggings, allow_destroy: true
 
+  alias_attribute :title_alias, :title
+
   ransacker :custom_title_searcher do |parent|
     parent.table[:title]
   end

--- a/spec/unit/filters/filter_form_builder_spec.rb
+++ b/spec/unit/filters/filter_form_builder_spec.rb
@@ -156,16 +156,35 @@ RSpec.describe ActiveAdmin::Filters::ViewHelper do
   end
 
   describe "string attribute, as a select" do
-    let(:body) { filter :title, as: :select }
     let(:builder) { ActiveAdmin::Inputs::Filters::SelectInput }
 
     context "when loading collection from DB" do
+      let(:body) { filter :title, as: :select }
+
       it "should use pluck for efficiency" do
         expect_any_instance_of(builder).to receive(:pluck_column) { [] }
         body
       end
 
       it "should remove original ordering to prevent PostgreSQL error" do
+        expect(scope.object.klass).to receive(:reorder).with("title asc") {
+          m = double distinct: double(pluck: ["A Title"])
+          expect(m.distinct).to receive(:pluck).with :title
+          m
+        }
+        body
+      end
+    end
+
+    context "when loading collection from DB using aliases" do
+      let(:body) { filter :title_alias, as: :select }
+
+      it "should use pluck for efficiency" do
+        expect_any_instance_of(builder).to receive(:pluck_column) { [] }
+        body
+      end
+
+      it "should remove original ordering to prevent PostgreSQL error using the real attribute name" do
         expect(scope.object.klass).to receive(:reorder).with("title asc") {
           m = double distinct: double(pluck: ["A Title"])
           expect(m.distinct).to receive(:pluck).with :title


### PR DESCRIPTION
## Summary

Given a model with an alias_attribute like so:
`alias_attribute :title_alias, :title`

Then it will be possible to use the alias as a valid filter:
`filter :title_alias, as: :select`

<!--

Thanks for contributing to ActiveAdmin!

You can find all the instructions for contributing at the [CONTRIBUTING file].

Before submitting your PR make sure that:

* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are splitted apart.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all github checks are passing, but feel free to ask for early feedback if you need guidance.

[CONTRIBUTING file]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->
