### PR TITLE
[Rails 7] Get rid of db-query-matchers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ group :test do
   gem "cuprite"
   gem "capybara"
   gem "webrick"
-  gem "db-query-matchers"
 
   gem "simplecov", require: false # Test coverage generator. Go to /coverage/ after running tests
   gem "cucumber-rails", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,9 +158,6 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
-    db-query-matchers (0.10.0)
-      activesupport (>= 4.0, < 7)
-      rspec (~> 3.0)
     devise (4.8.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -374,10 +371,6 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     rexml (3.2.5)
-    rspec (3.10.0)
-      rspec-core (~> 3.10.0)
-      rspec-expectations (~> 3.10.0)
-      rspec-mocks (~> 3.10.0)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.1)
@@ -483,7 +476,6 @@ DEPENDENCIES
   cucumber-rails
   cuprite
   database_cleaner
-  db-query-matchers
   devise
   draper
   i18n-spec

--- a/gemfiles/rails_52/Gemfile
+++ b/gemfiles/rails_52/Gemfile
@@ -24,7 +24,6 @@ group :test do
   gem "cuprite"
   gem "capybara"
   gem "webrick"
-  gem "db-query-matchers"
 
   gem "simplecov", require: false # Test coverage generator. Go to /coverage/ after running tests
   gem "cucumber-rails", require: false

--- a/gemfiles/rails_52/Gemfile.lock
+++ b/gemfiles/rails_52/Gemfile.lock
@@ -136,9 +136,6 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
-    db-query-matchers (0.10.0)
-      activesupport (>= 4.0, < 7)
-      rspec (~> 3.0)
     devise (4.8.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -289,10 +286,6 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     rexml (3.2.5)
-    rspec (3.10.0)
-      rspec-core (~> 3.10.0)
-      rspec-expectations (~> 3.10.0)
-      rspec-mocks (~> 3.10.0)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.1)
@@ -368,7 +361,6 @@ DEPENDENCIES
   cucumber-rails
   cuprite
   database_cleaner
-  db-query-matchers
   devise
   draper
   jasmine

--- a/gemfiles/rails_60/Gemfile
+++ b/gemfiles/rails_60/Gemfile
@@ -24,7 +24,6 @@ group :test do
   gem "cuprite"
   gem "capybara"
   gem "webrick"
-  gem "db-query-matchers"
 
   gem "simplecov", require: false # Test coverage generator. Go to /coverage/ after running tests
   gem "cucumber-rails", require: false

--- a/gemfiles/rails_60/Gemfile.lock
+++ b/gemfiles/rails_60/Gemfile.lock
@@ -149,9 +149,6 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
-    db-query-matchers (0.10.0)
-      activesupport (>= 4.0, < 7)
-      rspec (~> 3.0)
     devise (4.8.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -304,10 +301,6 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     rexml (3.2.5)
-    rspec (3.10.0)
-      rspec-core (~> 3.10.0)
-      rspec-expectations (~> 3.10.0)
-      rspec-mocks (~> 3.10.0)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.1)
@@ -384,7 +377,6 @@ DEPENDENCIES
   cucumber-rails
   cuprite
   database_cleaner
-  db-query-matchers
   devise
   draper
   jasmine

--- a/gemfiles/rails_61_turbolinks/Gemfile
+++ b/gemfiles/rails_61_turbolinks/Gemfile
@@ -26,7 +26,6 @@ group :test do
   gem "cuprite"
   gem "capybara"
   gem "webrick"
-  gem "db-query-matchers"
 
   gem "simplecov", require: false # Test coverage generator. Go to /coverage/ after running tests
   gem "cucumber-rails", require: false

--- a/gemfiles/rails_61_turbolinks/Gemfile.lock
+++ b/gemfiles/rails_61_turbolinks/Gemfile.lock
@@ -153,9 +153,6 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
-    db-query-matchers (0.10.0)
-      activesupport (>= 4.0, < 7)
-      rspec (~> 3.0)
     devise (4.8.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -308,10 +305,6 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     rexml (3.2.5)
-    rspec (3.10.0)
-      rspec-core (~> 3.10.0)
-      rspec-expectations (~> 3.10.0)
-      rspec-mocks (~> 3.10.0)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.1)
@@ -389,7 +382,6 @@ DEPENDENCIES
   cucumber-rails
   cuprite
   database_cleaner
-  db-query-matchers
   devise
   draper
   jasmine

--- a/gemfiles/rails_61_webpacker/Gemfile
+++ b/gemfiles/rails_61_webpacker/Gemfile
@@ -23,7 +23,6 @@ group :test do
   gem "cuprite"
   gem "capybara"
   gem "webrick"
-  gem "db-query-matchers"
 
   gem "simplecov", require: false # Test coverage generator. Go to /coverage/ after running tests
   gem "cucumber-rails", require: false

--- a/gemfiles/rails_61_webpacker/Gemfile.lock
+++ b/gemfiles/rails_61_webpacker/Gemfile.lock
@@ -153,9 +153,6 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
-    db-query-matchers (0.10.0)
-      activesupport (>= 4.0, < 7)
-      rspec (~> 3.0)
     devise (4.8.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -310,10 +307,6 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     rexml (3.2.5)
-    rspec (3.10.0)
-      rspec-core (~> 3.10.0)
-      rspec-expectations (~> 3.10.0)
-      rspec-mocks (~> 3.10.0)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.1)
@@ -385,7 +378,6 @@ DEPENDENCIES
   cucumber-rails
   cuprite
   database_cleaner
-  db-query-matchers
   devise
   draper
   jasmine

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 require "simplecov" if ENV["COVERAGE"] == "true"
 
+require_relative "support/matchers/perform_database_query_matcher"
+
 RSpec.configure do |config|
   config.disable_monkey_patching!
   config.filter_run focus: true

--- a/spec/support/matchers/perform_database_query_matcher.rb
+++ b/spec/support/matchers/perform_database_query_matcher.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :perform_database_query do |query|
+  match do |block|
+    @match = nil
+
+    callback = lambda do |_name, _started, _finished, _unique_id, payload|
+      @match = Regexp.new(Regexp.escape(query)).match?(payload[:sql])
+    end
+
+    ActiveSupport::Notifications.subscribed(callback, "sql.active_record", &block)
+
+    @match
+  end
+
+  failure_message do |_|
+    "Expected queries like \"#{query}\" but none were made"
+  end
+
+  failure_message_when_negated do |_|
+    "Expected no queries like \"#{query}\" but at least one were made"
+  end
+
+  supports_block_expectations
+end

--- a/spec/unit/views/components/paginated_collection_spec.rb
+++ b/spec/unit/views/components/paginated_collection_spec.rb
@@ -229,26 +229,22 @@ RSpec.describe ActiveAdmin::Views::PaginatedCollection do
     end
 
     it "makes no expensive COUNT queries when pagination_total is false" do
-      require "db-query-matchers"
-
       undecorated_collection = Post.all.page(1).per(30)
 
       expect { paginated_collection(undecorated_collection, pagination_total: false) }
-        .not_to make_database_queries(matching: "SELECT COUNT(*) FROM \"posts\"")
+        .not_to perform_database_query("SELECT COUNT(*) FROM \"posts\"")
 
       decorated_collection = controller_with_decorator("index", PostDecorator).apply_collection_decorator(undecorated_collection)
 
       expect { paginated_collection(decorated_collection, pagination_total: false) }
-        .not_to make_database_queries(matching: "SELECT COUNT(*) FROM \"posts\"")
+        .not_to perform_database_query("SELECT COUNT(*) FROM \"posts\"")
     end
 
     it "makes no COUNT queries to figure out the last element of each page" do
-      require "db-query-matchers"
-
       undecorated_collection = Post.all.page(1).per(30)
 
       expect { paginated_collection(undecorated_collection) }
-        .not_to make_database_queries(matching: "SELECT COUNT(*) FROM (SELECT")
+        .not_to perform_database_query("SELECT COUNT(*) FROM (SELECT")
     end
 
     context "when specifying per_page: array option" do


### PR DESCRIPTION
I've seen in this issue https://github.com/activeadmin/activeadmin/issues/7196 that `db-query-matchers` gem is incompatible with Rails 7 and looks no longer maintained.

I've introduced a custom Rspec matcher that subscribes to `sql.active_record` event and checks if the passed query matches (or not) with the executed ones.