### PR TITLE
remove upper version constraint on railties

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |s|
   s.add_dependency "inherited_resources", "~> 1.7"
   s.add_dependency "jquery-rails", "~> 4.2"
   s.add_dependency "kaminari", "~> 1.0", ">= 1.2.1"
-  s.add_dependency "railties", ">= 5.2", "< 6.2"
+  s.add_dependency "railties", ">= 5.2"
   s.add_dependency "ransack", "~> 2.1", ">= 2.1.1"
 end


### PR DESCRIPTION
Allow use with rails 7.0.0.alpha