### PR TITLE
Show ransackable_scopes filters in search results 

### DIFF
--- a/features/index/filters.feature
+++ b/features/index/filters.feature
@@ -341,3 +341,20 @@ Feature: Index Filtering
     And I am on the index page for posts
     Then I should see "Category" within "#filters_sidebar_section label[for="q_custom_category_id"]"
     And I should not see "Category name starts with" within "#filters_sidebar_section"
+
+  Scenario: Custom ransackable scopes filters
+    Given an index configuration of:
+    """
+      ActiveAdmin.register Post do
+        filter :fancy_filter, label: "Ransackable Custom Filter", as: :select, collection: ["Starred", "Not Starred"]
+      end
+    """
+    And 1 unstarred post with the title "Hello World" written by "Jane Doe" exists
+    When I select "Starred" from "Ransackable Custom Filter"
+    And I press "Filter"
+    Then I should see current filter "fancy_filter" equal to "Starred" with label "Ransackable Custom Filter"
+    And I should not see "Hello World"
+    When I select "Not Starred" from "Ransackable Custom Filter"
+    And I press "Filter"
+    Then I should see current filter "fancy_filter" equal to "Not Starred" with label "Ransackable Custom Filter"
+    And I should see "Hello World"

--- a/lib/active_admin/filters/active_sidebar.rb
+++ b/lib/active_admin/filters/active_sidebar.rb
@@ -11,32 +11,47 @@ module ActiveAdmin
 
       def block
         -> do
-          active_filters = ActiveAdmin::Filters::Active.new(active_admin_config, assigns[:search])
-          span do
-            if current_scope
-              h4 I18n.t("active_admin.search_status.current_scope"), style: "display: inline"
-              b scope_name(current_scope), class: "current_scope_name", style: "display: inline"
-            end
-            div style: "margin-top: 10px" do
-              h4 I18n.t("active_admin.search_status.current_filters"), style: "margin-bottom: 10px"
-              ul do
-                if active_filters.filters.blank?
-                  li I18n.t("active_admin.search_status.no_current_filters")
-                else
-                  active_filters.filters.each do |filter|
-                    li filter.html_options do
-                      span do
-                        text_node filter.label
-                      end
-                      b do
-                        text_node to_sentence(filter.values.map { |v| pretty_format(v) })
-                      end
-                    end
-                  end
-                end
+          def scope_block(current_scope)
+            return unless current_scope
+
+            h4 I18n.t("active_admin.search_status.current_scope"), style: "display: inline"
+            b scope_name(current_scope), class: "current_scope_name"
+          end
+
+          def filters_list(active_filters, active_scopes)
+            h4 I18n.t("active_admin.search_status.current_filters")
+            ul do
+              if active_filters.filters.blank? && active_scopes.blank?
+                li I18n.t("active_admin.search_status.no_current_filters")
+              else
+                active_filters.filters.each { |filter| filter_item(filter) }
+                active_scopes.each { |name, value| scope_item(name, value) }
               end
             end
           end
+
+          def filter_item(filter)
+            li filter.html_options do
+              span filter.label
+              b to_sentence(filter.values.map { |v| pretty_format(v) })
+            end
+          end
+
+          def scope_item(name, value)
+            filter = active_admin_config.filters[name.to_sym]
+            label = filter ? filter[:label] : name.titleize
+
+            li class: "current_filter_#{name}" do
+              span "#{label} #{Ransack::Translate.predicate('eq')}"
+              b value
+            end
+          end
+
+          active_filters = ActiveAdmin::Filters::Active.new(active_admin_config, assigns[:search])
+          active_scopes = assigns[:search].instance_variable_get("@scope_args")
+
+          scope_block(current_scope)
+          filters_list(active_filters, active_scopes)
         end
       end
 

--- a/lib/active_admin/filters/active_sidebar.rb
+++ b/lib/active_admin/filters/active_sidebar.rb
@@ -10,49 +10,7 @@ module ActiveAdmin
       end
 
       def block
-        -> do
-          def scope_block(current_scope)
-            return unless current_scope
-
-            h4 I18n.t("active_admin.search_status.current_scope"), style: "display: inline"
-            b scope_name(current_scope), class: "current_scope_name"
-          end
-
-          def filters_list(active_filters, active_scopes)
-            h4 I18n.t("active_admin.search_status.current_filters")
-            ul do
-              if active_filters.filters.blank? && active_scopes.blank?
-                li I18n.t("active_admin.search_status.no_current_filters")
-              else
-                active_filters.filters.each { |filter| filter_item(filter) }
-                active_scopes.each { |name, value| scope_item(name, value) }
-              end
-            end
-          end
-
-          def filter_item(filter)
-            li filter.html_options do
-              span filter.label
-              b to_sentence(filter.values.map { |v| pretty_format(v) })
-            end
-          end
-
-          def scope_item(name, value)
-            filter = active_admin_config.filters[name.to_sym]
-            label = filter ? filter[:label] : name.titleize
-
-            li class: "current_filter_#{name}" do
-              span "#{label} #{Ransack::Translate.predicate('eq')}"
-              b value
-            end
-          end
-
-          active_filters = ActiveAdmin::Filters::Active.new(active_admin_config, assigns[:search])
-          active_scopes = assigns[:search].instance_variable_get("@scope_args")
-
-          scope_block(current_scope)
-          filters_list(active_filters, active_scopes)
-        end
+        -> { active_filters_sidebar_content }
       end
 
       def title

--- a/lib/active_admin/views/components/active_filters_sidebar_content.rb
+++ b/lib/active_admin/views/components/active_filters_sidebar_content.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+require "active_admin/filters/active"
+
+module ActiveAdmin
+  module Views
+
+    class ActiveFiltersSidebarContent < ActiveAdmin::Component
+      builder_method :active_filters_sidebar_content
+
+      def build
+        active_filters = ActiveAdmin::Filters::Active.new(active_admin_config, assigns[:search])
+        active_scopes = assigns[:search].instance_variable_get("@scope_args")
+
+        scope_block(current_scope)
+        filters_list(active_filters, active_scopes)
+      end
+
+      def scope_block(current_scope)
+        return unless current_scope
+
+        h4 I18n.t("active_admin.search_status.current_scope"), style: "display: inline"
+        b scope_name(current_scope), class: "current_scope_name"
+      end
+
+      def filters_list(active_filters, active_scopes)
+        div style: "margin-top: 10px" do
+          h4 I18n.t("active_admin.search_status.current_filters"), style: "margin-bottom: 10px"
+          ul do
+            if active_filters.filters.blank? && active_scopes.blank?
+              li I18n.t("active_admin.search_status.no_current_filters")
+            else
+              active_filters.filters.each { |filter| filter_item(filter) }
+              active_scopes.each { |name, value| scope_item(name, value) }
+            end
+          end
+        end
+      end
+
+      def filter_item(filter)
+        li filter.html_options do
+          span filter.label
+          b to_sentence(filter.values.map { |v| pretty_format(v) })
+        end
+      end
+
+      def scope_item(name, value)
+        filter_name = name.gsub(/_eq$/, "")
+        filter = active_admin_config.filters[filter_name.to_sym]
+        label = filter.try(:[], :label) || filter_name.titleize
+
+        li class: "current_filter_#{name}" do
+          span "#{label} #{Ransack::Translate.predicate('eq')}"
+          b value
+        end
+      end
+    end
+
+  end
+end

--- a/spec/support/templates/models/post.rb
+++ b/spec/support/templates/models/post.rb
@@ -18,4 +18,14 @@ class Post < ActiveRecord::Base
   ransacker :custom_searcher_numeric, type: :numeric do
     # nothing to see here
   end
+
+  class << self
+    def ransackable_scopes(_auth_object = nil)
+      [:fancy_filter]
+    end
+
+    def fancy_filter(value)
+      where(starred: value == "Starred")
+    end
+  end
 end


### PR DESCRIPTION
In AA, we can filter our data using `ransackable_scopes` https://github.com/activerecord-hackery/ransack#using-scopesclass-methods
Data filtering works just fine, but the "Search Results" sidebar shows "Current filters: None"

This PR adds proper indication of those selected scopes. For example:


<img width="288" alt="Screen Shot 2021-08-27 at 21 33 13" src="https://user-images.githubusercontent.com/85142721/131127894-40375fc1-45c8-4cc7-98a7-aa6866e9633d.png">

This PR

* Fixes #7042
* Fixes #6887 (duplicating)