### PR TITLE
Small follow up to ruby 2.5 support drop

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,22 @@ on:
       - master
 
 jobs:
+  jruby:
+    name: Check Gemfile installs fine on JRuby
+    runs-on: ubuntu-20.04
+
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: jruby-9.3.2.0
+
+      - name: Run bug report template
+        run: ACTIVE_ADMIN_PATH=. ruby tasks/bug_report_template.rb
+
   lint:
     name: lint (${{ matrix.ruby.name }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -18,7 +18,7 @@ jobs:
 
       matrix:
         os: [ubuntu-20.04]
-        ruby: [{ name: jruby-9.2, value: jruby-9.2.16.0 }]
+        ruby: [{ name: jruby-9.3, value: jruby-9.3.2.0 }]
         deps: ["rails_52", "rails_60"]
 
     env:

--- a/tasks/bug_report_template.rb
+++ b/tasks/bug_report_template.rb
@@ -18,7 +18,6 @@ gemfile(true) do
   gem "sassc-rails", "2.1.2"
   gem "sqlite3", "1.4.1", platform: :mri
   gem "activerecord-jdbcsqlite3-adapter", "60.0", platform: :jruby
-  gem "jruby-openssl", "0.10.5", platform: :jruby
 end
 
 require "active_record"


### PR DESCRIPTION
We were testing against a Ruby 2.5-compatible JRuby, so we need to bump that too.