### PR TITLE
Avoid requesting sorted sql query for paginated collection.

### DIFF
--- a/lib/active_admin/views/components/paginated_collection.rb
+++ b/lib/active_admin/views/components/paginated_collection.rb
@@ -123,9 +123,9 @@ module ActiveAdmin
           entry_name = I18n.t "active_admin.pagination.entry", count: 1, default: "entry"
           entries_name = I18n.t "active_admin.pagination.entry", count: 2, default: "entries"
         else
-          key = "activerecord.models." + collection.first.class.model_name.i18n_key.to_s
+          key = "activerecord.models." + collection[0].class.model_name.i18n_key.to_s
 
-          entry_name = I18n.translate key, count: 1, default: collection.first.class.name.underscore.sub("_", " ")
+          entry_name = I18n.translate key, count: 1, default: collection[0].class.name.underscore.sub("_", " ")
           entries_name = I18n.translate key, count: collection.size, default: entry_name.pluralize
         end
 


### PR DESCRIPTION
Hi,

The `#first` method used in the `PaginatedCollection#page_entries_info` ([L126](https://github.com/jan-bw/activeadmin/blob/ed52920aed32dc412c2ea682981a0e2393774c2b/lib/active_admin/views/components/paginated_collection.rb#L126), [L128](https://github.com/jan-bw/activeadmin/blob/ed52920aed32dc412c2ea682981a0e2393774c2b/lib/active_admin/views/components/paginated_collection.rb#L128)) can cause performance issues on the bigger tables because it's building an SQL query with `ORDER BY` in it.

Using the `collection[0]` instead is going to take the first element from the paginated collection.

I was considering using `take`, but it works only for rails associations (won't pass the specs; won't work with `PaginatedArray`). Also considered using `collection.model_name` with same effect. Having that in mind I think the `collection[0]` might be a way to go.