### PR TITLE
Get rid of deprecated *_filter support

### DIFF
--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -145,10 +145,10 @@ module ActiveAdmin
 
     # Adds before, around and after filters to all controllers.
     # Example usage:
-    #   ActiveAdmin.before_filter :authenticate_admin!
+    #   ActiveAdmin.before_action :authenticate_admin!
     #
     AbstractController::Callbacks::ClassMethods.public_instance_methods.
-      select { |m| m.match(/(filter|action)/) }.each do |name|
+      select { |m| m.match(/_action\z/) }.each do |name|
       define_method name do |*args, &block|
         controllers_for_filters.each do |controller|
           controller.public_send name, *args, &block

--- a/lib/active_admin/resource_dsl.rb
+++ b/lib/active_admin/resource_dsl.rb
@@ -191,25 +191,9 @@ module ActiveAdmin
     delegate :before_save, :after_save, to: :controller
     delegate :before_destroy, :after_destroy, to: :controller
 
-    # This code defines both *_filter and *_action for Rails 5.0 and  *_action for Rails >= 5.1
-    phases = [
-      :before, :skip_before,
-      :after, :skip_after,
-      :around, :skip
-    ]
-    keywords = if Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR >= 1
-                 [:action]
-               else
-                 [:action, :filter]
-               end
-
-    keywords.each do |name|
-      phases.each do |action|
-       define_method "#{action}_#{name}" do |*args, &block|
-         controller.public_send "#{action}_action", *args, &block
-       end
-     end
-    end
+    standard_rails_filters =
+      AbstractController::Callbacks::ClassMethods.public_instance_methods.select { |m| m.match(/_action\z/) }
+    delegate *standard_rails_filters, to: :controller
 
     # Specify which actions to create in the controller
     #

--- a/spec/unit/controller_filters_spec.rb
+++ b/spec/unit/controller_filters_spec.rb
@@ -13,26 +13,16 @@ RSpec.describe ActiveAdmin::Application do
     ]
   end
 
-  expected_actions = (
-    prefixes = %w(skip append prepend) << nil
-    positions = %w(before around after)
-    suffixes = %w(action)
-    base = %w()
-
-    prefixes.each_with_object(base) do |prefix, stack|
-      positions.each do |position|
-        suffixes.each do |suffix|
-          stack << [prefix, position, suffix].compact.join("_").to_sym
-        end
-      end
-    end
-  )
-
-  expected_actions.each do |action|
-    it action do
+  %w[
+    skip_before_action skip_around_action skip_after_action
+    append_before_action append_around_action append_after_action
+    prepend_before_action prepend_around_action prepend_after_action
+    before_action around_action after_action
+  ].each do |filter|
+    it filter do
       args = [:my_filter, { only: :show }]
-      controllers.each { |c| expect(c).to receive(action).with(args) }
-      application.public_send action, args
+      controllers.each { |c| expect(c).to receive(filter).with(args) }
+      application.public_send filter, args
     end
   end
 end

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -324,15 +324,20 @@ module ActiveAdmin
         expect(resource).to receive(:controller).and_return(controller)
       end
 
-      context "actions" do
-        [
-          :before_action, :skip_before_action,
-          :after_action, :skip_after_action,
-          :around_action, :skip_action
-        ].each do |method|
-          it "delegates #{method}" do
-            expect(resource.send(method)).to eq "called #{method}"
-          end
+      %w[
+        before_build after_build
+        before_create after_create
+        before_update after_update
+        before_save after_save
+        before_destroy after_destroy
+        skip_before_action skip_around_action skip_after_action
+        append_before_action append_around_action append_after_action
+        prepend_before_action prepend_around_action prepend_after_action
+        before_action around_action after_action
+        actions
+      ].each do |method|
+        it "delegates #{method}" do
+          expect(resource.send(method)).to eq "called #{method}"
         end
       end
     end


### PR DESCRIPTION
`*_filter` methods were removed in Rails 5.1, see https://github.com/rails/rails/commit/d7be30e8babf5e37a891522869e7b0191b79b757.
Should've been done as a part of cdfea4c6c1ac8f1a227ce57db6b0f758ca376d28, so this is just a leftover addressed.

BTW `skip_action` added in fc876052476711074e0710f56166d193f9c0fa69 never existed in Rails.
`skip_filter` was renamed to `skip_action_callback` in Rails 4.2 https://github.com/rails/rails/commit/6c5f43bab8206747a8591435b2aa0ff7051ad3de
and then deprecated in Rails 5.1 https://github.com/rails/rails/commit/6976e1da07ac91f5e17c6bc02758122255d94d48.

Basically this commit reverts the implementation to 2010, similar to 83c1f220e6930e4c6e11cfda3d00028d99f34439 but more complete and up-to-date.

<!--

Thanks for contributing to ActiveAdmin!

You can find all the instructions for contributing at the [CONTRIBUTING file].

Before submitting your PR make sure that:

* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are splitted apart.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all github checks are passing, but feel free to ask for early feedback if you need guidance.

[CONTRIBUTING file]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->
