### PR TITLE
Bump i18n version to 1.9.1 as current version has been yanked

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,7 +215,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
     highline (2.0.3)
-    i18n (1.9.0)
+    i18n (1.9.1)
       concurrent-ruby (~> 1.0)
     i18n-spec (0.6.0)
       iso

--- a/gemfiles/rails_60/Gemfile.lock
+++ b/gemfiles/rails_60/Gemfile.lock
@@ -182,7 +182,7 @@ GEM
     has_scope (0.8.0)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
-    i18n (1.9.0)
+    i18n (1.9.1)
       concurrent-ruby (~> 1.0)
     inherited_resources (1.13.1)
       actionpack (>= 5.2, < 7.1)

--- a/gemfiles/rails_61_turbolinks/Gemfile.lock
+++ b/gemfiles/rails_61_turbolinks/Gemfile.lock
@@ -186,7 +186,7 @@ GEM
     has_scope (0.8.0)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
-    i18n (1.9.0)
+    i18n (1.9.1)
       concurrent-ruby (~> 1.0)
     inherited_resources (1.13.1)
       actionpack (>= 5.2, < 7.1)

--- a/gemfiles/rails_61_webpacker/Gemfile.lock
+++ b/gemfiles/rails_61_webpacker/Gemfile.lock
@@ -186,7 +186,7 @@ GEM
     has_scope (0.8.0)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
-    i18n (1.9.0)
+    i18n (1.9.1)
       concurrent-ruby (~> 1.0)
     inherited_resources (1.13.1)
       actionpack (>= 5.2, < 7.1)


### PR DESCRIPTION
The current version of `i18n` (1.9.0) gem is no longer in Rubygems, looks like has been yanked. A new patch version has been released reverting the code that was not working properly in the previous version.

![Screenshot 2022-01-30 at 09 55 58](https://user-images.githubusercontent.com/6084749/151693226-0ee41d20-1cf9-4ca2-bcb6-ba5cc47222d9.png)


So, this PR fixes the following error:

![Screenshot 2022-01-30 at 09 46 33](https://user-images.githubusercontent.com/6084749/151693148-67311609-8439-4fb2-bd0f-77dde01fb02e.png)

