### PR TITLE
Remove unused module NoActiveModel in specs

### DIFF
--- a/spec/unit/resource/naming_spec.rb
+++ b/spec/unit/resource/naming_spec.rb
@@ -11,7 +11,6 @@ module ActiveAdmin
     end
 
     module ::Mock class Resource < ActiveRecord::Base; end; end
-    module NoActiveModel class Resource; end; end
 
     describe "singular resource name" do
       context "when class" do


### PR DESCRIPTION
`NoActiveModel` module is dead code and can be safely removed from the specs

Dead since: b7b7401466daf463c696deaefba43aca7e5ef7f6