### PR TITLE
Adds hide_attribute to Resource DSL for hiding attribute from UI.

### DIFF
--- a/lib/active_admin/resource.rb
+++ b/lib/active_admin/resource.rb
@@ -67,6 +67,9 @@ module ActiveAdmin
     # nil to not decorate.
     attr_accessor :decorator_class_name
 
+    # List of attributes which should be hidden from the UI
+    attr_accessor :hidden_attributes
+
     module Base
       def initialize(namespace, resource_class, options = {})
         @namespace = namespace
@@ -75,6 +78,7 @@ module ActiveAdmin
         @sort_order = options[:sort_order]
         @member_actions = []
         @collection_actions = []
+        @hidden_attributes = []
       end
     end
 
@@ -141,6 +145,12 @@ module ActiveAdmin
       self.menu_item_options = false if @belongs_to.required?
       options[:class_name] ||= @belongs_to.resource.resource_class_name if @belongs_to.resource
       controller.send :belongs_to, target, options.dup
+    end
+
+    def hide_attribute(name)
+      if !@hidden_attributes.include?(name)
+        @hidden_attributes << name
+      end
     end
 
     def belongs_to_config

--- a/lib/active_admin/resource/attributes.rb
+++ b/lib/active_admin/resource/attributes.rb
@@ -25,7 +25,7 @@ module ActiveAdmin
       end
 
       def reject_col?(c)
-        primary_col?(c) || sti_col?(c) || counter_cache_col?(c) || filtered_col?(c)
+        primary_col?(c) || sti_col?(c) || counter_cache_col?(c) || filtered_col?(c) || hidden_col?(c)
       end
 
       def primary_col?(c)
@@ -42,6 +42,10 @@ module ActiveAdmin
 
       def filtered_col?(c)
         ActiveAdmin.application.filter_attributes.include?(c.name.to_sym)
+      end
+
+      def hidden_col?(c)
+        @hidden_attributes.include?(c.name.to_sym)
       end
     end
   end

--- a/lib/active_admin/resource_dsl.rb
+++ b/lib/active_admin/resource_dsl.rb
@@ -81,6 +81,11 @@ module ActiveAdmin
       end
     end
 
+    # Hides an attribute from the UI
+    def hide_attribute(name)
+      config.hide_attribute(name)
+    end
+
     # Configure the index page for the resource
     def index(options = {}, &block)
       options[:as] ||= :table

--- a/spec/unit/resource/attributes_spec.rb
+++ b/spec/unit/resource/attributes_spec.rb
@@ -32,6 +32,13 @@ module ActiveAdmin
         expect(subject).to_not include :published_date
         ActiveAdmin.application.filter_attributes = keep
       end
+
+      it "does not return hidden attributes" do
+        keep = resource_config.hidden_attributes
+        resource_config.hidden_attributes = [:created_at]
+        expect(subject).to_not include :created_at
+        resource_config.hidden_attributes = keep
+      end
     end
 
     describe "#association_columns" do


### PR DESCRIPTION
The hide_attribute is useful if the default index and show interfaces
would be perfect without any customisation, except that one of more
attributes (database columns) should just be completely hidden from the UI.

The hide_attribute works like the global Application filter_attributes
setting which allows hiding certain attributes from every resource.