### PR TITLE
Update config.register_javascript with options support

### DIFF
--- a/app/views/layouts/active_admin_logged_out.html.erb
+++ b/app/views/layouts/active_admin_logged_out.html.erb
@@ -12,11 +12,11 @@
       <%= stylesheet_link_tag style, **options %>
     <% end %>
   <% end %>
-  <% ActiveAdmin.application.javascripts.each do |path| %>
+  <% ActiveAdmin.application.javascripts.each do |path, options| %>
     <% if ActiveAdmin.application.use_webpacker %>
-      <%= javascript_pack_tag path %>
+      <%= javascript_pack_tag path, **options %>
     <% else %>
-      <%= javascript_include_tag path %>
+      <%= javascript_include_tag path, **options %>
     <% end %>
   <% end %>
 

--- a/lib/active_admin/asset_registration.rb
+++ b/lib/active_admin/asset_registration.rb
@@ -14,12 +14,12 @@ module ActiveAdmin
       stylesheets.clear
     end
 
-    def register_javascript(name)
-      javascripts.add name
+    def register_javascript(path, options = {})
+      javascripts[path] = options
     end
 
     def javascripts
-      @javascripts ||= Set.new
+      @javascripts ||= {}
     end
 
     def clear_javascripts!

--- a/lib/active_admin/engine.rb
+++ b/lib/active_admin/engine.rb
@@ -12,7 +12,7 @@ module ActiveAdmin
         ActiveAdmin.application.stylesheets.each do |path, _|
           app.config.assets.precompile << path
         end
-        ActiveAdmin.application.javascripts.each do |path|
+        ActiveAdmin.application.javascripts.each do |path, _|
           app.config.assets.precompile << path
         end
       end

--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -38,8 +38,8 @@ module ActiveAdmin
               text_node(meta(name: name, content: content))
             end
 
-            active_admin_application.javascripts.each do |path|
-              javascript_tag = active_admin_namespace.use_webpacker ? javascript_pack_tag(path) : javascript_include_tag(path)
+            active_admin_application.javascripts.each do |path, options|
+              javascript_tag = active_admin_namespace.use_webpacker ? javascript_pack_tag(path, **options) : javascript_include_tag(path, **options)
               text_node(javascript_tag)
             end
 

--- a/spec/unit/asset_registration_spec.rb
+++ b/spec/unit/asset_registration_spec.rb
@@ -35,12 +35,12 @@ RSpec.describe ActiveAdmin::AssetRegistration do
 
   it "should register a javascript file" do
     register_javascript "active_admin.js"
-    expect(javascripts).to eq ["active_admin.js"].to_set
+    expect(javascripts.keys).to eq ["active_admin.js"]
   end
 
   it "should clear all existing javascripts" do
     register_javascript "active_admin.js"
-    expect(javascripts).to eq ["active_admin.js"].to_set
+    expect(javascripts.keys).to eq ["active_admin.js"]
     clear_javascripts!
     expect(javascripts).to be_empty
   end
@@ -48,6 +48,6 @@ RSpec.describe ActiveAdmin::AssetRegistration do
   it "shouldn't register a javascript twice" do
     register_javascript "active_admin.js"
     register_javascript "active_admin.js"
-    expect(javascripts.length).to eq 1
+    expect(javascripts.size).to eq 1
   end
 end


### PR DESCRIPTION
I have replace the turbolink with turbo in my project. so I think it will be better to generate `<script>` tag like below

``` html
<script src='assets/admin.js' data-turbo-track='reload'></script>
```

However, the method `register_javascript` don't support `options` like `  config.register_stylesheet`

I think it will be a good idea to make it customizable

``` ruby
config.register_stylesheet 'active_admin.css', media: 'screen', 'data-turbo-track': 'reload'
config.register_javascript 'active_admin.js', 'data-turbo-track': 'reload'
```