### PR TITLE
Drop support for Ruby 2.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,19 +83,6 @@ jobs:
 
         deps: [rails_52, rails_60, rails_61, rails_61_turbolinks, rails_61_webpacker]
 
-        include:
-          - ruby: { name: 2.5, value: 2.5.8 }
-            os: ubuntu-20.04
-            deps: rails_52
-
-          - ruby: { name: 2.5, value: 2.5.8 }
-            os: ubuntu-20.04
-            deps: rails_60
-
-          - ruby: { name: 2.5, value: 2.5.8 }
-            os: ubuntu-20.04
-            deps: rails_61
-
     env:
       COVERAGE: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ require:
 
 AllCops:
   DisabledByDefault: true
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
 
   Exclude:
     - tmp/development_apps/**/*

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.extra_rdoc_files = %w[CHANGELOG.md CODE_OF_CONDUCT.md CONTRIBUTING.md README.md]
 
-  s.required_ruby_version = ">= 2.5"
+  s.required_ruby_version = ">= 2.6"
 
   s.add_dependency "arbre", "~> 1.2", ">= 1.2.1"
   s.add_dependency "formtastic", ">= 3.1", "< 5.0"


### PR DESCRIPTION
Ruby 2.5 arrived to EOL almost 9 months ago. Could be the moment to drop the support.