### PR TITLE
Fix pundit namespace detection

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 require "simplecov" if ENV["COVERAGE"] == "true"
 
 require_relative "support/matchers/perform_database_query_matcher"
+require_relative "support/shared_contexts/capture_stderr"
 
 RSpec.configure do |config|
   config.disable_monkey_patching!

--- a/spec/support/shared_contexts/capture_stderr.rb
+++ b/spec/support/shared_contexts/capture_stderr.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "capture stderr" do
+  around do |example|
+    original_stderr = $stderr
+    $stderr = StringIO.new
+    example.run
+    $stderr = original_stderr
+  end
+end

--- a/spec/unit/action_builder_spec.rb
+++ b/spec/unit/action_builder_spec.rb
@@ -123,12 +123,7 @@ RSpec.describe "defining actions from registration blocks", type: :controller do
   end
 
   context "when method with given name is already defined" do
-    around do |example|
-      original_stderr = $stderr
-      $stderr = StringIO.new
-      example.run
-      $stderr = original_stderr
-    end
+    include_context "capture stderr"
 
     describe "defining member action" do
       let :action! do


### PR DESCRIPTION
Given a following config:

```
config.authorization_adapter = ActiveAdmin::PunditAdapter
config.pundit_policy_namespace = :admin
```

ActiveAdmin will search policies with `Admin::` namespace.
But if model already contains the configured namespace name (anywhere in the model name), AA won't tell Pundit to search policy with configured namespace.

For example, if we have model called `ShopAdmin`, we'll look up for `ShopAdminPolicy` instead of `Admin::ShopAdminPolicy`

Replacing condition in https://github.com/activeadmin/activeadmin/blob/master/lib/active_admin/pundit_adapter.rb#L61 to something like this, fixes this bug:

```diff
- if default_policy_namespace && !object.class.to_s.include?(default_policy_namespace.to_s.camelize)
+ if default_policy_namespace && !object.class.to_s.match?(/^#{default_policy_namespace.to_s.camelize}::/)
```