### PR TITLE
Fix: id_column link to show page if policy forbids

### DIFF
--- a/lib/active_admin/views/index_as_table.rb
+++ b/lib/active_admin/views/index_as_table.rb
@@ -294,9 +294,9 @@ module ActiveAdmin
         def id_column
           raise "#{resource_class.name} has no primary_key!" unless resource_class.primary_key
           column(resource_class.human_attribute_name(resource_class.primary_key), sortable: resource_class.primary_key) do |resource|
-            if controller.action_methods.include?("show")
+            if controller.action_methods.include?("show") && authorized?(ActiveAdmin::Auth::READ, resource)
               link_to resource.id, resource_path(resource), class: "resource_id_link"
-            elsif controller.action_methods.include?("edit")
+            elsif controller.action_methods.include?("edit") && authorized?(ActiveAdmin::Auth::UPDATE, resource)
               link_to resource.id, edit_resource_path(resource), class: "resource_id_link"
             else
               resource.id


### PR DESCRIPTION
This PR is raised to fix => https://github.com/activeadmin/activeadmin/issues/6787
