### PR TITLE
Don't apply sorting to collection until after scoping

### DIFF
--- a/lib/active_admin/resource_controller/data_access.rb
+++ b/lib/active_admin/resource_controller/data_access.rb
@@ -24,9 +24,9 @@ module ActiveAdmin
 
       COLLECTION_APPLIES = [
         :authorization_scope,
-        :sorting,
         :filtering,
         :scoping,
+        :sorting,
         :includes,
         :pagination,
         :collection_decorator


### PR DESCRIPTION
Consider sorting that requires a `JOIN` as part of the SQL query (or really anything that was raised in #3085):

```ruby
ActiveAdmin.register Foo do
  config.order_clause = FooOrderClause

  index do
    column :latest_bar, sortable: 'bars.created_at' do
      ...
    end
  end
end

class FooOrderClause < ActiveAdmin::OrderClause
  def apply(chain)
    case table_column
    when 'bars.created_at'
      chain.joins(:bars).select(table_column)
    else
      super
    end
  end
end
```

Oftentimes, including that `JOIN` is not a huge deal in terms of performance, however, there have been situations where that table/column can increase the time it takes for a query to run by a couple hundred milliseconds, for various reasons.

Increasing the time to load the page slightly (0.1s) is not a big deal, in an admin, but imagine if you had 7-10 different scopes on that page as well? Because scopes leverage `collection_before_scope`, they will proceed to include the `JOIN` in their query, even though it is only necessary to do sorting of a collection that is not actually being sorted, only counted.

Applying sorting of the collection *after* scoping, instead of before, should have no bearing on the end-result, while ensuring that any custom sorting logic is not needlessly applied to all scope count queries.