### PR TITLE
Fix Dutch translation for password reset button

### DIFF
--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -114,7 +114,7 @@ nl:
         submit: "inloggen"
       reset_password:
         title: "Wachtwoord vergeten?"
-        submit: "Reset mijn wachtwoord vergeten"
+        submit: "Reset mijn wachtwoord"
       change_password:
         title: "Wijzig uw wachtwoord"
         submit: "Mijn wachtwoord wijzigen"


### PR DESCRIPTION
The existing translation was grammatically incorrect.