### PR TITLE
Fix disappearing BOM option for `CSVBuilder`

### DIFF
--- a/features/index/format_as_csv.feature
+++ b/features/index/format_as_csv.feature
@@ -143,6 +143,18 @@ Feature: Format as CSV
       | 012345 | (.*) |
     And the CSV file should contain "012345" in quotes
 
+  Scenario: With CSV option byte order mark
+    Given a configuration of:
+    """
+      ActiveAdmin.register Post do
+        csv byte_order_mark: "\xEF\xBB\xBF" do
+          column :title
+        end
+      end
+    """
+    When I visit the csv index page for posts twice
+    Then the CSV file should start with BOM
+
   Scenario: With default CSV separator option
     Given a configuration of:
     """

--- a/features/step_definitions/format_steps.rb
+++ b/features/step_definitions/format_steps.rb
@@ -58,6 +58,10 @@ Then /^the encoding of the CSV file should be "([^"]*)"$/ do |text|
   expect(page.driver.response.body.encoding).to be Encoding.find(Encoding.aliases[text] || text)
 end
 
+Then /^the CSV file should start with BOM$/ do
+  expect(page.driver.response.body.bytes).to start_with(239, 187, 191)
+end
+
 Then /^access denied$/ do
   expect(page).to have_content(I18n.t("active_admin.access_denied.message"))
 end

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -58,6 +58,10 @@ When /^I go to (.+)$/ do |page_name|
   visit path_to(page_name)
 end
 
+When /^I visit (.+) twice$/ do |page_name|
+  2.times { visit path_to(page_name) }
+end
+
 When /^I press "([^"]*)"$/ do |button|
   click_button(button)
 end

--- a/lib/active_admin/csv_builder.rb
+++ b/lib/active_admin/csv_builder.rb
@@ -45,9 +45,9 @@ module ActiveAdmin
     def build(controller, csv)
       @collection = controller.send :find_collection, except: :pagination
       columns = exec_columns controller.view_context
-      bom = options.delete :byte_order_mark
+      bom = options[:byte_order_mark]
       column_names = options.delete(:column_names) { true }
-      csv_options = options.except :encoding_options, :humanize_name
+      csv_options = options.except :encoding_options, :humanize_name, :byte_order_mark
 
       csv << bom if bom
 


### PR DESCRIPTION
When downloading csv file on index page second time, the bom was lost. Fixing `options.delete` to just accessing to option resolves this issue.

Fixes #7036.