### PR TITLE
Add test for helper method with kwargs call in form fails on Ruby 3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -519,4 +519,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.3.5
+   2.3.6

--- a/features/new_page.feature
+++ b/features/new_page.feature
@@ -56,6 +56,36 @@ Feature: New Page
     And I should see the attribute "Title" with "Hello World"
     And I should see the attribute "Body" with "This is the body"
 
+  Scenario: A form where calling a helper method with given kwargs is successful
+    Given a configuration of:
+    """
+      ActiveAdmin.register Post do
+        form do |f|
+          f.inputs "Publishing" do
+            f.input :published_date, input_html: { "data-time" => format_time(Time.current, format: :short) }
+          end
+          f.actions
+        end
+      end
+    """
+    And I follow "New Post"
+    Then I should see a fieldset titled "Publishing"
+
+  Scenario: A form where calling a helper method with no kwargs is successful
+    Given a configuration of:
+    """
+      ActiveAdmin.register Post do
+        form do |f|
+          f.inputs "Publishing" do
+            f.input :published_date, input_html: { "data-time" => format_time(Time.current) }
+          end
+          f.actions
+        end
+      end
+    """
+    And I follow "New Post"
+    Then I should see a fieldset titled "Publishing"
+
   Scenario: Generating a custom form decorated with virtual attributes
     Given a configuration of:
     """

--- a/gemfiles/rails_60/Gemfile.lock
+++ b/gemfiles/rails_60/Gemfile.lock
@@ -410,4 +410,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.3.5
+   2.3.6

--- a/gemfiles/rails_61_turbolinks/Gemfile.lock
+++ b/gemfiles/rails_61_turbolinks/Gemfile.lock
@@ -416,4 +416,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.3.5
+   2.3.6

--- a/gemfiles/rails_61_webpacker/Gemfile.lock
+++ b/gemfiles/rails_61_webpacker/Gemfile.lock
@@ -410,4 +410,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.3.5
+   2.3.6

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -50,6 +50,8 @@ template File.expand_path("templates/migrations/create_taggings.tt", __dir__), "
 
 copy_file File.expand_path("templates/models/tagging.rb", __dir__), "app/models/tagging.rb"
 
+copy_file File.expand_path("templates/helpers/time_helper.rb", __dir__), "app/helpers/time_helper.rb"
+
 gsub_file "config/environments/test.rb", /  config.cache_classes = true/, <<-RUBY
 
   config.cache_classes = !ENV['CLASS_RELOADING']

--- a/spec/support/templates/helpers/time_helper.rb
+++ b/spec/support/templates/helpers/time_helper.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+module TimeHelper
+
+  def format_time(time, format: :long)
+    time
+  end
+
+end


### PR DESCRIPTION
When a helper method accepts keyword arguments and **they are given**, required or not, this causes a failure in Ruby 3.

> wrong number of arguments (given 2, expected 1) (ActionView::Template::Error)
> ./tmp/test_apps/rails_61/app/helpers/time_helper.rb:3:in `format_time'

Note if the keyword arguments are all optional and not given, then no error occurs. I've added a second test case that indicates that it passes while the former case is failing but should pass.

This is due to an Arbre issue https://github.com/activeadmin/arbre/issues/312 but I was not able to figure out how to create a failing test in Arbre's test suite. Any attempts didn't recreate a failed test but it's easy to replicate on ActiveAdmin's end.
