### PR TITLE
Add `yalphabetize` gem

### DIFF
--- a/.yalphabetize.yml
+++ b/.yalphabetize.yml
@@ -1,0 +1,2 @@
+only:
+  - config/locales/

--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ group :lint do
   # Translations
   gem "i18n-tasks"
   gem "i18n-spec"
+  gem "yalphabetize"
 end
 
 group :docs do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -471,6 +471,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yalphabetize (0.6.2)
     yard (0.9.27)
       webrick (~> 1.7.0)
     zeitwerk (2.5.4)
@@ -516,6 +517,7 @@ DEPENDENCIES
   sprockets-rails
   sqlite3
   webrick
+  yalphabetize
   yard
 
 BUNDLED WITH

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -1,135 +1,135 @@
 ar:
   active_admin:
-    dashboard: "لوحة تحكم"
-    dashboard_welcome:
-      welcome: "مرحبًا بك في في صفحة الإدارة، وهذه هي الصفحة الإفتراضيّة."
-      call_to_action: "لإضافة أقسام إلى  لوحة التحكم, راجع: 'app/admin/dashboard.rb'"
-    view: "عرض"
-    edit: "تعديل"
-    delete: "حذف"
-    delete_confirmation: "هل تريد تأكيد الحذف؟"
-    new_model: "%{model} جديد"
-    edit_model: "تعديل %{model}"
-    delete_model: "حذف %{model}"
-    details: "تفاصيل %{model}"
-    cancel: "إلغاء"
-    empty: "فارغ"
-    previous: "السابق"
-    next: "التالي"
-    download: "تحميل"
-    has_many_new: "إضافة %{model} جديد"
-    has_many_delete: "حذف"
-    has_many_remove: "إزالة"
-    filters:
-      buttons:
-        filter: "تصفية"
-        clear: "تفريغ التصفية"
-      predicates:
-        contains: "يحتوي"
-        equals: "متساوي"
-        starts_with: "يبدأ بـ"
-        ends_with: "ينتهي بـ"
-        greater_than: "أكبر من"
-        less_than: "أقل من"
-    search_status:
-      headline: "حالات البحث:"
-      current_scope: "المجال:"
-      current_filters: "المُرشحات الحاليّة:"
-      no_current_filters: "بدون"
-    status_tag:
-      "yes": "نعم"
-      "no": "لا"
-      "unset": "لا"
-    main_content: "الرجاء تنفيذ %{model}#main_content لعرض المحتوى."
-    logout: "تسجيل الخروج"
-    powered_by: "تنفيذ %{active_admin} %{version}"
-    sidebars:
-      filters: "المُرشحات"
-      search_status: "حالات البحث"
-    pagination:
-      empty: "لا يوجد %{model} "
-      one: "عرض <b>1</b> %{model}"
-      one_page: "عرض <b>all %{n}</b> %{model}"
-      multiple: "عرض %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> من <b>%{total}</b> بالمجمل"
-      multiple_without_total: "عرض %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      entry:
-        one: "مدخل"
-        other: "مدخلات"
+    access_denied:
+      message: "لم يُصرّح لك بهذا الإجراء."
     any: "أي"
-    blank_slate:
-      content: "لايوجد %{resource_name} بعد."
-      link: "إنشاء"
-    dropdown_actions:
-      button_label: "إجراءات"
     batch_actions:
+      action_label: "اُختير %{title}"
       button_label: "إجراءات متعددة"
       default_confirmation: "هل أنت متأكّد؟"
       delete_confirmation: "هل أنت متأكّد من حذف هذه %{plural_model}؟"
+      labels:
+        destroy: "حذف"
+      selection_toggle_explanation: "(تتبيث الخيار)"
       succesfully_destroyed:
         one: "حُذف بنجاح 1 %{model}"
         other: "حُذف بنجاح %{count} %{plural_model}"
-      selection_toggle_explanation: "(تتبيث الخيار)"
-      action_label: "اُختير %{title}"
-      labels:
-        destroy: "حذف"
+    blank_slate:
+      content: "لايوجد %{resource_name} بعد."
+      link: "إنشاء"
+    cancel: "إلغاء"
     comments:
-      resource_type: "نوع المصدر"
+      add: "إضافة تعليق"
+      author: "مؤلّف"
+      author_missing: "مجهول"
       author_type: "نوع الؤلّف"
       body: "هيكل"
-      author: "مؤلّف"
-      add: "إضافة تعليق"
-      resource: "مصدر"
-      no_comments_yet: "لا يوجد تعليقات بعد."
-      author_missing: "مجهول"
-      title_content: "تعليقات (%{count})"
-      errors:
-        empty_text: "لم يُحفظ التعليق، النص فارغ."
       created_at: "أُنشئ"
       delete: "حذف تعليق"
       delete_confirmation: "هل أنت متأكّد من حذف هذه التعليقات؟"
+      errors:
+        empty_text: "لم يُحفظ التعليق، النص فارغ."
+      no_comments_yet: "لا يوجد تعليقات بعد."
+      resource: "مصدر"
+      resource_type: "نوع المصدر"
+      title_content: "تعليقات (%{count})"
+    dashboard: "لوحة تحكم"
+    dashboard_welcome:
+      call_to_action: "لإضافة أقسام إلى  لوحة التحكم, راجع: 'app/admin/dashboard.rb'"
+      welcome: "مرحبًا بك في في صفحة الإدارة، وهذه هي الصفحة الإفتراضيّة."
+    delete: "حذف"
+    delete_confirmation: "هل تريد تأكيد الحذف؟"
+    delete_model: "حذف %{model}"
+    details: "تفاصيل %{model}"
     devise:
-      username:
-        title: "اسم المستخدم"
+      change_password:
+        submit: "تغير كلمة المرور خاصتي"
+        title: "تغير كلمة المرور خاصتك"
       email:
         title: "البريد الإلكترونيّ"
-      subdomain:
-        title: "مجال فرعي"
-      password:
-        title: "كلمة المرور"
-      sign_up:
-        title: "تسجيل"
-        submit: "تسجيل"
+      links:
+        forgot_your_password: "هل نسيت كلمة المرور؟"
+        resend_confirmation_instructions: "إعادة إرسال تعليمات تأكيد الحساب"
+        resend_unlock_instructions: "إعادة إرسال تعليمات تنشيط الحساب"
+        sign_in: "تسجيل الدخول"
+        sign_in_with_omniauth_provider: "تسجيل الدخول بـ %{provider}"
+        sign_up: "التسجيل"
       login:
-        title: "تسجيل الدخول"
         remember_me: "تذكرني"
         submit: "تسجيل الدخول"
-      reset_password:
-        title: "هل نسيت كلمة المرور؟"
-        submit: "استرجاع كلمة المرور"
-      change_password:
-        title: "تغير كلمة المرور خاصتك"
-        submit: "تغير كلمة المرور خاصتي"
-      unlock:
-        title: "إعادة إرسال تعليمات فك الحظر"
-        submit: "إعادة إرسال تعليمات فك الحظر"
+        title: "تسجيل الدخول"
+      password:
+        title: "كلمة المرور"
       resend_confirmation_instructions:
-        title: "إعادة ارسال تعليمات التأكيد"
         submit: "إعادة ارسال تعليمات التأكيد"
-      links:
-        sign_up: "التسجيل"
-        sign_in: "تسجيل الدخول"
-        forgot_your_password: "هل نسيت كلمة المرور؟"
-        sign_in_with_omniauth_provider: "تسجيل الدخول بـ %{provider}"
-        resend_unlock_instructions: "إعادة إرسال تعليمات تنشيط الحساب"
-        resend_confirmation_instructions: "إعادة إرسال تعليمات تأكيد الحساب"
+        title: "إعادة ارسال تعليمات التأكيد"
+      reset_password:
+        submit: "استرجاع كلمة المرور"
+        title: "هل نسيت كلمة المرور؟"
+      sign_up:
+        submit: "تسجيل"
+        title: "تسجيل"
+      subdomain:
+        title: "مجال فرعي"
+      unlock:
+        submit: "إعادة إرسال تعليمات فك الحظر"
+        title: "إعادة إرسال تعليمات فك الحظر"
+      username:
+        title: "اسم المستخدم"
+    download: "تحميل"
+    dropdown_actions:
+      button_label: "إجراءات"
+    edit: "تعديل"
+    edit_model: "تعديل %{model}"
+    empty: "فارغ"
+    filters:
+      buttons:
+        clear: "تفريغ التصفية"
+        filter: "تصفية"
+      predicates:
+        contains: "يحتوي"
+        ends_with: "ينتهي بـ"
+        equals: "متساوي"
+        greater_than: "أكبر من"
+        less_than: "أقل من"
+        starts_with: "يبدأ بـ"
+    has_many_delete: "حذف"
+    has_many_new: "إضافة %{model} جديد"
+    has_many_remove: "إزالة"
+    index_list:
+      block: "قائمة"
+      blog: "مدونة"
+      grid: "شبكة"
+      table: "جدول"
+    logout: "تسجيل الخروج"
+    main_content: "الرجاء تنفيذ %{model}#main_content لعرض المحتوى."
+    new_model: "%{model} جديد"
+    next: "التالي"
+    pagination:
+      empty: "لا يوجد %{model} "
+      entry:
+        one: "مدخل"
+        other: "مدخلات"
+      multiple: "عرض %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> من <b>%{total}</b> بالمجمل"
+      multiple_without_total: "عرض %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      one: "عرض <b>1</b> %{model}"
+      one_page: "عرض <b>all %{n}</b> %{model}"
+    powered_by: "تنفيذ %{active_admin} %{version}"
+    previous: "السابق"
+    search_status:
+      current_filters: "المُرشحات الحاليّة:"
+      current_scope: "المجال:"
+      headline: "حالات البحث:"
+      no_current_filters: "بدون"
+    sidebars:
+      filters: "المُرشحات"
+      search_status: "حالات البحث"
+    status_tag:
+      "no": "لا"
+      "unset": "لا"
+      "yes": "نعم"
     unsupported_browser:
       headline: "يُرجى مُلاحظة أن (أكتف أدمن) لم تعد تدعم المُتصفّح إنترنت اكسبلوررالإصدار الثامن وما قبله"
       recommendation: "ننصح بالتحديث إلى الإصدارات الأخيرة من: <a href=\"http://windows.microsoft.com/ie\">Internet Explorer</a>, <a href=\"https://chrome.google.com/\">Google Chrome</a>, أو <a href=\"https://mozilla.org/firefox/\">Firefox</a>."
       turn_off_compatibility_view: "إن كنت تستخدم الإصدار التاسع وما يليه من إنترنت إكسبلورر تأكّد من <a href=\"https://support.microsoft.com/ar-ae/help/17471\">تعطيل \"Compatibility View\"</a>."
-    access_denied:
-      message: "لم يُصرّح لك بهذا الإجراء."
-    index_list:
-      table: "جدول"
-      block: "قائمة"
-      grid: "شبكة"
-      blog: "مدونة"
+    view: "عرض"

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -1,138 +1,138 @@
 az:
   active_admin:
-    dashboard: "İdarəetmə paneli"
-    dashboard_welcome:
-      welcome: "Active Admin-ə xoş gəlmişsiniz. Bu saytla idarəetmənin standart səhifəsidir."
-      call_to_action: "Buraya nə isə əlavə etmək üçün 'app/admin/dashboard.rb' sənədini dəyişin"
-    view: "Aç"
-    edit: "Dəyiş"
-    delete: "Sil"
-    delete_confirmation: "Siz bunu silmək istədiyinizdən əminsiniz?"
-    new_model: "%{model} yarat"
-    edit_model: "%{model} dəyiş"
-    delete_model: "%{model} sil"
-    details: "%{model} haqqında"
-    cancel: "İmtina"
-    empty: "Boş"
-    previous: "Geri"
-    next: "İrəli"
-    download: "Yüklənmə:"
-    has_many_new: "%{model} əlavə et"
-    has_many_delete: "Sil"
-    has_many_remove: "Yığışdır"
-    filters:
-      buttons:
-        filter: "Filtrlə"
-        clear: "Təmizlə"
-      predicates:
-        contains: "Yerləşir"
-        equals: "Bərabərdir"
-        starts_with: "Başlayır"
-        ends_with: "Bitir"
-        greater_than: "böyük"
-        less_than: "kiçik"
-    search_status:
-      headline: "Axtarışın statusu:"
-      current_scope: "Sahə:"
-      current_filters: "Cari filter:"
-      no_current_filters: "Heç biri"
-    status_tag:
-      "yes": "Bəli"
-      "no": "Xeyr"
-    main_content: "Создайте %{model}#main_content для отображения содержимого."
-    logout: "Çıxış"
-    powered_by: "Работает на %{active_admin} %{version}"
-    sidebars:
-      filters: "Filterlə"
-      search_status: "Axtarışın statusu"
-    pagination:
-      empty: "%{model} tapılmadı"
-      one: "Nəticə: <b>1</b> %{model}"
-      one_page: "Nəticə: <b>%{n}</b> %{model}"
-      multiple: "Nəticə: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> <b>%{total}</b>"
-      multiple_without_total: "Nəticə: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      entry:
-        one: "yazı"
-        few: "yazı"
-        many: "yazı"
-        other: "yazı"
+    access_denied:
+      message: "Bunu etmək üçün daxil olmalısınız."
     any: "İstənilən"
-    blank_slate:
-      content: "%{resource_name} hələ yoxdur."
-      link: "Yarat"
-    dropdown_actions:
-      button_label: "Əməliyyatlar"
     batch_actions:
+      action_label: "%{title} seçilmiş"
       button_label: "Qrup əməliyyatları"
       default_confirmation: "Siz bunu etməyinizə əminsiniz?"
       delete_confirmation: "Siz %{plural_model} silməyə əminsiniz?"
-      succesfully_destroyed:
-        one: "Uğurla silindi: 1 %{model}"
-        few: "Uğurla silindi: %{count} %{plural_model}"
-        many: "Uğurla silindi: %{count} %{plural_model}"
-        other: "Uğurla silindi: %{count} %{plural_model}"
-      selection_toggle_explanation: "(Hamısını seç / Seçilmişləri sıfırla)"
-      action_label: "%{title} seçilmiş"
       labels:
         destroy: "Sil"
+      selection_toggle_explanation: "(Hamısını seç / Seçilmişləri sıfırla)"
+      succesfully_destroyed:
+        few: "Uğurla silindi: %{count} %{plural_model}"
+        many: "Uğurla silindi: %{count} %{plural_model}"
+        one: "Uğurla silindi: 1 %{model}"
+        other: "Uğurla silindi: %{count} %{plural_model}"
+    blank_slate:
+      content: "%{resource_name} hələ yoxdur."
+      link: "Yarat"
+    cancel: "İmtina"
     comments:
-      created_at: "Yaranma tarixi"
-      resource_type: "Resursun tipi"
+      add: "Şərh əlavə et"
+      author: "Müəllif"
+      author_missing: "Naməlum"
       author_type: "Müəllifin tipi"
       body: "Mətn"
-      author: "Müəllif"
-      add: "Şərh əlavə et"
+      created_at: "Yaranma tarixi"
       delete: "Şərhi sil"
       delete_confirmation: "Siz bu şərhi silmək istədiyinizdən əminsiniz?"
-      resource: "Resurs"
-      no_comments_yet: "Hələ şərhlər yoxdur."
-      author_missing: "Naməlum"
-      title_content: "Şərhlər (%{count})"
       errors:
         empty_text: "Şərh yadda saxlanılmadı, mətn boş ola bilməz."
+      no_comments_yet: "Hələ şərhlər yoxdur."
+      resource: "Resurs"
+      resource_type: "Resursun tipi"
+      title_content: "Şərhlər (%{count})"
+    dashboard: "İdarəetmə paneli"
+    dashboard_welcome:
+      call_to_action: "Buraya nə isə əlavə etmək üçün 'app/admin/dashboard.rb' sənədini dəyişin"
+      welcome: "Active Admin-ə xoş gəlmişsiniz. Bu saytla idarəetmənin standart səhifəsidir."
+    delete: "Sil"
+    delete_confirmation: "Siz bunu silmək istədiyinizdən əminsiniz?"
+    delete_model: "%{model} sil"
+    details: "%{model} haqqında"
     devise:
-      username:
-        title: "İstifadəçi adı"
+      change_password:
+        submit: "Şifrəni dəyiş"
+        title: "Şifrənin dəyişdirilməsi"
       email:
         title: "E-poçt"
-      subdomain:
-        title: "Subdomen"
-      password:
-        title: "Şifrə"
-      sign_up:
-        title: "Qeydiyyat"
-        submit: "Qeydiyyatdan keç"
+      links:
+        forgot_your_password: "Şifrəni unutmusunuz?"
+        resend_confirmation_instructions: "Aktivləşdirmə ismarışını yenidən göndərilməsi"
+        resend_unlock_instructions: "Blokdan çıxarma üzrə təlimatı yenidən göndərilməsi"
+        sign_in: "Giriş"
+        sign_in_with_omniauth_provider: "%{provider} vasitəsilə daxil ol"
+        sign_up: "Qeydiyyat"
       login:
-        title: "Giriş"
         remember_me: "Məni yadda saxla"
         submit: "Daxil ol"
-      reset_password:
-        title: "Şifrəni unutmusunuz?"
-        submit: "Şifrəni sıfırla"
-      change_password:
-        title: "Şifrənin dəyişdirilməsi"
-        submit: "Şifrəni dəyiş"
-      unlock:
-        title: "Blokdan çıxarma üzrə təlimatı yenidən göndərmək"
-        submit: "Blokdan çıxarma üzrə təlimatı yenidən göndərmək"
+        title: "Giriş"
+      password:
+        title: "Şifrə"
       resend_confirmation_instructions:
-        title: "Aktivləşdirmə ismarışını yenidən göndərmək"
         submit: "Aktivləşdirmə ismarışını yenidən göndərmək"
-      links:
-        sign_up: "Qeydiyyat"
-        sign_in: "Giriş"
-        forgot_your_password: "Şifrəni unutmusunuz?"
-        sign_in_with_omniauth_provider: "%{provider} vasitəsilə daxil ol"
-        resend_unlock_instructions: "Blokdan çıxarma üzrə təlimatı yenidən göndərilməsi"
-        resend_confirmation_instructions: "Aktivləşdirmə ismarışını yenidən göndərilməsi"
+        title: "Aktivləşdirmə ismarışını yenidən göndərmək"
+      reset_password:
+        submit: "Şifrəni sıfırla"
+        title: "Şifrəni unutmusunuz?"
+      sign_up:
+        submit: "Qeydiyyatdan keç"
+        title: "Qeydiyyat"
+      subdomain:
+        title: "Subdomen"
+      unlock:
+        submit: "Blokdan çıxarma üzrə təlimatı yenidən göndərmək"
+        title: "Blokdan çıxarma üzrə təlimatı yenidən göndərmək"
+      username:
+        title: "İstifadəçi adı"
+    download: "Yüklənmə:"
+    dropdown_actions:
+      button_label: "Əməliyyatlar"
+    edit: "Dəyiş"
+    edit_model: "%{model} dəyiş"
+    empty: "Boş"
+    filters:
+      buttons:
+        clear: "Təmizlə"
+        filter: "Filtrlə"
+      predicates:
+        contains: "Yerləşir"
+        ends_with: "Bitir"
+        equals: "Bərabərdir"
+        greater_than: "böyük"
+        less_than: "kiçik"
+        starts_with: "Başlayır"
+    has_many_delete: "Sil"
+    has_many_new: "%{model} əlavə et"
+    has_many_remove: "Yığışdır"
+    index_list:
+      block: "Siyahı"
+      blog: "Bloq"
+      grid: "Tor"
+      table: "Cədvəl"
+    logout: "Çıxış"
+    main_content: "Создайте %{model}#main_content для отображения содержимого."
+    new_model: "%{model} yarat"
+    next: "İrəli"
+    pagination:
+      empty: "%{model} tapılmadı"
+      entry:
+        few: "yazı"
+        many: "yazı"
+        one: "yazı"
+        other: "yazı"
+      multiple: "Nəticə: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> <b>%{total}</b>"
+      multiple_without_total: "Nəticə: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      one: "Nəticə: <b>1</b> %{model}"
+      one_page: "Nəticə: <b>%{n}</b> %{model}"
+    powered_by: "Работает на %{active_admin} %{version}"
+    previous: "Geri"
+    search_status:
+      current_filters: "Cari filter:"
+      current_scope: "Sahə:"
+      headline: "Axtarışın statusu:"
+      no_current_filters: "Heç biri"
+    sidebars:
+      filters: "Filterlə"
+      search_status: "Axtarışın statusu"
+    status_tag:
+      "no": "Xeyr"
+      "yes": "Bəli"
     unsupported_browser:
       headline: "Zəhmət olmasa, bilin ki, Active Admin artıq Internet Explorer-in köhnə versiyalarını daha dəstəkləmir və yalnız IE 8 versiyasından başlayaraq dəstəkləyir"
       recommendation: "Biz sizin brauzerinizin versiyasını yeniləməyi məsləhət görürük (<a href=\"http://windows.microsoft.com/ie\">Internet Explorer</a>, <a href=\"https://chrome.google.com/\">Google Chrome</a>, və ya <a href=\"https://mozilla.org/firefox/\">Firefox</a>)."
       turn_off_compatibility_view: "Əgər siz IE 9  və ya daha yeni versiya istifadə edirsinizsə, əmin olun ki, <a href=\"https://support.microsoft.com/ru-ru/help/17471\">\"Uyğunluğun rejimində baxış\"</a> seçimini söndürmüsünüz."
-    access_denied:
-      message: "Bunu etmək üçün daxil olmalısınız."
-    index_list:
-      table: "Cədvəl"
-      block: "Siyahı"
-      grid: "Tor"
-      blog: "Bloq"
+    view: "Aç"

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -1,119 +1,119 @@
 bg:
   active_admin:
-    dashboard: Табло
-    dashboard_welcome:
-      welcome: "Добре дошли в Active Admin. Това е таблото по подразбиране."
-      call_to_action: "За да добавите секции, редактирайте 'app/admin/dashboard.rb'"
-    view: "Преглед"
-    edit: "Редакция"
-    delete: "Изтриване"
-    delete_confirmation: "Сигурни ли сте, че искате да изтриете това?"
-    new_model: "Създаване на %{model}"
-    edit_model: "Редакция на %{model}"
-    delete_model: "Изтриване на %{model}"
-    details: "%{model} детайли"
-    cancel: "Отказ"
-    empty: "Празно"
-    previous: "Предишно"
-    next: "Следващо"
-    download: "Изтегляне:"
-    has_many_new: "Добавяне на %{model}"
-    has_many_delete: "Изтриване"
-    has_many_remove: "Премахване"
-    filters:
-      buttons:
-        filter: "Филтриране"
-        clear: "Изчистване"
-      predicates:
-        contains: "съдържа"
-        equals: "равно на"
-        starts_with: "Започва с"
-        ends_with: "Завършва с"
-        greater_than: "по-голямо от"
-        less_than: "по-малко от"
-    status_tag:
-      "yes": "Да"
-      "no": "не"
-      "unset": "не"
-    main_content: "Добавете %{model}#main_content за да видите съдържание."
-    logout: "Изход"
-    powered_by: "Задвижва се от %{active_admin} %{version}"
-    sidebars:
-      filters: "Филтри"
-    pagination:
-      empty: "Не са намерени %{model}"
-      one: "Показване на <b>1</b> %{model}"
-      one_page: "Показване на <b>всички %{n}</b> %{model}"
-      multiple: "Показване %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> от общо <b>%{total}</b>"
-      multiple_without_total: "Показване %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      entry:
-        one: "запис"
-        other: "записи"
+    access_denied:
+      message: "Нямате права да извършите това действие."
     any: "Без значение"
-    blank_slate:
-      content: "Все още няма добавени %{resource_name}."
-      link: "Създаване"
-    dropdown_actions:
-      button_label: "действия"
     batch_actions:
+      action_label: "%{title} избран"
       button_label: "Масови действия"
       default_confirmation: "Наистина ли искате да направите това?"
       delete_confirmation: "Сигурни ли сте, че искате да изтриете тези %{plural_model}?"
+      labels:
+        destroy: "Изтриване"
+      selection_toggle_explanation: "(Инвертиране на маркирането)"
       succesfully_destroyed:
         one: "Успешно изтриване на 1 %{model}"
         other: "Успешно изтриване на %{count} %{plural_model}"
-      selection_toggle_explanation: "(Инвертиране на маркирането)"
-      action_label: "%{title} избран"
-      labels:
-        destroy: "Изтриване"
+    blank_slate:
+      content: "Все още няма добавени %{resource_name}."
+      link: "Създаване"
+    cancel: "Отказ"
     comments:
-      resource_type: "Тип ресурс"
+      add: "Добавяне на коментар"
+      author: "Автор"
+      author_missing: "Анонимен"
       author_type: "Тип автор"
       body: "Текст"
-      author: "Автор"
-      add: "Добавяне на коментар"
-      resource: "Ресурс"
-      no_comments_yet: "Все още няма коментари."
-      author_missing: "Анонимен"
-      title_content: "Коментари (%{count})"
       errors:
         empty_text: "Коментарът с празен текст не беше запазен."
+      no_comments_yet: "Все още няма коментари."
+      resource: "Ресурс"
+      resource_type: "Тип ресурс"
+      title_content: "Коментари (%{count})"
+    dashboard: Табло
+    dashboard_welcome:
+      call_to_action: "За да добавите секции, редактирайте 'app/admin/dashboard.rb'"
+      welcome: "Добре дошли в Active Admin. Това е таблото по подразбиране."
+    delete: "Изтриване"
+    delete_confirmation: "Сигурни ли сте, че искате да изтриете това?"
+    delete_model: "Изтриване на %{model}"
+    details: "%{model} детайли"
     devise:
-      username:
-        title: "Потребителско име"
+      change_password:
+        submit: "Промяна на паролата"
+        title: "Промяна на паролата"
       email:
         title: "Поща"
-      subdomain:
-        title: "Поддомейн"
-      password:
-        title: "Парола"
-      sign_up:
-        title: "Регистрация"
-        submit: "Регистрация"
+      links:
+        forgot_your_password: "Забравена парола?"
+        sign_in: "Вход"
+        sign_in_with_omniauth_provider: "Влез с %{provider}"
       login:
-        title: "Вход"
         remember_me: "Запомни ме"
         submit: "Вход"
-      reset_password:
-        title: "Забравена парола?"
-        submit: "Изпращане на нова парола"
-      change_password:
-        title: "Промяна на паролата"
-        submit: "Промяна на паролата"
-      unlock:
-        title: "Изпрати отново инструкциите за отключване"
-        submit: "Изпрати отново инструкциите за отключване"
+        title: "Вход"
+      password:
+        title: "Парола"
       resend_confirmation_instructions:
-        title: "Изпрати отново инструкциите за потвърждаване"
         submit: "Изпрати отново инструкциите за потвърждаване"
-      links:
-        sign_in: "Вход"
-        forgot_your_password: "Забравена парола?"
-        sign_in_with_omniauth_provider: "Влез с %{provider}"
-    access_denied:
-      message: "Нямате права да извършите това действие."
+        title: "Изпрати отново инструкциите за потвърждаване"
+      reset_password:
+        submit: "Изпращане на нова парола"
+        title: "Забравена парола?"
+      sign_up:
+        submit: "Регистрация"
+        title: "Регистрация"
+      subdomain:
+        title: "Поддомейн"
+      unlock:
+        submit: "Изпрати отново инструкциите за отключване"
+        title: "Изпрати отново инструкциите за отключване"
+      username:
+        title: "Потребителско име"
+    download: "Изтегляне:"
+    dropdown_actions:
+      button_label: "действия"
+    edit: "Редакция"
+    edit_model: "Редакция на %{model}"
+    empty: "Празно"
+    filters:
+      buttons:
+        clear: "Изчистване"
+        filter: "Филтриране"
+      predicates:
+        contains: "съдържа"
+        ends_with: "Завършва с"
+        equals: "равно на"
+        greater_than: "по-голямо от"
+        less_than: "по-малко от"
+        starts_with: "Започва с"
+    has_many_delete: "Изтриване"
+    has_many_new: "Добавяне на %{model}"
+    has_many_remove: "Премахване"
     index_list:
-      table: "Таблица"
       block: "Списък"
-      grid: "Грид"
       blog: "Блог"
+      grid: "Грид"
+      table: "Таблица"
+    logout: "Изход"
+    main_content: "Добавете %{model}#main_content за да видите съдържание."
+    new_model: "Създаване на %{model}"
+    next: "Следващо"
+    pagination:
+      empty: "Не са намерени %{model}"
+      entry:
+        one: "запис"
+        other: "записи"
+      multiple: "Показване %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> от общо <b>%{total}</b>"
+      multiple_without_total: "Показване %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      one: "Показване на <b>1</b> %{model}"
+      one_page: "Показване на <b>всички %{n}</b> %{model}"
+    powered_by: "Задвижва се от %{active_admin} %{version}"
+    previous: "Предишно"
+    sidebars:
+      filters: "Филтри"
+    status_tag:
+      "no": "не"
+      "unset": "не"
+      "yes": "Да"
+    view: "Преглед"

--- a/config/locales/bs.yml
+++ b/config/locales/bs.yml
@@ -1,121 +1,121 @@
 bs:
   active_admin:
-    dashboard: "Upravljačka ploča"
-    dashboard_welcome:
-      welcome: "Dobrodošli u Active Admin. Ovo je početna upravljačka ploča."
-      call_to_action: "Da biste dodali nove odjeljke na upravljačku ploču, pogledajte 'app/admin/dashboard.rb'"
-    view: "Pregledaj"
-    edit: "Uredi"
-    delete: "Obriši"
-    delete_confirmation: "Jeste li sigurni da želite ovo obrisati?"
-    new_model: "Novi %{model}"
-    edit_model: "Uredi %{model}"
-    delete_model: "Obriši %{model}"
-    details: "%{model} detalji"
-    cancel: "Odustani"
-    empty: "Prazno"
-    previous: "Prethodni"
-    next: "Sljedeći"
-    download: "Spremi na računalo:"
-    has_many_new: "Dodaj novi %{model}"
-    has_many_delete: "Obriši"
-    has_many_remove: "Ukloniti"
-    filters:
-      buttons:
-        filter: "Filtriraj"
-        clear: "Ukloni filtere"
-      predicates:
-        contains: "Sadrži"
-        equals: "Jednako"
-        starts_with: "počinje s"
-        ends_with: "Završava sa"
-        greater_than: "Veće od"
-        less_than: "Manje od"
-    status_tag:
-      "yes": "Da"
-      "no": "Nema"
-      "unset": "Nema"
-    main_content: "Molim Vas, implementirajte %{model}#main_content da biste prikazali sadržaj."
-    logout: "Odjavi se"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filtriranje"
-    pagination:
-      empty: "Nije pronađen niti jedan %{model}."
-      one: "Prikazan <b>1</b> %{model}"
-      one_page: "Prikazano <b>svih %{n}</b> %{model}"
-      multiple: "Prikazani %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> od ukupno <b>%{total}</b>"
-      multiple_without_total: "Prikazani %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      entry:
-        one: "zapis"
-        few: "zapisa"
-        many: "zapisa"
-        other: "zapisa"
+    access_denied:
+      message: "Nemaš dopuštenja."
     any: "Bilo koji"
-    blank_slate:
-      content: "Još uvijek ne postoji niti jedan zapis tipa %{resource_name}."
-      link: "Izradi jedan"
     batch_actions:
+      action_label: "%{title} označene"
       button_label: "Grupne akcije"
       default_confirmation: "Jeste li sigurni da želite to učiniti?"
       delete_confirmation: "Jeste li sigurni da želite obrisati %{plural_model}?"
-      succesfully_destroyed:
-        one: "Uspješno je obrisan 1 %{model}"
-        few: "Uspješno su obrisana %{count} %{plural_model}"
-        many: "Uspješno je obrisano %{count} %{plural_model}"
-        other: "Uspješno je obrisano %{count} %{plural_model}"
-      selection_toggle_explanation: "(Izmijeni odabir)"
-      action_label: "%{title} označene"
       labels:
         destroy: "Obriši"
+      selection_toggle_explanation: "(Izmijeni odabir)"
+      succesfully_destroyed:
+        few: "Uspješno su obrisana %{count} %{plural_model}"
+        many: "Uspješno je obrisano %{count} %{plural_model}"
+        one: "Uspješno je obrisan 1 %{model}"
+        other: "Uspješno je obrisano %{count} %{plural_model}"
+    blank_slate:
+      content: "Još uvijek ne postoji niti jedan zapis tipa %{resource_name}."
+      link: "Izradi jedan"
+    cancel: "Odustani"
     comments:
-      resource_type: "Tip objekta"
+      add: "Dodaj komentar"
+      author: "Autor"
+      author_missing: "Anoniman"
       author_type: "Tip autora"
       body: "Sadržaj"
-      author: "Autor"
-      add: "Dodaj komentar"
-      resource: "Objekt"
-      no_comments_yet: "Još nema komentara."
-      author_missing: "Anoniman"
-      title_content: "Komentari (%{count})"
       errors:
         empty_text: "Komentar nije spremljen, sadržaj je prazan."
+      no_comments_yet: "Još nema komentara."
+      resource: "Objekt"
+      resource_type: "Tip objekta"
+      title_content: "Komentari (%{count})"
+    dashboard: "Upravljačka ploča"
+    dashboard_welcome:
+      call_to_action: "Da biste dodali nove odjeljke na upravljačku ploču, pogledajte 'app/admin/dashboard.rb'"
+      welcome: "Dobrodošli u Active Admin. Ovo je početna upravljačka ploča."
+    delete: "Obriši"
+    delete_confirmation: "Jeste li sigurni da želite ovo obrisati?"
+    delete_model: "Obriši %{model}"
+    details: "%{model} detalji"
     devise:
-      username:
-        title: "Korisničko ime"
+      change_password:
+        submit: "Izmijeni lozinku"
+        title: "Izmjena lozinke"
       email:
         title: "Email"
-      subdomain:
-        title: "Poddomena"
-      password:
-        title: "Lozinka"
-      sign_up:
-        title: "Registracija"
-        submit: "Registruj"
+      links:
+        forgot_your_password: "Zaboravljena lozinka?"
+        sign_in: "Prijavi se"
+        sign_in_with_omniauth_provider: "Prijavite se za %{provider}"
       login:
-        title: "Prijava"
         remember_me: "Zapamti me"
         submit: "Prijavi se"
-      reset_password:
-        title: "Zaboravljena lozinka?"
-        submit: "Resetuj lozinku"
-      change_password:
-        title: "Izmjena lozinke"
-        submit: "Izmijeni lozinku"
-      unlock:
-        title: "Ponovno slanje uputstva za otključavanje"
-        submit: "Pošalji"
+        title: "Prijava"
+      password:
+        title: "Lozinka"
       resend_confirmation_instructions:
-        title: "Ponovno slanje uputstva za potvrdu"
         submit: "Pošalji"
-      links:
-        sign_in: "Prijavi se"
-        forgot_your_password: "Zaboravljena lozinka?"
-        sign_in_with_omniauth_provider: "Prijavite se za %{provider}"
-    access_denied:
-      message: "Nemaš dopuštenja."
+        title: "Ponovno slanje uputstva za potvrdu"
+      reset_password:
+        submit: "Resetuj lozinku"
+        title: "Zaboravljena lozinka?"
+      sign_up:
+        submit: "Registruj"
+        title: "Registracija"
+      subdomain:
+        title: "Poddomena"
+      unlock:
+        submit: "Pošalji"
+        title: "Ponovno slanje uputstva za otključavanje"
+      username:
+        title: "Korisničko ime"
+    download: "Spremi na računalo:"
+    edit: "Uredi"
+    edit_model: "Uredi %{model}"
+    empty: "Prazno"
+    filters:
+      buttons:
+        clear: "Ukloni filtere"
+        filter: "Filtriraj"
+      predicates:
+        contains: "Sadrži"
+        ends_with: "Završava sa"
+        equals: "Jednako"
+        greater_than: "Veće od"
+        less_than: "Manje od"
+        starts_with: "počinje s"
+    has_many_delete: "Obriši"
+    has_many_new: "Dodaj novi %{model}"
+    has_many_remove: "Ukloniti"
     index_list:
-      table: "Tabela"
       block: "Lista"
-      grid: "Rešetka"
       blog: "Blog"
+      grid: "Rešetka"
+      table: "Tabela"
+    logout: "Odjavi se"
+    main_content: "Molim Vas, implementirajte %{model}#main_content da biste prikazali sadržaj."
+    new_model: "Novi %{model}"
+    next: "Sljedeći"
+    pagination:
+      empty: "Nije pronađen niti jedan %{model}."
+      entry:
+        few: "zapisa"
+        many: "zapisa"
+        one: "zapis"
+        other: "zapisa"
+      multiple: "Prikazani %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> od ukupno <b>%{total}</b>"
+      multiple_without_total: "Prikazani %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      one: "Prikazan <b>1</b> %{model}"
+      one_page: "Prikazano <b>svih %{n}</b> %{model}"
+    powered_by: "Powered by %{active_admin} %{version}"
+    previous: "Prethodni"
+    sidebars:
+      filters: "Filtriranje"
+    status_tag:
+      "no": "Nema"
+      "unset": "Nema"
+      "yes": "Da"
+    view: "Pregledaj"

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1,105 +1,105 @@
 ca:
   active_admin:
-    dashboard: Tauler
-    dashboard_welcome:
-      welcome: "Benvingut a Active Admin. Aquest és el tauler per defecte."
-      call_to_action: "Mira l'arxiu 'app/admin/dashboard.rb' per afegir seccions al tauler"
-    view: "Mostra"
-    edit: "Edita"
-    delete: "Elimina"
-    delete_confirmation: "Segur que vols eliminar-ho?"
-    new_model: "Crear %{model}"
-    edit_model: "Editar %{model}"
-    delete_model: "Eliminar %{model}"
-    details: "Detalls de %{model}"
-    cancel: "Cancel·lar"
-    empty: "Buit"
-    previous: "Anterior"
-    next: "Següent"
-    download: "Descarregar:"
-    has_many_new: "Afegir %{model}"
-    has_many_delete: "Eliminar"
-    has_many_remove: "Treure"
-    filters:
-      buttons:
-        filter: "Filtrar"
-        clear: "Treure filtres"
-      predicates:
-        contains: "Conté"
-        equals: "Igual a"
-        starts_with: "Comença amb"
-        ends_with: "Acaba amb"
-        greater_than: "Més gran que"
-        less_than: "Més petit que"
-    status_tag:
-      "yes": "Sí"
-      "no": "No"
-      "unset": "No"
-    main_content: "Implementa %{model}#main_content per mostrar contingut."
-    logout: "Desconnecta't"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filtres"
-    pagination:
-      empty: "No hi ha %{model}"
-      one: "S'està mostrant <b>1</b> %{model}"
-      one_page: "S'estan mostrant <b>tots %{n}</b> %{model}"
-      multiple: "S'estan mostrant %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> de <b>%{total}</b> en total"
-      multiple_without_total: "S'estan mostrant %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      entry:
-        one: "entrada"
-        other: "entrades"
+    access_denied:
+      message: "No esta autoritzat a realitzar aquesta acció."
     any: "Qualsevol"
-    blank_slate:
-      content: "Encara no hi ha cap %{resource_name}."
-      link: "Crea'n un/a"
-    dropdown_actions:
-      button_label: "accions"
     batch_actions:
+      action_label: "%{title} seleccionat"
       button_label: "les accions per lots"
       default_confirmation: "¿Esteu segur que voleu fer-ho?"
       delete_confirmation: "¿Està segur que desitja eliminar aquests %{plural_model}?"
+      labels:
+        destroy: "esborrar"
+      selection_toggle_explanation: "(Selecció de Canviar)"
       succesfully_destroyed:
         one: "Va destruir amb èxit 1 %{model}"
         other: "Va destruir amb èxit %{count} %{plural_model}"
-      selection_toggle_explanation: "(Selecció de Canviar)"
-      action_label: "%{title} seleccionat"
-      labels:
-        destroy: "esborrar"
+    blank_slate:
+      content: "Encara no hi ha cap %{resource_name}."
+      link: "Crea'n un/a"
+    cancel: "Cancel·lar"
     comments:
-      body: "Cos"
-      author: "autor"
       add: "Afegeix comentari"
-      resource: "Recurs"
-      no_comments_yet: "No hi ha comentaris"
-      title_content: "comentaris (%{count})"
+      author: "autor"
+      body: "Cos"
       errors:
         empty_text: "El comentari no es va salvar, el text estava buida."
+      no_comments_yet: "No hi ha comentaris"
+      resource: "Recurs"
+      title_content: "comentaris (%{count})"
+    dashboard: Tauler
+    dashboard_welcome:
+      call_to_action: "Mira l'arxiu 'app/admin/dashboard.rb' per afegir seccions al tauler"
+      welcome: "Benvingut a Active Admin. Aquest és el tauler per defecte."
+    delete: "Elimina"
+    delete_confirmation: "Segur que vols eliminar-ho?"
+    delete_model: "Eliminar %{model}"
+    details: "Detalls de %{model}"
     devise:
+      change_password:
+        submit: "Canviar la contrasenya"
+        title: "Canvieu la contrasenya"
+      links:
+        forgot_your_password: "Heu perdut la contrasenya?"
+        sign_in: "Registrar"
+        sign_in_with_omniauth_provider: "Connecta't amb %{provider}"
       login:
-        title: "iniciar sessió"
         remember_me: "Recordar"
         submit: "iniciar sessió"
-      reset_password:
-        title: "Heu perdut la contrasenya?"
-        submit: "Restablir la contrasenya"
-      change_password:
-        title: "Canvieu la contrasenya"
-        submit: "Canviar la contrasenya"
-      unlock:
-        title: "Reenvia instruccions per a desbloquejar"
-        submit: "Reenvia instruccions per a desbloquejar"
+        title: "iniciar sessió"
       resend_confirmation_instructions:
-        title: "Reenviar instruccions de confirmació"
         submit: "Reenviar instruccions de confirmació"
-      links:
-        sign_in: "Registrar"
-        forgot_your_password: "Heu perdut la contrasenya?"
-        sign_in_with_omniauth_provider: "Connecta't amb %{provider}"
-    access_denied:
-      message: "No esta autoritzat a realitzar aquesta acció."
+        title: "Reenviar instruccions de confirmació"
+      reset_password:
+        submit: "Restablir la contrasenya"
+        title: "Heu perdut la contrasenya?"
+      unlock:
+        submit: "Reenvia instruccions per a desbloquejar"
+        title: "Reenvia instruccions per a desbloquejar"
+    download: "Descarregar:"
+    dropdown_actions:
+      button_label: "accions"
+    edit: "Edita"
+    edit_model: "Editar %{model}"
+    empty: "Buit"
+    filters:
+      buttons:
+        clear: "Treure filtres"
+        filter: "Filtrar"
+      predicates:
+        contains: "Conté"
+        ends_with: "Acaba amb"
+        equals: "Igual a"
+        greater_than: "Més gran que"
+        less_than: "Més petit que"
+        starts_with: "Comença amb"
+    has_many_delete: "Eliminar"
+    has_many_new: "Afegir %{model}"
+    has_many_remove: "Treure"
     index_list:
-      table: "Taula"
       block: "Llista"
-      grid: "Graella"
       blog: "Bloc"
+      grid: "Graella"
+      table: "Taula"
+    logout: "Desconnecta't"
+    main_content: "Implementa %{model}#main_content per mostrar contingut."
+    new_model: "Crear %{model}"
+    next: "Següent"
+    pagination:
+      empty: "No hi ha %{model}"
+      entry:
+        one: "entrada"
+        other: "entrades"
+      multiple: "S'estan mostrant %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> de <b>%{total}</b> en total"
+      multiple_without_total: "S'estan mostrant %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      one: "S'està mostrant <b>1</b> %{model}"
+      one_page: "S'estan mostrant <b>tots %{n}</b> %{model}"
+    powered_by: "Powered by %{active_admin} %{version}"
+    previous: "Anterior"
+    sidebars:
+      filters: "Filtres"
+    status_tag:
+      "no": "No"
+      "unset": "No"
+      "yes": "Sí"
+    view: "Mostra"

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -1,109 +1,109 @@
 cs:
   active_admin:
-    dashboard: Úvod
-    dashboard_welcome:
-      welcome: "Vítejte v Active Admin. Toto je nástěnka."
-      call_to_action: "Pro přidání sekcí na nástěnku se podívejte do souboru 'app/admin/dashboard.rb'"
-    view: "Zobrazit"
-    edit: "Upravit"
-    delete: "Smazat"
-    delete_confirmation: "Jste si jistí, že chcete tuto položku smazat?"
-    new_model: "Vytvořit"
-    edit_model: "Upravit"
-    delete_model: "Smazat"
-    details: "Detaily"
-    cancel: "Zrušit"
-    empty: "Prázdné"
-    previous: "Předchozí"
-    next: "Následující"
-    download: "Stáhnout:"
-    has_many_new: "Přidat nový"
-    has_many_delete: "Smazat"
-    has_many_remove: "Odstranit"
-    filters:
-      buttons:
-        filter: "Filtrovat"
-        clear: "Vyčistit filtry"
-      predicates:
-        contains: "Obsahuje"
-        equals: "Odpovídá"
-        starts_with: "Začíná na"
-        ends_with: "Končí na"
-        greater_than: "Větší než"
-        less_than: "Menší než"
-    status_tag:
-      "yes": "Ano"
-      "no": "Ne"
-      "unset": "Ne"
-    main_content: "Implementujte prosím %{model}#main_content pro zobrazení obsahu."
-    logout: "Odhlásit"
-    powered_by: "%{active_admin} %{version}"
-    sidebars:
-      filters: "Filtry"
-    pagination:
-      empty: "Nenalezen."
-      one: "Zobrazena  <b>1</b> položka"
-      one_page: "Počet zobrazených položek %{n}"
-      multiple: "<b>%{from}&nbsp;-&nbsp;%{to}</b> z <b>%{total}</b>"
-      multiple_without_total: "<b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      entry:
-        one: "položka"
-        few: "položky"
-        other: "položky"
+    access_denied:
+      message: "Nemáte oprávnění k provedení této akce."
     any: "Kterákoliv"
-    blank_slate:
-      content: "Zatím zde není žádný obsah."
-      link: "Vytvořit"
-    dropdown_actions:
-      button_label: "Akce"
     batch_actions:
+      action_label: "%{title}"
       button_label: "Hromadné akce"
       default_confirmation: "Jste si jisti, že chcete provést?"
       delete_confirmation: "Jste si jisti, že chcete smazat tyto %{plural_model}?"
-      succesfully_destroyed:
-        zero: "Nebyl smazán žádný %{model}"
-        one: "Úspěšně smazán %{model}"
-        few: "Úspěšně smazány %{count} %{plural_model}"
-        other: "Úspěšně smazáno %{count} %{plural_model}"
-      selection_toggle_explanation: "(Změnit výběr)"
-      action_label: "%{title}"
       labels:
         destroy: "Vymazat"
+      selection_toggle_explanation: "(Změnit výběr)"
+      succesfully_destroyed:
+        few: "Úspěšně smazány %{count} %{plural_model}"
+        one: "Úspěšně smazán %{model}"
+        other: "Úspěšně smazáno %{count} %{plural_model}"
+        zero: "Nebyl smazán žádný %{model}"
+    blank_slate:
+      content: "Zatím zde není žádný obsah."
+      link: "Vytvořit"
+    cancel: "Zrušit"
     comments:
-      resource_type: "Typ zdroje"
+      add: "Přidat komentář"
+      author: "Autor"
+      author_missing: "Anonymní"
       author_type: "Typ autora"
       body: "Tělo"
-      author: "Autor"
-      add: "Přidat komentář"
-      resource: "Zdroj"
-      no_comments_yet: "Žádný komentář"
-      author_missing: "Anonymní"
-      title_content: "Komentáře administrátorů (%{count})"
       errors:
         empty_text: "Komentář nebyl uložen, je prázdný."
+      no_comments_yet: "Žádný komentář"
+      resource: "Zdroj"
+      resource_type: "Typ zdroje"
+      title_content: "Komentáře administrátorů (%{count})"
+    dashboard: Úvod
+    dashboard_welcome:
+      call_to_action: "Pro přidání sekcí na nástěnku se podívejte do souboru 'app/admin/dashboard.rb'"
+      welcome: "Vítejte v Active Admin. Toto je nástěnka."
+    delete: "Smazat"
+    delete_confirmation: "Jste si jistí, že chcete tuto položku smazat?"
+    delete_model: "Smazat"
+    details: "Detaily"
     devise:
+      change_password:
+        submit: "Změnit své heslo"
+        title: "Změnit heslo"
+      links:
+        forgot_your_password: "Zapomněli jste heslo?"
+        sign_in: "Přihlásit se"
+        sign_in_with_omniauth_provider: "Přihlásit se přes %{provider}"
+        sign_up: "Registrovat se"
       login:
-        title: "Přihlášení"
         remember_me: "Zapamatovat si mě"
         submit: "Přihlásit"
+        title: "Přihlášení"
       reset_password:
-        title: "Zapomněli jste heslo?"
         submit: "Obnovit heslo"
-      change_password:
-        title: "Změnit heslo"
-        submit: "Změnit své heslo"
+        title: "Zapomněli jste heslo?"
       unlock:
-        title: "Zaslání instrukcí k odemčení účtu"
         submit: "Zaslat instrukce k odemčení účtu"
-      links:
-        sign_in: "Přihlásit se"
-        sign_up: "Registrovat se"
-        forgot_your_password: "Zapomněli jste heslo?"
-        sign_in_with_omniauth_provider: "Přihlásit se přes %{provider}"
-    access_denied:
-      message: "Nemáte oprávnění k provedení této akce."
+        title: "Zaslání instrukcí k odemčení účtu"
+    download: "Stáhnout:"
+    dropdown_actions:
+      button_label: "Akce"
+    edit: "Upravit"
+    edit_model: "Upravit"
+    empty: "Prázdné"
+    filters:
+      buttons:
+        clear: "Vyčistit filtry"
+        filter: "Filtrovat"
+      predicates:
+        contains: "Obsahuje"
+        ends_with: "Končí na"
+        equals: "Odpovídá"
+        greater_than: "Větší než"
+        less_than: "Menší než"
+        starts_with: "Začíná na"
+    has_many_delete: "Smazat"
+    has_many_new: "Přidat nový"
+    has_many_remove: "Odstranit"
     index_list:
-      table: "Tabulka"
       block: "Seznam"
-      grid: "Tabulka"
       blog: "Blog"
+      grid: "Tabulka"
+      table: "Tabulka"
+    logout: "Odhlásit"
+    main_content: "Implementujte prosím %{model}#main_content pro zobrazení obsahu."
+    new_model: "Vytvořit"
+    next: "Následující"
+    pagination:
+      empty: "Nenalezen."
+      entry:
+        few: "položky"
+        one: "položka"
+        other: "položky"
+      multiple: "<b>%{from}&nbsp;-&nbsp;%{to}</b> z <b>%{total}</b>"
+      multiple_without_total: "<b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      one: "Zobrazena  <b>1</b> položka"
+      one_page: "Počet zobrazených položek %{n}"
+    powered_by: "%{active_admin} %{version}"
+    previous: "Předchozí"
+    sidebars:
+      filters: "Filtry"
+    status_tag:
+      "no": "Ne"
+      "unset": "Ne"
+      "yes": "Ano"
+    view: "Zobrazit"

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -1,137 +1,137 @@
 da:
   active_admin:
-    dashboard: "Kontrolpanel"
-    dashboard_welcome:
-      welcome: "Velkommen til Active Admin. Dette er standardoversigtssiden."
-      call_to_action: "Rediger 'app/admin/dashboard.rb' for at tilføje nye elementer til oversigtssiden."
-    view: "Vis"
-    edit: "Rediger"
-    delete: "Slet"
-    delete_confirmation: "Er du sikker på, at du ønsker at slette?"
-    create_another: "Opret endnu en %{model}"
-    new_model: "Ny(t) %{model}"
-    edit_model: "Rediger %{model}"
-    delete_model: "Slet %{model}"
-    details: "%{model} detaljer"
-    cancel: "Fortryd"
-    empty: "Tom"
-    previous: "Forrige"
-    next: "Næste"
-    download: "Download:"
-    has_many_new: "Tilføj ny(t) %{model}"
-    has_many_delete: "Slet"
-    has_many_remove: "Fjern"
-    filters:
-      buttons:
-        filter: "Filtrer"
-        clear: "Ryd filtre"
-      predicates:
-        contains: "Indeholder"
-        equals: "Lig"
-        starts_with: "Begynder med"
-        ends_with: "Slutter med"
-        greater_than: "Større end"
-        less_than: "Mindre end"
-    search_status:
-      headline: "Søgestatus:"
-      current_scope: "Perspektiv:"
-      current_filters: "Valgte filtre:"
-      no_current_filters: "Ingen"
-    status_tag:
-      "yes": "Ja"
-      "no": "Nej"
-      "unset": "Nej"
-    main_content: "Implementer venligst %{model}#main_content for at vise noget indhold."
-    logout: "Log ud"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filtre"
-      search_status: "Søgestatus"
-    pagination:
-      empty: "Ingen %{model} fundet"
-      one: "Viser <b>1</b> %{model}"
-      one_page: "Viser <b>alle %{n}</b> %{model}"
-      multiple: "Viser %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> af <b>%{total}</b> i alt"
-      multiple_without_total: "Viser %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      per_page: "Per side: "
-      entry:
-        one: "post"
-        other: "poster"
+    access_denied:
+      message: "Du har ikke rettigheder til at udføre denne handling."
     any: "Alle"
-    blank_slate:
-      content: "Der er ingen %{resource_name} endnu."
-      link: "Opret"
-    dropdown_actions:
-      button_label: "Handlinger"
     batch_actions:
+      action_label: "%{title} Valgte"
       button_label: "Batch Handlinger"
       default_confirmation: "Er du sikker på du vil gøre dette?"
       delete_confirmation: "Er du sikker på du vil slette disse %{plural_model}?"
+      labels:
+        destroy: "Slet"
+      selection_toggle_explanation: "(Skift valg)"
       succesfully_destroyed:
         one: "Vellykket ødelagt 1 %{model}"
         other: "Vellykket ødelagt %{count} %{plural_model}"
-      selection_toggle_explanation: "(Skift valg)"
-      action_label: "%{title} Valgte"
-      labels:
-        destroy: "Slet"
+    blank_slate:
+      content: "Der er ingen %{resource_name} endnu."
+      link: "Opret"
+    cancel: "Fortryd"
     comments:
-      created_at: "Oprettet"
-      resource_type: "Resource type"
+      add: "Tilføj Kommentar"
+      author: "Forfatter"
+      author_missing: "Anonym"
       author_type: "Forfatter type"
       body: "Krop"
-      author: "Forfatter"
-      add: "Tilføj Kommentar"
+      created_at: "Oprettet"
       delete: "Slet kommentar"
       delete_confirmation: "Er du sikker på du vil slette disse kommentarer?"
-      resource: "Resource"
-      no_comments_yet: "Ingen kommentarer endnu."
-      author_missing: "Anonym"
-      title_content: "Kommentarer (%{count})"
       errors:
         empty_text: "Kommentar blev ikke gemt, tekst var tom."
+      no_comments_yet: "Ingen kommentarer endnu."
+      resource: "Resource"
+      resource_type: "Resource type"
+      title_content: "Kommentarer (%{count})"
+    create_another: "Opret endnu en %{model}"
+    dashboard: "Kontrolpanel"
+    dashboard_welcome:
+      call_to_action: "Rediger 'app/admin/dashboard.rb' for at tilføje nye elementer til oversigtssiden."
+      welcome: "Velkommen til Active Admin. Dette er standardoversigtssiden."
+    delete: "Slet"
+    delete_confirmation: "Er du sikker på, at du ønsker at slette?"
+    delete_model: "Slet %{model}"
+    details: "%{model} detaljer"
     devise:
-      username:
-        title: "Brugernavn"
+      change_password:
+        submit: "Skift min adgangskode"
+        title: "Skift din adgangskode"
       email:
         title: "Email"
-      subdomain:
-        title: "Underdomæne"
-      password:
-        title: "Kodeord"
-      sign_up:
-        title: "Opret bruger"
-        submit: "Opret bruger"
+      links:
+        forgot_your_password: "Glemt din adgangskode?"
+        resend_confirmation_instructions: "Send oplåsningsinstruktioner igen"
+        resend_unlock_instructions: "Send oplåsningsinstruktioner igen"
+        sign_in: "Log ind"
+        sign_in_with_omniauth_provider: "Log ind med %{provider}"
+        sign_up: "Opret bruger"
       login:
-        title: "Login"
         remember_me: "Husk mig"
         submit: "Login"
-      reset_password:
-        title: "Glemt din adgangskode?"
-        submit: "Nulstille min adgangskode"
-      change_password:
-        title: "Skift din adgangskode"
-        submit: "Skift min adgangskode"
-      unlock:
-        title: "Send oplåsningsinstruktioner igen"
-        submit: "Send oplåsningsinstruktioner igen"
+        title: "Login"
+      password:
+        title: "Kodeord"
       resend_confirmation_instructions:
-        title: "Send bekræftigelsesinstruktioner igen"
         submit: "Send bekræftigelsesinstruktioner igen"
-      links:
-        sign_up: "Opret bruger"
-        sign_in: "Log ind"
-        forgot_your_password: "Glemt din adgangskode?"
-        sign_in_with_omniauth_provider: "Log ind med %{provider}"
-        resend_unlock_instructions: "Send oplåsningsinstruktioner igen"
-        resend_confirmation_instructions: "Send oplåsningsinstruktioner igen"
+        title: "Send bekræftigelsesinstruktioner igen"
+      reset_password:
+        submit: "Nulstille min adgangskode"
+        title: "Glemt din adgangskode?"
+      sign_up:
+        submit: "Opret bruger"
+        title: "Opret bruger"
+      subdomain:
+        title: "Underdomæne"
+      unlock:
+        submit: "Send oplåsningsinstruktioner igen"
+        title: "Send oplåsningsinstruktioner igen"
+      username:
+        title: "Brugernavn"
+    download: "Download:"
+    dropdown_actions:
+      button_label: "Handlinger"
+    edit: "Rediger"
+    edit_model: "Rediger %{model}"
+    empty: "Tom"
+    filters:
+      buttons:
+        clear: "Ryd filtre"
+        filter: "Filtrer"
+      predicates:
+        contains: "Indeholder"
+        ends_with: "Slutter med"
+        equals: "Lig"
+        greater_than: "Større end"
+        less_than: "Mindre end"
+        starts_with: "Begynder med"
+    has_many_delete: "Slet"
+    has_many_new: "Tilføj ny(t) %{model}"
+    has_many_remove: "Fjern"
+    index_list:
+      block: "Liste"
+      blog: "Blog"
+      grid: "Gitter"
+      table: "Tabel"
+    logout: "Log ud"
+    main_content: "Implementer venligst %{model}#main_content for at vise noget indhold."
+    new_model: "Ny(t) %{model}"
+    next: "Næste"
+    pagination:
+      empty: "Ingen %{model} fundet"
+      entry:
+        one: "post"
+        other: "poster"
+      multiple: "Viser %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> af <b>%{total}</b> i alt"
+      multiple_without_total: "Viser %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      one: "Viser <b>1</b> %{model}"
+      one_page: "Viser <b>alle %{n}</b> %{model}"
+      per_page: "Per side: "
+    powered_by: "Powered by %{active_admin} %{version}"
+    previous: "Forrige"
+    search_status:
+      current_filters: "Valgte filtre:"
+      current_scope: "Perspektiv:"
+      headline: "Søgestatus:"
+      no_current_filters: "Ingen"
+    sidebars:
+      filters: "Filtre"
+      search_status: "Søgestatus"
+    status_tag:
+      "no": "Nej"
+      "unset": "Nej"
+      "yes": "Ja"
     unsupported_browser:
       headline: "Vær venligst opmærksom på, at ActiveAdmin ikke længere understøtter Internet Explorer version 8 eller tidligere."
       recommendation: "Vi anbefaler at du opgraderer til den nyeste <a href=\"http://windows.microsoft.com/ie\">Internet Explorer</a>, <a href=\"https://chrome.google.com/\">Google Chrome</a>, eller <a href=\"https://mozilla.org/firefox/\">Firefox</a>."
       turn_off_compatibility_view: "Hvis du bruger IE 9 eller senere, så vær sikker på, at du <a href=\"https://support.microsoft.com/da-dk/help/17471\">slår \"Compatibility View\" fra</a>."
-    access_denied:
-      message: "Du har ikke rettigheder til at udføre denne handling."
-    index_list:
-      table: "Tabel"
-      block: "Liste"
-      grid: "Gitter"
-      blog: "Blog"
+    view: "Vis"

--- a/config/locales/de-CH.yml
+++ b/config/locales/de-CH.yml
@@ -1,101 +1,101 @@
 "de-CH":
   active_admin:
-    dashboard: Übersicht
-    dashboard_welcome:
-      welcome: "Willkommen in Active Admin. Dies ist die Standard-Übersichtsseite."
-      call_to_action: "Siehe 'app/admin/dashboards.rb', um Übersichts-Bereiche hinzuzufügen."
-    view: "Anzeigen"
-    edit: "Bearbeiten"
-    delete: "Löschen"
-    delete_confirmation: "Wollen Sie dieses Element wirklich löschen?"
-    new_model: "%{model} erstellen"
-    edit_model: "%{model} bearbeiten"
-    delete_model: "%{model} löschen"
-    details: "%{model} Details"
-    cancel: "Abbrechen"
-    empty: "Leer"
-    previous: "Zurück"
-    next: "Weiter"
-    download: "Herunterladen:"
-    has_many_new: "%{model} hinzufügen"
-    has_many_delete: "Löschen"
-    has_many_remove: "Entfernen"
-    filters:
-      buttons:
-        filter: "Filtern"
-        clear: "Filter entfernen"
-      predicates:
-        contains: "Enthält"
-        equals: "Gleich"
-        starts_with: "Beginnt mit"
-        ends_with: "Endet mit"
-        greater_than: "Grösser als"
-        less_than: "Kleiner als"
-    status_tag:
-      "yes": "Ja"
-      "no": "Nicht"
-      "unset": "Nicht"
-    main_content: "Bitte implementieren Sie %{model}#main_content, um Inhalte anzuzeigen."
-    logout: "Abmelden"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filter"
-    pagination:
-      empty: "Keine %{model} gefunden"
-      one: "Zeige <b>1</b> %{model}"
-      one_page: "Zeige <b>alle %{n}</b> %{model}"
-      multiple: "Zeige %{model} <b>%{from}&nbsp;–&nbsp;%{to}</b> von <b>%{total}</b>"
-      multiple_without_total: "Zeige %{model} <b>%{from}&nbsp;–&nbsp;%{to}</b>"
-      entry:
-        one: "Eintrag"
-        other: "Einträge"
     any: "Alle"
-    blank_slate:
-      content: "Es gibt noch keine %{resource_name}."
-      link: "Erstellen"
-    dropdown_actions:
-      button_label: "Aktionen"
     batch_actions:
+      action_label: "%{title} ausgewählte"
       button_label: "Stapelverarbeitung"
       default_confirmation: "Bist du sicher, dass Sie dies tun wollen?"
       delete_confirmation: "Sind Sie sicher dass sie diese %{plural_model} löschen wollen?"
+      labels:
+        destroy: "Lösche"
+      selection_toggle_explanation: "(Auswahl umschalten)"
       succesfully_destroyed:
         one: "Erfolgreich 1 %{model} gelöscht"
         other: "Erfolgreich %{count} %{plural_model} gelöscht"
-      selection_toggle_explanation: "(Auswahl umschalten)"
-      action_label: "%{title} ausgewählte"
-      labels:
-        destroy: "Lösche"
+    blank_slate:
+      content: "Es gibt noch keine %{resource_name}."
+      link: "Erstellen"
+    cancel: "Abbrechen"
     comments:
-      body: "Inhalt"
-      author: "Autor"
-      resource: "Resource"
       add: "Kommentar hinzufügen"
+      author: "Autor"
+      body: "Inhalt"
       delete: "Löschen"
       delete_confirmation: "Sind Sie sicher dass sie diesen Kommentar löschen wollen?"
-      no_comments_yet: "Es gibt noch keine Kommentare."
-      title_content: "Kommentare (%{count})"
       errors:
         empty_text: "Der Kommentar wurde nicht gespeichert, da der Text fehlt."
+      no_comments_yet: "Es gibt noch keine Kommentare."
+      resource: "Resource"
+      title_content: "Kommentare (%{count})"
+    dashboard: Übersicht
+    dashboard_welcome:
+      call_to_action: "Siehe 'app/admin/dashboards.rb', um Übersichts-Bereiche hinzuzufügen."
+      welcome: "Willkommen in Active Admin. Dies ist die Standard-Übersichtsseite."
+    delete: "Löschen"
+    delete_confirmation: "Wollen Sie dieses Element wirklich löschen?"
+    delete_model: "%{model} löschen"
+    details: "%{model} Details"
     devise:
+      change_password:
+        submit: "Mein Passwort ändern"
+        title: "Ändern Sie Ihr Passwort"
+      links:
+        forgot_your_password: "Passwort vergessen?"
+        resend_confirmation_instructions: "Bestätigungsanweisung erneut senden"
+        resend_unlock_instructions: "Entsperrungsanweisung erneut senden"
+        sign_in: "Anmeldung"
+        sign_in_with_omniauth_provider: "Anmeldung mit %{provider}"
+        sign_up: "Registrieren"
       login:
-        title: "Login"
         remember_me: "erinnere dich an mich"
         submit: "Login"
+        title: "Login"
       reset_password:
-        title: "Passwort vergessen?"
         submit: "Mein Passwort zurücksetzen"
-      change_password:
-        title: "Ändern Sie Ihr Passwort"
-        submit: "Mein Passwort ändern"
-      links:
-        sign_up: "Registrieren"
-        sign_in: "Anmeldung"
-        forgot_your_password: "Passwort vergessen?"
-        sign_in_with_omniauth_provider: "Anmeldung mit %{provider}"
-        resend_unlock_instructions: "Entsperrungsanweisung erneut senden"
-        resend_confirmation_instructions: "Bestätigungsanweisung erneut senden"
+        title: "Passwort vergessen?"
+    download: "Herunterladen:"
+    dropdown_actions:
+      button_label: "Aktionen"
+    edit: "Bearbeiten"
+    edit_model: "%{model} bearbeiten"
+    empty: "Leer"
+    filters:
+      buttons:
+        clear: "Filter entfernen"
+        filter: "Filtern"
+      predicates:
+        contains: "Enthält"
+        ends_with: "Endet mit"
+        equals: "Gleich"
+        greater_than: "Grösser als"
+        less_than: "Kleiner als"
+        starts_with: "Beginnt mit"
+    has_many_delete: "Löschen"
+    has_many_new: "%{model} hinzufügen"
+    has_many_remove: "Entfernen"
+    logout: "Abmelden"
+    main_content: "Bitte implementieren Sie %{model}#main_content, um Inhalte anzuzeigen."
+    new_model: "%{model} erstellen"
+    next: "Weiter"
+    pagination:
+      empty: "Keine %{model} gefunden"
+      entry:
+        one: "Eintrag"
+        other: "Einträge"
+      multiple: "Zeige %{model} <b>%{from}&nbsp;–&nbsp;%{to}</b> von <b>%{total}</b>"
+      multiple_without_total: "Zeige %{model} <b>%{from}&nbsp;–&nbsp;%{to}</b>"
+      one: "Zeige <b>1</b> %{model}"
+      one_page: "Zeige <b>alle %{n}</b> %{model}"
+    powered_by: "Powered by %{active_admin} %{version}"
+    previous: "Zurück"
+    sidebars:
+      filters: "Filter"
+    status_tag:
+      "no": "Nicht"
+      "unset": "Nicht"
+      "yes": "Ja"
     unsupported_browser:
       headline: "ActiveAdmin unterstützt nicht länger den Internet Explorer in Version 8 oder niedriger."
       recommendation: "Wir empfehlen die Nutzung von <a href=\"http://windows.microsoft.com/ie\">Internet Explorer</a>, <a href=\"https://chrome.google.com/\">Google Chrome</a>, oder <a href=\"https://mozilla.org/firefox/\">Firefox</a>."
       turn_off_compatibility_view: "Wenn sie IE 9 oder neuer benutzen, stellen sie sicher das sie den <a href=\"https://support.microsoft.com/de-ch/help/17471\">\"Kompatibilitätsansicht\" ausgeschaltet</a> haben."
+    view: "Anzeigen"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,12 +1,150 @@
 de:
+  active_admin:
+    access_denied:
+      message: "Sie haben nicht die Berechtigung um diese Aktion auszuführen."
+    any: "Alle"
+    batch_actions:
+      action_label: "%{title} ausgewählte"
+      button_label: "Stapelverarbeitung"
+      default_confirmation: "Bist du sicher, dass Sie dies tun wollen?"
+      delete_confirmation: "Sind Sie sicher dass sie diese %{plural_model} löschen wollen?"
+      labels:
+        destroy: "Lösche"
+      selection_toggle_explanation: "(Auswahl umschalten)"
+      succesfully_destroyed:
+        one: "Erfolgreich 1 %{model} gelöscht"
+        other: "Erfolgreich %{count} %{plural_model} gelöscht"
+    blank_slate:
+      content: "Es gibt noch keine %{resource_name}."
+      link: "Erstellen"
+    cancel: "Abbrechen"
+    comments:
+      add: "Kommentar hinzufügen"
+      author: "Autor"
+      author_missing: "Unbekannt"
+      author_type: "Autor-Typ"
+      body: "Inhalt"
+      created_at: "Erstellt"
+      delete: "Löschen"
+      delete_confirmation: "Sind Sie sicher dass sie diesen Kommentar löschen wollen?"
+      errors:
+        empty_text: "Der Kommentar wurde nicht gespeichert, da der Text fehlt."
+      no_comments_yet: "Es gibt noch keine Kommentare."
+      resource: "Res­sour­ce"
+      resource_type: "Res­sour­cen-Typ"
+      title_content: "Kommentare (%{count})"
+    create_another: "Mehr %{model} erstellen"
+    dashboard: Übersicht
+    dashboard_welcome:
+      call_to_action: "Siehe 'app/admin/dashboard.rb', um Übersichts-Bereiche hinzuzufügen."
+      welcome: "Willkommen in Active Admin. Dies ist die Standard-Übersichtsseite."
+    delete: "Löschen"
+    delete_confirmation: "Wollen Sie dieses Element wirklich löschen?"
+    delete_model: "%{model} löschen"
+    details: "%{model} Details"
+    devise:
+      change_password:
+        submit: "Mein Passwort ändern"
+        title: "Ändern Sie Ihr Passwort"
+      email:
+        title: "E-Mail-Adresse"
+      links:
+        forgot_your_password: "Passwort vergessen?"
+        resend_confirmation_instructions: "Bestätigungsanweisung erneut senden"
+        resend_unlock_instructions: "Entsperrungsanweisung erneut senden"
+        sign_in: "Anmeldung"
+        sign_in_with_omniauth_provider: "Anmeldung mit %{provider}"
+        sign_up: "Registrieren"
+      login:
+        remember_me: "Angemeldet bleiben"
+        submit: "Login"
+        title: "Login"
+      password:
+        title: "Passwort"
+      password_confirmation:
+        title: "Passwort Bestätigung"
+      resend_confirmation_instructions:
+        submit: "Anleitung zur Bestätigung noch mal schicken"
+        title: "Anleitung zur Bestätigung noch mal schicken"
+      reset_password:
+        submit: "Mein Passwort zurücksetzen"
+        title: "Passwort vergessen?"
+      sign_up:
+        submit: "Registrieren"
+        title: "Registrieren"
+      subdomain:
+        title: "Subdomain"
+      unlock:
+        submit: "Entsperrungsanweisung erneut senden"
+        title: "Entsperrungsanweisung erneut senden"
+      username:
+        title: "Benutzername"
+    download: "Herunterladen:"
+    dropdown_actions:
+      button_label: "Aktionen"
+    edit: "Bearbeiten"
+    edit_model: "%{model} bearbeiten"
+    empty: "Leer"
+    filters:
+      buttons:
+        clear: "Filter entfernen"
+        filter: "Filtern"
+      predicates:
+        contains: "Enthält"
+        ends_with: "Endet mit"
+        equals: "Gleich"
+        from: "Von"
+        greater_than: "Größer als"
+        gteq_datetime: "Größer gleich"
+        less_than: "Kleiner als"
+        lteq_datetime: "Kleiner gleich"
+        starts_with: "Beginnt mit"
+        to: "Bis"
+    has_many_delete: "Löschen"
+    has_many_new: "%{model} hinzufügen"
+    has_many_remove: "Entfernen"
+    index_list:
+      block: "Liste"
+      blog: "Blog"
+      grid: "Gitter"
+      table: "Tabelle"
+    logout: "Abmelden"
+    main_content: "Bitte implementieren Sie %{model}#main_content, um Inhalte anzuzeigen."
+    move: "Bewegen"
+    new_model: "%{model} erstellen"
+    next: "Weiter"
+    pagination:
+      empty: "Keine %{model} gefunden"
+      entry:
+        one: "Eintrag"
+        other: "Einträge"
+      multiple: "Zeige %{model} <b>%{from}&nbsp;–&nbsp;%{to}</b> von <b>%{total}</b>"
+      multiple_without_total: "Zeige %{model} <b>%{from}&nbsp;–&nbsp;%{to}</b>"
+      one: "Zeige <b>1</b> %{model}"
+      one_page: "Zeige <b>alle %{n}</b> %{model}"
+      per_page: "Pro Seite: "
+    powered_by: "Powered by %{active_admin} %{version}"
+    previous: "Zurück"
+    scopes:
+      all: "Alle"
+    search_status:
+      current_filters: "Aktuelle Filter:"
+      current_scope: "Anwendungsbereich:"
+      headline: "Filter"
+      no_current_filters: "Keine"
+    sidebars:
+      filters: "Filter"
+      search_status: "Suchstatus"
+    status_tag:
+      "no": "Nein"
+      "unset": "Nein"
+      "yes": "Ja"
+    unsupported_browser:
+      headline: "ActiveAdmin unterstützt nicht länger den Internet Explorer in Version 8 oder niedriger."
+      recommendation: "Wir empfehlen die Nutzung von <a href=\"http://windows.microsoft.com/ie\">Internet Explorer</a>, <a href=\"https://chrome.google.com/\">Google Chrome</a>, oder <a href=\"https://mozilla.org/firefox/\">Firefox</a>."
+      turn_off_compatibility_view: "Wenn sie IE 9 oder neuer benutzen, stellen sie sicher das sie den <a href=\"https://support.microsoft.com/de-de/help/17471\">\"Kompatibilitätsansicht\" ausgeschaltet</a> haben."
+    view: "Anzeigen"
   activerecord:
-    models:
-      comment:
-        one: "Kommentar"
-        other: "Kommentare"
-      active_admin/comment:
-        one: "Kommentar"
-        other: "Kommentare"
     attributes:
       active_admin/comment:
         author_type: "Autortyp"
@@ -15,148 +153,10 @@ de:
         namespace: "Namensraum"
         resource_type: "Ressourcentyp"
         updated_at: "Aktualisiert"
-  active_admin:
-    dashboard: Übersicht
-    dashboard_welcome:
-      welcome: "Willkommen in Active Admin. Dies ist die Standard-Übersichtsseite."
-      call_to_action: "Siehe 'app/admin/dashboard.rb', um Übersichts-Bereiche hinzuzufügen."
-    view: "Anzeigen"
-    edit: "Bearbeiten"
-    delete: "Löschen"
-    delete_confirmation: "Wollen Sie dieses Element wirklich löschen?"
-    create_another: "Mehr %{model} erstellen"
-    new_model: "%{model} erstellen"
-    edit_model: "%{model} bearbeiten"
-    delete_model: "%{model} löschen"
-    details: "%{model} Details"
-    cancel: "Abbrechen"
-    empty: "Leer"
-    previous: "Zurück"
-    next: "Weiter"
-    download: "Herunterladen:"
-    has_many_new: "%{model} hinzufügen"
-    has_many_delete: "Löschen"
-    has_many_remove: "Entfernen"
-    move: "Bewegen"
-    filters:
-      buttons:
-        filter: "Filtern"
-        clear: "Filter entfernen"
-      predicates:
-        contains: "Enthält"
-        equals: "Gleich"
-        starts_with: "Beginnt mit"
-        ends_with: "Endet mit"
-        greater_than: "Größer als"
-        less_than: "Kleiner als"
-        gteq_datetime: "Größer gleich"
-        lteq_datetime: "Kleiner gleich"
-        from: "Von"
-        to: "Bis"
-    scopes:
-      all: "Alle"
-    search_status:
-      headline: "Filter"
-      current_scope: "Anwendungsbereich:"
-      current_filters: "Aktuelle Filter:"
-      no_current_filters: "Keine"
-    status_tag:
-      "yes": "Ja"
-      "no": "Nein"
-      "unset": "Nein"
-    main_content: "Bitte implementieren Sie %{model}#main_content, um Inhalte anzuzeigen."
-    logout: "Abmelden"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filter"
-      search_status: "Suchstatus"
-    pagination:
-      empty: "Keine %{model} gefunden"
-      one: "Zeige <b>1</b> %{model}"
-      one_page: "Zeige <b>alle %{n}</b> %{model}"
-      multiple: "Zeige %{model} <b>%{from}&nbsp;–&nbsp;%{to}</b> von <b>%{total}</b>"
-      multiple_without_total: "Zeige %{model} <b>%{from}&nbsp;–&nbsp;%{to}</b>"
-      per_page: "Pro Seite: "
-      entry:
-        one: "Eintrag"
-        other: "Einträge"
-    any: "Alle"
-    blank_slate:
-      content: "Es gibt noch keine %{resource_name}."
-      link: "Erstellen"
-    dropdown_actions:
-      button_label: "Aktionen"
-    batch_actions:
-      button_label: "Stapelverarbeitung"
-      default_confirmation: "Bist du sicher, dass Sie dies tun wollen?"
-      delete_confirmation: "Sind Sie sicher dass sie diese %{plural_model} löschen wollen?"
-      succesfully_destroyed:
-        one: "Erfolgreich 1 %{model} gelöscht"
-        other: "Erfolgreich %{count} %{plural_model} gelöscht"
-      selection_toggle_explanation: "(Auswahl umschalten)"
-      action_label: "%{title} ausgewählte"
-      labels:
-        destroy: "Lösche"
-    comments:
-      created_at: "Erstellt"
-      resource_type: "Res­sour­cen-Typ"
-      author_type: "Autor-Typ"
-      body: "Inhalt"
-      author: "Autor"
-      add: "Kommentar hinzufügen"
-      delete: "Löschen"
-      delete_confirmation: "Sind Sie sicher dass sie diesen Kommentar löschen wollen?"
-      resource: "Res­sour­ce"
-      no_comments_yet: "Es gibt noch keine Kommentare."
-      author_missing: "Unbekannt"
-      title_content: "Kommentare (%{count})"
-      errors:
-        empty_text: "Der Kommentar wurde nicht gespeichert, da der Text fehlt."
-    devise:
-      username:
-        title: "Benutzername"
-      email:
-        title: "E-Mail-Adresse"
-      subdomain:
-        title: "Subdomain"
-      password:
-        title: "Passwort"
-      password_confirmation:
-        title: "Passwort Bestätigung"
-      sign_up:
-        title: "Registrieren"
-        submit: "Registrieren"
-      login:
-        title: "Login"
-        remember_me: "Angemeldet bleiben"
-        submit: "Login"
-      reset_password:
-        title: "Passwort vergessen?"
-        submit: "Mein Passwort zurücksetzen"
-      change_password:
-        title: "Ändern Sie Ihr Passwort"
-        submit: "Mein Passwort ändern"
-      unlock:
-        title: "Entsperrungsanweisung erneut senden"
-        submit: "Entsperrungsanweisung erneut senden"
-      resend_confirmation_instructions:
-        title: "Anleitung zur Bestätigung noch mal schicken"
-        submit: "Anleitung zur Bestätigung noch mal schicken"
-      links:
-        sign_up: "Registrieren"
-        sign_in: "Anmeldung"
-        forgot_your_password: "Passwort vergessen?"
-        sign_in_with_omniauth_provider: "Anmeldung mit %{provider}"
-        resend_unlock_instructions: "Entsperrungsanweisung erneut senden"
-        resend_confirmation_instructions: "Bestätigungsanweisung erneut senden"
-    unsupported_browser:
-      headline: "ActiveAdmin unterstützt nicht länger den Internet Explorer in Version 8 oder niedriger."
-      recommendation: "Wir empfehlen die Nutzung von <a href=\"http://windows.microsoft.com/ie\">Internet Explorer</a>, <a href=\"https://chrome.google.com/\">Google Chrome</a>, oder <a href=\"https://mozilla.org/firefox/\">Firefox</a>."
-      turn_off_compatibility_view: "Wenn sie IE 9 oder neuer benutzen, stellen sie sicher das sie den <a href=\"https://support.microsoft.com/de-de/help/17471\">\"Kompatibilitätsansicht\" ausgeschaltet</a> haben."
-    access_denied:
-      message: "Sie haben nicht die Berechtigung um diese Aktion auszuführen."
-    index_list:
-      table: "Tabelle"
-      block: "Liste"
-      grid: "Gitter"
-      blog: "Blog"
+    models:
+      active_admin/comment:
+        one: "Kommentar"
+        other: "Kommentare"
+      comment:
+        one: "Kommentar"
+        other: "Kommentare"

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -1,126 +1,126 @@
 el:
   active_admin:
-    dashboard: "Σελίδα διαχείρισης"
-    dashboard_welcome:
-      welcome: "Καλωσορίσατε στο Active Admin. Αυτή είναι η αρχική σελίδα διαχείρισης."
-      call_to_action: "Για να προσθέσετε ενότητες, ανατρέξτε στο αρχείο 'app/admin/dashboard.rb'"
-    view: "Προβολή"
-    edit: "Επεξεργασία"
-    delete: "Διαγραφή"
-    delete_confirmation: "Είστε σίγουρος πως θέλετε να το διαγράψετε;"
-    new_model: "Δημιουργία %{model}"
-    edit_model: "Επεξεργασία %{model}"
-    delete_model: "Διαγραφή %{model}"
-    details: "Λεπτομέρειες %{model}"
-    cancel: "Ακύρωση"
-    empty: "Άδειο"
-    previous: "Προηγούμενη"
-    next: "Επόμενη"
-    download: "Κατέβασμα:"
-    has_many_new: "Προσθήκη Νέου %{model}"
-    has_many_delete: "Διαγραφή"
-    has_many_remove: "Αφαίρεση"
-    filters:
-      buttons:
-        filter: "Φίλτρα"
-        clear: "Καθαρισμός Φίλτρων"
-      predicates:
-        contains: "Περιέχει"
-        equals: "Είναι ίσο με"
-        starts_with: "Αρχίζει με"
-        ends_with: "Καταλήγει σε"
-        greater_than: "Μεγαλύτερο από"
-        less_than: "Μικρότερο από"
-    status_tag:
-      "yes": "Ναι"
-      "no": "Όχι"
-      "unset": "Όχι"
-    main_content: "Παρακαλώ υλοποιήστε την %{model}#main_content για να εμφανίσετε περιεχόμενο."
-    logout: "Αποσύνδεση"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Φίλτρα"
-    pagination:
-      empty: "Δε βρέθηκαν %{model}"
-      one: "Εμφάνιζεται <b>1</b> %{model}"
-      one_page: "Εμφανίζονται <b>όλες οι %{n}</b> εγγραφές %{model}"
-      multiple: "Εμφανίζονται %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> από <b>%{total}</b> συνολικά"
-      multiple_without_total: "Εμφανίζονται %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      entry:
-        one: "εγγραφή"
-        other: "εγγραφές"
+    access_denied:
+      message: "Δεν έχετε πρόσβαση για αυτή την ενέργεια."
     any: "Όλες οι εγγραφές"
-    blank_slate:
-      content: "Δεν υπάρχουν %{resource_name} ακόμα."
-      link: "Δημιουργήστε μία εγγραφή"
-    dropdown_actions:
-      button_label: "Ενέργειες"
     batch_actions:
+      action_label: "%{title} επιλεγμένων"
       button_label: "Μαζικές Ενέργειες"
       default_confirmation: "Είστε σίγουρος πως θέλετε να το κάνετε αυτό;"
       delete_confirmation: "Είστε σίγουρος πως θέλετε να διαγράψετε αυτά τα %{plural_model}?"
+      labels:
+        destroy: "Διαγραφή"
+      selection_toggle_explanation: "(Αντιστροφή επιλογών)"
       succesfully_destroyed:
         one: "Διαγράφηκε επιτυχώς 1 %{model}"
         other: "Διαγράφηκαν επιτυχώς %{count} %{plural_model}"
-      selection_toggle_explanation: "(Αντιστροφή επιλογών)"
-      action_label: "%{title} επιλεγμένων"
-      labels:
-        destroy: "Διαγραφή"
+    blank_slate:
+      content: "Δεν υπάρχουν %{resource_name} ακόμα."
+      link: "Δημιουργήστε μία εγγραφή"
+    cancel: "Ακύρωση"
     comments:
-      resource_type: "Τύπος Εγγραφής"
+      add: "Προσθήκη Σχολίου"
+      author: "Συγγραφέας"
+      author_missing: "Ανώνυμος"
       author_type: "Τύπος Συγγραφέα"
       body: "Κείμενο"
-      author: "Συγγραφέας"
-      add: "Προσθήκη Σχολίου"
-      resource: "Εγγραφή"
-      no_comments_yet: "Δεν υπάρχει κανένα σχόλιο."
-      author_missing: "Ανώνυμος"
-      title_content: "Σχόλια (%{count})"
       errors:
         empty_text: "Το σχόλιο δε σώθηκε, το κείμενο ήταν κενό."
+      no_comments_yet: "Δεν υπάρχει κανένα σχόλιο."
+      resource: "Εγγραφή"
+      resource_type: "Τύπος Εγγραφής"
+      title_content: "Σχόλια (%{count})"
+    dashboard: "Σελίδα διαχείρισης"
+    dashboard_welcome:
+      call_to_action: "Για να προσθέσετε ενότητες, ανατρέξτε στο αρχείο 'app/admin/dashboard.rb'"
+      welcome: "Καλωσορίσατε στο Active Admin. Αυτή είναι η αρχική σελίδα διαχείρισης."
+    delete: "Διαγραφή"
+    delete_confirmation: "Είστε σίγουρος πως θέλετε να το διαγράψετε;"
+    delete_model: "Διαγραφή %{model}"
+    details: "Λεπτομέρειες %{model}"
     devise:
-      username:
-        title: "Όνομα χρήστη"
+      change_password:
+        submit: "Αλλαγή του κωδικού"
+        title: "Αλλάξτε τον κωδικό σας"
       email:
         title: "Email"
-      subdomain:
-        title: "Subdomain"
-      password:
-        title: "Κωδικός"
-      sign_up:
-        title: "Εγγραφή"
-        submit: "Εγγραφή"
+      links:
+        forgot_your_password: "Ξεχάσατε τον κωδικό σας;"
+        resend_confirmation_instructions: "Αποστολή οδηγιών επιβεβαίωσης"
+        resend_unlock_instructions: "Αποστολή οδηγιών ξεκλειδώματος"
+        sign_in: "Σύνδεση"
+        sign_in_with_omniauth_provider: "Σύνδεση με %{provider}"
+        sign_up: "Εγγραφή"
       login:
-        title: "Σύνδεση"
         remember_me: "Να με θυμάσαι"
         submit: "Σύνδεση"
-      reset_password:
-        title: "Ξεχάσατε τον κωδικό σας;"
-        submit: "Επαναφορά κωδικού"
-      change_password:
-        title: "Αλλάξτε τον κωδικό σας"
-        submit: "Αλλαγή του κωδικού"
-      unlock:
-        title: "Αποστολή οδηγιών ξεκλειδώματος"
-        submit: "Αποστολή οδηγιών ξεκλειδώματος"
+        title: "Σύνδεση"
+      password:
+        title: "Κωδικός"
       resend_confirmation_instructions:
-        title: "Αποστολή οδηγιών επιβεβαίωσης"
         submit: "Αποστολή οδηγιών επιβεβαίωσης"
-      links:
-        sign_in: "Σύνδεση"
-        sign_up: "Εγγραφή"
-        forgot_your_password: "Ξεχάσατε τον κωδικό σας;"
-        sign_in_with_omniauth_provider: "Σύνδεση με %{provider}"
-        resend_unlock_instructions: "Αποστολή οδηγιών ξεκλειδώματος"
-        resend_confirmation_instructions: "Αποστολή οδηγιών επιβεβαίωσης"
+        title: "Αποστολή οδηγιών επιβεβαίωσης"
+      reset_password:
+        submit: "Επαναφορά κωδικού"
+        title: "Ξεχάσατε τον κωδικό σας;"
+      sign_up:
+        submit: "Εγγραφή"
+        title: "Εγγραφή"
+      subdomain:
+        title: "Subdomain"
+      unlock:
+        submit: "Αποστολή οδηγιών ξεκλειδώματος"
+        title: "Αποστολή οδηγιών ξεκλειδώματος"
+      username:
+        title: "Όνομα χρήστη"
+    download: "Κατέβασμα:"
+    dropdown_actions:
+      button_label: "Ενέργειες"
+    edit: "Επεξεργασία"
+    edit_model: "Επεξεργασία %{model}"
+    empty: "Άδειο"
+    filters:
+      buttons:
+        clear: "Καθαρισμός Φίλτρων"
+        filter: "Φίλτρα"
+      predicates:
+        contains: "Περιέχει"
+        ends_with: "Καταλήγει σε"
+        equals: "Είναι ίσο με"
+        greater_than: "Μεγαλύτερο από"
+        less_than: "Μικρότερο από"
+        starts_with: "Αρχίζει με"
+    has_many_delete: "Διαγραφή"
+    has_many_new: "Προσθήκη Νέου %{model}"
+    has_many_remove: "Αφαίρεση"
+    index_list:
+      block: "Λίστα"
+      blog: "Blog"
+      grid: "Πλέγμα"
+      table: "Πίνακας"
+    logout: "Αποσύνδεση"
+    main_content: "Παρακαλώ υλοποιήστε την %{model}#main_content για να εμφανίσετε περιεχόμενο."
+    new_model: "Δημιουργία %{model}"
+    next: "Επόμενη"
+    pagination:
+      empty: "Δε βρέθηκαν %{model}"
+      entry:
+        one: "εγγραφή"
+        other: "εγγραφές"
+      multiple: "Εμφανίζονται %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> από <b>%{total}</b> συνολικά"
+      multiple_without_total: "Εμφανίζονται %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      one: "Εμφάνιζεται <b>1</b> %{model}"
+      one_page: "Εμφανίζονται <b>όλες οι %{n}</b> εγγραφές %{model}"
+    powered_by: "Powered by %{active_admin} %{version}"
+    previous: "Προηγούμενη"
+    sidebars:
+      filters: "Φίλτρα"
+    status_tag:
+      "no": "Όχι"
+      "unset": "Όχι"
+      "yes": "Ναι"
     unsupported_browser:
       headline: "Το ActiveAdmin δεν υποστηρίζει πλεον τον Internet Explorer έκδοση 8 η μικρότερη."
       recommendation: "Σας προτείνουμε να αναβαθμίσετε στην τελευταία <a href=\"http://windows.microsoft.com/ie\">Internet Explorer</a>, <a href=\"https://chrome.google.com/\">Google Chrome</a>, or <a href=\"https://mozilla.org/firefox/\">Firefox</a>."
       turn_off_compatibility_view: "Αν χρησιμοποιείτε IE 9 ή μεγαλύτερη έκδοση, σιγουρευτείτε ότι <a href=\"https://support.microsoft.com/el-gr/help/17471\">turn off \"Compatibility View\"</a>."
-    access_denied:
-      message: "Δεν έχετε πρόσβαση για αυτή την ενέργεια."
-    index_list:
-      table: "Πίνακας"
-      block: "Λίστα"
-      grid: "Πλέγμα"
-      blog: "Blog"
+    view: "Προβολή"

--- a/config/locales/en-CA.yml
+++ b/config/locales/en-CA.yml
@@ -1,139 +1,139 @@
 "en-CA":
   active_admin:
-    dashboard: Dashboard
-    dashboard_welcome:
-      welcome: "Welcome to Active Admin. This is the default dashboard page."
-      call_to_action: "To add dashboard sections, checkout 'app/admin/dashboards.rb'"
-    view: "View"
-    edit: "Edit"
-    delete: "Delete"
-    delete_confirmation: "Are you sure you want to delete this?"
-    create_another: "Create another %{model}"
-    new_model: "New %{model}"
-    edit_model: "Edit %{model}"
-    delete_model: "Delete %{model}"
-    details: "%{model} Details"
-    cancel: "Cancel"
-    empty: "Empty"
-    previous: "Previous"
-    next: "Next"
-    download: "Download:"
-    has_many_new: "Add New %{model}"
-    has_many_delete: "Delete"
-    has_many_remove: "Remove"
-    filters:
-      buttons:
-        filter: "Filter"
-        clear: "Clear Filters"
-      predicates:
-        contains: "Contains"
-        equals: "Equals"
-        starts_with: "Starts with"
-        ends_with: "Ends with"
-        greater_than: "Greater than"
-        less_than: "Less than"
-    search_status:
-      headline: "Search status:"
-      current_scope: "Scope:"
-      current_filters: "Current filters:"
-      no_current_filters: "None"
-    status_tag:
-      "yes": "Yes"
-      "no": "No"
-      "unset": "No"
-    main_content: "Please implement %{model}#main_content to display content."
-    logout: "Logout"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filters"
-      search_status: "Search Status"
-    pagination:
-      empty: "No %{model} found"
-      one: "Displaying <b>1</b> %{model}"
-      one_page: "Displaying <b>all %{n}</b> %{model}"
-      multiple: "Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> of <b>%{total}</b> in total"
-      multiple_without_total: "Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      per_page: "Per page: "
-      entry:
-        one: "entry"
-        other: "entries"
+    access_denied:
+      message: "You are not authorized to perform this action."
     any: "Any"
-    blank_slate:
-      content: "There are no %{resource_name} yet."
-      link: "Create one"
-    dropdown_actions:
-      button_label: "Actions"
     batch_actions:
+      action_label: "%{title} Selected"
       button_label: "Batch Actions"
       default_confirmation: "Are you sure you want to do this?"
       delete_confirmation: "Are you sure you want to delete these %{plural_model}?"
+      labels:
+        destroy: "Delete"
+      selection_toggle_explanation: "(Toggle Selection)"
       succesfully_destroyed:
         one: "Successfully deleted 1 %{model}"
         other: "Successfully deleted %{count} %{plural_model}"
-      selection_toggle_explanation: "(Toggle Selection)"
-      action_label: "%{title} Selected"
-      labels:
-        destroy: "Delete"
+    blank_slate:
+      content: "There are no %{resource_name} yet."
+      link: "Create one"
+    cancel: "Cancel"
     comments:
-      created_at: "Created"
-      resource_type: "Resource Type"
+      add: "Add Comment"
+      author: "Author"
+      author_missing: "Anonymous"
       author_type: "Author Type"
       body: "Body"
-      author: "Author"
-      add: "Add Comment"
+      created_at: "Created"
       delete: "Delete Comment"
       delete_confirmation: "Are you sure you want to delete these comments?"
-      resource: "Resource"
-      no_comments_yet: "No comments yet."
-      author_missing: "Anonymous"
-      title_content: "Comments (%{count})"
       errors:
         empty_text: "Comment wasn't saved, text was empty."
+      no_comments_yet: "No comments yet."
+      resource: "Resource"
+      resource_type: "Resource Type"
+      title_content: "Comments (%{count})"
+    create_another: "Create another %{model}"
+    dashboard: Dashboard
+    dashboard_welcome:
+      call_to_action: "To add dashboard sections, checkout 'app/admin/dashboards.rb'"
+      welcome: "Welcome to Active Admin. This is the default dashboard page."
+    delete: "Delete"
+    delete_confirmation: "Are you sure you want to delete this?"
+    delete_model: "Delete %{model}"
+    details: "%{model} Details"
     devise:
-      username:
-        title: "Username"
+      change_password:
+        submit: "Change my password"
+        title: "Change your password"
       email:
         title: "Email"
-      subdomain:
-        title: "Subdomain"
+      links:
+        forgot_your_password: "Forgot your password?"
+        resend_confirmation_instructions: "Resend confirmation instructions"
+        resend_unlock_instructions: "Resend unlock instructions"
+        sign_in: "Sign in"
+        sign_in_with_omniauth_provider: "Sign in with %{provider}"
+        sign_up: "Sign up"
+      login:
+        remember_me: "Remember me"
+        submit: "Login"
+        title: "Login"
       password:
         title: "Password"
       password_confirmation:
         title: "Confirm Password"
-      sign_up:
-        title: "Sign up"
-        submit: "Sign up"
-      login:
-        title: "Login"
-        remember_me: "Remember me"
-        submit: "Login"
-      reset_password:
-        title: "Forgot your password?"
-        submit: "Reset My Password"
-      change_password:
-        title: "Change your password"
-        submit: "Change my password"
-      unlock:
-        title: "Resend unlock instructions"
-        submit: "Resend unlock instructions"
       resend_confirmation_instructions:
-        title: "Resend confirmation instructions"
         submit: "Resend confirmation instructions"
-      links:
-        sign_up: "Sign up"
-        sign_in: "Sign in"
-        forgot_your_password: "Forgot your password?"
-        sign_in_with_omniauth_provider: "Sign in with %{provider}"
-        resend_unlock_instructions: "Resend unlock instructions"
-        resend_confirmation_instructions: "Resend confirmation instructions"
+        title: "Resend confirmation instructions"
+      reset_password:
+        submit: "Reset My Password"
+        title: "Forgot your password?"
+      sign_up:
+        submit: "Sign up"
+        title: "Sign up"
+      subdomain:
+        title: "Subdomain"
+      unlock:
+        submit: "Resend unlock instructions"
+        title: "Resend unlock instructions"
+      username:
+        title: "Username"
+    download: "Download:"
+    dropdown_actions:
+      button_label: "Actions"
+    edit: "Edit"
+    edit_model: "Edit %{model}"
+    empty: "Empty"
+    filters:
+      buttons:
+        clear: "Clear Filters"
+        filter: "Filter"
+      predicates:
+        contains: "Contains"
+        ends_with: "Ends with"
+        equals: "Equals"
+        greater_than: "Greater than"
+        less_than: "Less than"
+        starts_with: "Starts with"
+    has_many_delete: "Delete"
+    has_many_new: "Add New %{model}"
+    has_many_remove: "Remove"
+    index_list:
+      block: "List"
+      blog: "Blog"
+      grid: "Grid"
+      table: "Table"
+    logout: "Logout"
+    main_content: "Please implement %{model}#main_content to display content."
+    new_model: "New %{model}"
+    next: "Next"
+    pagination:
+      empty: "No %{model} found"
+      entry:
+        one: "entry"
+        other: "entries"
+      multiple: "Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> of <b>%{total}</b> in total"
+      multiple_without_total: "Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      one: "Displaying <b>1</b> %{model}"
+      one_page: "Displaying <b>all %{n}</b> %{model}"
+      per_page: "Per page: "
+    powered_by: "Powered by %{active_admin} %{version}"
+    previous: "Previous"
+    search_status:
+      current_filters: "Current filters:"
+      current_scope: "Scope:"
+      headline: "Search status:"
+      no_current_filters: "None"
+    sidebars:
+      filters: "Filters"
+      search_status: "Search Status"
+    status_tag:
+      "no": "No"
+      "unset": "No"
+      "yes": "Yes"
     unsupported_browser:
       headline: "Please note that ActiveAdmin no longer supports Internet Explorer versions 8 or less."
       recommendation: "We recommend upgrading to the latest <a href=\"http://windows.microsoft.com/ie\">Internet Explorer</a>, <a href=\"https://chrome.google.com/\">Google Chrome</a>, or <a href=\"https://mozilla.org/firefox/\">Firefox</a>."
       turn_off_compatibility_view: "If you are using IE 9 or later, make sure you <a href=\"https://support.microsoft.com/en-ca/help/17471\">turn off \"Compatibility View\"</a>."
-    access_denied:
-      message: "You are not authorized to perform this action."
-    index_list:
-      table: "Table"
-      block: "List"
-      grid: "Grid"
-      blog: "Blog"
+    view: "View"

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -1,139 +1,139 @@
 "en-GB":
   active_admin:
-    dashboard: Dashboard
-    dashboard_welcome:
-      welcome: "Welcome to Active Admin. This is the default dashboard page."
-      call_to_action: "To add dashboard sections, checkout 'app/admin/dashboards.rb'"
-    view: "View"
-    edit: "Edit"
-    delete: "Delete"
-    delete_confirmation: "Are you sure you want to delete this?"
-    create_another: "Create another %{model}"
-    new_model: "New %{model}"
-    edit_model: "Edit %{model}"
-    delete_model: "Delete %{model}"
-    details: "%{model} Details"
-    cancel: "Cancel"
-    empty: "Empty"
-    previous: "Previous"
-    next: "Next"
-    download: "Download:"
-    has_many_new: "Add New %{model}"
-    has_many_delete: "Delete"
-    has_many_remove: "Remove"
-    filters:
-      buttons:
-        filter: "Filter"
-        clear: "Clear Filters"
-      predicates:
-        contains: "Contains"
-        equals: "Equals"
-        starts_with: "Starts with"
-        ends_with: "Ends with"
-        greater_than: "Greater than"
-        less_than: "Less than"
-    search_status:
-      headline: "Search status:"
-      current_scope: "Scope:"
-      current_filters: "Current filters:"
-      no_current_filters: "None"
-    status_tag:
-      "yes": "Yes"
-      "no": "No"
-      "unset": "No"
-    main_content: "Please implement %{model}#main_content to display content."
-    logout: "Logout"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filters"
-      search_status: "Search Status"
-    pagination:
-      empty: "No %{model} found"
-      one: "Displaying <b>1</b> %{model}"
-      one_page: "Displaying <b>all %{n}</b> %{model}"
-      multiple: "Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> of <b>%{total}</b> in total"
-      multiple_without_total: "Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      per_page: "Per page: "
-      entry:
-        one: "entry"
-        other: "entries"
+    access_denied:
+      message: "You are not authorised to perform this action."
     any: "Any"
-    blank_slate:
-      content: "There are no %{resource_name} yet."
-      link: "Create one"
-    dropdown_actions:
-      button_label: "Actions"
     batch_actions:
+      action_label: "%{title} Selected"
       button_label: "Batch Actions"
       default_confirmation: "Are you sure you want to do this?"
       delete_confirmation: "Are you sure you want to delete these %{plural_model}?"
+      labels:
+        destroy: "Delete"
+      selection_toggle_explanation: "(Toggle Selection)"
       succesfully_destroyed:
         one: "Successfully deleted 1 %{model}"
         other: "Successfully deleted %{count} %{plural_model}"
-      selection_toggle_explanation: "(Toggle Selection)"
-      action_label: "%{title} Selected"
-      labels:
-        destroy: "Delete"
+    blank_slate:
+      content: "There are no %{resource_name} yet."
+      link: "Create one"
+    cancel: "Cancel"
     comments:
-      created_at: "Created"
-      resource_type: "Resource Type"
+      add: "Add Comment"
+      author: "Author"
+      author_missing: "Anonymous"
       author_type: "Author Type"
       body: "Body"
-      author: "Author"
-      add: "Add Comment"
+      created_at: "Created"
       delete: "Delete Comment"
       delete_confirmation: "Are you sure you want to delete these comments?"
-      resource: "Resource"
-      no_comments_yet: "No comments yet."
-      author_missing: "Anonymous"
-      title_content: "Comments (%{count})"
       errors:
         empty_text: "Comment wasn't saved, text was empty."
+      no_comments_yet: "No comments yet."
+      resource: "Resource"
+      resource_type: "Resource Type"
+      title_content: "Comments (%{count})"
+    create_another: "Create another %{model}"
+    dashboard: Dashboard
+    dashboard_welcome:
+      call_to_action: "To add dashboard sections, checkout 'app/admin/dashboards.rb'"
+      welcome: "Welcome to Active Admin. This is the default dashboard page."
+    delete: "Delete"
+    delete_confirmation: "Are you sure you want to delete this?"
+    delete_model: "Delete %{model}"
+    details: "%{model} Details"
     devise:
-      username:
-        title: "Username"
+      change_password:
+        submit: "Change my password"
+        title: "Change your password"
       email:
         title: "Email"
-      subdomain:
-        title: "Subdomain"
+      links:
+        forgot_your_password: "Forgot your password?"
+        resend_confirmation_instructions: "Resend confirmation instructions"
+        resend_unlock_instructions: "Resend unlock instructions"
+        sign_in: "Sign in"
+        sign_in_with_omniauth_provider: "Sign in with %{provider}"
+        sign_up: "Sign up"
+      login:
+        remember_me: "Remember me"
+        submit: "Login"
+        title: "Login"
       password:
         title: "Password"
       password_confirmation:
         title: "Confirm Password"
-      sign_up:
-        title: "Sign up"
-        submit: "Sign up"
-      login:
-        title: "Login"
-        remember_me: "Remember me"
-        submit: "Login"
-      reset_password:
-        title: "Forgot your password?"
-        submit: "Reset My Password"
-      change_password:
-        title: "Change your password"
-        submit: "Change my password"
-      unlock:
-        title: "Resend unlock instructions"
-        submit: "Resend unlock instructions"
       resend_confirmation_instructions:
-        title: "Resend confirmation instructions"
         submit: "Resend confirmation instructions"
-      links:
-        sign_up: "Sign up"
-        sign_in: "Sign in"
-        forgot_your_password: "Forgot your password?"
-        sign_in_with_omniauth_provider: "Sign in with %{provider}"
-        resend_unlock_instructions: "Resend unlock instructions"
-        resend_confirmation_instructions: "Resend confirmation instructions"
+        title: "Resend confirmation instructions"
+      reset_password:
+        submit: "Reset My Password"
+        title: "Forgot your password?"
+      sign_up:
+        submit: "Sign up"
+        title: "Sign up"
+      subdomain:
+        title: "Subdomain"
+      unlock:
+        submit: "Resend unlock instructions"
+        title: "Resend unlock instructions"
+      username:
+        title: "Username"
+    download: "Download:"
+    dropdown_actions:
+      button_label: "Actions"
+    edit: "Edit"
+    edit_model: "Edit %{model}"
+    empty: "Empty"
+    filters:
+      buttons:
+        clear: "Clear Filters"
+        filter: "Filter"
+      predicates:
+        contains: "Contains"
+        ends_with: "Ends with"
+        equals: "Equals"
+        greater_than: "Greater than"
+        less_than: "Less than"
+        starts_with: "Starts with"
+    has_many_delete: "Delete"
+    has_many_new: "Add New %{model}"
+    has_many_remove: "Remove"
+    index_list:
+      block: "List"
+      blog: "Blog"
+      grid: "Grid"
+      table: "Table"
+    logout: "Logout"
+    main_content: "Please implement %{model}#main_content to display content."
+    new_model: "New %{model}"
+    next: "Next"
+    pagination:
+      empty: "No %{model} found"
+      entry:
+        one: "entry"
+        other: "entries"
+      multiple: "Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> of <b>%{total}</b> in total"
+      multiple_without_total: "Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      one: "Displaying <b>1</b> %{model}"
+      one_page: "Displaying <b>all %{n}</b> %{model}"
+      per_page: "Per page: "
+    powered_by: "Powered by %{active_admin} %{version}"
+    previous: "Previous"
+    search_status:
+      current_filters: "Current filters:"
+      current_scope: "Scope:"
+      headline: "Search status:"
+      no_current_filters: "None"
+    sidebars:
+      filters: "Filters"
+      search_status: "Search Status"
+    status_tag:
+      "no": "No"
+      "unset": "No"
+      "yes": "Yes"
     unsupported_browser:
       headline: "Please note that ActiveAdmin no longer supports Internet Explorer versions 8 or less."
       recommendation: "We recommend upgrading to the latest <a href=\"http://windows.microsoft.com/ie\">Internet Explorer</a>, <a href=\"https://chrome.google.com/\">Google Chrome</a>, or <a href=\"https://mozilla.org/firefox/\">Firefox</a>."
       turn_off_compatibility_view: "If you are using IE 9 or later, make sure you <a href=\"https://support.microsoft.com/en-gb/help/17471\">turn off \"Compatibility View\"</a>."
-    access_denied:
-      message: "You are not authorised to perform this action."
-    index_list:
-      table: "Table"
-      block: "List"
-      grid: "Grid"
-      blog: "Blog"
+    view: "View"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,12 +1,150 @@
 en:
+  active_admin:
+    access_denied:
+      message: "You are not authorized to perform this action."
+    any: "Any"
+    batch_actions:
+      action_label: "%{title} Selected"
+      button_label: "Batch Actions"
+      default_confirmation: "Are you sure you want to do this?"
+      delete_confirmation: "Are you sure you want to delete these %{plural_model}?"
+      labels:
+        destroy: "Delete"
+      selection_toggle_explanation: "(Toggle Selection)"
+      succesfully_destroyed:
+        one: "Successfully deleted 1 %{model}"
+        other: "Successfully deleted %{count} %{plural_model}"
+    blank_slate:
+      content: "There are no %{resource_name} yet."
+      link: "Create one"
+    cancel: "Cancel"
+    comments:
+      add: "Add Comment"
+      author: "Author"
+      author_missing: "Anonymous"
+      author_type: "Author Type"
+      body: "Body"
+      created_at: "Created"
+      delete: "Delete Comment"
+      delete_confirmation: "Are you sure you want to delete these comments?"
+      errors:
+        empty_text: "Comment wasn't saved, text was empty."
+      no_comments_yet: "No comments yet."
+      resource: "Resource"
+      resource_type: "Resource Type"
+      title_content: "Comments (%{count})"
+    create_another: "Create another %{model}"
+    dashboard: "Dashboard"
+    dashboard_welcome:
+      call_to_action: "To add dashboard sections, checkout 'app/admin/dashboard.rb'"
+      welcome: "Welcome to Active Admin. This is the default dashboard page."
+    delete: "Delete"
+    delete_confirmation: "Are you sure you want to delete this?"
+    delete_model: "Delete %{model}"
+    details: "%{model} Details"
+    devise:
+      change_password:
+        submit: "Change my password"
+        title: "Change your password"
+      email:
+        title: "Email"
+      links:
+        forgot_your_password: "Forgot your password?"
+        resend_confirmation_instructions: "Resend confirmation instructions"
+        resend_unlock_instructions: "Resend unlock instructions"
+        sign_in: "Sign in"
+        sign_in_with_omniauth_provider: "Sign in with %{provider}"
+        sign_up: "Sign up"
+      login:
+        remember_me: "Remember me"
+        submit: "Login"
+        title: "Login"
+      password:
+        title: "Password"
+      password_confirmation:
+        title: "Confirm Password"
+      resend_confirmation_instructions:
+        submit: "Resend confirmation instructions"
+        title: "Resend confirmation instructions"
+      reset_password:
+        submit: "Reset My Password"
+        title: "Forgot your password?"
+      sign_up:
+        submit: "Sign up"
+        title: "Sign up"
+      subdomain:
+        title: "Subdomain"
+      unlock:
+        submit: "Resend unlock instructions"
+        title: "Resend unlock instructions"
+      username:
+        title: "Username"
+    download: "Download:"
+    dropdown_actions:
+      button_label: "Actions"
+    edit: "Edit"
+    edit_model: "Edit %{model}"
+    empty: "Empty"
+    filters:
+      buttons:
+        clear: "Clear Filters"
+        filter: "Filter"
+      predicates:
+        contains: "Contains"
+        ends_with: "Ends with"
+        equals: "Equals"
+        from: "From"
+        greater_than: "Greater than"
+        gteq_datetime: "Greater or equal to"
+        less_than: "Less than"
+        lteq_datetime: "Lesser or equal to"
+        starts_with: "Starts with"
+        to: "To"
+    has_many_delete: "Delete"
+    has_many_new: "Add New %{model}"
+    has_many_remove: "Remove"
+    index_list:
+      block: "List"
+      blog: "Blog"
+      grid: "Grid"
+      table: "Table"
+    logout: "Logout"
+    main_content: "Please implement %{model}#main_content to display content."
+    move: "Move"
+    new_model: "New %{model}"
+    next: "Next"
+    pagination:
+      empty: "No %{model} found"
+      entry:
+        one: "entry"
+        other: "entries"
+      multiple: "Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> of <b>%{total}</b> in total"
+      multiple_without_total: "Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      one: "Displaying <b>1</b> %{model}"
+      one_page: "Displaying <b>all %{n}</b> %{model}"
+      per_page: "Per page: "
+    powered_by: "Powered by %{active_admin} %{version}"
+    previous: "Previous"
+    scopes:
+      all: "All"
+    search_status:
+      current_filters: "Current filters:"
+      current_scope: "Scope:"
+      headline: "Search status:"
+      no_current_filters: "None"
+    sidebars:
+      filters: "Filters"
+      search_status: "Search Status"
+    status_tag:
+      "no": "No"
+      "unset": "No"
+      "yes": "Yes"
+    unsupported_browser:
+      headline: "Please note that ActiveAdmin no longer supports Internet Explorer versions 8 or less."
+      recommendation: "We recommend that you <a href=\"http://browsehappy.com/\">upgrade your browser</a> to improve your experience."
+      turn_off_compatibility_view: "If you are using IE 9 or later, make sure you <a href=\"https://support.microsoft.com/en-us/help/17471\">turn off \"Compatibility View\"</a>."
+    view: "View"
   activerecord:
-    models:
-      comment:
-        one: "Comment"
-        other: "Comments"
-      active_admin/comment:
-        one: "Comment"
-        other: "Comments"
     attributes:
       active_admin/comment:
         author_type: "Author type"
@@ -15,148 +153,10 @@ en:
         namespace: "Namespace"
         resource_type: "Resource type"
         updated_at: "Updated"
-  active_admin:
-    dashboard: "Dashboard"
-    dashboard_welcome:
-      welcome: "Welcome to Active Admin. This is the default dashboard page."
-      call_to_action: "To add dashboard sections, checkout 'app/admin/dashboard.rb'"
-    view: "View"
-    edit: "Edit"
-    delete: "Delete"
-    delete_confirmation: "Are you sure you want to delete this?"
-    create_another: "Create another %{model}"
-    new_model: "New %{model}"
-    edit_model: "Edit %{model}"
-    delete_model: "Delete %{model}"
-    details: "%{model} Details"
-    cancel: "Cancel"
-    empty: "Empty"
-    previous: "Previous"
-    next: "Next"
-    download: "Download:"
-    has_many_new: "Add New %{model}"
-    has_many_delete: "Delete"
-    has_many_remove: "Remove"
-    move: "Move"
-    filters:
-      buttons:
-        filter: "Filter"
-        clear: "Clear Filters"
-      predicates:
-        contains: "Contains"
-        equals: "Equals"
-        starts_with: "Starts with"
-        ends_with: "Ends with"
-        greater_than: "Greater than"
-        less_than: "Less than"
-        gteq_datetime: "Greater or equal to"
-        lteq_datetime: "Lesser or equal to"
-        from: "From"
-        to: "To"
-    scopes:
-      all: "All"
-    search_status:
-      headline: "Search status:"
-      current_scope: "Scope:"
-      current_filters: "Current filters:"
-      no_current_filters: "None"
-    status_tag:
-      "yes": "Yes"
-      "no": "No"
-      "unset": "No"
-    main_content: "Please implement %{model}#main_content to display content."
-    logout: "Logout"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filters"
-      search_status: "Search Status"
-    pagination:
-      empty: "No %{model} found"
-      one: "Displaying <b>1</b> %{model}"
-      one_page: "Displaying <b>all %{n}</b> %{model}"
-      multiple: "Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> of <b>%{total}</b> in total"
-      multiple_without_total: "Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      per_page: "Per page: "
-      entry:
-        one: "entry"
-        other: "entries"
-    any: "Any"
-    blank_slate:
-      content: "There are no %{resource_name} yet."
-      link: "Create one"
-    dropdown_actions:
-      button_label: "Actions"
-    batch_actions:
-      button_label: "Batch Actions"
-      default_confirmation: "Are you sure you want to do this?"
-      delete_confirmation: "Are you sure you want to delete these %{plural_model}?"
-      succesfully_destroyed:
-        one: "Successfully deleted 1 %{model}"
-        other: "Successfully deleted %{count} %{plural_model}"
-      selection_toggle_explanation: "(Toggle Selection)"
-      action_label: "%{title} Selected"
-      labels:
-        destroy: "Delete"
-    comments:
-      created_at: "Created"
-      resource_type: "Resource Type"
-      author_type: "Author Type"
-      body: "Body"
-      author: "Author"
-      add: "Add Comment"
-      delete: "Delete Comment"
-      delete_confirmation: "Are you sure you want to delete these comments?"
-      resource: "Resource"
-      no_comments_yet: "No comments yet."
-      author_missing: "Anonymous"
-      title_content: "Comments (%{count})"
-      errors:
-        empty_text: "Comment wasn't saved, text was empty."
-    devise:
-      username:
-        title: "Username"
-      email:
-        title: "Email"
-      subdomain:
-        title: "Subdomain"
-      password:
-        title: "Password"
-      password_confirmation:
-        title: "Confirm Password"
-      sign_up:
-        title: "Sign up"
-        submit: "Sign up"
-      login:
-        title: "Login"
-        remember_me: "Remember me"
-        submit: "Login"
-      reset_password:
-        title: "Forgot your password?"
-        submit: "Reset My Password"
-      change_password:
-        title: "Change your password"
-        submit: "Change my password"
-      unlock:
-        title: "Resend unlock instructions"
-        submit: "Resend unlock instructions"
-      resend_confirmation_instructions:
-        title: "Resend confirmation instructions"
-        submit: "Resend confirmation instructions"
-      links:
-        sign_up: "Sign up"
-        sign_in: "Sign in"
-        forgot_your_password: "Forgot your password?"
-        sign_in_with_omniauth_provider: "Sign in with %{provider}"
-        resend_unlock_instructions: "Resend unlock instructions"
-        resend_confirmation_instructions: "Resend confirmation instructions"
-    unsupported_browser:
-      headline: "Please note that ActiveAdmin no longer supports Internet Explorer versions 8 or less."
-      recommendation: "We recommend that you <a href=\"http://browsehappy.com/\">upgrade your browser</a> to improve your experience."
-      turn_off_compatibility_view: "If you are using IE 9 or later, make sure you <a href=\"https://support.microsoft.com/en-us/help/17471\">turn off \"Compatibility View\"</a>."
-    access_denied:
-      message: "You are not authorized to perform this action."
-    index_list:
-      table: "Table"
-      block: "List"
-      grid: "Grid"
-      blog: "Blog"
+    models:
+      active_admin/comment:
+        one: "Comment"
+        other: "Comments"
+      comment:
+        one: "Comment"
+        other: "Comments"

--- a/config/locales/eo.yml
+++ b/config/locales/eo.yml
@@ -1,145 +1,144 @@
 eo:
   active_admin:
-    dashboard: Panelo
-    dashboard_welcome:
-      welcome: "Bonvenon al Active Admin. Jen la defaŭlta panela paĝo."
-      call_to_action: "Por aldoni sekciojn al via panelo, vidu 'app/admin/dashboard.rb'"
-    view: "Vidi"
-    edit: "Redakti"
-    delete: "Forigi"
-    delete_confirmation: "Ĉu vi certas, ke vi volas forigi tion?"
-    create_another: "Krei alian %{model}"
-    new_model: "Nova %{model}"
-    edit_model: "Redakti %{model}"
-    delete_model: "Forigi %{model}"
-    details: "Detaloj de %{model}"
-    cancel: "Nuligi"
-    empty: "Malplena"
-    previous: "Antaŭa"
-    next: "Sekva"
-    download: "Elŝuti:"
-    has_many_new: "Aldoni novan %{model}"
-    has_many_delete: "Forigi"
-    has_many_remove: "Forigi"
-    move: "Movi"
-    filters:
-      buttons:
-        filter: "Filtri"
-        clear: "Viŝi filtrilojn"
-      predicates:
-        contains: "Enhavas"
-        equals: "Egalas al"
-        starts_with: "Komenciĝas per"
-        ends_with: "Finiĝas per"
-        greater_than: "Pli grandas ol"
-        less_than: "Malpli grandas ol"
-        gteq_datetime: "Pli grandas ol aŭ egalas al"
-        lteq_datetime: "Malpli grandas ol aŭ egalas al"
-        from: "De"
-        to: "Al"
-    search_status:
-      headline: "Serĉstato:"
-      current_scope: "Regiono:"
-      current_filters: "Nunaj filtriloj:"
-      no_current_filters: "Neniu"
-    status_tag:
-      "yes": "Jes"
-      "no": "Ne"
-      "unset": "Ne"
-    main_content: "Aldonu %{model}#main_content por montri la enhavon."
-    logout: "Elsaluti"
-    powered_by: "Povigita de %{active_admin} %{version}"
-    sidebars:
-      filters: "Filtriloj"
-      search_status: "Serĉstato"
-    pagination:
-      empty: "Neniu %{model} trovita"
-      one: "Montras <b>1</b> %{model}"
-      one_page: "Montras <b>ĉiujn %{n}</b> %{model}"
-      multiple: "Montras %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> de <b>%{total}</b> entute"
-      multiple_without_total: "Montras %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      per_page: "Paĝe: "
-      entry:
-        one: "ero"
-        other: "eroj"
+    access_denied:
+      message: "Vi ne rajtas fari tiun agon."
     any: "Ĉiuj"
-    blank_slate:
-      content: "Ankoraŭ ne estas %{resource_name}."
-      link: "Krei novan"
-    dropdown_actions:
-      button_label: "Agoj"
     batch_actions:
+      action_label: "%{title} elektita"
       button_label: "Amasagoj"
       default_confirmation: "Ĉu vi certas, ke vi volas fari tion?"
       delete_confirmation: "Ĉu vi certas, ke vi volas forigi tiujn %{plural_model}?"
+      labels:
+        destroy: "Forigi"
+      selection_toggle_explanation: "(Baskuligi elekton)"
       succesfully_destroyed:
         one: "1 %{model} sukcese forigita"
         other: "%{count} %{plural_model} sukcese forigitaj"
-      selection_toggle_explanation: "(Baskuligi elekton)"
-      action_label: "%{title} elektita"
-      labels:
-        destroy: "Forigi"
+    blank_slate:
+      content: "Ankoraŭ ne estas %{resource_name}."
+      link: "Krei novan"
+    cancel: "Nuligi"
     comments:
-      created_at: "Kreita"
-      resource_type: "Resursotipo"
+      add: "Aldoni komenton"
+      author: "Aŭtoro"
+      author_missing: "Anonimulo"
       author_type: "Aŭtorotipo"
       body: "Enhavo"
-      author: "Aŭtoro"
-      add: "Aldoni komenton"
+      created_at: "Kreita"
       delete: "Forigi komenton"
       delete_confirmation: "Ĉu vi certas, ke vi volas forigi tiun komenton?"
-      resource: "Resurso"
-      no_comments_yet: "Ankoraŭ neniu komento."
-      author_missing: "Anonimulo"
-      title_content: "Komentoj (%{count})"
       errors:
         empty_text: "La komento ne estis konservita, la teksto estis malplena."
+      no_comments_yet: "Ankoraŭ neniu komento."
+      resource: "Resurso"
+      resource_type: "Resursotipo"
+      title_content: "Komentoj (%{count})"
+    create_another: "Krei alian %{model}"
+    dashboard: Panelo
+    dashboard_welcome:
+      call_to_action: "Por aldoni sekciojn al via panelo, vidu 'app/admin/dashboard.rb'"
+      welcome: "Bonvenon al Active Admin. Jen la defaŭlta panela paĝo."
+    delete: "Forigi"
+    delete_confirmation: "Ĉu vi certas, ke vi volas forigi tion?"
+    delete_model: "Forigi %{model}"
+    details: "Detaloj de %{model}"
     devise:
-      username:
-        title: "Uzantnomo"
+      change_password:
+        submit: "Ŝanĝi mian pasvorton"
+        title: "Ŝanĝi vian pasvorton"
       email:
         title: "Retpoŝtadreso"
-      subdomain:
-        title: "Subdomajno"
+      links:
+        forgot_your_password: "Ĉu vi forgesis vian pasvorton?"
+        resend_confirmation_instructions: "Resendi klarigojn por konfirmi"
+        resend_unlock_instructions: "Resendi klarigojn por malŝlosi"
+        sign_in: "Ensaluti"
+        sign_in_with_omniauth_provider: "Ensaluti per %{provider}"
+        sign_up: "Registriĝi"
+      login:
+        remember_me: "Memori min"
+        submit: "Ensaluti"
+        title: "Ensaluti"
       password:
         title: "Pasvorto"
       password_confirmation:
         title: "Konfirmi pasvorton"
-      sign_up:
-        title: "Registriĝi"
-        submit: "Registriĝi"
-      login:
-        title: "Ensaluti"
-        remember_me: "Memori min"
-        submit: "Ensaluti"
-      reset_password:
-        title: "Ĉu vi forgesis vian pasvorton?"
-        submit: "Restarigi mian pasvorton"
-      change_password:
-        title: "Ŝanĝi vian pasvorton"
-        submit: "Ŝanĝi mian pasvorton"
-      unlock:
-        title: "Resendi klarigojn por malŝlosi"
-        submit: "Resendi klarigojn por malŝlosi"
       resend_confirmation_instructions:
-        title: "Resendi klarigojn por konfirmi"
         submit: "Resendi klarigojn por konfirmi"
-      links:
-        sign_up: "Registriĝi"
-        sign_in: "Ensaluti"
-        forgot_your_password: "Ĉu vi forgesis vian pasvorton?"
-        sign_in_with_omniauth_provider: "Ensaluti per %{provider}"
-        resend_unlock_instructions: "Resendi klarigojn por malŝlosi"
-        resend_confirmation_instructions: "Resendi klarigojn por konfirmi"
+        title: "Resendi klarigojn por konfirmi"
+      reset_password:
+        submit: "Restarigi mian pasvorton"
+        title: "Ĉu vi forgesis vian pasvorton?"
+      sign_up:
+        submit: "Registriĝi"
+        title: "Registriĝi"
+      subdomain:
+        title: "Subdomajno"
+      unlock:
+        submit: "Resendi klarigojn por malŝlosi"
+        title: "Resendi klarigojn por malŝlosi"
+      username:
+        title: "Uzantnomo"
+    download: "Elŝuti:"
+    dropdown_actions:
+      button_label: "Agoj"
+    edit: "Redakti"
+    edit_model: "Redakti %{model}"
+    empty: "Malplena"
+    filters:
+      buttons:
+        clear: "Viŝi filtrilojn"
+        filter: "Filtri"
+      predicates:
+        contains: "Enhavas"
+        ends_with: "Finiĝas per"
+        equals: "Egalas al"
+        from: "De"
+        greater_than: "Pli grandas ol"
+        gteq_datetime: "Pli grandas ol aŭ egalas al"
+        less_than: "Malpli grandas ol"
+        lteq_datetime: "Malpli grandas ol aŭ egalas al"
+        starts_with: "Komenciĝas per"
+        to: "Al"
+    has_many_delete: "Forigi"
+    has_many_new: "Aldoni novan %{model}"
+    has_many_remove: "Forigi"
+    index_list:
+      block: "Listo"
+      blog: "Blogo"
+      grid: "Krado"
+      table: "Tabelo"
+    logout: "Elsaluti"
+    main_content: "Aldonu %{model}#main_content por montri la enhavon."
+    move: "Movi"
+    new_model: "Nova %{model}"
+    next: "Sekva"
+    pagination:
+      empty: "Neniu %{model} trovita"
+      entry:
+        one: "ero"
+        other: "eroj"
+      multiple: "Montras %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> de <b>%{total}</b> entute"
+      multiple_without_total: "Montras %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      one: "Montras <b>1</b> %{model}"
+      one_page: "Montras <b>ĉiujn %{n}</b> %{model}"
+      per_page: "Paĝe: "
+    powered_by: "Povigita de %{active_admin} %{version}"
+    previous: "Antaŭa"
+    search_status:
+      current_filters: "Nunaj filtriloj:"
+      current_scope: "Regiono:"
+      headline: "Serĉstato:"
+      no_current_filters: "Neniu"
+    sidebars:
+      filters: "Filtriloj"
+      search_status: "Serĉstato"
+    status_tag:
+      "no": "Ne"
+      "unset": "Ne"
+      "yes": "Jes"
     unsupported_browser:
-      headline: "Rimarku ke ActiveAdmin ne plu subtenas versiojn 8 kaj mal
-      de Internet Explorer."
+      headline: "Rimarku ke ActiveAdmin ne plu subtenas versiojn 8 kaj mal de Internet Explorer."
       recommendation: "Ni rekomendas, ke vi <a href=\"http://browsehappy.com/\">ĝisdatigu vian retumilon</a> por plibonigi vian sperton."
       turn_off_compatibility_view: "Se vi uzas version 8 aŭ pli novan de Internet Explorer, estu certa, ke vi <a href=\"https://support.microsoft.com/en-us/help/17471\">malŝaltu \"kongruecan reĝimon\"</a>."
-    access_denied:
-      message: "Vi ne rajtas fari tiun agon."
-    index_list:
-      table: "Tabelo"
-      block: "Listo"
-      grid: "Krado"
-      blog: "Blogo"
+    view: "Vidi"

--- a/config/locales/es-MX.yml
+++ b/config/locales/es-MX.yml
@@ -1,97 +1,97 @@
 es-MX:
   active_admin:
-    dashboard: Inicio
-    dashboard_welcome:
-      welcome: "Bienvenido a Active Admin. Esta es la página de inicio predeterminada."
-      call_to_action: "Para agregar secciones edite 'app/admin/dashboard.rb'"
-    view: "Ver"
-    edit: "Editar"
-    delete: "Eliminar"
-    delete_confirmation: "¿Está seguro de que quiere eliminar esto?"
-    new_model: "Añadir %{model}"
-    edit_model: "Editar %{model}"
-    delete_model: "Eliminar %{model}"
-    details: "Detalles de %{model}"
-    cancel: "Cancelar"
-    empty: "Vacío"
-    previous: "Anterior"
-    next: "Siguiente"
-    download: "Descargar:"
-    has_many_new: "Añadir %{model}"
-    has_many_delete: "Eliminar"
-    has_many_remove: "Quitar"
-    filters:
-      buttons:
-        filter: "Filtrar"
-        clear: "Quitar Filtros"
-      predicates:
-        contains: "Contiene"
-        equals: "Igual a"
-        starts_with: "Empieza con"
-        ends_with: "Termina con"
-        greater_than: "Mayor que"
-        less_than: "Menor que"
-    status_tag:
-      "yes": "Sí"
-      "no": "No"
-      "unset": "No"
-    main_content: "Por favor implemente %{model}#main_content para mostrar contenido."
-    logout: "Salir"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filtros"
-    pagination:
-      empty: "No se han encontrado %{model}"
-      one: "Mostrando <b>1</b> %{model}"
-      one_page: "Mostrando <b>un total de %{n}</b> %{model}"
-      multiple: "Mostrando %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> de un total de <b>%{total}</b>"
-      entry:
-        one:
-        other:
-    blank_slate:
-      content: "No hay %{resource_name} aún."
-      link: "Añadir"
     any: "Cualquiera"
-    dropdown_actions:
-      button_label: "Acciones"
     batch_actions:
+      action_label: "%{title} seleccionados"
       button_label: "Acciones en masa"
       default_confirmation: "¿Seguro que quieres hacer esto?"
       delete_confirmation: "Eliminar %{plural_model}: ¿Está seguro?"
+      labels:
+        destroy: "Borrar"
+      selection_toggle_explanation: "(Cambiar selección)"
       succesfully_destroyed:
         one: "Se ha destruido 1 %{model} con éxito"
         other: "Se han destruido %{count} %{plural_model} con éxito"
-      selection_toggle_explanation: "(Cambiar selección)"
-      action_label: "%{title} seleccionados"
-      labels:
-        destroy: "Borrar"
+    blank_slate:
+      content: "No hay %{resource_name} aún."
+      link: "Añadir"
+    cancel: "Cancelar"
     comments:
-      body: "Cuerpo"
-      author: "Autor"
       add: "Comentar"
-      resource: "Recurso"
-      no_comments_yet: "Aún sin comentarios."
-      title_content: "Comentarios (%{count})"
+      author: "Autor"
+      body: "Cuerpo"
       errors:
         empty_text: "El comentario no fue guardado, el texto estaba vacío."
+      no_comments_yet: "Aún sin comentarios."
+      resource: "Recurso"
+      title_content: "Comentarios (%{count})"
+    dashboard: Inicio
+    dashboard_welcome:
+      call_to_action: "Para agregar secciones edite 'app/admin/dashboard.rb'"
+      welcome: "Bienvenido a Active Admin. Esta es la página de inicio predeterminada."
+    delete: "Eliminar"
+    delete_confirmation: "¿Está seguro de que quiere eliminar esto?"
+    delete_model: "Eliminar %{model}"
+    details: "Detalles de %{model}"
     devise:
+      change_password:
+        submit: "Cambiar mi contraseña"
+        title: "Cambie su contraseña"
+      links:
+        forgot_your_password: "¿Olvidó su contraseña?"
+        sign_in: "Iniciar Sesión"
+        sign_in_with_omniauth_provider: "Conéctate con %{provider}"
+        sign_up: "Registrarse"
       login:
-        title: "Iniciar Sesión"
         remember_me: "Recordarme"
         submit: "Iniciar Sesión"
+        title: "Iniciar Sesión"
       reset_password:
-        title: "¿Olvidó su contraseña?"
         submit: "Restablecer mi contraseña"
-      change_password:
-        title: "Cambie su contraseña"
-        submit: "Cambiar mi contraseña"
-      links:
-        sign_in: "Iniciar Sesión"
-        sign_up: "Registrarse"
-        forgot_your_password: "¿Olvidó su contraseña?"
-        sign_in_with_omniauth_provider: "Conéctate con %{provider}"
+        title: "¿Olvidó su contraseña?"
+    download: "Descargar:"
+    dropdown_actions:
+      button_label: "Acciones"
+    edit: "Editar"
+    edit_model: "Editar %{model}"
+    empty: "Vacío"
+    filters:
+      buttons:
+        clear: "Quitar Filtros"
+        filter: "Filtrar"
+      predicates:
+        contains: "Contiene"
+        ends_with: "Termina con"
+        equals: "Igual a"
+        greater_than: "Mayor que"
+        less_than: "Menor que"
+        starts_with: "Empieza con"
+    has_many_delete: "Eliminar"
+    has_many_new: "Añadir %{model}"
+    has_many_remove: "Quitar"
     index_list:
-      table: "Tabla"
       block: "Lista"
-      grid: "Cuadrícula"
       blog: "Blog"
+      grid: "Cuadrícula"
+      table: "Tabla"
+    logout: "Salir"
+    main_content: "Por favor implemente %{model}#main_content para mostrar contenido."
+    new_model: "Añadir %{model}"
+    next: "Siguiente"
+    pagination:
+      empty: "No se han encontrado %{model}"
+      entry:
+        one:
+        other:
+      multiple: "Mostrando %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> de un total de <b>%{total}</b>"
+      one: "Mostrando <b>1</b> %{model}"
+      one_page: "Mostrando <b>un total de %{n}</b> %{model}"
+    powered_by: "Powered by %{active_admin} %{version}"
+    previous: "Anterior"
+    sidebars:
+      filters: "Filtros"
+    status_tag:
+      "no": "No"
+      "unset": "No"
+      "yes": "Sí"
+    view: "Ver"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,162 +1,162 @@
 es:
-  activerecord:
-    models:
-      comment:
-        one: "Comentario"
-        other: "Comentarios"
-      active_admin/comment:
-        one: "Comentario"
-        other: "Comentarios"
-    attributes:
-      active_admin/comment:
-        namespace: "Espacio de nombres"
-        body: "Cuerpo"
-        resource_type: "Tipo de recurso"
-        author_type: "Tipo de autor"
-        created_at: "Fecha de creación"
-        updated_at: "Fecha de actualización"
   active_admin:
-    dashboard: "Inicio"
-    dashboard_welcome:
-      welcome: "Bienvenido a Active Admin. Esta es la página de inicio predeterminada."
-      call_to_action: "Para agregar secciones edite 'app/admin/dashboard.rb'"
-    view: "Ver"
-    edit: "Editar"
-    delete: "Eliminar"
-    delete_confirmation: "¿Confirma que desea borrar este elemento?"
-    create_another: "Crear otro %{model}"
-    new_model: "Añadir %{model}"
-    edit_model: "Editar %{model}"
-    delete_model: "Eliminar %{model}"
-    details: "Detalles de %{model}"
-    cancel: "Cancelar"
-    empty: "Vacío"
-    previous: "Anterior"
-    next: "Siguiente"
-    download: "Descargar:"
-    has_many_new: "Añadir %{model}"
-    has_many_delete: "Eliminar"
-    has_many_remove: "Quitar"
-    move: "Mover"
-    filters:
-      buttons:
-        filter: "Filtrar"
-        clear: "Quitar Filtros"
-      predicates:
-        contains: "Contiene"
-        equals: "Igual a"
-        starts_with: "Empieza con"
-        ends_with: "Termina con"
-        greater_than: "Mayor que"
-        less_than: "Menor que"
-        gteq_datetime: "Mayor o igual que"
-        lteq_datetime: "Menor o igual que"
-        from: "Desde"
-        to: "Hasta"
-    scopes:
-      all: "Todos"
-    search_status:
-      headline: "Estado de la búsqueda:"
-      current_scope: "Alcance:"
-      current_filters: "Filtros actuales:"
-      no_current_filters: "Ninguno"
-    status_tag:
-      "yes": "Sí"
-      "no": "No"
-      "unset": "No"
-    main_content: "Por favor implemente %{model}#main_content para mostrar contenido."
-    logout: "Salir"
-    powered_by: "Funciona con %{active_admin} %{version}"
-    sidebars:
-      filters: "Filtros"
-      search_status: "Estado de la búsqueda"
-    pagination:
-      empty: "No se han encontrado %{model}"
-      one: "Mostrando <b>1</b> %{model}"
-      one_page: "Mostrando <b>un total de %{n}</b> %{model}"
-      multiple: "Mostrando %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> de un total de <b>%{total}</b>"
-      multiple_without_total: "Mostrando %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      per_page: "Por página: "
-      entry:
-        one: "registro"
-        other: "registros"
+    access_denied:
+      message: "No está autorizado/a a realizar esta acción."
     any: "Cualquiera"
-    blank_slate:
-      content: "No hay %{resource_name} aún."
-      link: "Añadir"
-    dropdown_actions:
-      button_label: "Acciones"
     batch_actions:
+      action_label: "%{title} seleccionados"
       button_label: "Acciones en masa"
       default_confirmation: "¿Seguro que quieres hacer esto?"
       delete_confirmation: "Se eliminarán %{plural_model}. ¿Desea continuar?"
+      labels:
+        destroy: "Borrar"
+      selection_toggle_explanation: "(Cambiar selección)"
       succesfully_destroyed:
         one: "Se ha destruido 1 %{model} con éxito"
         other: "Se han destruido %{count} %{plural_model} con éxito"
-      selection_toggle_explanation: "(Cambiar selección)"
-      action_label: "%{title} seleccionados"
-      labels:
-        destroy: "Borrar"
+    blank_slate:
+      content: "No hay %{resource_name} aún."
+      link: "Añadir"
+    cancel: "Cancelar"
     comments:
-      created_at: "Fecha de creación"
-      resource_type: "Tipo de recurso"
+      add: "Comentar"
+      author: "Autor"
+      author_missing: "Anónimo"
       author_type: "Tipo de autor"
       body: "Cuerpo"
-      author: "Autor"
-      add: "Comentar"
+      created_at: "Fecha de creación"
       delete: "Borrar Comentario"
       delete_confirmation: "¿Confirma que desea borrar este comentario?"
-      resource: "Recurso"
-      no_comments_yet: "No hay comentarios aún."
-      author_missing: "Anónimo"
-      title_content: "Comentarios (%{count})"
       errors:
         empty_text: "El comentario no fue guardado, el texto estaba vacío."
+      no_comments_yet: "No hay comentarios aún."
+      resource: "Recurso"
+      resource_type: "Tipo de recurso"
+      title_content: "Comentarios (%{count})"
+    create_another: "Crear otro %{model}"
+    dashboard: "Inicio"
+    dashboard_welcome:
+      call_to_action: "Para agregar secciones edite 'app/admin/dashboard.rb'"
+      welcome: "Bienvenido a Active Admin. Esta es la página de inicio predeterminada."
+    delete: "Eliminar"
+    delete_confirmation: "¿Confirma que desea borrar este elemento?"
+    delete_model: "Eliminar %{model}"
+    details: "Detalles de %{model}"
     devise:
-      username:
-        title: "Nombre de usuario"
+      change_password:
+        submit: "Cambiar mi contraseña"
+        title: "Cambie su contraseña"
       email:
         title: "Email"
-      subdomain:
-        title: "Subdominio"
+      links:
+        forgot_your_password: "¿Olvidó su contraseña?"
+        resend_confirmation_instructions: "Reenviar instrucciones de confirmación"
+        resend_unlock_instructions: "Reenviar instrucciones de desbloqueo"
+        sign_in: "Iniciar Sesión"
+        sign_in_with_omniauth_provider: "Conéctate con %{provider}"
+        sign_up: "Registrarse"
+      login:
+        remember_me: "Recordarme"
+        submit: "Iniciar Sesión"
+        title: "Iniciar Sesión"
       password:
         title: "Contraseña"
       password_confirmation:
         title: "Confirmar Contraseña"
-      sign_up:
-        title: "Registrarse"
-        submit: "Registrarse"
-      login:
-        title: "Iniciar Sesión"
-        remember_me: "Recordarme"
-        submit: "Iniciar Sesión"
-      reset_password:
-        title: "¿Olvidó su contraseña?"
-        submit: "Restablecer mi contraseña"
-      change_password:
-        title: "Cambie su contraseña"
-        submit: "Cambiar mi contraseña"
-      unlock:
-        title: "Reenviar instrucciones de desbloqueo"
-        submit: "Reenviar instrucciones de desbloqueo"
       resend_confirmation_instructions:
-        title: "Reenviar instrucciones de confirmación"
         submit: "Reenviar instrucciones de confirmación"
-      links:
-        sign_up: "Registrarse"
-        sign_in: "Iniciar Sesión"
-        forgot_your_password: "¿Olvidó su contraseña?"
-        sign_in_with_omniauth_provider: "Conéctate con %{provider}"
-        resend_unlock_instructions: "Reenviar instrucciones de desbloqueo"
-        resend_confirmation_instructions: "Reenviar instrucciones de confirmación"
+        title: "Reenviar instrucciones de confirmación"
+      reset_password:
+        submit: "Restablecer mi contraseña"
+        title: "¿Olvidó su contraseña?"
+      sign_up:
+        submit: "Registrarse"
+        title: "Registrarse"
+      subdomain:
+        title: "Subdominio"
+      unlock:
+        submit: "Reenviar instrucciones de desbloqueo"
+        title: "Reenviar instrucciones de desbloqueo"
+      username:
+        title: "Nombre de usuario"
+    download: "Descargar:"
+    dropdown_actions:
+      button_label: "Acciones"
+    edit: "Editar"
+    edit_model: "Editar %{model}"
+    empty: "Vacío"
+    filters:
+      buttons:
+        clear: "Quitar Filtros"
+        filter: "Filtrar"
+      predicates:
+        contains: "Contiene"
+        ends_with: "Termina con"
+        equals: "Igual a"
+        from: "Desde"
+        greater_than: "Mayor que"
+        gteq_datetime: "Mayor o igual que"
+        less_than: "Menor que"
+        lteq_datetime: "Menor o igual que"
+        starts_with: "Empieza con"
+        to: "Hasta"
+    has_many_delete: "Eliminar"
+    has_many_new: "Añadir %{model}"
+    has_many_remove: "Quitar"
+    index_list:
+      block: "Lista"
+      blog: "Blog"
+      grid: "Grilla"
+      table: "Tabla"
+    logout: "Salir"
+    main_content: "Por favor implemente %{model}#main_content para mostrar contenido."
+    move: "Mover"
+    new_model: "Añadir %{model}"
+    next: "Siguiente"
+    pagination:
+      empty: "No se han encontrado %{model}"
+      entry:
+        one: "registro"
+        other: "registros"
+      multiple: "Mostrando %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> de un total de <b>%{total}</b>"
+      multiple_without_total: "Mostrando %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      one: "Mostrando <b>1</b> %{model}"
+      one_page: "Mostrando <b>un total de %{n}</b> %{model}"
+      per_page: "Por página: "
+    powered_by: "Funciona con %{active_admin} %{version}"
+    previous: "Anterior"
+    scopes:
+      all: "Todos"
+    search_status:
+      current_filters: "Filtros actuales:"
+      current_scope: "Alcance:"
+      headline: "Estado de la búsqueda:"
+      no_current_filters: "Ninguno"
+    sidebars:
+      filters: "Filtros"
+      search_status: "Estado de la búsqueda"
+    status_tag:
+      "no": "No"
+      "unset": "No"
+      "yes": "Sí"
     unsupported_browser:
       headline: "Por favor tenga en cuenta que Active Admin no soporta versiones de Internet Explorer menores a 8."
       recommendation: "Recomendamos que actualice a la última versión de <a href=\"http://windows.microsoft.com/ie\">Internet Explorer</a>, <a href=\"https://chrome.google.com/\">Google Chrome</a>, o <a href=\"https://mozilla.org/firefox/\">Firefox</a>."
       turn_off_compatibility_view: "Si está usando IE 9 o superior, asegúrese de <a href=\"https://support.microsoft.com/es-es/help/17471\">apagar la \"Vista de compatibilidad\"</a>."
-    access_denied:
-      message: "No está autorizado/a a realizar esta acción."
-    index_list:
-      table: "Tabla"
-      block: "Lista"
-      grid: "Grilla"
-      blog: "Blog"
+    view: "Ver"
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: "Tipo de autor"
+        body: "Cuerpo"
+        created_at: "Fecha de creación"
+        namespace: "Espacio de nombres"
+        resource_type: "Tipo de recurso"
+        updated_at: "Fecha de actualización"
+    models:
+      active_admin/comment:
+        one: "Comentario"
+        other: "Comentarios"
+      comment:
+        one: "Comentario"
+        other: "Comentarios"

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -1,119 +1,119 @@
 fa:
   active_admin:
-    dashboard: "داشبرد"
-    dashboard_welcome:
-      welcome: "به اکتیو ادمین خوش آمدید. این صفحه اول داشبرد است."
-      call_to_action: "برای اضافه کردن قسمت‌هایی به داشبرد اینجا را چک کنید: 'app/admin/dashboard.rb'"
-    view: "نمایش"
-    edit: "ویرایش"
-    delete: "حذف"
-    delete_confirmation: "آیا برای حذف این آیتم اطمینان دارید؟"
-    new_model: "%{model} جدید"
-    edit_model: "ویرایش %{model}"
-    delete_model: "حذف %{model}"
-    details: "جزئیات %{model}"
-    cancel: "لغو"
-    empty: "خالی"
-    previous: "قبلی"
-    next: "بعدی"
-    download: "دریافت:"
-    has_many_new: "اضافه کردن %{model} جدید"
-    has_many_delete: "حذف"
-    has_many_remove: "حذف"
-    filters:
-      buttons:
-        filter: "فیلتر"
-        clear: "پاک کردن فیلتر"
-      predicates:
-        contains: "شامل"
-        equals: "برابر با"
-        starts_with: "شروع با"
-        ends_with: "پایان با"
-        greater_than: "بزرگتر از"
-        less_than: "کوچکتر از"
-    status_tag:
-      "yes": "بله"
-      "no": "بدون"
-      "unset": "بدون"
-    main_content: "لطفا %{model}#main_content را پیاده سازی کنید تا محتوی نمایش داده شود."
-    logout: "خروج"
-    powered_by: "قدرت گرفته از %{active_admin} %{version}"
-    sidebars:
-      filters: "فیلتر‌ها"
-    pagination:
-      empty: "هیچ رکورد %{model} یافت نشد"
-      one: "نمایش <b>1</b> %{model}"
-      one_page: "نمایش <b>همه %{n}</b> %{model}"
-      multiple: "نمایش %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> از کل <b>%{total}</b> رکورد"
-      multiple_without_total: "نمایش %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      entry:
-        one: "آیتم"
-        other: "آیتم‌ها"
+    access_denied:
+      message: "شما دسترسی لازم برای انجام این عملیات را ندارید."
     any: "هرکدام"
-    blank_slate:
-      content: "هنوز هیچ رکوردی از %{resource_name} درج نشده."
-      link: "درج اولین رکورد"
-    dropdown_actions:
-      button_label: "عملیات"
     batch_actions:
+      action_label: "%{title} انتخاب شده است"
       button_label: "عملیات‌های دسته‌ای"
       default_confirmation: "آیا برای اجرای این عملیات اطمینان دارید؟"
       delete_confirmation: "آیا برای حذف همه رکوردهای %{plural_model} اطمینان دارید؟"
+      labels:
+        destroy: "حذف"
+      selection_toggle_explanation: "(انتخاب‌ها برعکس شوند)"
       succesfully_destroyed:
         one: "1 %{model} با موفقیت حذف شد"
         other: "%{count} %{plural_model} با موفقت حذف شدند."
-      selection_toggle_explanation: "(انتخاب‌ها برعکس شوند)"
-      action_label: "%{title} انتخاب شده است"
-      labels:
-        destroy: "حذف"
+    blank_slate:
+      content: "هنوز هیچ رکوردی از %{resource_name} درج نشده."
+      link: "درج اولین رکورد"
+    cancel: "لغو"
     comments:
-      resource_type: "نوع رکورد"
+      add: "افزودن کامنت"
+      author: "ایجاد کننده"
+      author_missing: "بی‌نام"
       author_type: "نوع ایجاد کننده"
       body: "بدنه"
-      author: "ایجاد کننده"
-      add: "افزودن کامنت"
-      resource: "رکورد"
-      no_comments_yet: "هنوز هیچ کامنتی نوشته نشده."
-      author_missing: "بی‌نام"
-      title_content: "کامنت‌ها (%{count})"
       errors:
         empty_text: "کامنت درج نشد، متن کامنت خالی بود."
+      no_comments_yet: "هنوز هیچ کامنتی نوشته نشده."
+      resource: "رکورد"
+      resource_type: "نوع رکورد"
+      title_content: "کامنت‌ها (%{count})"
+    dashboard: "داشبرد"
+    dashboard_welcome:
+      call_to_action: "برای اضافه کردن قسمت‌هایی به داشبرد اینجا را چک کنید: 'app/admin/dashboard.rb'"
+      welcome: "به اکتیو ادمین خوش آمدید. این صفحه اول داشبرد است."
+    delete: "حذف"
+    delete_confirmation: "آیا برای حذف این آیتم اطمینان دارید؟"
+    delete_model: "حذف %{model}"
+    details: "جزئیات %{model}"
     devise:
-      username:
-        title: "نام کاربری"
+      change_password:
+        submit: "تغییر کلمه عبور"
+        title: "تغییر کلمه عبور"
       email:
         title: "ایمیل"
-      subdomain:
-        title: "Subdomain"
-      password:
-        title: "کلمه‌عبور"
-      sign_up:
-        title: "ثبت‌نام"
-        submit: "ثبت‌نام"
+      links:
+        forgot_your_password: "کلمه عبور را فراموش کرده‌اید؟"
+        sign_in: "ورود"
+        sign_in_with_omniauth_provider: "ورود با حساب %{provider}"
       login:
-        title: "ورود"
         remember_me: "مرا به خاطر بسپار"
         submit: "ورود"
-      reset_password:
-        title: "کلمه عبور را فراموش کرده‌اید؟"
-        submit: "دریافت کلمه عبور جدید"
-      change_password:
-        title: "تغییر کلمه عبور"
-        submit: "تغییر کلمه عبور"
-      unlock:
-        title: "ارسال مجدد دستورالعمل بازگشایی حساب کاربری"
-        submit: "ارسال مجدد دستورالعمل بازگشایی حساب کاربری"
+        title: "ورود"
+      password:
+        title: "کلمه‌عبور"
       resend_confirmation_instructions:
-        title: "ارسال مجدد تاییدیه ایمیل"
         submit: "ارسال مجدد تاییدیه ایمیل"
-      links:
-        sign_in: "ورود"
-        forgot_your_password: "کلمه عبور را فراموش کرده‌اید؟"
-        sign_in_with_omniauth_provider: "ورود با حساب %{provider}"
-    access_denied:
-      message: "شما دسترسی لازم برای انجام این عملیات را ندارید."
+        title: "ارسال مجدد تاییدیه ایمیل"
+      reset_password:
+        submit: "دریافت کلمه عبور جدید"
+        title: "کلمه عبور را فراموش کرده‌اید؟"
+      sign_up:
+        submit: "ثبت‌نام"
+        title: "ثبت‌نام"
+      subdomain:
+        title: "Subdomain"
+      unlock:
+        submit: "ارسال مجدد دستورالعمل بازگشایی حساب کاربری"
+        title: "ارسال مجدد دستورالعمل بازگشایی حساب کاربری"
+      username:
+        title: "نام کاربری"
+    download: "دریافت:"
+    dropdown_actions:
+      button_label: "عملیات"
+    edit: "ویرایش"
+    edit_model: "ویرایش %{model}"
+    empty: "خالی"
+    filters:
+      buttons:
+        clear: "پاک کردن فیلتر"
+        filter: "فیلتر"
+      predicates:
+        contains: "شامل"
+        ends_with: "پایان با"
+        equals: "برابر با"
+        greater_than: "بزرگتر از"
+        less_than: "کوچکتر از"
+        starts_with: "شروع با"
+    has_many_delete: "حذف"
+    has_many_new: "اضافه کردن %{model} جدید"
+    has_many_remove: "حذف"
     index_list:
-      table: "جدول"
       block: "لیست"
-      grid: "گرید"
       blog: "وبلاگ"
+      grid: "گرید"
+      table: "جدول"
+    logout: "خروج"
+    main_content: "لطفا %{model}#main_content را پیاده سازی کنید تا محتوی نمایش داده شود."
+    new_model: "%{model} جدید"
+    next: "بعدی"
+    pagination:
+      empty: "هیچ رکورد %{model} یافت نشد"
+      entry:
+        one: "آیتم"
+        other: "آیتم‌ها"
+      multiple: "نمایش %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> از کل <b>%{total}</b> رکورد"
+      multiple_without_total: "نمایش %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      one: "نمایش <b>1</b> %{model}"
+      one_page: "نمایش <b>همه %{n}</b> %{model}"
+    powered_by: "قدرت گرفته از %{active_admin} %{version}"
+    previous: "قبلی"
+    sidebars:
+      filters: "فیلتر‌ها"
+    status_tag:
+      "no": "بدون"
+      "unset": "بدون"
+      "yes": "بله"
+    view: "نمایش"

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -1,112 +1,112 @@
 fi:
   active_admin:
-    dashboard: Etusivu
-    dashboard_welcome:
-      welcome: "Tervetuloa! Tämä on Active Adminin oletusetusivu."
-      call_to_action: "Lisätäksesi etusivun osioita katso: 'app/admin/dashboard.rb'"
-    view: "Katso"
-    edit: "Muokkaa"
-    delete: "Poista"
-    delete_confirmation: "Oletko varma, että haluat poistaa tämän?"
-    new_model: "Uusi %{model}"
-    edit_model: "Muokkaa %{model}"
-    delete_model: "Poista %{model}"
-    details: "%{model} Tiedot"
-    cancel: "Peruuta"
-    empty: "Tyhjä"
-    previous: "Edellinen"
-    next: "Seuraava"
-    download: "Lataa:"
-    has_many_new: "Lisää uusi %{model}"
-    has_many_delete: "Poista"
-    has_many_remove: "Poista"
-    filters:
-      buttons:
-        filter: "Hae"
-        clear: "Tyhjennä valinnat"
-      predicates:
-        contains: "Sisältää"
-        equals: "On yhtä kuin"
-        starts_with: "Alkaa"
-        ends_with: "Päättyy"
-        greater_than: "Suurempi kuin"
-        less_than: "Pienempi kuin"
-    status_tag:
-      "yes": "Kyllä"
-      "no": "Ei"
-      "unset": "Ei"
-    main_content: "Ole hyvä, käytä %{model}#main_content:ia nähdäksesi jotain."
-    logout: "Kirjaudu ulos"
-    powered_by: "Käyttää %{active_admin} %{version}:ia"
-    sidebars:
-      filters: "Haku"
-    pagination:
-      empty: "%{model}:ia ei löytynyt"
-      one: "Näytetään <b>1</b> %{model}"
-      one_page: "Näytetään <b>kaikki %{n}</b> %{model}:it"
-      multiple: "Näytetään %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> (yhteensä <b>%{total}</b>)"
-      multiple_without_total: "Näytetään %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      entry:
-        one: "syöte"
-        other: "syötteet"
+    access_denied:
+      message: "Sinulla ei ole oikeuksia suorittaa yrittämääsi toimintoa."
     any: "mikä vain"
-    blank_slate:
-      content: "Järjestelmässä ei ole yhtään %{resource_name}:ia vielä."
-      link: "Luo ensimmäinen"
-    dropdown_actions:
-      button_label: "Acciones"
     batch_actions:
+      action_label: "%{title} Valittu"
       button_label: "Toimet"
       default_confirmation: "Oletko varma, että haluat tehdä tämän?"
       delete_confirmation: "Oletko varma, että haluat poistaa nämä %{plural_model}:t?"
+      labels:
+        destroy: "Poista"
+      selection_toggle_explanation: "(Vaihda valintaa)"
       succesfully_destroyed:
         one: "1 %{model} poistettu"
         other: "%{count} %{plural_model}:a poistettu"
-      selection_toggle_explanation: "(Vaihda valintaa)"
-      action_label: "%{title} Valittu"
-      labels:
-        destroy: "Poista"
+    blank_slate:
+      content: "Järjestelmässä ei ole yhtään %{resource_name}:ia vielä."
+      link: "Luo ensimmäinen"
+    cancel: "Peruuta"
     comments:
-      resource_type: "Resurssityyppi"
+      add: "Lisää kommentti"
+      author: "Luoja"
       author_type: "Luoja-tyyppi"
       body: "Runko"
-      author: "Luoja"
-      add: "Lisää kommentti"
-      resource: "Resurssi"
-      no_comments_yet: "Ei kommentteja."
-      title_content: "Kommentteja (%{count})"
       errors:
         empty_text: "Kommenttia ei pystytty tallentamaan, et kirjoittanut kommenttitekstiä."
+      no_comments_yet: "Ei kommentteja."
+      resource: "Resurssi"
+      resource_type: "Resurssityyppi"
+      title_content: "Kommentteja (%{count})"
+    dashboard: Etusivu
+    dashboard_welcome:
+      call_to_action: "Lisätäksesi etusivun osioita katso: 'app/admin/dashboard.rb'"
+      welcome: "Tervetuloa! Tämä on Active Adminin oletusetusivu."
+    delete: "Poista"
+    delete_confirmation: "Oletko varma, että haluat poistaa tämän?"
+    delete_model: "Poista %{model}"
+    details: "%{model} Tiedot"
     devise:
-      username:
-        title: "Käyttäjänimi"
+      change_password:
+        submit: "Vaihda salasana"
+        title: "Vaihda salasana"
       email:
         title: "Sähköposti"
-      subdomain:
-        title: "Subdomain"
-      password:
-        title: "Salasana"
+      links:
+        forgot_your_password: "Unohtunut salasana?"
+        sign_in: "Kirjaudu sisään"
+        sign_in_with_omniauth_provider: "Kirjaudu sisään %{provider}:ia käyttäen"
       login:
-        title: "Sisäänkirjautuminen"
         remember_me: "Muista minut"
         submit: "Kirjaudu sisään"
+        title: "Sisäänkirjautuminen"
+      password:
+        title: "Salasana"
       reset_password:
-        title: "Unohtunut salasana?"
         submit: "Resetoi salasana"
-      change_password:
-        title: "Vaihda salasana"
-        submit: "Vaihda salasana"
+        title: "Unohtunut salasana?"
+      subdomain:
+        title: "Subdomain"
       unlock:
-        title: "Lähetä ohjeet lukituksen poistoon"
         submit: "Lähetä ohjeet lukituksen poistoon"
-      links:
-        sign_in: "Kirjaudu sisään"
-        forgot_your_password: "Unohtunut salasana?"
-        sign_in_with_omniauth_provider: "Kirjaudu sisään %{provider}:ia käyttäen"
-    access_denied:
-      message: "Sinulla ei ole oikeuksia suorittaa yrittämääsi toimintoa."
+        title: "Lähetä ohjeet lukituksen poistoon"
+      username:
+        title: "Käyttäjänimi"
+    download: "Lataa:"
+    dropdown_actions:
+      button_label: "Acciones"
+    edit: "Muokkaa"
+    edit_model: "Muokkaa %{model}"
+    empty: "Tyhjä"
+    filters:
+      buttons:
+        clear: "Tyhjennä valinnat"
+        filter: "Hae"
+      predicates:
+        contains: "Sisältää"
+        ends_with: "Päättyy"
+        equals: "On yhtä kuin"
+        greater_than: "Suurempi kuin"
+        less_than: "Pienempi kuin"
+        starts_with: "Alkaa"
+    has_many_delete: "Poista"
+    has_many_new: "Lisää uusi %{model}"
+    has_many_remove: "Poista"
     index_list:
-      table: "Taulukko"
       block: "Lista"
-      grid: "Ruudukko"
       blog: "Blogi"
+      grid: "Ruudukko"
+      table: "Taulukko"
+    logout: "Kirjaudu ulos"
+    main_content: "Ole hyvä, käytä %{model}#main_content:ia nähdäksesi jotain."
+    new_model: "Uusi %{model}"
+    next: "Seuraava"
+    pagination:
+      empty: "%{model}:ia ei löytynyt"
+      entry:
+        one: "syöte"
+        other: "syötteet"
+      multiple: "Näytetään %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> (yhteensä <b>%{total}</b>)"
+      multiple_without_total: "Näytetään %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      one: "Näytetään <b>1</b> %{model}"
+      one_page: "Näytetään <b>kaikki %{n}</b> %{model}:it"
+    powered_by: "Käyttää %{active_admin} %{version}:ia"
+    previous: "Edellinen"
+    sidebars:
+      filters: "Haku"
+    status_tag:
+      "no": "Ei"
+      "unset": "Ei"
+      "yes": "Kyllä"
+    view: "Katso"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,141 +1,141 @@
 fr:
   active_admin:
-    dashboard: "Tableau de bord"
-    dashboard_welcome:
-      welcome: "Bienvenue dans Active Admin. Ceci est la page par défaut."
-      call_to_action: "Pour ajouter des sections au tableau de bord, consultez 'app/admin/dashboard.rb'"
-    view: "Voir"
-    edit: "Modifier"
-    delete: "Supprimer"
-    delete_confirmation: "Voulez-vous vraiment supprimer ceci ?"
-    create_another: "Créer autre %{model}"
-    new_model: "Créer %{model}"
-    edit_model: "Modifier %{model}"
-    delete_model: "Supprimer %{model}"
-    details: "Détails de %{model}"
-    cancel: "Annuler"
-    empty: "Vide"
-    previous: "Précédent"
-    next: "Suivant"
-    download: "Télécharger :"
-    has_many_new: "Ajouter un(e) %{model}"
-    has_many_delete: "Supprimer"
-    has_many_remove: "Enlever"
-    filters:
-      buttons:
-        filter: "Filtrer"
-        clear: "Supprimer les filtres"
-      predicates:
-        contains: "Contient"
-        equals: "Égal à"
-        starts_with: "Commence par"
-        ends_with: "Se termine par"
-        greater_than: "Plus grand que"
-        less_than: "Plus petit que"
-        gteq_datetime: "Ultérieur ou égal à"
-        lteq_datetime: "Antérieur ou égal à"
-        from: "De"
-        to: "À"
-    search_status:
-      headline: "Statut de la recherche :"
-      current_scope: "Etendu du filtre :"
-      current_filters: "Filtres actuels :"
-      no_current_filters: "Aucun filtres"
-    status_tag:
-      "yes": "Oui"
-      "no": "Non"
-      "unset": "Non"
-    main_content: "Veuillez implémenter %{model}#main_content pour afficher le contenu."
-    logout: "Déconnexion"
-    powered_by: "Propulsé par %{active_admin} %{version}"
-    sidebars:
-      filters: "Filtres"
-      search_status: "Statut de la recherche"
-    pagination:
-      empty: "Aucun %{model} trouvé"
-      one: "Affichage de <b>1</b> %{model}"
-      one_page: "Affichage des <b>%{n}</b> %{model}"
-      multiple: "Affichage de %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> sur un total de <b>%{total}</b>"
-      multiple_without_total: "Affichage de %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      per_page: "Par page: "
-      entry:
-        one: "entrée"
-        other: "entrées"
+    access_denied:
+      message: "Vous n'êtes pas autorisé à exécuter cette action"
     any: "N'importe lequel"
-    blank_slate:
-      content: "Il n'y a pas encore de %{resource_name}."
-      link: "Créez en un"
-    dropdown_actions:
-      button_label: "Actions"
     batch_actions:
+      action_label: "%{title} les éléments sélectionnés"
       button_label: "Actions groupées"
       default_confirmation: "Voulez-vous vraiment faire cela ?"
       delete_confirmation: "Voulez-vous vraiment supprimer ces %{plural_model} ?"
+      labels:
+        destroy: "Supprimer"
+      selection_toggle_explanation: "(Inverser la sélection)"
       succesfully_destroyed:
         one: "1 %{model} supprimé"
         other: "%{count} %{plural_model} supprimés"
-      selection_toggle_explanation: "(Inverser la sélection)"
-      action_label: "%{title} les éléments sélectionnés"
-      labels:
-        destroy: "Supprimer"
+    blank_slate:
+      content: "Il n'y a pas encore de %{resource_name}."
+      link: "Créez en un"
+    cancel: "Annuler"
     comments:
-      created_at: "Créé le"
-      resource_type: "Type de ressource"
+      add: "Ajouter un commentaire"
+      author: "Auteur"
+      author_missing: "Anonyme"
       author_type: "Profil de l'auteur"
       body: "Corps"
-      author: "Auteur"
-      add: "Ajouter un commentaire"
+      created_at: "Créé le"
       delete: "Supprimer ce commentaire"
       delete_confirmation: "Voulez-vous vraiment supprimer ce commentaire ?"
-      resource: "Ressource"
-      no_comments_yet: "Aucun commentaire actuellement"
-      author_missing: "Anonyme"
-      title_content: "Commentaires (%{count})"
       errors:
         empty_text: "Le commentaire n'a pas été enregistré puisque le texte était vide."
+      no_comments_yet: "Aucun commentaire actuellement"
+      resource: "Ressource"
+      resource_type: "Type de ressource"
+      title_content: "Commentaires (%{count})"
+    create_another: "Créer autre %{model}"
+    dashboard: "Tableau de bord"
+    dashboard_welcome:
+      call_to_action: "Pour ajouter des sections au tableau de bord, consultez 'app/admin/dashboard.rb'"
+      welcome: "Bienvenue dans Active Admin. Ceci est la page par défaut."
+    delete: "Supprimer"
+    delete_confirmation: "Voulez-vous vraiment supprimer ceci ?"
+    delete_model: "Supprimer %{model}"
+    details: "Détails de %{model}"
     devise:
-      username:
-        title: "Nom d'utilisateur"
+      change_password:
+        submit: "Changer mon mot de passe"
+        title: "Changez votre mot de passe"
       email:
         title: "Email"
-      subdomain:
-        title: "Sous-domaine"
-      password:
-        title: "Mot de passe"
-      sign_up:
-        title: "S'inscrire"
-        submit: "S'inscrire"
+      links:
+        forgot_your_password: "Vous avez oublié votre mot de passe ?"
+        resend_confirmation_instructions: "Renvoyer les instructions de confirmation"
+        resend_unlock_instructions: "Renvoyer les informations de déverrouillage"
+        sign_in: "Connectez-vous"
+        sign_in_with_omniauth_provider: "Connectez-vous avec %{provider}"
+        sign_up: "Inscrivez-vous"
       login:
-        title: "Connexion"
         remember_me: "Garder ma session ouverte"
         submit: "Se connecter"
-      reset_password:
-        title: "Vous avez oublié votre mot de passe ?"
-        submit: "Réinitialiser mon mot de passe"
-      change_password:
-        title: "Changez votre mot de passe"
-        submit: "Changer mon mot de passe"
-      unlock:
-        title: "Renvoyer les informations de déverrouillage"
-        submit: "Renvoyer les informations de déverrouillage"
+        title: "Connexion"
+      password:
+        title: "Mot de passe"
       resend_confirmation_instructions:
-        title: "Renvoyer les instructions de confirmation"
         submit: "Renvoyer les instructions de confirmation"
-      links:
-        sign_up: "Inscrivez-vous"
-        sign_in: "Connectez-vous"
-        forgot_your_password: "Vous avez oublié votre mot de passe ?"
-        sign_in_with_omniauth_provider: "Connectez-vous avec %{provider}"
-        resend_unlock_instructions: "Renvoyer les informations de déverrouillage"
-        resend_confirmation_instructions: "Renvoyer les instructions de confirmation"
+        title: "Renvoyer les instructions de confirmation"
+      reset_password:
+        submit: "Réinitialiser mon mot de passe"
+        title: "Vous avez oublié votre mot de passe ?"
+      sign_up:
+        submit: "S'inscrire"
+        title: "S'inscrire"
+      subdomain:
+        title: "Sous-domaine"
+      unlock:
+        submit: "Renvoyer les informations de déverrouillage"
+        title: "Renvoyer les informations de déverrouillage"
+      username:
+        title: "Nom d'utilisateur"
+    download: "Télécharger :"
+    dropdown_actions:
+      button_label: "Actions"
+    edit: "Modifier"
+    edit_model: "Modifier %{model}"
+    empty: "Vide"
+    filters:
+      buttons:
+        clear: "Supprimer les filtres"
+        filter: "Filtrer"
+      predicates:
+        contains: "Contient"
+        ends_with: "Se termine par"
+        equals: "Égal à"
+        from: "De"
+        greater_than: "Plus grand que"
+        gteq_datetime: "Ultérieur ou égal à"
+        less_than: "Plus petit que"
+        lteq_datetime: "Antérieur ou égal à"
+        starts_with: "Commence par"
+        to: "À"
+    has_many_delete: "Supprimer"
+    has_many_new: "Ajouter un(e) %{model}"
+    has_many_remove: "Enlever"
+    index_list:
+      block: "Liste"
+      blog: "Blog"
+      grid: "Grille"
+      table: "Tableau"
+    logout: "Déconnexion"
+    main_content: "Veuillez implémenter %{model}#main_content pour afficher le contenu."
+    new_model: "Créer %{model}"
+    next: "Suivant"
+    pagination:
+      empty: "Aucun %{model} trouvé"
+      entry:
+        one: "entrée"
+        other: "entrées"
+      multiple: "Affichage de %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> sur un total de <b>%{total}</b>"
+      multiple_without_total: "Affichage de %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      one: "Affichage de <b>1</b> %{model}"
+      one_page: "Affichage des <b>%{n}</b> %{model}"
+      per_page: "Par page: "
+    powered_by: "Propulsé par %{active_admin} %{version}"
+    previous: "Précédent"
+    search_status:
+      current_filters: "Filtres actuels :"
+      current_scope: "Etendu du filtre :"
+      headline: "Statut de la recherche :"
+      no_current_filters: "Aucun filtres"
+    sidebars:
+      filters: "Filtres"
+      search_status: "Statut de la recherche"
+    status_tag:
+      "no": "Non"
+      "unset": "Non"
+      "yes": "Oui"
     unsupported_browser:
       headline: "Veuillez noter que ActiveAdmin ne supporte plus les versions d'Internet Explorer 8 ou moins."
       recommendation: "Nous vous recommandons de <a href=\"http://browsehappy.com/\">mettre à jour votre navigateur</a> pour améliorer votre expérience."
       turn_off_compatibility_view: "Si vous utilisez IE 9 ou une version ultérieure, assurez-vous d'<a href=\"https://support.microsoft.com/fr-fr/help/17471\">activer \"Affichage de compatibilité\"</a>."
-    access_denied:
-      message: "Vous n'êtes pas autorisé à exécuter cette action"
-    index_list:
-      table: "Tableau"
-      block: "Liste"
-      grid: "Grille"
-      blog: "Blog"
+    view: "Voir"

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1,141 +1,141 @@
 he:
   active_admin:
-    dashboard: פנל ניהול
-    dashboard_welcome:
-      welcome: "ברוכים הבאים לאקטיב אדמין. זהו פנל הניהול"
-      call_to_action: "כדי להוסיף אזורים בפנל הניהול, אנא בדוק את,  'app/admin/dashboard.rb'"
-    view: "צפייה"
-    edit: "עריכה"
-    delete: "מחיקה"
-    delete_confirmation: "האם אתה בטוח שאתה רוצה למחוק את זה?"
-    create_another: "צור עוד %{model}"
-    new_model: "%{model} חדש"
-    edit_model: "ערוך %{model}"
-    delete_model: "מחיקת %{model}"
-    details: "פרטים על %{model}"
-    cancel: "ביטול"
-    empty: "ריק"
-    previous: "הקודם"
-    next: "הבא"
-    download: "הורד:"
-    has_many_new: "הוספת %{model} חדש"
-    has_many_delete: "מחיקה"
-    has_many_remove: "להסיר"
-    filters:
-      buttons:
-        filter: "סינון"
-        clear: "איפוס שדות"
-      predicates:
-        contains: "מכיל"
-        equals: "שווה ל"
-        starts_with: "מתחיל עם"
-        ends_with: "מסתיים ב"
-        greater_than: "גדול מ"
-        less_than: "פחות מ"
-        gteq_datetime: "אחרי או בתאריך"
-        lteq_datetime: "לפני או בתאריך"
-    search_status:
-      headline: "תוצאות חיפוש:"
-      current_scope: "תחום:"
-      current_filters: "מסננים:"
-      no_current_filters: "ללא"
-    status_tag:
-      "yes": "כן"
-      "no": "לא"
-      "unset": "לא"
-    main_content: "אנא הטמע את %{model}#main_content בכדי להציג תוכן."
-    logout: "התנתקות"
-    powered_by: "ממונע בעזרת %{active_admin} %{version}"
-    sidebars:
-      filters: "סינון"
-      search_status: "מצב החיפוש"
-    pagination:
-      empty: "אין %{model} בנמצא"
-      one: "מציג <b>1</b> %{model}"
-      one_page: "הצגת <b>כל %{n}</b> %{model}"
-      multiple: "מציג %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> מתוך <b>%{total}</b> בסך הכל"
-      multiple_without_total: "מציג %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      per_page: "בדף: "
-      entry:
-        one: "רשומה בודדה"
-        other: "רשומות"
+    access_denied:
+      message: "אינך רשאי לבצע פעולה זו."
     any: "Any"
-    blank_slate:
-      content: "כרגע אין עוד אף %{resource_name}."
-      link: "צור אחד"
-    dropdown_actions:
-      button_label: "פעולו"
     batch_actions:
+      action_label: "%{title} נבחר"
       button_label: "פעולות מרובות"
       default_confirmation: "אתה בטוח שאתה רוצה לעשות את זה?"
       delete_confirmation: "האם הנך בטוח שאתה רוצה למרוח את %{plural_model}?"
+      labels:
+        destroy: "מחק"
+      selection_toggle_explanation: "(שינוי בחירה)"
       succesfully_destroyed:
         one: "1 %{model} נמחק בהצלחה"
         other: "%{count} %{plural_model} נמחק בהצלחה"
-      selection_toggle_explanation: "(שינוי בחירה)"
-      action_label: "%{title} נבחר"
-      labels:
-        destroy: "מחק"
+    blank_slate:
+      content: "כרגע אין עוד אף %{resource_name}."
+      link: "צור אחד"
+    cancel: "ביטול"
     comments:
-      created_at: "נוצר"
-      resource_type: "סוג רישום"
+      add: "הוסף תגובה"
+      author: 'נוצר ע"י'
+      author_missing: "אנונימי"
       author_type: "סוג מחבר"
       body: "תוכן"
-      author: 'נוצר ע"י'
-      add: "הוסף תגובה"
+      created_at: "נוצר"
       delete: "מחק תגובה"
       delete_confirmation: "האם אתה בטוח שברצונך למחוק תגובה זאת?"
-      resource: "רשומה"
-      no_comments_yet: "אין עדיין תגובות."
-      author_missing: "אנונימי"
-      title_content: "תגובות (%{count})"
       errors:
         empty_text: "התגובה לא נשמרה, שדה התוכן ריק."
+      no_comments_yet: "אין עדיין תגובות."
+      resource: "רשומה"
+      resource_type: "סוג רישום"
+      title_content: "תגובות (%{count})"
+    create_another: "צור עוד %{model}"
+    dashboard: פנל ניהול
+    dashboard_welcome:
+      call_to_action: "כדי להוסיף אזורים בפנל הניהול, אנא בדוק את,  'app/admin/dashboard.rb'"
+      welcome: "ברוכים הבאים לאקטיב אדמין. זהו פנל הניהול"
+    delete: "מחיקה"
+    delete_confirmation: "האם אתה בטוח שאתה רוצה למחוק את זה?"
+    delete_model: "מחיקת %{model}"
+    details: "פרטים על %{model}"
     devise:
-      username:
-        title: "שם משתמש"
+      change_password:
+        submit: "שנה את הסיסמא שלי"
+        title: "שנה את הסיסמא שלך"
       email:
         title: "כתובת דוא״ל"
-      subdomain:
-        title: "תת-דומיין"
+      links:
+        forgot_your_password: "שכחת את הסיסמא שלך?"
+        resend_confirmation_instructions: "שלח שוב הוראות אישור"
+        resend_unlock_instructions: "שלח שוב הוראות שיחרור"
+        sign_in: "כניסה"
+        sign_in_with_omniauth_provider: "%{provider} היכנס עם"
+        sign_up: "הרשמה"
+      login:
+        remember_me: "זכור אותי"
+        submit: "הכנס"
+        title: "כניסה"
       password:
         title: "סיסמא"
       password_confirmation:
         title: "אישור סיסמא"
-      sign_up:
-        title: "הרשמה"
-        submit: "הרשמה"
-      login:
-        title: "כניסה"
-        remember_me: "זכור אותי"
-        submit: "הכנס"
-      reset_password:
-        title: "שכחת סיסמא?"
-        submit: "אפס את הסיסמא שלי"
-      change_password:
-        title: "שנה את הסיסמא שלך"
-        submit: "שנה את הסיסמא שלי"
-      unlock:
-        title: "שלח שוב הוראות שיחרור"
-        submit: "שלח שוב הוראות שיחרור"
       resend_confirmation_instructions:
-        title: "שלח שוב הוראות אישור"
         submit: "שלח שוב הוראות אישור"
-      links:
-        sign_up: "הרשמה"
-        sign_in: "כניסה"
-        forgot_your_password: "שכחת את הסיסמא שלך?"
-        sign_in_with_omniauth_provider: "%{provider} היכנס עם"
-        resend_unlock_instructions: "שלח שוב הוראות שיחרור"
-        resend_confirmation_instructions: "שלח שוב הוראות אישור"
+        title: "שלח שוב הוראות אישור"
+      reset_password:
+        submit: "אפס את הסיסמא שלי"
+        title: "שכחת סיסמא?"
+      sign_up:
+        submit: "הרשמה"
+        title: "הרשמה"
+      subdomain:
+        title: "תת-דומיין"
+      unlock:
+        submit: "שלח שוב הוראות שיחרור"
+        title: "שלח שוב הוראות שיחרור"
+      username:
+        title: "שם משתמש"
+    download: "הורד:"
+    dropdown_actions:
+      button_label: "פעולו"
+    edit: "עריכה"
+    edit_model: "ערוך %{model}"
+    empty: "ריק"
+    filters:
+      buttons:
+        clear: "איפוס שדות"
+        filter: "סינון"
+      predicates:
+        contains: "מכיל"
+        ends_with: "מסתיים ב"
+        equals: "שווה ל"
+        greater_than: "גדול מ"
+        gteq_datetime: "אחרי או בתאריך"
+        less_than: "פחות מ"
+        lteq_datetime: "לפני או בתאריך"
+        starts_with: "מתחיל עם"
+    has_many_delete: "מחיקה"
+    has_many_new: "הוספת %{model} חדש"
+    has_many_remove: "להסיר"
+    index_list:
+      block: "רשימה"
+      blog: "בלוג"
+      grid: "גריד"
+      table: "טבלה"
+    logout: "התנתקות"
+    main_content: "אנא הטמע את %{model}#main_content בכדי להציג תוכן."
+    new_model: "%{model} חדש"
+    next: "הבא"
+    pagination:
+      empty: "אין %{model} בנמצא"
+      entry:
+        one: "רשומה בודדה"
+        other: "רשומות"
+      multiple: "מציג %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> מתוך <b>%{total}</b> בסך הכל"
+      multiple_without_total: "מציג %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      one: "מציג <b>1</b> %{model}"
+      one_page: "הצגת <b>כל %{n}</b> %{model}"
+      per_page: "בדף: "
+    powered_by: "ממונע בעזרת %{active_admin} %{version}"
+    previous: "הקודם"
+    search_status:
+      current_filters: "מסננים:"
+      current_scope: "תחום:"
+      headline: "תוצאות חיפוש:"
+      no_current_filters: "ללא"
+    sidebars:
+      filters: "סינון"
+      search_status: "מצב החיפוש"
+    status_tag:
+      "no": "לא"
+      "unset": "לא"
+      "yes": "כן"
     unsupported_browser:
       headline: "שים לב ש-ActiveAdmin אינו תומך יותר ב-Internet Explorer גרסא 8 ומטה."
       recommendation: "אנו ממליצים <a href=\"http://browsehappy.com/\">לשדרג את הדפדפן שלך</a> על מנת לשפר את חווית הגלישה."
       turn_off_compatibility_view: "אם אתה משתמש ב- IE 9 ואילך, ודא ש<a href=\"https://support.microsoft.com/he-il/help/17471\">כיבית \"תצוגת תאימות\"</a>."
-    access_denied:
-      message: "אינך רשאי לבצע פעולה זו."
-    index_list:
-      table: "טבלה"
-      block: "רשימה"
-      grid: "גריד"
-      blog: "בלוג"
+    view: "צפייה"

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -1,123 +1,123 @@
 hr:
   active_admin:
-    dashboard: "Upravljačka ploča"
-    dashboard_welcome:
-      welcome: "Dobrodošli u Active Admin. Ovo je početna upravljačka ploča."
-      call_to_action: "Da biste dodali nove odjeljke na upravljačku ploču, pogledajte 'app/admin/dashboard.rb'"
-    view: "Pregledaj"
-    edit: "Uredi"
-    delete: "Obriši"
-    delete_confirmation: "Jeste li sigurni da želite ovo obrisati?"
-    new_model: "Novi %{model}"
-    edit_model: "Uredi %{model}"
-    delete_model: "Obriši %{model}"
-    details: "%{model} detalji"
-    cancel: "Odustani"
-    empty: "Prazno"
-    previous: "Prijašnji"
-    next: "Sljedeći"
-    download: "Spremi na računalo:"
-    has_many_new: "Dodaj novi %{model}"
-    has_many_delete: "Obriši"
-    has_many_remove: "Ukloniti"
-    filters:
-      buttons:
-        filter: "Filtriraj"
-        clear: "Očisti filtere"
-      predicates:
-        contains: "Sadrži"
-        equals: "Jednako"
-        starts_with: "počinje s"
-        ends_with: "Završava sa"
-        greater_than: "Veće od"
-        less_than: "Manje od"
-    status_tag:
-      "yes": "Da"
-      "no": "Nema"
-      "unset": "Nema"
-    main_content: "Molim Vas, implementirajte %{model}#main_content da biste prikazali sadržaj."
-    logout: "Odjavi se"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filtriranje"
-    pagination:
-      empty: "Nije pronađen niti jedan %{model}."
-      one: "Prikazan <b>1</b> %{model}"
-      one_page: "Prikazano <b>svih %{n}</b> %{model}"
-      multiple: "Prikazani %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> od ukupno <b>%{total}</b>"
-      multiple_without_total: "Prikazani %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      entry:
-        one: "zapis"
-        few: "zapisa"
-        many: "zapisa"
-        other: "zapisa"
+    access_denied:
+      message: "Nemaš dopuštenja."
     any: "Bilo koji"
-    blank_slate:
-      content: "Još uvijek ne postoji niti jedan zapis tipa %{resource_name}."
-      link: "Izradi jedan"
-    dropdown_actions:
-      button_label: "Ukrepi"
     batch_actions:
+      action_label: "%{title} označene"
       button_label: "Grupne akcije"
       default_confirmation: "Jeste li sigurni da želite to učiniti?"
       delete_confirmation: "Jeste li sigurni da želite obrisati %{plural_model}?"
-      succesfully_destroyed:
-        one: "Uspješno je obrisan 1 %{model}"
-        few: "Uspješno su obrisana %{count} %{plural_model}"
-        many: "Uspješno je obrisano %{count} %{plural_model}"
-        other: "Uspješno je obrisano %{count} %{plural_model}"
-      selection_toggle_explanation: "(Izmijeni odabir)"
-      action_label: "%{title} označene"
       labels:
         destroy: "Obriši"
+      selection_toggle_explanation: "(Izmijeni odabir)"
+      succesfully_destroyed:
+        few: "Uspješno su obrisana %{count} %{plural_model}"
+        many: "Uspješno je obrisano %{count} %{plural_model}"
+        one: "Uspješno je obrisan 1 %{model}"
+        other: "Uspješno je obrisano %{count} %{plural_model}"
+    blank_slate:
+      content: "Još uvijek ne postoji niti jedan zapis tipa %{resource_name}."
+      link: "Izradi jedan"
+    cancel: "Odustani"
     comments:
-      resource_type: "Tip objekta"
+      add: "Dodaj komentar"
+      author: "Autor"
+      author_missing: "Anoniman"
       author_type: "Tip autora"
       body: "Sadržaj"
-      author: "Autor"
-      add: "Dodaj komentar"
-      resource: "Objekt"
-      no_comments_yet: "Još nema komentara."
-      author_missing: "Anoniman"
-      title_content: "Komentari (%{count})"
       errors:
         empty_text: "Komentar nije spremljen, sadržaj je prazan."
+      no_comments_yet: "Još nema komentara."
+      resource: "Objekt"
+      resource_type: "Tip objekta"
+      title_content: "Komentari (%{count})"
+    dashboard: "Upravljačka ploča"
+    dashboard_welcome:
+      call_to_action: "Da biste dodali nove odjeljke na upravljačku ploču, pogledajte 'app/admin/dashboard.rb'"
+      welcome: "Dobrodošli u Active Admin. Ovo je početna upravljačka ploča."
+    delete: "Obriši"
+    delete_confirmation: "Jeste li sigurni da želite ovo obrisati?"
+    delete_model: "Obriši %{model}"
+    details: "%{model} detalji"
     devise:
-      username:
-        title: "Korisničko ime"
+      change_password:
+        submit: "Izmijeni lozinku"
+        title: "Izmjena lozinke"
       email:
         title: "Email"
-      subdomain:
-        title: "Poddomena"
-      password:
-        title: "Lozinka"
-      sign_up:
-        title: "Registracija"
-        submit: "Registruj"
+      links:
+        forgot_your_password: "Zaboravljena lozinka?"
+        sign_in: "Prijavi se"
+        sign_in_with_omniauth_provider: "Prijavite se za %{provider}"
       login:
-        title: "Prijava"
         remember_me: "Zapamti me"
         submit: "Prijavi se"
-      reset_password:
-        title: "Zaboravljena lozinka?"
-        submit: "Resetiraj lozinku"
-      change_password:
-        title: "Izmjena lozinke"
-        submit: "Izmijeni lozinku"
-      unlock:
-        title: "Ponovno slanje uputstva za otključavanje"
-        submit: "Pošalji"
+        title: "Prijava"
+      password:
+        title: "Lozinka"
       resend_confirmation_instructions:
-        title: "Ponovno slanje uputstva za potvrdu"
         submit: "Pošalji"
-      links:
-        sign_in: "Prijavi se"
-        forgot_your_password: "Zaboravljena lozinka?"
-        sign_in_with_omniauth_provider: "Prijavite se za %{provider}"
-    access_denied:
-      message: "Nemaš dopuštenja."
+        title: "Ponovno slanje uputstva za potvrdu"
+      reset_password:
+        submit: "Resetiraj lozinku"
+        title: "Zaboravljena lozinka?"
+      sign_up:
+        submit: "Registruj"
+        title: "Registracija"
+      subdomain:
+        title: "Poddomena"
+      unlock:
+        submit: "Pošalji"
+        title: "Ponovno slanje uputstva za otključavanje"
+      username:
+        title: "Korisničko ime"
+    download: "Spremi na računalo:"
+    dropdown_actions:
+      button_label: "Ukrepi"
+    edit: "Uredi"
+    edit_model: "Uredi %{model}"
+    empty: "Prazno"
+    filters:
+      buttons:
+        clear: "Očisti filtere"
+        filter: "Filtriraj"
+      predicates:
+        contains: "Sadrži"
+        ends_with: "Završava sa"
+        equals: "Jednako"
+        greater_than: "Veće od"
+        less_than: "Manje od"
+        starts_with: "počinje s"
+    has_many_delete: "Obriši"
+    has_many_new: "Dodaj novi %{model}"
+    has_many_remove: "Ukloniti"
     index_list:
-      table: "Tabela"
       block: "Lista"
-      grid: "Rešetka"
       blog: "Blog"
+      grid: "Rešetka"
+      table: "Tabela"
+    logout: "Odjavi se"
+    main_content: "Molim Vas, implementirajte %{model}#main_content da biste prikazali sadržaj."
+    new_model: "Novi %{model}"
+    next: "Sljedeći"
+    pagination:
+      empty: "Nije pronađen niti jedan %{model}."
+      entry:
+        few: "zapisa"
+        many: "zapisa"
+        one: "zapis"
+        other: "zapisa"
+      multiple: "Prikazani %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> od ukupno <b>%{total}</b>"
+      multiple_without_total: "Prikazani %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      one: "Prikazan <b>1</b> %{model}"
+      one_page: "Prikazano <b>svih %{n}</b> %{model}"
+    powered_by: "Powered by %{active_admin} %{version}"
+    previous: "Prijašnji"
+    sidebars:
+      filters: "Filtriranje"
+    status_tag:
+      "no": "Nema"
+      "unset": "Nema"
+      "yes": "Da"
+    view: "Pregledaj"

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -1,102 +1,102 @@
 hu:
   active_admin:
-    dashboard: Vezérlőpult
-    dashboard_welcome:
-      welcome: "Üdvözöljük az Active Admin felületén. Ez a vezérlőpult kezdőlapja"
-      call_to_action: "Elemek hozzáadásához nézze meg a 'app/admin/dashboard.rb' fájlt"
-    view: "Megtekintés"
-    edit: "Szerkesztés"
-    delete: "Törlés"
-    delete_confirmation: "Biztosan törli ezt az elemet?"
-    new_model: "Új %{model}"
-    edit_model: "%{model} módosítása"
-    delete_model: "%{model} törlése"
-    details: "%{model} részletei"
-    cancel: "Mégsem"
-    empty: "Üres"
-    previous: "Előző"
-    next: "Következő"
-    download: "Letöltés:"
-    has_many_new: "Új %{model} hozzáadása"
-    has_many_delete: "Törlés"
-    has_many_remove: "Eltávolít"
-    filters:
-      buttons:
-        filter: "Szűrés"
-        clear: "Feltételek törlése"
-      predicates:
-        contains: "Tartalmazza"
-        equals: "Pontosan"
-        starts_with: "kezdődik"
-        ends_with: "végződik"
-        greater_than: "Nagyobb, mint"
-        less_than: "Kisebb, mint"
-        gteq_datetime: "Nagyobb vagy egyenlő, mint"
-        lteq_datetime: "Kisebb vagy egyenlő, mint"
-        from: "-tól"
-        to: "-ig"
-    status_tag:
-      "yes": "Igen"
-      "no": "Nem"
-      "unset": "Nem"
-    main_content: "Kérem, implementálja a %{model}#main_content metódust a tartalom megjelenítéséhez."
-    logout: "Kilépés"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Szűrők"
-    pagination:
-      empty: "Nincs több %{model}"
-      one: "<b>Egy</b> %{model} megjelenítése"
-      one_page: "<b>Az összes (%{n} db)</b> %{model} megjelenítése"
-      multiple: "%{model} listájának megjelenítése, <b>%{from}&nbsp;-&nbsp;%{to}</b>/<b>%{total}</b> "
-      multiple_without_total: "%{model} listájának megjelenítése, <b>%{from}&nbsp;-&nbsp;%{to}</b> "
-      entry:
-        one: "elem"
-        other: "elem"
     any: "Összes"
-    blank_slate:
-      content: "Még nincs létrehozva %{resource_name}."
-      link: "Létrehozás most"
-    dropdown_actions:
-      button_label: "Műveletek"
     batch_actions:
+      action_label: "%{title} kiválasztva"
       button_label: "Tömeges műveletek"
       default_confirmation: "Biztos vagy benne, hogy a ön akar-hoz csinál ez?"
       delete_confirmation: "Biztosan törli ezeket a %{plural_model}?"
+      labels:
+        destroy: "Törlés"
+      selection_toggle_explanation: "(Kijelölés megfordítása)"
       succesfully_destroyed:
         one: "1 %{model} sikeresen törölve"
         other: "%{count} %{plural_model} sikeresen törölve"
-      selection_toggle_explanation: "(Kijelölés megfordítása)"
-      action_label: "%{title} kiválasztva"
-      labels:
-        destroy: "Törlés"
+    blank_slate:
+      content: "Még nincs létrehozva %{resource_name}."
+      link: "Létrehozás most"
+    cancel: "Mégsem"
     comments:
-      body: "Törzs"
-      author: "Szerző"
       add: "Új hozzászólás"
-      resource: "Erőforrás"
-      no_comments_yet: "Nincsenek hozzászólások."
-      title_content: "%{count} hozzászólás"
+      author: "Szerző"
+      body: "Törzs"
       errors:
         empty_text: "A hozzászólás nem lett mentve, a törzs nem lehet üres."
+      no_comments_yet: "Nincsenek hozzászólások."
+      resource: "Erőforrás"
+      title_content: "%{count} hozzászólás"
+    dashboard: Vezérlőpult
+    dashboard_welcome:
+      call_to_action: "Elemek hozzáadásához nézze meg a 'app/admin/dashboard.rb' fájlt"
+      welcome: "Üdvözöljük az Active Admin felületén. Ez a vezérlőpult kezdőlapja"
+    delete: "Törlés"
+    delete_confirmation: "Biztosan törli ezt az elemet?"
+    delete_model: "%{model} törlése"
+    details: "%{model} részletei"
     devise:
+      change_password:
+        submit: "Jelszó módosítása"
+        title: "A jelszó módosítása"
+      links:
+        forgot_your_password: "Elfelejtette a jelszavát?"
+        sign_in: "Bejelentkezés"
+        sign_in_with_omniauth_provider: "Jelentkezzen be a %{provider}"
       login:
-        title: "Bejelentkezés"
         remember_me: "Emlékezz rám"
         submit: "Belépés"
-      reset_password:
-        title: "Elfelejtette a jelszavát?"
-        submit: "Jelszó visszaállítása"
-      change_password:
-        title: "A jelszó módosítása"
-        submit: "Jelszó módosítása"
-      unlock:
-        title: "Újraküldés unlock utasítások"
-        submit: "Újraküldés unlock utasítások"
+        title: "Bejelentkezés"
       resend_confirmation_instructions:
-        title: "Megerősítő levél újraküldése"
         submit: "Megerősítő levél újraküldése"
-      links:
-        sign_in: "Bejelentkezés"
-        forgot_your_password: "Elfelejtette a jelszavát?"
-        sign_in_with_omniauth_provider: "Jelentkezzen be a %{provider}"
+        title: "Megerősítő levél újraküldése"
+      reset_password:
+        submit: "Jelszó visszaállítása"
+        title: "Elfelejtette a jelszavát?"
+      unlock:
+        submit: "Újraküldés unlock utasítások"
+        title: "Újraküldés unlock utasítások"
+    download: "Letöltés:"
+    dropdown_actions:
+      button_label: "Műveletek"
+    edit: "Szerkesztés"
+    edit_model: "%{model} módosítása"
+    empty: "Üres"
+    filters:
+      buttons:
+        clear: "Feltételek törlése"
+        filter: "Szűrés"
+      predicates:
+        contains: "Tartalmazza"
+        ends_with: "végződik"
+        equals: "Pontosan"
+        from: "-tól"
+        greater_than: "Nagyobb, mint"
+        gteq_datetime: "Nagyobb vagy egyenlő, mint"
+        less_than: "Kisebb, mint"
+        lteq_datetime: "Kisebb vagy egyenlő, mint"
+        starts_with: "kezdődik"
+        to: "-ig"
+    has_many_delete: "Törlés"
+    has_many_new: "Új %{model} hozzáadása"
+    has_many_remove: "Eltávolít"
+    logout: "Kilépés"
+    main_content: "Kérem, implementálja a %{model}#main_content metódust a tartalom megjelenítéséhez."
+    new_model: "Új %{model}"
+    next: "Következő"
+    pagination:
+      empty: "Nincs több %{model}"
+      entry:
+        one: "elem"
+        other: "elem"
+      multiple: "%{model} listájának megjelenítése, <b>%{from}&nbsp;-&nbsp;%{to}</b>/<b>%{total}</b> "
+      multiple_without_total: "%{model} listájának megjelenítése, <b>%{from}&nbsp;-&nbsp;%{to}</b> "
+      one: "<b>Egy</b> %{model} megjelenítése"
+      one_page: "<b>Az összes (%{n} db)</b> %{model} megjelenítése"
+    powered_by: "Powered by %{active_admin} %{version}"
+    previous: "Előző"
+    sidebars:
+      filters: "Szűrők"
+    status_tag:
+      "no": "Nem"
+      "unset": "Nem"
+      "yes": "Igen"
+    view: "Megtekintés"

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -1,135 +1,135 @@
 id:
   active_admin:
-    dashboard: Dashboard
-    dashboard_welcome:
-      welcome: "Selamat datang di Active Admin. Ini adalah tampilan standar halaman dashboard."
-      call_to_action: "Tampilan halaman ini bisa diubah di file 'app/admin/dashboard.rb'"
-    view: "Lihat"
-    edit: "Ubah"
-    delete: "Hapus"
-    delete_confirmation: "Apakah anda yakin ingin menghapus data ini?"
-    new_model: "Tambah %{model} baru"
-    edit_model: "Ubah %{model}"
-    delete_model: "Hapus %{model}"
-    details: "Detail %{model}"
-    cancel: "Batal"
-    empty: "Kosong"
-    previous: "Sebelumnya"
-    next: "Berikutnya"
-    download: "Unduh:"
-    has_many_new: "Tambah %{model} baru"
-    has_many_delete: "Hapus"
-    has_many_remove: "Hapus"
-    filters:
-      buttons:
-        filter: "Filter"
-        clear: "Hapus Filters"
-      predicates:
-        contains: "Mengandung"
-        equals: "Sama dengan"
-        starts_with: "Diawali dengan"
-        ends_with: "Diakhiri dengan"
-        greater_than: "Lebih besar dari"
-        less_than: "Lebih kecil dari"
-    search_status:
-      headline: "Status Pencarian:"
-      current_scope: "Scope:"
-      current_filters: "Filter kini:"
-      no_current_filters: "Tidak ada"
-    status_tag:
-      "yes": "Ya"
-      "no": "Tidak"
-      "unset": "Tidak"
-    main_content: "Harap mengimplementasikan %{model}#main_content untuk menampilkan konten."
-    logout: "Keluar"
-    powered_by: "Dibuat dengan %{active_admin} %{version}"
-    sidebars:
-      filters: "Filter"
-      search_status: "Status Pencarian"
-    pagination:
-      empty: "Tidak ada %{model} yang bisa ditemukan"
-      one: "Menampilkan <b>1</b> %{model}"
-      one_page: "Menampilkan <b>semua %{n}</b> %{model}"
-      multiple: "Menampilkan <b>%{from}&nbsp;-&nbsp;%{to}</b> dari <b>%{total}</b> keseluruhan %{model}"
-      multiple_without_total: "Menampilkan <b>%{from}&nbsp;-&nbsp;%{to} %{model}</b>"
-      entry:
-        one: "data"
-        other: "data"
+    access_denied:
+      message: "Anda tidak diperkenankan melakukan aksi tersebut."
     any: "Apapun"
-    blank_slate:
-      content: "%{resource_name} masih belum ada sama sekali."
-      link: "Tambah data"
-    dropdown_actions:
-      button_label: "Tindakan"
     batch_actions:
+      action_label: "%{title} terpilih"
       button_label: "Tindakan Serentak"
       default_confirmation: "Apakah anda yakin akan melakukan ini?"
       delete_confirmation: "Apakah anda yakin akan menghapus %{plural_model}?"
+      labels:
+        destroy: "Hapus"
+      selection_toggle_explanation: "(Tampilkan Pilihan)"
       succesfully_destroyed:
         one: "Berhasil menghapus %{model}"
         other: "Berhasil menghapus %{count} %{plural_model}"
-      selection_toggle_explanation: "(Tampilkan Pilihan)"
-      action_label: "%{title} terpilih"
-      labels:
-        destroy: "Hapus"
+    blank_slate:
+      content: "%{resource_name} masih belum ada sama sekali."
+      link: "Tambah data"
+    cancel: "Batal"
     comments:
-      created_at: "Dibuat"
-      resource_type: "Jenis Resource"
+      add: "Tambah Komentar"
+      author: "Penulis"
+      author_missing: "Anonim"
       author_type: "Tipe Penulis"
       body: "Isi"
-      author: "Penulis"
-      add: "Tambah Komentar"
+      created_at: "Dibuat"
       delete: "Hapus Komentar"
       delete_confirmation: "Apakah anda yakin akan menghapus komentar tersebut?"
-      resource: "Resource"
-      no_comments_yet: "Belum ada komentar sama sekali."
-      author_missing: "Anonim"
-      title_content: "Komentar (%{count})"
       errors:
         empty_text: "Komentar tak bisa disimpan, text tidak boleh dikosongi."
+      no_comments_yet: "Belum ada komentar sama sekali."
+      resource: "Resource"
+      resource_type: "Jenis Resource"
+      title_content: "Komentar (%{count})"
+    dashboard: Dashboard
+    dashboard_welcome:
+      call_to_action: "Tampilan halaman ini bisa diubah di file 'app/admin/dashboard.rb'"
+      welcome: "Selamat datang di Active Admin. Ini adalah tampilan standar halaman dashboard."
+    delete: "Hapus"
+    delete_confirmation: "Apakah anda yakin ingin menghapus data ini?"
+    delete_model: "Hapus %{model}"
+    details: "Detail %{model}"
     devise:
-      username:
-        title: "Username"
+      change_password:
+        submit: "Kirimkan instruksi pengaturan ulang password"
+        title: " - Atur Ulang Password"
       email:
         title: "Email"
-      subdomain:
-        title: "Subdomain"
-      password:
-        title: "Password"
-      sign_up:
-        title: " - Daftar"
-        submit: "Daftar"
+      links:
+        forgot_your_password: "Lupa password?"
+        resend_confirmation_instructions: "Kirim lagi instruksi konfirmasi akun"
+        resend_unlock_instructions: "Kirim instruksi pengaktifan kembali akun"
+        sign_in: "Masuk"
+        sign_in_with_omniauth_provider: "Daftar melalui %{provider}"
+        sign_up: "Daftar"
       login:
-        title: " - Masuk"
         remember_me: "Ingat saya"
         submit: "Masuk"
-      reset_password:
-        title: " - Form Atur Ulang Password"
-        submit: "Atur ulang password"
-      change_password:
-        title: " - Atur Ulang Password"
-        submit: "Kirimkan instruksi pengaturan ulang password"
-      unlock:
-        title: " - Kirim Instruksi Pengaktifan Kembali Akun"
-        submit: "Kirimkan instruksi pengaktifan kembali akun"
+        title: " - Masuk"
+      password:
+        title: "Password"
       resend_confirmation_instructions:
-        title: " - Kirim Lagi Instruksi Konfirmasi Akun"
         submit: "Kirimkan lagi instruksi konfirmasi akun"
-      links:
-        sign_up: "Daftar"
-        sign_in: "Masuk"
-        forgot_your_password: "Lupa password?"
-        sign_in_with_omniauth_provider: "Daftar melalui %{provider}"
-        resend_unlock_instructions: "Kirim instruksi pengaktifan kembali akun"
-        resend_confirmation_instructions: "Kirim lagi instruksi konfirmasi akun"
+        title: " - Kirim Lagi Instruksi Konfirmasi Akun"
+      reset_password:
+        submit: "Atur ulang password"
+        title: " - Form Atur Ulang Password"
+      sign_up:
+        submit: "Daftar"
+        title: " - Daftar"
+      subdomain:
+        title: "Subdomain"
+      unlock:
+        submit: "Kirimkan instruksi pengaktifan kembali akun"
+        title: " - Kirim Instruksi Pengaktifan Kembali Akun"
+      username:
+        title: "Username"
+    download: "Unduh:"
+    dropdown_actions:
+      button_label: "Tindakan"
+    edit: "Ubah"
+    edit_model: "Ubah %{model}"
+    empty: "Kosong"
+    filters:
+      buttons:
+        clear: "Hapus Filters"
+        filter: "Filter"
+      predicates:
+        contains: "Mengandung"
+        ends_with: "Diakhiri dengan"
+        equals: "Sama dengan"
+        greater_than: "Lebih besar dari"
+        less_than: "Lebih kecil dari"
+        starts_with: "Diawali dengan"
+    has_many_delete: "Hapus"
+    has_many_new: "Tambah %{model} baru"
+    has_many_remove: "Hapus"
+    index_list:
+      block: "Daftar"
+      blog: "Blog"
+      grid: "Grid"
+      table: "Tabel"
+    logout: "Keluar"
+    main_content: "Harap mengimplementasikan %{model}#main_content untuk menampilkan konten."
+    new_model: "Tambah %{model} baru"
+    next: "Berikutnya"
+    pagination:
+      empty: "Tidak ada %{model} yang bisa ditemukan"
+      entry:
+        one: "data"
+        other: "data"
+      multiple: "Menampilkan <b>%{from}&nbsp;-&nbsp;%{to}</b> dari <b>%{total}</b> keseluruhan %{model}"
+      multiple_without_total: "Menampilkan <b>%{from}&nbsp;-&nbsp;%{to} %{model}</b>"
+      one: "Menampilkan <b>1</b> %{model}"
+      one_page: "Menampilkan <b>semua %{n}</b> %{model}"
+    powered_by: "Dibuat dengan %{active_admin} %{version}"
+    previous: "Sebelumnya"
+    search_status:
+      current_filters: "Filter kini:"
+      current_scope: "Scope:"
+      headline: "Status Pencarian:"
+      no_current_filters: "Tidak ada"
+    sidebars:
+      filters: "Filter"
+      search_status: "Status Pencarian"
+    status_tag:
+      "no": "Tidak"
+      "unset": "Tidak"
+      "yes": "Ya"
     unsupported_browser:
       headline: "Harap dicatat bahwa ActiveAdmin sudah tidak mendukung InternetExplorer versi 8 atau versi sebelum itu."
       recommendation: "Kami sarankan agar anda mengupgrade ke versi <a href=\"http://windows.microsoft.com/ie\">Internet Explorer</a>, <a href=\"https://chrome.google.com/\">Google Chrome</a>, atau <a href=\"https://mozilla.org/firefox/\">Firefox</a> yang terbaru."
       turn_off_compatibility_view: "Kalau anda menggunakan IE 9 atau yang lebih baru, pastikan anda <a href=\"https://support.microsoft.com/id-id/help/17471\">mematikan \"Compatibility View\"</a>."
-    access_denied:
-      message: "Anda tidak diperkenankan melakukan aksi tersebut."
-    index_list:
-      table: "Tabel"
-      block: "Daftar"
-      grid: "Grid"
-      blog: "Blog"
+    view: "Lihat"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,12 +1,150 @@
 it:
+  active_admin:
+    access_denied:
+      message: "Non hai le autorizzazioni necessarie per eseguire questa azione."
+    any: "Qualsiasi"
+    batch_actions:
+      action_label: "%{title} Selezionati"
+      button_label: "Azioni multiple"
+      default_confirmation: "Sei sicuro di che voler proseguire?"
+      delete_confirmation: "Sei sicuro di volere cancellare %{plural_model}?"
+      labels:
+        destroy: "Elimina"
+      selection_toggle_explanation: "(cambia selezione)"
+      succesfully_destroyed:
+        one: "Eliminato con successo 1 %{model}"
+        other: "Eliminati con successo %{count} %{plural_model}"
+    blank_slate:
+      content: "Non sono presenti %{resource_name}"
+      link: "Crea nuovo/a"
+    cancel: "Annulla"
+    comments:
+      add: "Aggiungi Commento"
+      author: "Autore"
+      author_missing: "Anonimo"
+      author_type: "Tipo di Autore"
+      body: "Corpo"
+      created_at: "Creato il"
+      delete: "Cancella Commento"
+      delete_confirmation: "Sei sicuro di voler cancellare questo commento?"
+      errors:
+        empty_text: "Il commento non può essere salvato, il testo è vuoto."
+      no_comments_yet: "Nessun commento."
+      resource: "Risorsa"
+      resource_type: "Tipo di risorsa"
+      title_content: "Commenti (%{count})"
+    create_another: "Crea un altro %{model}"
+    dashboard: Dashboard
+    dashboard_welcome:
+      call_to_action: "Per aggiungere sezioni alla dashboard controlla il file 'app/admin/dashboard.rb'"
+      welcome: "Benvenuti in Active Admin. Questa è la pagina dashboard di default."
+    delete: "Rimuovi"
+    delete_confirmation: "Sei sicuro di volerlo rimuovere?"
+    delete_model: "Rimuovi %{model}"
+    details: "Dettagli %{model}"
+    devise:
+      change_password:
+        submit: "Cambia la mia password"
+        title: "Cambia la tua password"
+      email:
+        title: "Email"
+      links:
+        forgot_your_password: "Dimenticato la password?"
+        resend_confirmation_instructions: "Invia di nuovo le istruzioni per la conferma"
+        resend_unlock_instructions: "Invia di nuovo le istruzioni per lo sblocco"
+        sign_in: "Entra"
+        sign_in_with_omniauth_provider: "Collegati a %{provider}"
+        sign_up: "Iscriviti"
+      login:
+        remember_me: "Ricordami"
+        submit: "Entra"
+        title: "Entra"
+      password:
+        title: "Password"
+      password_confirmation:
+        title: "Conferma password"
+      resend_confirmation_instructions:
+        submit: "Invia di nuovo le istruzioni per la conferma"
+        title: "Invia di nuovo le istruzioni per la conferma"
+      reset_password:
+        submit: "Reimposta la tua password"
+        title: "Dimenticato la password?"
+      sign_up:
+        submit: "Iscriviti"
+        title: "Iscriviti"
+      subdomain:
+        title: "Sottodominio"
+      unlock:
+        submit: "Invia di nuovo le istruzioni per sbloccare"
+        title: "Invia di nuovo le istruzioni per sbloccare"
+      username:
+        title: "Nome Utente"
+    download: "Scarica:"
+    dropdown_actions:
+      button_label: "Azioni"
+    edit: "Modifica"
+    edit_model: "Modifica %{model}"
+    empty: "Vuoto"
+    filters:
+      buttons:
+        clear: "Rimuovi filtri"
+        filter: "Filtra"
+      predicates:
+        contains: "Contiene"
+        ends_with: "Finisce con"
+        equals: "Uguale a"
+        from: "Da"
+        greater_than: "Maggiore di"
+        gteq_datetime: "Maggiore o uguale a"
+        less_than: "Minore di"
+        lteq_datetime: "Minore o uguale a"
+        starts_with: "Inizia con"
+        to: "A"
+    has_many_delete: "Rimuovi"
+    has_many_new: "Aggiungi nuovo/a %{model}"
+    has_many_remove: "Rimuovi"
+    index_list:
+      block: "Lista"
+      blog: "Blog"
+      grid: "Griglia"
+      table: "Tabella"
+    logout: "Esci"
+    main_content: "Devi implemetare %{model}#main_content per mostrarne il contenuto."
+    move: "Sposta"
+    new_model: "Aggiungi %{model}"
+    next: "Prossimo"
+    pagination:
+      empty: "Nessun %{model} trovato"
+      entry:
+        one: "voce"
+        other: "voci"
+      multiple: "Sto mostrando %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> di <b>%{total}</b> in totale"
+      multiple_without_total: "Sto mostrando %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      one: "Sto mostrando <b>1</b> %{model}"
+      one_page: "Sto mostrando <b>%{n}</b> %{model}. Lista completa."
+      per_page: "Oggetti per pagina: "
+    powered_by: "Powered by %{active_admin} %{version}"
+    previous: "Precedente"
+    scopes:
+      all: "Tutti"
+    search_status:
+      current_filters: "Filtri attivi:"
+      current_scope: "Contesto selezionato:"
+      headline: "Situazione filtri:"
+      no_current_filters: "Nessuno"
+    sidebars:
+      filters: "Filtri"
+      search_status: "Informazioni sulla ricerca"
+    status_tag:
+      "no": "No"
+      "unset": "No"
+      "yes": "Sì"
+    unsupported_browser:
+      headline: "Avviso: ActiveAdmin non supporta Internet Explorer 8 o inferiore"
+      recommendation: "Ti raccomandiamo di aggiornare alla versione più recente di <a href=\"http://windows.microsoft.com/ie\">Internet Explorer</a>, <a href=\"https://chrome.google.com/\">Google Chrome</a>, o <a href=\"https://mozilla.org/firefox/\">Firefox</a>."
+      turn_off_compatibility_view: "Se stai utilizzando Internet Explorer 9 o successivo, assicurati di <a href=\"https://support.microsoft.com/it-it/help/17471\">disabilitare la \"Modalità Compatibilità\"</a>."
+    view: "Mostra"
   activerecord:
-    models:
-      comment:
-        one: "Commento"
-        other: "Commenti"
-      active_admin/comment:
-        one: "Commento"
-        other: "Commenti"
     attributes:
       active_admin/comment:
         author_type: "Tipo di Autore"
@@ -15,148 +153,10 @@ it:
         namespace: "Namespace"
         resource_type: "Tipo di risorsa"
         updated_at: "Aggiornato il"
-  active_admin:
-    dashboard: Dashboard
-    dashboard_welcome:
-      welcome: "Benvenuti in Active Admin. Questa è la pagina dashboard di default."
-      call_to_action: "Per aggiungere sezioni alla dashboard controlla il file 'app/admin/dashboard.rb'"
-    view: "Mostra"
-    edit: "Modifica"
-    delete: "Rimuovi"
-    delete_confirmation: "Sei sicuro di volerlo rimuovere?"
-    create_another: "Crea un altro %{model}"
-    new_model: "Aggiungi %{model}"
-    edit_model: "Modifica %{model}"
-    delete_model: "Rimuovi %{model}"
-    details: "Dettagli %{model}"
-    cancel: "Annulla"
-    empty: "Vuoto"
-    previous: "Precedente"
-    next: "Prossimo"
-    download: "Scarica:"
-    has_many_new: "Aggiungi nuovo/a %{model}"
-    has_many_delete: "Rimuovi"
-    has_many_remove: "Rimuovi"
-    move: "Sposta"
-    filters:
-      buttons:
-        filter: "Filtra"
-        clear: "Rimuovi filtri"
-      predicates:
-        contains: "Contiene"
-        equals: "Uguale a"
-        starts_with: "Inizia con"
-        ends_with: "Finisce con"
-        greater_than: "Maggiore di"
-        less_than: "Minore di"
-        gteq_datetime: "Maggiore o uguale a"
-        lteq_datetime: "Minore o uguale a"
-        from: "Da"
-        to: "A"
-    scopes:
-      all: "Tutti"
-    search_status:
-      headline: "Situazione filtri:"
-      current_scope: "Contesto selezionato:"
-      current_filters: "Filtri attivi:"
-      no_current_filters: "Nessuno"
-    status_tag:
-      "yes": "Sì"
-      "no": "No"
-      "unset": "No"
-    main_content: "Devi implemetare %{model}#main_content per mostrarne il contenuto."
-    logout: "Esci"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filtri"
-      search_status: "Informazioni sulla ricerca"
-    pagination:
-      empty: "Nessun %{model} trovato"
-      one: "Sto mostrando <b>1</b> %{model}"
-      one_page: "Sto mostrando <b>%{n}</b> %{model}. Lista completa."
-      multiple: "Sto mostrando %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> di <b>%{total}</b> in totale"
-      multiple_without_total: "Sto mostrando %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      per_page: "Oggetti per pagina: "
-      entry:
-        one: "voce"
-        other: "voci"
-    any: "Qualsiasi"
-    blank_slate:
-      content: "Non sono presenti %{resource_name}"
-      link: "Crea nuovo/a"
-    dropdown_actions:
-      button_label: "Azioni"
-    batch_actions:
-      button_label: "Azioni multiple"
-      default_confirmation: "Sei sicuro di che voler proseguire?"
-      delete_confirmation: "Sei sicuro di volere cancellare %{plural_model}?"
-      succesfully_destroyed:
-        one: "Eliminato con successo 1 %{model}"
-        other: "Eliminati con successo %{count} %{plural_model}"
-      selection_toggle_explanation: "(cambia selezione)"
-      action_label: "%{title} Selezionati"
-      labels:
-        destroy: "Elimina"
-    comments:
-      created_at: "Creato il"
-      resource_type: "Tipo di risorsa"
-      author_type: "Tipo di Autore"
-      body: "Corpo"
-      author: "Autore"
-      add: "Aggiungi Commento"
-      delete: "Cancella Commento"
-      delete_confirmation: "Sei sicuro di voler cancellare questo commento?"
-      resource: "Risorsa"
-      no_comments_yet: "Nessun commento."
-      author_missing: "Anonimo"
-      title_content: "Commenti (%{count})"
-      errors:
-        empty_text: "Il commento non può essere salvato, il testo è vuoto."
-    devise:
-      username:
-        title: "Nome Utente"
-      email:
-        title: "Email"
-      subdomain:
-        title: "Sottodominio"
-      password:
-        title: "Password"
-      password_confirmation:
-        title: "Conferma password"
-      sign_up:
-        title: "Iscriviti"
-        submit: "Iscriviti"
-      login:
-        title: "Entra"
-        remember_me: "Ricordami"
-        submit: "Entra"
-      reset_password:
-        title: "Dimenticato la password?"
-        submit: "Reimposta la tua password"
-      change_password:
-        title: "Cambia la tua password"
-        submit: "Cambia la mia password"
-      unlock:
-        title: "Invia di nuovo le istruzioni per sbloccare"
-        submit: "Invia di nuovo le istruzioni per sbloccare"
-      resend_confirmation_instructions:
-        title: "Invia di nuovo le istruzioni per la conferma"
-        submit: "Invia di nuovo le istruzioni per la conferma"
-      links:
-        sign_up: "Iscriviti"
-        sign_in: "Entra"
-        forgot_your_password: "Dimenticato la password?"
-        sign_in_with_omniauth_provider: "Collegati a %{provider}"
-        resend_unlock_instructions: "Invia di nuovo le istruzioni per lo sblocco"
-        resend_confirmation_instructions: "Invia di nuovo le istruzioni per la conferma"
-    unsupported_browser:
-      headline: "Avviso: ActiveAdmin non supporta Internet Explorer 8 o inferiore"
-      recommendation: "Ti raccomandiamo di aggiornare alla versione più recente di <a href=\"http://windows.microsoft.com/ie\">Internet Explorer</a>, <a href=\"https://chrome.google.com/\">Google Chrome</a>, o <a href=\"https://mozilla.org/firefox/\">Firefox</a>."
-      turn_off_compatibility_view: "Se stai utilizzando Internet Explorer 9 o successivo, assicurati di <a href=\"https://support.microsoft.com/it-it/help/17471\">disabilitare la \"Modalità Compatibilità\"</a>."
-    access_denied:
-      message: "Non hai le autorizzazioni necessarie per eseguire questa azione."
-    index_list:
-      table: "Tabella"
-      block: "Lista"
-      grid: "Griglia"
-      blog: "Blog"
+    models:
+      active_admin/comment:
+        one: "Commento"
+        other: "Commenti"
+      comment:
+        one: "Commento"
+        other: "Commenti"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,141 +1,141 @@
 ja:
   active_admin:
-    dashboard: "ダッシュボード"
-    dashboard_welcome:
-      welcome: "Active Admin へようこそ。ダッシュボードの初期ページを表示しています。"
-      call_to_action: "ダッシュボードに項目を追加するために 'app/admin/dashboard.rb' を編集してください。"
-    view: "閲覧"
-    edit: "編集"
-    delete: "削除"
-    delete_confirmation: "本当に削除しますか？"
-    create_another: "%{model} を続けて作成する"
-    new_model: "%{model} を作成する"
-    edit_model: "%{model} を編集する"
-    delete_model: "%{model} を削除する"
-    details: "%{model} の詳細"
-    cancel: "取り消す"
-    empty: "空"
-    previous: "前"
-    next: "次"
-    download: "ダウンロード:"
-    has_many_new: "%{model} を追加する"
-    has_many_delete: "削除する"
-    has_many_remove: "削除する"
-    filters:
-      buttons:
-        filter: "絞り込む"
-        clear: "条件を削除する"
-      predicates:
-        contains: "を含む"
-        equals: "等しい"
-        starts_with: "で始まる"
-        ends_with: "で終わる"
-        greater_than: "より大きい"
-        less_than: "より小さい"
-        gteq_datetime: "以上"
-        lteq_datetime: "以下"
-        from: "開始"
-        to: "終了"
-    search_status:
-      headline: "検索条件:"
-      current_scope: "範囲:"
-      current_filters: "現在の絞り込み:"
-      no_current_filters: "なし"
-    status_tag:
-      "yes": "はい"
-      "no": "いいえ"
-      "unset": "いいえ"
-    main_content: "内容を表示するために %{model}#main_content を実装してください。"
-    logout: "ログアウト"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "検索条件"
-      search_status: "検索状態"
-    pagination:
-      empty: "%{model} は見つかりませんでした"
-      one: "<b>1</b> 件の %{model} を表示しています"
-      one_page: "<b>全 %{n}</b> 件の %{model} を表示しています"
-      multiple: "全 <b>%{total}</b> 件中 <b>%{from}&nbsp;-&nbsp;%{to}</b> 件の %{model} を表示しています"
-      multiple_without_total: "<b>%{from}&nbsp;-&nbsp;%{to}</b> 件の %{model} を表示しています"
-      per_page: "表示件数: "
-      entry:
-        one: "レコード"
-        other: "レコード"
+    access_denied:
+      message: "アクションを実行する権限がありません"
     any: "任意"
-    blank_slate:
-      content: "%{resource_name} はまだありません。"
-      link: "作成する"
-    dropdown_actions:
-      button_label: "操作"
     batch_actions:
+      action_label: "選択した行を%{title}"
       button_label: "一括操作"
       default_confirmation: "本当によろしいですか？"
       delete_confirmation: "%{plural_model} を削除してもよろしいですか？"
+      labels:
+        destroy: "削除する"
+      selection_toggle_explanation: "(選択)"
       succesfully_destroyed:
         one: "1件の %{model} を削除しました"
         other: "%{count}件の %{plural_model} を削除しました"
-      selection_toggle_explanation: "(選択)"
-      action_label: "選択した行を%{title}"
-      labels:
-        destroy: "削除する"
+    blank_slate:
+      content: "%{resource_name} はまだありません。"
+      link: "作成する"
+    cancel: "取り消す"
     comments:
-      created_at: "作成日"
-      resource_type: "リソース種別"
+      add: "コメントを追加"
+      author: "作成者"
+      author_missing: "匿名ユーザ"
       author_type: "作成者種別"
       body: "本文"
-      author: "作成者"
-      add: "コメントを追加"
+      created_at: "作成日"
       delete: "コメントを削除"
       delete_confirmation: "本当にコメントを削除しますか？"
-      resource: "リソース"
-      no_comments_yet: "コメントはまだありません。"
-      author_missing: "匿名ユーザ"
-      title_content: "コメント (%{count})"
       errors:
         empty_text: "テキストが空のため、コメントは保存されませんでした。"
+      no_comments_yet: "コメントはまだありません。"
+      resource: "リソース"
+      resource_type: "リソース種別"
+      title_content: "コメント (%{count})"
+    create_another: "%{model} を続けて作成する"
+    dashboard: "ダッシュボード"
+    dashboard_welcome:
+      call_to_action: "ダッシュボードに項目を追加するために 'app/admin/dashboard.rb' を編集してください。"
+      welcome: "Active Admin へようこそ。ダッシュボードの初期ページを表示しています。"
+    delete: "削除"
+    delete_confirmation: "本当に削除しますか？"
+    delete_model: "%{model} を削除する"
+    details: "%{model} の詳細"
     devise:
-      username:
-        title: "ユーザ名"
+      change_password:
+        submit: "パスワードを変更する"
+        title: "パスワードを変更する"
       email:
         title: "メールアドレス"
-      subdomain:
-        title: "サブドメイン"
-      password:
-        title: "パスワード"
-      sign_up:
-        title: "登録"
-        submit: "登録"
-      login:
-        title: "ログイン"
-        remember_me: "次回から自動的にログイン"
-        submit: "ログイン"
-      reset_password:
-        title: "パスワードをお忘れですか？"
-        submit: "パスワードをリセットする"
-      change_password:
-        title: "パスワードを変更する"
-        submit: "パスワードを変更する"
-      unlock:
-        title: "ロックの解除方法を送る"
-        submit: "ロックの解除方法を送る"
-      resend_confirmation_instructions:
-        title: "確認方法を再送信する"
-        submit: "確認方法を再送信する"
       links:
-        sign_in: "サインイン"
-        sign_up: "ユーザ登録"
         forgot_your_password: "パスワードをお忘れですか？"
-        sign_in_with_omniauth_provider: "%{provider}のアカウントを使ってログイン"
         resend_confirmation_instructions: "ユーザ確認手順を再送する"
         resend_unlock_instructions: "ロックの解除方法を再送する"
+        sign_in: "サインイン"
+        sign_in_with_omniauth_provider: "%{provider}のアカウントを使ってログイン"
+        sign_up: "ユーザ登録"
+      login:
+        remember_me: "次回から自動的にログイン"
+        submit: "ログイン"
+        title: "ログイン"
+      password:
+        title: "パスワード"
+      resend_confirmation_instructions:
+        submit: "確認方法を再送信する"
+        title: "確認方法を再送信する"
+      reset_password:
+        submit: "パスワードをリセットする"
+        title: "パスワードをお忘れですか？"
+      sign_up:
+        submit: "登録"
+        title: "登録"
+      subdomain:
+        title: "サブドメイン"
+      unlock:
+        submit: "ロックの解除方法を送る"
+        title: "ロックの解除方法を送る"
+      username:
+        title: "ユーザ名"
+    download: "ダウンロード:"
+    dropdown_actions:
+      button_label: "操作"
+    edit: "編集"
+    edit_model: "%{model} を編集する"
+    empty: "空"
+    filters:
+      buttons:
+        clear: "条件を削除する"
+        filter: "絞り込む"
+      predicates:
+        contains: "を含む"
+        ends_with: "で終わる"
+        equals: "等しい"
+        from: "開始"
+        greater_than: "より大きい"
+        gteq_datetime: "以上"
+        less_than: "より小さい"
+        lteq_datetime: "以下"
+        starts_with: "で始まる"
+        to: "終了"
+    has_many_delete: "削除する"
+    has_many_new: "%{model} を追加する"
+    has_many_remove: "削除する"
+    index_list:
+      block: "リスト"
+      blog: "ブログ"
+      grid: "グリッド"
+      table: "テーブル"
+    logout: "ログアウト"
+    main_content: "内容を表示するために %{model}#main_content を実装してください。"
+    new_model: "%{model} を作成する"
+    next: "次"
+    pagination:
+      empty: "%{model} は見つかりませんでした"
+      entry:
+        one: "レコード"
+        other: "レコード"
+      multiple: "全 <b>%{total}</b> 件中 <b>%{from}&nbsp;-&nbsp;%{to}</b> 件の %{model} を表示しています"
+      multiple_without_total: "<b>%{from}&nbsp;-&nbsp;%{to}</b> 件の %{model} を表示しています"
+      one: "<b>1</b> 件の %{model} を表示しています"
+      one_page: "<b>全 %{n}</b> 件の %{model} を表示しています"
+      per_page: "表示件数: "
+    powered_by: "Powered by %{active_admin} %{version}"
+    previous: "前"
+    search_status:
+      current_filters: "現在の絞り込み:"
+      current_scope: "範囲:"
+      headline: "検索条件:"
+      no_current_filters: "なし"
+    sidebars:
+      filters: "検索条件"
+      search_status: "検索状態"
+    status_tag:
+      "no": "いいえ"
+      "unset": "いいえ"
+      "yes": "はい"
     unsupported_browser:
       headline: "ActiveAdminは、Internet Explorer 8以下はサポートはしていません。"
       recommendation: "最新版の<a href=\"http://windows.microsoft.com/ie\">Internet Explorer</a>、<a href=\"https://chrome.google.com/\">Google Chrome</a>、もしくは<a href=\"https://mozilla.org/firefox/\">Firefox</a>を使うことを推奨します。"
       turn_off_compatibility_view: "Internet Explorer 9以降を使っている場合、<a href=\"https://support.microsoft.com/ja-jp/help/17471\">互換表示をオフ</a>にしてください。"
-    access_denied:
-      message: "アクションを実行する権限がありません"
-    index_list:
-      table: "テーブル"
-      block: "リスト"
-      grid: "グリッド"
-      blog: "ブログ"
+    view: "閲覧"

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -1,120 +1,120 @@
 ko:
   active_admin:
-    dashboard: "대시보드"
-    dashboard_welcome:
-      welcome: "ActiveAdmin에 오신 것을 환영합니다. 기본 대시보드 페이지 입니다."
-      call_to_action: "대시보드에 섹션을 추가하시려면 'app/admin/dashboard.rb' 파일을 수정하십시오."
-    view: "보기"
-    edit: "수정"
-    delete: "삭제"
-    delete_confirmation: "정말로 삭제 하시겠습니까?"
-    new_model: "%{model} 추가"
-    edit_model: "%{model} 수정"
-    delete_model: "%{model} 삭제"
-    details: "%{model} 상세보기"
-    cancel: "취소"
-    empty: "내용이 없습니다"
-    previous: "이전"
-    next: "다음"
-    download: "다운로드:"
-    has_many_new: "%{model} 추가"
-    has_many_delete: "삭제"
-    has_many_remove: "삭제"
-    filters:
-      buttons:
-        filter: "필터"
-        clear: "필터 초기화"
-      predicates:
-        contains: "포함하는 문구"
-        equals: "일치하는 문구"
-        starts_with: "시작하는 문구"
-        ends_with: "종료하는 문구"
-        greater_than: "초과"
-        less_than: "미만"
-    search_status:
-      headline: "검색 상태:"
-      current_scope: "검색 범위:"
-      current_filters: "적용된 필터:"
-      no_current_filters: "현재 적용된 필터가 없습니다"
-    status_tag:
-      "yes": "있음"
-      "no": "없음"
-      "unset": "없음"
-    main_content: "내용을 보시려면 %{model}#main_content의 코드를 먼저 구현해 주시기 바랍니다."
-    logout: "로그아웃"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "필터 목록"
-      search_status: "검색 상태"
-    pagination:
-      empty: "%{model} 이/가 없습니다."
-      one: "<b>1</b>개 %{model} 표시중"
-      one_page: "<b>%{n}</b>개 %{model} 표시중"
-      multiple: "<b>%{total}</b>개 중 <b>%{from}&nbsp;-&nbsp;%{to}</b> %{model} 표시중"
-      multiple_without_total: "<b>%{from}&nbsp;-&nbsp;%{to}</b> %{model} 표시중"
-      entry:
-        one: "항목"
-        other: "항목들"
     any: "어떤"
-    blank_slate:
-      content: "아직 %{resource_name} 이/가 없습니다."
-      link: "추가하기"
-    dropdown_actions:
-      button_label: "작업"
     batch_actions:
+      action_label: "선택한 항목 %{title}"
       button_label: "배치 작업"
       default_confirmation: "확실하십니까?"
       delete_confirmation: "%{plural_model}을/를 삭제하시겠습니까?"
+      labels:
+        destroy: "삭제"
+      selection_toggle_explanation: "(선택 항목 바꾸기)"
       succesfully_destroyed:
         one: "성공적으로 1개 %{model}을/를 삭제하였습니다"
         other: "성공적으로 %{count}개의 %{plural_model}을/를 삭제하였습니다"
-      selection_toggle_explanation: "(선택 항목 바꾸기)"
-      action_label: "선택한 항목 %{title}"
-      labels:
-        destroy: "삭제"
+    blank_slate:
+      content: "아직 %{resource_name} 이/가 없습니다."
+      link: "추가하기"
+    cancel: "취소"
     comments:
-      created_at: "작성시간"
-      resource_type: "첨부파일 형태"
+      add: "댓글 추가"
+      author: "글쓴이"
       author_type: "글쓴이 종류"
       body: "내용"
-      author: "글쓴이"
-      add: "댓글 추가"
-      resource: "첨부파일"
-      no_comments_yet: "아직 댓글이 없습니다."
-      title_content: "댓글 (%{count})"
+      created_at: "작성시간"
       errors:
         empty_text: "댓글이 저장되지 않았습니다. 내용을 입력해주세요."
+      no_comments_yet: "아직 댓글이 없습니다."
+      resource: "첨부파일"
+      resource_type: "첨부파일 형태"
+      title_content: "댓글 (%{count})"
+    dashboard: "대시보드"
+    dashboard_welcome:
+      call_to_action: "대시보드에 섹션을 추가하시려면 'app/admin/dashboard.rb' 파일을 수정하십시오."
+      welcome: "ActiveAdmin에 오신 것을 환영합니다. 기본 대시보드 페이지 입니다."
+    delete: "삭제"
+    delete_confirmation: "정말로 삭제 하시겠습니까?"
+    delete_model: "%{model} 삭제"
+    details: "%{model} 상세보기"
     devise:
-      username:
-        title: "아이디"
+      change_password:
+        submit: "내 비밀번호 변경"
+        title: "비밀번호 변경"
       email:
         title: "이메일"
-      subdomain:
-        title: "서브도메인"
-      password:
-        title: "비밀번호"
-      sign_up:
-        title: "가입하기"
-        submit: "가입하기"
+      links:
+        forgot_your_password: "비밀번호를 잊으셨나요?"
+        resend_confirmation_instructions: "계정 승인 요청하기"
+        resend_unlock_instructions: "계정 잠금 해제하기"
+        sign_in: "로그인"
+        sign_in_with_omniauth_provider: "%{provider} 으로 로그인"
       login:
-        title: "로그인"
         remember_me: "내 계정 정보 기억"
         submit: "로그인"
-      reset_password:
-        title: "비밀번호를 잊으셨나요?"
-        submit: "비밀번호 재설정"
-      change_password:
-        title: "비밀번호 변경"
-        submit: "내 비밀번호 변경"
-      unlock:
-        title: "계정 잠금 해제하기"
-        submit: "계정 잠금 해제하기"
+        title: "로그인"
+      password:
+        title: "비밀번호"
       resend_confirmation_instructions:
-        title: "계정 승인 요청하기"
         submit: "계정 승인 요청하기"
-      links:
-        sign_in: "로그인"
-        forgot_your_password: "비밀번호를 잊으셨나요?"
-        sign_in_with_omniauth_provider: "%{provider} 으로 로그인"
-        resend_unlock_instructions: "계정 잠금 해제하기"
-        resend_confirmation_instructions: "계정 승인 요청하기"
+        title: "계정 승인 요청하기"
+      reset_password:
+        submit: "비밀번호 재설정"
+        title: "비밀번호를 잊으셨나요?"
+      sign_up:
+        submit: "가입하기"
+        title: "가입하기"
+      subdomain:
+        title: "서브도메인"
+      unlock:
+        submit: "계정 잠금 해제하기"
+        title: "계정 잠금 해제하기"
+      username:
+        title: "아이디"
+    download: "다운로드:"
+    dropdown_actions:
+      button_label: "작업"
+    edit: "수정"
+    edit_model: "%{model} 수정"
+    empty: "내용이 없습니다"
+    filters:
+      buttons:
+        clear: "필터 초기화"
+        filter: "필터"
+      predicates:
+        contains: "포함하는 문구"
+        ends_with: "종료하는 문구"
+        equals: "일치하는 문구"
+        greater_than: "초과"
+        less_than: "미만"
+        starts_with: "시작하는 문구"
+    has_many_delete: "삭제"
+    has_many_new: "%{model} 추가"
+    has_many_remove: "삭제"
+    logout: "로그아웃"
+    main_content: "내용을 보시려면 %{model}#main_content의 코드를 먼저 구현해 주시기 바랍니다."
+    new_model: "%{model} 추가"
+    next: "다음"
+    pagination:
+      empty: "%{model} 이/가 없습니다."
+      entry:
+        one: "항목"
+        other: "항목들"
+      multiple: "<b>%{total}</b>개 중 <b>%{from}&nbsp;-&nbsp;%{to}</b> %{model} 표시중"
+      multiple_without_total: "<b>%{from}&nbsp;-&nbsp;%{to}</b> %{model} 표시중"
+      one: "<b>1</b>개 %{model} 표시중"
+      one_page: "<b>%{n}</b>개 %{model} 표시중"
+    powered_by: "Powered by %{active_admin} %{version}"
+    previous: "이전"
+    search_status:
+      current_filters: "적용된 필터:"
+      current_scope: "검색 범위:"
+      headline: "검색 상태:"
+      no_current_filters: "현재 적용된 필터가 없습니다"
+    sidebars:
+      filters: "필터 목록"
+      search_status: "검색 상태"
+    status_tag:
+      "no": "없음"
+      "unset": "없음"
+      "yes": "있음"
+    view: "보기"

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -1,142 +1,142 @@
 lt:
   active_admin:
-    dashboard: Valdymo skydelis
-    dashboard_welcome:
-      welcome: "Sveiki atvykę į Active Admin. Tai yra numatytasis valdymo skydelis."
-      call_to_action: 'Norėdami pridėti skydelyje skyrius, žiūrėkite app/admin/dashboard.rb'
-    view: 'Žiūrėti'
-    edit: 'Redaguoti'
-    delete: 'Šalinti'
-    delete_confirmation: 'Ar jūs tikrai norite tai pašalinti?'
-    new_model: 'Naujas %{model}'
-    edit_model: 'Redaguoti %{model}'
-    delete_model: 'Pašalinti %{model}'
-    details: '%{model} Informacija'
-    cancel: 'Atšaukti'
-    empty: 'Tuščia'
-    previous: 'Atgal'
-    next: 'Toliau'
-    download: 'Atsisiųsti'
-    has_many_new: 'Pridėti naują %{model}'
-    has_many_delete: 'Šalinti'
-    has_many_remove: 'Pašalinti'
-    filters:
-      buttons:
-        filter: 'Filtras'
-        clear: 'Išvalyti filtrus'
-      predicates:
-        contains: "Sudėtyje yra"
-        equals: 'lygus'
-        starts_with: "Prasideda nuo"
-        ends_with: "Baigiasi"
-        greater_than: 'didesnis nei'
-        less_than: 'mažiau nei'
-        gteq_datetime: "daugiau arba lygu nei"
-        lteq_datetime: "mažiau arba lygu nei"
-        from: "Nuo"
-        to: "Iki"
-    search_status:
-      headline: "Paieškos būsena:"
-      current_scope: "Apimtis:"
-      current_filters: "Esami filtrai:"
-      no_current_filters: "nėra"
-    status_tag:
-      "yes": "Taip"
-      "no": "Nėra"
-      "unset": "Nėra"
-    main_content: 'Prašome realizuoti %{model}#main_content turiniui vaizduoti.'
-    logout: 'Išeiti'
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: 'Filtrai'
-      search_status: "Paieškos būsena"
-    pagination:
-      empty: '%{model} nerastas'
-      one: 'Rodoma <B> 1 </ b> %{model}'
-      one_page: 'Rodoma <b>visi %{n} </ b> %{model}'
-      multiple: 'Rodomi %{model} <b>%{from}&nbsp;-&nbsp;%{to} </ b> iš<b>%{total} </ b> iš viso'
-      multiple_without_total: 'Rodomi %{model} <b>%{from}&nbsp;-&nbsp;%{to} </ b> '
-      per_page: "Puslapyje: "
-      entry:
-        one: 'įrašas'
-        other: 'įrašai'
+    access_denied:
+      message: 'Jūs nesate įgaliotas atlikti šį veiksmą.'
     any: 'Bet kokia'
-    blank_slate:
-      content: 'Nėra %{resource_name}.'
-      link: 'Sukurti'
-    dropdown_actions:
-      button_label: "Veiksmai"
     batch_actions:
+      action_label: '%{title} Pasirinkta'
       button_label: 'Veiksmai su pažymėtais'
       default_confirmation: 'Ar jūs tikrai norite tai padaryti?'
       delete_confirmation: 'Ar jūs tikrai norite pašalinti šiuos %{plural_model}?'
+      labels:
+        destroy: 'Šalinti'
+      selection_toggle_explanation: '(Žymėti)'
       succesfully_destroyed:
         one: 'Sėkmingai pašalintas 1 %{model}'
         other: 'Sėkmingai pašalinti %{count} %{plural_model}'
-      selection_toggle_explanation: '(Žymėti)'
-      action_label: '%{title} Pasirinkta'
-      labels:
-        destroy: 'Šalinti'
+    blank_slate:
+      content: 'Nėra %{resource_name}.'
+      link: 'Sukurti'
+    cancel: 'Atšaukti'
     comments:
-      created_at: "Sukurta"
-      resource_type: 'Resurso Tipas'
+      add: 'Pridėti komentarą'
+      author: 'Autorius'
+      author_missing: 'Anonimas'
       author_type: 'Autoriaus Tipas'
       body: 'Įrašas'
-      author: 'Autorius'
-      add: 'Pridėti komentarą'
+      created_at: "Sukurta"
       delete: "Trinti komentarą"
       delete_confirmation: "Ar tikrai norite ištrinti šį komentarą?"
-      resource: 'Išteklių'
-      no_comments_yet: 'Dar nėra komentarų.'
-      author_missing: 'Anonimas'
-      title_content: 'Komentarai (%{count})'
       errors:
         empty_text: 'Komentaras neišsaugotas, tekstas buvo tuščias.'
+      no_comments_yet: 'Dar nėra komentarų.'
+      resource: 'Išteklių'
+      resource_type: 'Resurso Tipas'
+      title_content: 'Komentarai (%{count})'
+    dashboard: Valdymo skydelis
+    dashboard_welcome:
+      call_to_action: 'Norėdami pridėti skydelyje skyrius, žiūrėkite app/admin/dashboard.rb'
+      welcome: "Sveiki atvykę į Active Admin. Tai yra numatytasis valdymo skydelis."
+    delete: 'Šalinti'
+    delete_confirmation: 'Ar jūs tikrai norite tai pašalinti?'
+    delete_model: 'Pašalinti %{model}'
+    details: '%{model} Informacija'
     devise:
-      username:
-        title: 'Vartotojo Vardas'
+      change_password:
+        submit: 'Pakeisti mano slaptažodį'
+        title: 'Slaptažodžio Keitimas'
       email:
         title: 'El. paštas'
-      subdomain:
-        title: 'Subdomenas'
+      links:
+        forgot_your_password: 'Pamiršote slaptažodį?'
+        resend_confirmation_instructions: "Persiųsti patvirtinimo instrukcijas"
+        resend_unlock_instructions: "Persiųsti pakartotinio atrakinimo instrukcijas"
+        sign_in: 'Prisijungti'
+        sign_in_with_omniauth_provider: 'Prisijungti su %{provider}'
+        sign_up: "Užsiregistruoti"
+      login:
+        remember_me: 'Prisiminti Mane'
+        submit: 'Prisijungti'
+        title: 'Prisijungimas'
       password:
         title: 'Slaptažodis'
       password_confirmation:
         title: "Pakartokite slaptažodį"
-      sign_up:
-        title: 'Registracija'
-        submit: 'Užsiregistruoti'
-      login:
-        title: 'Prisijungimas'
-        remember_me: 'Prisiminti Mane'
-        submit: 'Prisijungti'
-      reset_password:
-        title: 'Pamiršote slaptažodį?'
-        submit: 'Sukurti Naują Slaptažodį'
-      change_password:
-        title: 'Slaptažodžio Keitimas'
-        submit: 'Pakeisti mano slaptažodį'
-      unlock:
-        title: 'Pakartotinio Atrakinimo Instrukcijos'
-        submit: 'Pakartotinai siųsti atrakinimo instrukcijas'
       resend_confirmation_instructions:
-        title: 'Patvirtinimo Instrukcijos'
         submit: 'Siųsti patvirtinimo instrukcijas'
-      links:
-        sign_up: "Užsiregistruoti"
-        sign_in: 'Prisijungti'
-        forgot_your_password: 'Pamiršote slaptažodį?'
-        sign_in_with_omniauth_provider: 'Prisijungti su %{provider}'
-        resend_unlock_instructions: "Persiųsti pakartotinio atrakinimo instrukcijas"
-        resend_confirmation_instructions: "Persiųsti patvirtinimo instrukcijas"
+        title: 'Patvirtinimo Instrukcijos'
+      reset_password:
+        submit: 'Sukurti Naują Slaptažodį'
+        title: 'Pamiršote slaptažodį?'
+      sign_up:
+        submit: 'Užsiregistruoti'
+        title: 'Registracija'
+      subdomain:
+        title: 'Subdomenas'
+      unlock:
+        submit: 'Pakartotinai siųsti atrakinimo instrukcijas'
+        title: 'Pakartotinio Atrakinimo Instrukcijos'
+      username:
+        title: 'Vartotojo Vardas'
+    download: 'Atsisiųsti'
+    dropdown_actions:
+      button_label: "Veiksmai"
+    edit: 'Redaguoti'
+    edit_model: 'Redaguoti %{model}'
+    empty: 'Tuščia'
+    filters:
+      buttons:
+        clear: 'Išvalyti filtrus'
+        filter: 'Filtras'
+      predicates:
+        contains: "Sudėtyje yra"
+        ends_with: "Baigiasi"
+        equals: 'lygus'
+        from: "Nuo"
+        greater_than: 'didesnis nei'
+        gteq_datetime: "daugiau arba lygu nei"
+        less_than: 'mažiau nei'
+        lteq_datetime: "mažiau arba lygu nei"
+        starts_with: "Prasideda nuo"
+        to: "Iki"
+    has_many_delete: 'Šalinti'
+    has_many_new: 'Pridėti naują %{model}'
+    has_many_remove: 'Pašalinti'
+    index_list:
+      block: "Sąrašas"
+      blog: "Blog"
+      grid: "Tinklelis"
+      table: "Lentelė"
+    logout: 'Išeiti'
+    main_content: 'Prašome realizuoti %{model}#main_content turiniui vaizduoti.'
+    new_model: 'Naujas %{model}'
+    next: 'Toliau'
+    pagination:
+      empty: '%{model} nerastas'
+      entry:
+        one: 'įrašas'
+        other: 'įrašai'
+      multiple: 'Rodomi %{model} <b>%{from}&nbsp;-&nbsp;%{to} </ b> iš<b>%{total} </ b> iš viso'
+      multiple_without_total: 'Rodomi %{model} <b>%{from}&nbsp;-&nbsp;%{to} </ b> '
+      one: 'Rodoma <B> 1 </ b> %{model}'
+      one_page: 'Rodoma <b>visi %{n} </ b> %{model}'
+      per_page: "Puslapyje: "
+    powered_by: "Powered by %{active_admin} %{version}"
+    previous: 'Atgal'
+    search_status:
+      current_filters: "Esami filtrai:"
+      current_scope: "Apimtis:"
+      headline: "Paieškos būsena:"
+      no_current_filters: "nėra"
+    sidebars:
+      filters: 'Filtrai'
+      search_status: "Paieškos būsena"
+    status_tag:
+      "no": "Nėra"
+      "unset": "Nėra"
+      "yes": "Taip"
     unsupported_browser:
       headline: "Atkreipiame dėmesį, kad ActiveAdmin nebepalaiko Internet Explorer 8 arba žemesnių versijų."
       recommendation: "Rekomenduojame atsinaujinti į naujausią <a href=\"http://windows.microsoft.com/ie\">Internet Explorer</a>, <a href=\"https://chrome.google.com/\">Google Chrome</a>, arba <a href=\"https://mozilla.org/firefox/\">Firefox</a>."
       turn_off_compatibility_view: "Jei naudojate IE 9 ar vėlesnę versiją, įsitikinkite kad <a href=\"http://windows.microsoft.com/en-US/windows7/webpages-look-incorrect-in-Internet-Explorer\">išjungėte \"Suderinamumo rodinį\"</a>."
-    access_denied:
-      message: 'Jūs nesate įgaliotas atlikti šį veiksmą.'
-    index_list:
-      table: "Lentelė"
-      block: "Sąrašas"
-      grid: "Tinklelis"
-      blog: "Blog"
+    view: 'Žiūrėti'

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -1,92 +1,92 @@
 lv:
   active_admin:
-    dashboard: Panelis
-    dashboard_welcome:
-      welcome: "Laipni lūgti Active Admin."
-      call_to_action: "Izmantojiet 'app/admin/dashboard.rb', lai pievienotu sadaļas panelim."
-    view: "Apskatīt"
-    edit: "Labot"
-    delete: "Dzēst"
-    delete_confirmation: "Vai Tu tiešām vēlies dzēst?"
-    new_model: "Pievienot '%{model}' ierakstu"
-    edit_model: "Labot '%{model}' ierakstu"
-    delete_model: "Dzēst '%{model}' ierakstu"
-    details: "Apraksts"
-    cancel: "Atcelt"
-    empty: "Tukšs"
-    previous: "Iepriekšējā"
-    next: "Nākošā"
-    download: "Lejuplādēt:"
-    has_many_new: "Pievienot jaunu '%{model}' ierakstu"
-    has_many_delete: "Dzēst"
-    has_many_remove: "Noņemt"
-    filters:
-      buttons:
-        filter: "Filtrēt"
-        clear: "Novākt filtrus"
-      predicates:
-        contains: "Satur"
-        equals: "Vienāds ar"
-        starts_with: "Sākas ar"
-        ends_with: "Beidzas ar"
-        greater_than: "Lielāks par"
-        less_than: "Mazāks par"
-    status_tag:
-      "yes": "Jā"
-      "no": "Nē"
-      "unset": "Nē"
-    main_content: "Lūdzu implementēt %{model}#main_content, lai rādītos saturs."
-    logout: "Iziet"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filtri"
-    pagination:
-      empty: "Nav ierakstu"
-      one: "<b>1</b> ieraksts"
-      one_page: "<b>%{n}</b> ieraksti"
-      multiple: "<b>%{from}&nbsp;-&nbsp;%{to}</b> ieraksti no <b>%{total}</b> kopā"
-      multiple_without_total: "<b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      entry:
-        one: "ieraksts"
-        other: "ieraksti"
     any: "Jebkurš"
-    blank_slate:
-      content: "Sadaļā '%{resource_name}' nav neviena ieraksta."
-      link: "Izveidot jaunu"
-    dropdown_actions:
-      button_label: "Actions"
     batch_actions:
+      action_label: "%{title} Selected"
       button_label: "Batch Actions"
       default_confirmation: "Vai tiešām vēlaties to darīt?"
       delete_confirmation: "Vai tiešām vēlaties dzēst šos %{plural_model}?"
+      labels:
+        destroy: "Delete"
+      selection_toggle_explanation: "(Toggle Selection)"
       succesfully_destroyed:
         one: "Successfully deleted 1 %{model}"
         other: "Successfully deleted %{count} %{plural_model}"
-      selection_toggle_explanation: "(Toggle Selection)"
-      action_label: "%{title} Selected"
-      labels:
-        destroy: "Delete"
+    blank_slate:
+      content: "Sadaļā '%{resource_name}' nav neviena ieraksta."
+      link: "Izveidot jaunu"
+    cancel: "Atcelt"
     comments:
-      body: "Saturs"
-      author: "Autors"
       add: "Pievienot komentāru"
-      resource: "Resurss"
-      no_comments_yet: "Nav neviena komentāra."
-      title_content: "Komentāri (%{count})"
+      author: "Autors"
+      body: "Saturs"
       errors:
         empty_text: "Komentārs netika saglabāts - nekas nav ierakstīts"
+      no_comments_yet: "Nav neviena komentāra."
+      resource: "Resurss"
+      title_content: "Komentāri (%{count})"
+    dashboard: Panelis
+    dashboard_welcome:
+      call_to_action: "Izmantojiet 'app/admin/dashboard.rb', lai pievienotu sadaļas panelim."
+      welcome: "Laipni lūgti Active Admin."
+    delete: "Dzēst"
+    delete_confirmation: "Vai Tu tiešām vēlies dzēst?"
+    delete_model: "Dzēst '%{model}' ierakstu"
+    details: "Apraksts"
     devise:
+      change_password:
+        submit: "Nomainīt savu paroli"
+        title: "Nomainīt paroli"
+      links:
+        forgot_your_password: "Aizmirsāt savu paroli?"
+        sign_in: "pierakstīties"
+        sign_in_with_omniauth_provider: "Pierakstieties ar %{provider}"
       login:
-        title: "Ielogojaties"
         remember_me: "atcerēties mani"
         submit: "Ielogojaties"
+        title: "Ielogojaties"
       reset_password:
-        title: "Aizmirsāt savu paroli?"
         submit: "Atjaunotu savu paroli"
-      change_password:
-        title: "Nomainīt paroli"
-        submit: "Nomainīt savu paroli"
-      links:
-        sign_in: "pierakstīties"
-        forgot_your_password: "Aizmirsāt savu paroli?"
-        sign_in_with_omniauth_provider: "Pierakstieties ar %{provider}"
+        title: "Aizmirsāt savu paroli?"
+    download: "Lejuplādēt:"
+    dropdown_actions:
+      button_label: "Actions"
+    edit: "Labot"
+    edit_model: "Labot '%{model}' ierakstu"
+    empty: "Tukšs"
+    filters:
+      buttons:
+        clear: "Novākt filtrus"
+        filter: "Filtrēt"
+      predicates:
+        contains: "Satur"
+        ends_with: "Beidzas ar"
+        equals: "Vienāds ar"
+        greater_than: "Lielāks par"
+        less_than: "Mazāks par"
+        starts_with: "Sākas ar"
+    has_many_delete: "Dzēst"
+    has_many_new: "Pievienot jaunu '%{model}' ierakstu"
+    has_many_remove: "Noņemt"
+    logout: "Iziet"
+    main_content: "Lūdzu implementēt %{model}#main_content, lai rādītos saturs."
+    new_model: "Pievienot '%{model}' ierakstu"
+    next: "Nākošā"
+    pagination:
+      empty: "Nav ierakstu"
+      entry:
+        one: "ieraksts"
+        other: "ieraksti"
+      multiple: "<b>%{from}&nbsp;-&nbsp;%{to}</b> ieraksti no <b>%{total}</b> kopā"
+      multiple_without_total: "<b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      one: "<b>1</b> ieraksts"
+      one_page: "<b>%{n}</b> ieraksti"
+    powered_by: "Powered by %{active_admin} %{version}"
+    previous: "Iepriekšējā"
+    sidebars:
+      filters: "Filtri"
+    status_tag:
+      "no": "Nē"
+      "unset": "Nē"
+      "yes": "Jā"
+    view: "Apskatīt"

--- a/config/locales/mk.yml
+++ b/config/locales/mk.yml
@@ -1,134 +1,134 @@
 mk:
-  activerecord:
-    models:
-      comment:
-        one: "Коментар"
-        other: "Коментари"
-      active_admin/comment:
-        one: "Коментар"
-        other: "Коментари"
   active_admin:
-    dashboard: "Почетна"
-    dashboard_welcome:
-      welcome: "Добредојдовте во Active Admin. Ова е стандардна верзија на почетната страна."
-      call_to_action: "За да додадете секции на почетната страна, прегледајте го 'app/admin/dashboard.rb'."
-    view: "Прегледај"
-    edit: "Измени"
-    delete: "Избриши"
-    delete_confirmation: "Дали сте сигурни дека сакате да го избришете записот?"
-    create_another: "Креирај нов %{model}"
-    new_model: "Додај нов %{model}"
-    edit_model: "Измени %{model}"
-    delete_model: "Избриши %{model}"
-    details: "Детали за %{model}"
-    cancel: "Откажи"
-    empty: "Празно"
-    previous: "Претходно"
-    next: "Следно"
-    download: "Преземи во понудените формати:"
-    has_many_new: "Додај нов %{model}"
-    has_many_delete: "Избриши"
-    has_many_remove: "Отстрани"
-    move: "Премести"
-    filters:
-      buttons:
-        filter: "Пребарај"
-        clear: "Исчисти филтри"
-      predicates:
-        contains: "Содржи"
-        equals: "Е еднакво со"
-        starts_with: "Започнува со"
-        ends_with: "Завршува сo"
-        greater_than: "Е поголемо од"
-        less_than: "Е помало од"
-        gteq_datetime: "Е поголемо или еднакво со"
-        lteq_datetime: "Е помало или еднакво со"
-        from: "Од"
-        to: "До"
-    search_status:
-      headline: "Пронајдени резултати:"
-      current_filters: "Резултати врз основа на следниве филтри:"
-      no_current_filters: "Моментално нема филтри"
-    status_tag:
-      "yes": "Да"
-      "no": "Не"
-      "unset": "Не"
-    main_content: "Ве замолуваме имплементирајте %{model}#main_content за да прикажете содржина."
-    logout: "Одјави се"
-    powered_by: "Овозможено од %{active_admin} %{version}"
-    sidebars:
-      filters: "Филтри за пребарување"
-      search_status: "Резултати од пребарување"
-    pagination:
-      empty: "Нема пронајдени записи за %{model}"
-      one: "Прикажан <b>1</b> %{model}"
-      one_page: "Прикажани <b>сите %{n}</b> %{model}"
-      multiple: "Прикажани %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> од вкупно <b>%{total}</b>"
-      multiple_without_total: "Прикажани %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      per_page: "Прикази на записи по страна:"
-      entry:
-        one: "запис"
-        other: "записи"
+    access_denied:
+      message: "Немате овластување да ја извршите оваа активност."
     any: "Било кој"
-    blank_slate:
-      content: "Не се креирани записи од типот на %{resource_name}."
-      link: "Креирај нов"
-    dropdown_actions:
-      button_label: "Активности"
     batch_actions:
+      action_label: "%{title} го селектираното"
       button_label: "Групни активности"
       default_confirmation: "Дали сте сигурни?"
       delete_confirmation: "Дали сте сигурни дека сакате да ги избришете %{plural_model}?"
+      labels:
+        destroy: "Избриши"
+      selection_toggle_explanation: "(Toggle Selection)"
       succesfully_destroyed:
         one: "Успешно е избришан 1 %{model}"
         other: "Успешно се избришани %{count} %{plural_model}"
-      selection_toggle_explanation: "(Toggle Selection)"
-      action_label: "%{title} го селектираното"
-      labels:
-        destroy: "Избриши"
+    blank_slate:
+      content: "Не се креирани записи од типот на %{resource_name}."
+      link: "Креирај нов"
+    cancel: "Откажи"
+    create_another: "Креирај нов %{model}"
+    dashboard: "Почетна"
+    dashboard_welcome:
+      call_to_action: "За да додадете секции на почетната страна, прегледајте го 'app/admin/dashboard.rb'."
+      welcome: "Добредојдовте во Active Admin. Ова е стандардна верзија на почетната страна."
+    delete: "Избриши"
+    delete_confirmation: "Дали сте сигурни дека сакате да го избришете записот?"
+    delete_model: "Избриши %{model}"
+    details: "Детали за %{model}"
     devise:
-      username:
-        title: "Корисничко име"
+      change_password:
+        submit: "Промени лозинка"
+        title: "Променете ја лозинката"
       email:
         title: "Е-маил"
+      links:
+        forgot_your_password: "Ја заборавивте Вашата лозинка?"
+        resend_confirmation_instructions: "Повторно испрати инструкции за потврдување на профил"
+        resend_unlock_instructions: "Повторно испрати инструкции за отклучување на профил"
+        sign_in: "Најави се"
+        sign_in_with_omniauth_provider: "Најави се со %{provider}"
+        sign_up: "Креирај профил"
+      login:
+        remember_me: "Запомни ме"
+        submit: "Најави се"
+        title: "Најави се"
       password:
         title: "Лозинка"
       password_confirmation:
         title: "Потврди Лозинка"
-      sign_up:
-        title: "Креирај профил"
-        submit: "Креирај"
-      login:
-        title: "Најави се"
-        remember_me: "Запомни ме"
-        submit: "Најави се"
-      reset_password:
-        title: "Ја заборавивте Вашата лозинка?"
-        submit: "Промени лозинка"
-      change_password:
-        title: "Променете ја лозинката"
-        submit: "Промени лозинка"
-      unlock:
-        title: "Повторно испраќање на инструкции за отклучување на профил"
-        submit: "Испрати инструкции"
       resend_confirmation_instructions:
-        title: "Повторно испраќање на инструкции за потврдување на профил"
         submit: "Инспрати инструкции"
-      links:
-        sign_up: "Креирај профил"
-        sign_in: "Најави се"
-        forgot_your_password: "Ја заборавивте Вашата лозинка?"
-        sign_in_with_omniauth_provider: "Најави се со %{provider}"
-        resend_unlock_instructions: "Повторно испрати инструкции за отклучување на профил"
-        resend_confirmation_instructions: "Повторно испрати инструкции за потврдување на профил"
+        title: "Повторно испраќање на инструкции за потврдување на профил"
+      reset_password:
+        submit: "Промени лозинка"
+        title: "Ја заборавивте Вашата лозинка?"
+      sign_up:
+        submit: "Креирај"
+        title: "Креирај профил"
+      unlock:
+        submit: "Испрати инструкции"
+        title: "Повторно испраќање на инструкции за отклучување на профил"
+      username:
+        title: "Корисничко име"
+    download: "Преземи во понудените формати:"
+    dropdown_actions:
+      button_label: "Активности"
+    edit: "Измени"
+    edit_model: "Измени %{model}"
+    empty: "Празно"
+    filters:
+      buttons:
+        clear: "Исчисти филтри"
+        filter: "Пребарај"
+      predicates:
+        contains: "Содржи"
+        ends_with: "Завршува сo"
+        equals: "Е еднакво со"
+        from: "Од"
+        greater_than: "Е поголемо од"
+        gteq_datetime: "Е поголемо или еднакво со"
+        less_than: "Е помало од"
+        lteq_datetime: "Е помало или еднакво со"
+        starts_with: "Започнува со"
+        to: "До"
+    has_many_delete: "Избриши"
+    has_many_new: "Додај нов %{model}"
+    has_many_remove: "Отстрани"
+    index_list:
+      block: "Листа"
+      blog: "Блог"
+      grid: "Грид"
+      table: "Табела"
+    logout: "Одјави се"
+    main_content: "Ве замолуваме имплементирајте %{model}#main_content за да прикажете содржина."
+    move: "Премести"
+    new_model: "Додај нов %{model}"
+    next: "Следно"
+    pagination:
+      empty: "Нема пронајдени записи за %{model}"
+      entry:
+        one: "запис"
+        other: "записи"
+      multiple: "Прикажани %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> од вкупно <b>%{total}</b>"
+      multiple_without_total: "Прикажани %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      one: "Прикажан <b>1</b> %{model}"
+      one_page: "Прикажани <b>сите %{n}</b> %{model}"
+      per_page: "Прикази на записи по страна:"
+    powered_by: "Овозможено од %{active_admin} %{version}"
+    previous: "Претходно"
+    search_status:
+      current_filters: "Резултати врз основа на следниве филтри:"
+      headline: "Пронајдени резултати:"
+      no_current_filters: "Моментално нема филтри"
+    sidebars:
+      filters: "Филтри за пребарување"
+      search_status: "Резултати од пребарување"
+    status_tag:
+      "no": "Не"
+      "unset": "Не"
+      "yes": "Да"
     unsupported_browser:
       headline: "Ве замолуваме, имајте во предвид дека ActiveAdmin не нуди поддршка за Internet Explorer 8 верзијата или претходни верзии."
       recommendation: "Ви порачуваме да го <a href=\"http://browsehappy.com/\"> ажурирате Вашиот пребарувач</a> за да си го подобрите пребарувањето."
       turn_off_compatibility_view: "Доколку користите IE 9 или понова верзија, Ве замолуваме <a href=\"https://support.microsoft.com/en-us/help/17471\">да исклучите \"Compatibility View\"</a>."
-    access_denied:
-      message: "Немате овластување да ја извршите оваа активност."
-    index_list:
-      table: "Табела"
-      block: "Листа"
-      grid: "Грид"
-      blog: "Блог"
+    view: "Прегледај"
+  activerecord:
+    models:
+      active_admin/comment:
+        one: "Коментар"
+        other: "Коментари"
+      comment:
+        one: "Коментар"
+        other: "Коментари"

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -1,130 +1,130 @@
 nb:
   active_admin:
-    dashboard: Oversikt
-    dashboard_welcome:
-      welcome: "Velkommen til Active Admin. Dette er standardoversiktssiden."
-      call_to_action: "Rediger 'app/admin/dashboard.rb' for å legge til elementer i oversikten."
-    view: "Vis"
-    edit: "Rediger"
-    delete: "Slett"
-    delete_confirmation: "Er du sikker på at du vil slette denne?"
-    new_model: "Ny %{model}"
-    edit_model: "Rediger %{model}"
-    delete_model: "Slett %{model}"
-    details: "%{model} Detaljer"
-    cancel: "Avbryt"
-    empty: "Tom"
-    previous: "Forrige"
-    next: "Neste"
-    download: "Last ned:"
-    has_many_new: "Legg til ny %{model}"
-    has_many_delete: "Slett"
-    has_many_remove: "Fjern"
-    filters:
-      buttons:
-        filter: "Filter"
-        clear: "Fjern filter"
-      predicates:
-        contains: "Inneholder"
-        equals: "Er lik"
-        starts_with: "Starter med"
-        ends_with: "Slutter med"
-        greater_than: "Større enn"
-        less_than: "Mindre enn"
-        gteq_datetime: "Større enn eller lik"
-        lteq_datetime: "Mindre enn eller lik"
-        from: "Fra"
-        to: "Til"
-    search_status:
-      headline: "Søkestatus:"
-      current_scope: "Søkeområde:"
-      current_filters: "Gjeldende filtre:"
-      no_current_filters: "Ingen"
-    status_tag:
-      "yes": "Ja"
-      "no": "Nei"
-      "unset": "Nei"
-    main_content: "Vennligst implementer %{model}#main_content for å vise innhold."
-    logout: "Logg ut"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filtere"
-    pagination:
-      empty: "Fant ingen %{model}"
-      one: "Viser <b>1</b> %{model}"
-      one_page: "Viser <b>alle %{n}</b> %{model}"
-      multiple: "Viser %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> av <b>%{total}</b> totalt"
-      multiple_without_total: "Viser %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      entry:
-        one: "innslag"
-        other: "innslag"
+    access_denied:
+      message: "Du er ikke autorisert til å utføre denne handlingen."
     any: "Alle"
-    blank_slate:
-      content: "Her er det ingen %{resource_name} enda."
-      link: "Opprett en"
-    dropdown_actions:
-      button_label: "Handlinger"
     batch_actions:
+      action_label: "%{title} valgt"
       button_label: "Gruppehandlinger"
       delete_confirmation: "Er du sikker på at du vil slette disse %{plural_model}? Dette kan ikke reverseres."
+      labels:
+        destroy: "Slett"
+      selection_toggle_explanation: "(Toggle Selection)"
       succesfully_destroyed:
         one: "Slettet én %{model}"
         other: "Slettet %{count} %{plural_model}"
-      selection_toggle_explanation: "(Toggle Selection)"
-      action_label: "%{title} valgt"
-      labels:
-        destroy: "Slett"
+    blank_slate:
+      content: "Her er det ingen %{resource_name} enda."
+      link: "Opprett en"
+    cancel: "Avbryt"
     comments:
-      created_at: "Opprettet"
-      resource_type: "Ressurstype"
+      add: "Legg til kommentar"
+      author: "Forfatter"
+      author_missing: "Anonym"
       author_type: "Forfattertype"
       body: "Brødtekst"
-      author: "Forfatter"
-      add: "Legg til kommentar"
+      created_at: "Opprettet"
       delete: "Slett kommentar"
       delete_confirmation: "Er du sikker på at du ønsker å slette kommentaren?"
-      resource: "Ressurs"
-      no_comments_yet: "Ingen kommentarer ennå."
-      author_missing: "Anonym"
-      title_content: "Kommentarer (%{count})"
       errors:
         empty_text: "Kommentar ble ikke lagret, teksten var tom."
+      no_comments_yet: "Ingen kommentarer ennå."
+      resource: "Ressurs"
+      resource_type: "Ressurstype"
+      title_content: "Kommentarer (%{count})"
+    dashboard: Oversikt
+    dashboard_welcome:
+      call_to_action: "Rediger 'app/admin/dashboard.rb' for å legge til elementer i oversikten."
+      welcome: "Velkommen til Active Admin. Dette er standardoversiktssiden."
+    delete: "Slett"
+    delete_confirmation: "Er du sikker på at du vil slette denne?"
+    delete_model: "Slett %{model}"
+    details: "%{model} Detaljer"
     devise:
-      username:
-        title: "Brukernavn"
+      change_password:
+        submit: "Endre mitt passord"
+        title: "Endre passordet"
       email:
         title: "E-post"
-      subdomain:
-        title: "Subdomene"
-      password:
-        title: "Passord"
-      sign_up:
-        title: "Opprett brukerkonto"
-        submit: "Opprett"
+      links:
+        forgot_your_password: "Glemt passord?"
+        sign_in: "Logg inn"
+        sign_in_with_omniauth_provider: "Logg på med %{provider}"
       login:
-        title: "Innlogging"
         remember_me: "Husk meg"
         submit: "Logg inn"
-      reset_password:
-        title: "Glemt passord?"
-        submit: "Tilbakestille passordet mitt"
-      change_password:
-        title: "Endre passordet"
-        submit: "Endre mitt passord"
-      unlock:
-        title: "Send info om gjenoppretting på nytt"
-        submit: "Send info om gjenoppretting på nytt"
+        title: "Innlogging"
+      password:
+        title: "Passord"
       resend_confirmation_instructions:
-        title: "Send bekreftelsesinformasjon på nytt"
         submit: "Send bekreftelsesinformasjon på nytt"
-      links:
-        sign_in: "Logg inn"
-        forgot_your_password: "Glemt passord?"
-        sign_in_with_omniauth_provider: "Logg på med %{provider}"
-    access_denied:
-      message: "Du er ikke autorisert til å utføre denne handlingen."
+        title: "Send bekreftelsesinformasjon på nytt"
+      reset_password:
+        submit: "Tilbakestille passordet mitt"
+        title: "Glemt passord?"
+      sign_up:
+        submit: "Opprett"
+        title: "Opprett brukerkonto"
+      subdomain:
+        title: "Subdomene"
+      unlock:
+        submit: "Send info om gjenoppretting på nytt"
+        title: "Send info om gjenoppretting på nytt"
+      username:
+        title: "Brukernavn"
+    download: "Last ned:"
+    dropdown_actions:
+      button_label: "Handlinger"
+    edit: "Rediger"
+    edit_model: "Rediger %{model}"
+    empty: "Tom"
+    filters:
+      buttons:
+        clear: "Fjern filter"
+        filter: "Filter"
+      predicates:
+        contains: "Inneholder"
+        ends_with: "Slutter med"
+        equals: "Er lik"
+        from: "Fra"
+        greater_than: "Større enn"
+        gteq_datetime: "Større enn eller lik"
+        less_than: "Mindre enn"
+        lteq_datetime: "Mindre enn eller lik"
+        starts_with: "Starter med"
+        to: "Til"
+    has_many_delete: "Slett"
+    has_many_new: "Legg til ny %{model}"
+    has_many_remove: "Fjern"
     index_list:
-      table: "Tabell"
       block: "Liste"
-      grid: "Gitter"
       blog: "Blogg"
+      grid: "Gitter"
+      table: "Tabell"
+    logout: "Logg ut"
+    main_content: "Vennligst implementer %{model}#main_content for å vise innhold."
+    new_model: "Ny %{model}"
+    next: "Neste"
+    pagination:
+      empty: "Fant ingen %{model}"
+      entry:
+        one: "innslag"
+        other: "innslag"
+      multiple: "Viser %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> av <b>%{total}</b> totalt"
+      multiple_without_total: "Viser %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      one: "Viser <b>1</b> %{model}"
+      one_page: "Viser <b>alle %{n}</b> %{model}"
+    powered_by: "Powered by %{active_admin} %{version}"
+    previous: "Forrige"
+    search_status:
+      current_filters: "Gjeldende filtre:"
+      current_scope: "Søkeområde:"
+      headline: "Søkestatus:"
+      no_current_filters: "Ingen"
+    sidebars:
+      filters: "Filtere"
+    status_tag:
+      "no": "Nei"
+      "unset": "Nei"
+      "yes": "Ja"
+    view: "Vis"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,144 +1,144 @@
 nl:
   active_admin:
-    dashboard: Dashboard
-    dashboard_welcome:
-      welcome: "Welkom bij Active Admin. Dit is de standaard dashboard pagina"
-      call_to_action: "Pas uw eigen dashboard aan in het bestand 'app/admin/dashboard.rb'"
-    view: "Bekijk"
-    edit: "Wijzig"
-    delete: "Verwijder"
-    delete_confirmation: "Weet u zeker dat je dit item wilt verwijderen?"
-    create_another: "Maak nog een %{model}"
-    new_model: "Nieuwe %{model}"
-    edit_model: "Wijzig %{model}"
-    delete_model: "Verwijder %{model}"
-    details: "%{model} details"
-    cancel: "Annuleren"
-    empty: "Leeg"
-    previous: "Vorige"
-    next: "Volgende"
-    download: "Download"
-    has_many_new: "Voeg nieuwe %{model} toe"
-    has_many_delete: "Verwijderen"
-    has_many_remove: "Verwijderen"
-    move: "Verplaats"
-    filters:
-      buttons:
-        filter: "Filter"
-        clear: "Maak Filters Ongedaan"
-      predicates:
-        contains: "Bevat"
-        equals: "Gelijk aan"
-        starts_with: "Begint met"
-        ends_with: "Eindigt op"
-        greater_than: "Groter dan"
-        less_than: "Kleiner dan"
-        from: Van
-        gteq_datetime: Groter of gelijk aan
-        lteq_datetime: Kleiner of gelijk aan
-        to: Tot
-    search_status:
-      current_scope: "Scope:"
-      current_filters: "Huidige filters:"
-      no_current_filters: "Geen"
-      headline: "Zoek status"
-    status_tag:
-      "yes": "Ja"
-      "no": "Geen"
-      "unset": "Geen"
-    main_content: "Implementeer %{model}#main_content om de content weer te geven."
-    logout: "Uitloggen"
-    powered_by: "Mogelijk gemaakt door %{active_admin} %{version}"
-    sidebars:
-      filters: "Filters"
-      search_status: "Zoek status"
-    pagination:
-      empty: "Geen %{model} gevonden"
-      one: "Geeft <b>1</b> %{model} weer"
-      one_page: "Geeft <b>%{n}</b> %{model} weer"
-      multiple: "Geeft %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> van de <b>%{total}</b> weer"
-      multiple_without_total: "Geeft %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      entry:
-        one: "entry"
-        other: "entries"
-      per_page: "Per pagina: "
+    access_denied:
+      message: "U bent niet gemachtigd voor deze actie."
     any: "Alle"
-    blank_slate:
-      content: "Er zijn geen %{resource_name} gevonden."
-      link: "Maak aan"
-    dropdown_actions:
-      button_label: "Acties"
     batch_actions:
+      action_label: "%{title} geselecteerde"
       button_label: "Batch acties"
       default_confirmation: "Weet u zeker dat u dit wilt doen?"
       delete_confirmation: "Weet u zeker dat u deze %{plural_model} wilt verwijderen?"
+      labels:
+        destroy: "Verwijder"
+      selection_toggle_explanation: "(Toggle selectie)"
       succesfully_destroyed:
         one: "1 %{model} verwijderd."
         other: "%{count} %{plural_model} verwijderd."
-      selection_toggle_explanation: "(Toggle selectie)"
-      action_label: "%{title} geselecteerde"
-      labels:
-        destroy: "Verwijder"
+    blank_slate:
+      content: "Er zijn geen %{resource_name} gevonden."
+      link: "Maak aan"
+    cancel: "Annuleren"
     comments:
-      created_at: 'Aangemaakt op'
-      resource_type: "Resource Type"
+      add: "Voeg commentaar toe"
+      author: "Auteur"
+      author_missing: "Anoniem"
       author_type: "Auteur Type"
       body: "Tekst"
-      author: "Auteur"
-      add: "Voeg commentaar toe"
+      created_at: 'Aangemaakt op'
       delete: 'Verwijder commentaar'
       delete_confirmation: "Weet u zeker dat u dit commentaar wilt verwijderen?"
-      resource: "Resource"
-      no_comments_yet: "Nog geen reacties."
-      author_missing: "Anoniem"
-      title_content: "Reacties (%{count})"
       errors:
         empty_text: "De reactie is niet opgeslagen, de tekst was leeg."
+      no_comments_yet: "Nog geen reacties."
+      resource: "Resource"
+      resource_type: "Resource Type"
+      title_content: "Reacties (%{count})"
+    create_another: "Maak nog een %{model}"
+    dashboard: Dashboard
+    dashboard_welcome:
+      call_to_action: "Pas uw eigen dashboard aan in het bestand 'app/admin/dashboard.rb'"
+      welcome: "Welkom bij Active Admin. Dit is de standaard dashboard pagina"
+    delete: "Verwijder"
+    delete_confirmation: "Weet u zeker dat je dit item wilt verwijderen?"
+    delete_model: "Verwijder %{model}"
+    details: "%{model} details"
     devise:
-      username:
-        title: "Gebruikersnaam"
+      change_password:
+        submit: "Mijn wachtwoord wijzigen"
+        title: "Wijzig uw wachtwoord"
       email:
         title: "Email"
-      subdomain:
-        title: "Subdomein"
+      links:
+        forgot_your_password: "Wachtwoord vergeten?"
+        resend_confirmation_instructions: "Bevestigingsinstructies opnieuw versturen"
+        resend_unlock_instructions: "Ontgrendelinstructies opnieuw versturen"
+        sign_in: "Meld u aan"
+        sign_in_with_omniauth_provider: "Log in met %{provider}"
+        sign_up: "Registreren"
+      login:
+        remember_me: "Onthoud mij"
+        submit: "inloggen"
+        title: "inloggen"
       password:
         title: "Wachtwoord"
       password_confirmation:
         title: "Bevestig password"
-      sign_up:
-        title: "Registreren"
-        submit: "Registreren"
-      login:
-        title: "inloggen"
-        remember_me: "Onthoud mij"
-        submit: "inloggen"
-      reset_password:
-        title: "Wachtwoord vergeten?"
-        submit: "Reset mijn wachtwoord"
-      change_password:
-        title: "Wijzig uw wachtwoord"
-        submit: "Mijn wachtwoord wijzigen"
-      unlock:
-        title: "Verstuur ontgrendelinstructies opnieuw"
-        submit: "Verstuur ontgrendelinstructies opnieuw"
       resend_confirmation_instructions:
-        title: "Verstuur bevestigingsinstructies opnieuw"
         submit: "Verstuur bevestigingsinstructies opnieuw"
-      links:
-        sign_up: "Registreren"
-        sign_in: "Meld u aan"
-        forgot_your_password: "Wachtwoord vergeten?"
-        sign_in_with_omniauth_provider: "Log in met %{provider}"
-        resend_unlock_instructions: "Ontgrendelinstructies opnieuw versturen"
-        resend_confirmation_instructions: "Bevestigingsinstructies opnieuw versturen"
+        title: "Verstuur bevestigingsinstructies opnieuw"
+      reset_password:
+        submit: "Reset mijn wachtwoord"
+        title: "Wachtwoord vergeten?"
+      sign_up:
+        submit: "Registreren"
+        title: "Registreren"
+      subdomain:
+        title: "Subdomein"
+      unlock:
+        submit: "Verstuur ontgrendelinstructies opnieuw"
+        title: "Verstuur ontgrendelinstructies opnieuw"
+      username:
+        title: "Gebruikersnaam"
+    download: "Download"
+    dropdown_actions:
+      button_label: "Acties"
+    edit: "Wijzig"
+    edit_model: "Wijzig %{model}"
+    empty: "Leeg"
+    filters:
+      buttons:
+        clear: "Maak Filters Ongedaan"
+        filter: "Filter"
+      predicates:
+        contains: "Bevat"
+        ends_with: "Eindigt op"
+        equals: "Gelijk aan"
+        from: Van
+        greater_than: "Groter dan"
+        gteq_datetime: Groter of gelijk aan
+        less_than: "Kleiner dan"
+        lteq_datetime: Kleiner of gelijk aan
+        starts_with: "Begint met"
+        to: Tot
+    has_many_delete: "Verwijderen"
+    has_many_new: "Voeg nieuwe %{model} toe"
+    has_many_remove: "Verwijderen"
+    index_list:
+      block: "Lijst"
+      blog: "Blog"
+      grid: "Rooster"
+      table: "Tabel"
+    logout: "Uitloggen"
+    main_content: "Implementeer %{model}#main_content om de content weer te geven."
+    move: "Verplaats"
+    new_model: "Nieuwe %{model}"
+    next: "Volgende"
+    pagination:
+      empty: "Geen %{model} gevonden"
+      entry:
+        one: "entry"
+        other: "entries"
+      multiple: "Geeft %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> van de <b>%{total}</b> weer"
+      multiple_without_total: "Geeft %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      one: "Geeft <b>1</b> %{model} weer"
+      one_page: "Geeft <b>%{n}</b> %{model} weer"
+      per_page: "Per pagina: "
+    powered_by: "Mogelijk gemaakt door %{active_admin} %{version}"
+    previous: "Vorige"
+    search_status:
+      current_filters: "Huidige filters:"
+      current_scope: "Scope:"
+      headline: "Zoek status"
+      no_current_filters: "Geen"
+    sidebars:
+      filters: "Filters"
+      search_status: "Zoek status"
+    status_tag:
+      "no": "Geen"
+      "unset": "Geen"
+      "yes": "Ja"
     unsupported_browser:
       headline: "Opgelet, ActiveAdmin bied geen support meer voor Internet Explorer 8 of lager"
       recommendation: "Wij raden aan om te upgraden naar de nieuwste <a href=\"http://windows.microsoft.com/ie\">Internet Explorer</a>, <a href=\"https://chrome.google.com/\">Google Chrome</a>, of <a href=\"https://mozilla.org/firefox/\">Firefox</a>."
       turn_off_compatibility_view: "Als u IE 9 of nieuwer gebruikt, zorg ervoor dat u <a href=\"https://support.microsoft.com/nl-nl/help/17471\"> \"Compatibility View\" uit zet</a>."
-    access_denied:
-      message: "U bent niet gemachtigd voor deze actie."
-    index_list:
-      table: "Tabel"
-      block: "Lijst"
-      grid: "Rooster"
-      blog: "Blog"
+    view: "Bekijk"

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -1,16 +1,152 @@
 pl:
+  active_admin:
+    access_denied:
+      message: "Nie masz uprawnień wystarczających do wykonania tej akcji."
+    any: "Jakikolwiek"
+    batch_actions:
+      action_label: "%{title} zaznaczone"
+      button_label: "Akcje na partiach"
+      default_confirmation: "Czy na pewno chcesz to zrobić?"
+      delete_confirmation: "Czy na pewno chcesz usunąć te %{plural_model}?"
+      labels:
+        destroy: "Usuń"
+      selection_toggle_explanation: "(Przełącz zaznaczenie)"
+      succesfully_destroyed:
+        few: "Poprawnie usunięto %{count} %{plural_model}"
+        many: "Poprawnie usunięto %{count} %{plural_model}"
+        one: "Poprawnie usunięto 1 %{model}"
+        other: "Poprawnie usunięto %{count} %{plural_model}"
+    blank_slate:
+      content: "Nie ma jeszcze zasobu %{resource_name}."
+      link: "Utwórz go"
+    cancel: "Anuluj"
+    comments:
+      add: "Dodaj komentarz"
+      author: "Autor"
+      author_missing: "Anonim"
+      author_type: "Typ autora"
+      body: "Treść"
+      created_at: "Utworzony"
+      delete: "Usuń komentarz"
+      delete_confirmation: "Czy na pewno chcesz usunąć ten komentarz?"
+      errors:
+        empty_text: "Komentarz nie został zapisany, zawartość była pusta."
+      no_comments_yet: "Nie ma jeszcze komentarzy."
+      resource: "Zasób"
+      resource_type: "Typ zasobu"
+      title_content: "Komentarze (%{count})"
+    create_another: "Utwórz kolejny %{model}"
+    dashboard: Pulpit
+    dashboard_welcome:
+      call_to_action: "Aby dodać sekcje do pulpitu, sprawdź 'app/admin/dashboard.rb'"
+      welcome: "Witaj w Active Adminie. To jest domyślny pulpit."
+    delete: "Usuń"
+    delete_confirmation: "Jesteś pewien, że chcesz to usunąć?"
+    delete_model: "Usuń %{model}"
+    details: "Szczegóły %{model}"
+    devise:
+      change_password:
+        submit: "Zmień hasło"
+        title: "Zmień hasło"
+      email:
+        title: "Email"
+      links:
+        forgot_your_password: "Nie pamiętasz hasła?"
+        resend_confirmation_instructions: "Ponownie wyślij instrukcje aktywacji"
+        resend_unlock_instructions: "Ponownie wyślij instrukcję odblokowania konta"
+        sign_in: "Zaloguj się"
+        sign_in_with_omniauth_provider: "Zaloguj się z %{provider}"
+        sign_up: "Zarejestruj się"
+      login:
+        remember_me: "Zapamiętaj mnie"
+        submit: "Zaloguj się"
+        title: "Logowanie"
+      password:
+        title: "Hasło"
+      password_confirmation:
+        title: "Powtórz hasło"
+      resend_confirmation_instructions:
+        submit: "Ponownie wyślij instrukcje aktywacji"
+        title: "Ponownie wyślij instrukcje aktywacji"
+      reset_password:
+        submit: "Zresetować hasło"
+        title: "Nie pamiętasz hasła?"
+      sign_up:
+        submit: "Zarejestruj się"
+        title: "Rejestracja"
+      subdomain:
+        title: "Subdomena"
+      unlock:
+        submit: "Ponownie wyślij instrukcję odblokowania konta"
+        title: "Ponownie wyślij instrukcję odblokowania konta"
+      username:
+        title: "Nazwa użytkownika"
+    download: "Pobierz:"
+    dropdown_actions:
+      button_label: "Akcje"
+    edit: "Edytuj"
+    edit_model: "Edytuj %{model}"
+    empty: "Pusty"
+    filters:
+      buttons:
+        clear: "Wyczyść Filtry"
+        filter: "Filtruj"
+      predicates:
+        contains: "Zawiera"
+        ends_with: "Kończy się"
+        equals: "Równe"
+        from: "Od"
+        greater_than: "Większe niż"
+        gteq_datetime: "Większe lub równe"
+        less_than: "Mniejsze niż"
+        lteq_datetime: "Mniejsze lub równe"
+        starts_with: "Zaczyna się"
+        to: "Do"
+    has_many_delete: "Usuń"
+    has_many_new: "Dodaj nowy %{model}"
+    has_many_remove: "Usuń"
+    index_list:
+      block: "Lista"
+      blog: "Blog"
+      grid: "Siatka"
+      table: "Tabela"
+    logout: "Wyloguj"
+    main_content: "Zaimplementuj %{model}#main_content aby wyświetlić treść."
+    move: "Przenieś"
+    new_model: "Nowy %{model}"
+    next: "Następna"
+    pagination:
+      empty: "Nie znaleziono %{model}"
+      entry:
+        one:
+        other:
+      multiple: "Wyświetlanie %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> z <b>%{total}</b>"
+      multiple_without_total: "Wyświetlanie %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      one: "Wyświetlanie <b>1</b> %{model}"
+      one_page: "Wyświetlanie <b>wszystkich %{n}</b> %{model}"
+      per_page: "Na stronę: "
+    powered_by: "Powered by %{active_admin} %{version}"
+    previous: "Poprzednia"
+    scopes:
+      all: "Wszystko"
+    search_status:
+      current_filters: "Aktywne filtry:"
+      current_scope: "Aktywny zakres:"
+      headline: "Status wyszukiwania:"
+      no_current_filters: "Brak"
+    sidebars:
+      filters: "Filtry"
+      search_status: "Status wyszukiwania"
+    status_tag:
+      "no": "Nie"
+      "unset": "Nie"
+      "yes": "Tak"
+    unsupported_browser:
+      headline: "ActiveAdmin nie wspiera przeglądarki Internet Explorer w wersjach 8 i niższych."
+      recommendation: "Polecamy <a href=\"http://browsehappy.com/\">aktualizację przeglądarki</a>."
+      turn_off_compatibility_view: "Jeśli używasz Internet Explorera w wersji 9 lub nowszej, upewnij się, że <a href=\"https://support.microsoft.com/en-us/help/17471\">\"tryb zgodności\" został wyłączony.</a>."
+    view: "Podgląd"
   activerecord:
-    models:
-      comment:
-        one: "Komentarz"
-        few: "Komentarze"
-        many: "Komentarzy"
-        other: "Komentarze"
-      active_admin/comment:
-        one: "Komentarz"
-        few: "Komentarze"
-        many: "Komentarzy"
-        other: "Komentarze"
     attributes:
       active_admin/comment:
         author_type: "Typ autora"
@@ -19,150 +155,14 @@ pl:
         namespace: "Namespace"
         resource_type: "Typ zasobu"
         updated_at: "Zaktualizowany"
-  active_admin:
-    dashboard: Pulpit
-    dashboard_welcome:
-      welcome: "Witaj w Active Adminie. To jest domyślny pulpit."
-      call_to_action: "Aby dodać sekcje do pulpitu, sprawdź 'app/admin/dashboard.rb'"
-    view: "Podgląd"
-    edit: "Edytuj"
-    delete: "Usuń"
-    delete_confirmation: "Jesteś pewien, że chcesz to usunąć?"
-    create_another: "Utwórz kolejny %{model}"
-    new_model: "Nowy %{model}"
-    edit_model: "Edytuj %{model}"
-    delete_model: "Usuń %{model}"
-    details: "Szczegóły %{model}"
-    cancel: "Anuluj"
-    empty: "Pusty"
-    previous: "Poprzednia"
-    next: "Następna"
-    download: "Pobierz:"
-    has_many_new: "Dodaj nowy %{model}"
-    has_many_delete: "Usuń"
-    has_many_remove: "Usuń"
-    move: "Przenieś"
-    filters:
-      buttons:
-        filter: "Filtruj"
-        clear: "Wyczyść Filtry"
-      predicates:
-        contains: "Zawiera"
-        equals: "Równe"
-        starts_with: "Zaczyna się"
-        ends_with: "Kończy się"
-        greater_than: "Większe niż"
-        less_than: "Mniejsze niż"
-        gteq_datetime: "Większe lub równe"
-        lteq_datetime: "Mniejsze lub równe"
-        from: "Od"
-        to: "Do"
-    scopes:
-      all: "Wszystko"
-    search_status:
-      headline: "Status wyszukiwania:"
-      current_scope: "Aktywny zakres:"
-      current_filters: "Aktywne filtry:"
-      no_current_filters: "Brak"
-    status_tag:
-      "yes": "Tak"
-      "no": "Nie"
-      "unset": "Nie"
-    main_content: "Zaimplementuj %{model}#main_content aby wyświetlić treść."
-    logout: "Wyloguj"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filtry"
-      search_status: "Status wyszukiwania"
-    pagination:
-      empty: "Nie znaleziono %{model}"
-      one: "Wyświetlanie <b>1</b> %{model}"
-      one_page: "Wyświetlanie <b>wszystkich %{n}</b> %{model}"
-      multiple: "Wyświetlanie %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> z <b>%{total}</b>"
-      multiple_without_total: "Wyświetlanie %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      per_page: "Na stronę: "
-      entry:
-        one:
-        other:
-    any: "Jakikolwiek"
-    blank_slate:
-      content: "Nie ma jeszcze zasobu %{resource_name}."
-      link: "Utwórz go"
-    dropdown_actions:
-      button_label: "Akcje"
-    batch_actions:
-      button_label: "Akcje na partiach"
-      default_confirmation: "Czy na pewno chcesz to zrobić?"
-      delete_confirmation: "Czy na pewno chcesz usunąć te %{plural_model}?"
-      succesfully_destroyed:
-        one: "Poprawnie usunięto 1 %{model}"
-        other: "Poprawnie usunięto %{count} %{plural_model}"
-        many: "Poprawnie usunięto %{count} %{plural_model}"
-        few: "Poprawnie usunięto %{count} %{plural_model}"
-      selection_toggle_explanation: "(Przełącz zaznaczenie)"
-      action_label: "%{title} zaznaczone"
-      labels:
-        destroy: "Usuń"
-    comments:
-      created_at: "Utworzony"
-      resource_type: "Typ zasobu"
-      author_type: "Typ autora"
-      body: "Treść"
-      author: "Autor"
-      add: "Dodaj komentarz"
-      delete: "Usuń komentarz"
-      delete_confirmation: "Czy na pewno chcesz usunąć ten komentarz?"
-      resource: "Zasób"
-      no_comments_yet: "Nie ma jeszcze komentarzy."
-      author_missing: "Anonim"
-      title_content: "Komentarze (%{count})"
-      errors:
-        empty_text: "Komentarz nie został zapisany, zawartość była pusta."
-    devise:
-      username:
-        title: "Nazwa użytkownika"
-      email:
-        title: "Email"
-      subdomain:
-        title: "Subdomena"
-      password:
-        title: "Hasło"
-      password_confirmation:
-        title: "Powtórz hasło"
-      sign_up:
-        title: "Rejestracja"
-        submit: "Zarejestruj się"
-      login:
-        title: "Logowanie"
-        remember_me: "Zapamiętaj mnie"
-        submit: "Zaloguj się"
-      reset_password:
-        title: "Nie pamiętasz hasła?"
-        submit: "Zresetować hasło"
-      change_password:
-        title: "Zmień hasło"
-        submit: "Zmień hasło"
-      unlock:
-        title: "Ponownie wyślij instrukcję odblokowania konta"
-        submit: "Ponownie wyślij instrukcję odblokowania konta"
-      resend_confirmation_instructions:
-        title: "Ponownie wyślij instrukcje aktywacji"
-        submit: "Ponownie wyślij instrukcje aktywacji"
-      links:
-        sign_up: "Zarejestruj się"
-        sign_in: "Zaloguj się"
-        forgot_your_password: "Nie pamiętasz hasła?"
-        sign_in_with_omniauth_provider: "Zaloguj się z %{provider}"
-        resend_unlock_instructions: "Ponownie wyślij instrukcję odblokowania konta"
-        resend_confirmation_instructions: "Ponownie wyślij instrukcje aktywacji"
-    unsupported_browser:
-      headline: "ActiveAdmin nie wspiera przeglądarki Internet Explorer w wersjach 8 i niższych."
-      recommendation: "Polecamy <a href=\"http://browsehappy.com/\">aktualizację przeglądarki</a>."
-      turn_off_compatibility_view: "Jeśli używasz Internet Explorera w wersji 9 lub nowszej, upewnij się, że <a href=\"https://support.microsoft.com/en-us/help/17471\">\"tryb zgodności\" został wyłączony.</a>."
-    access_denied:
-      message: "Nie masz uprawnień wystarczających do wykonania tej akcji."
-    index_list:
-      table: "Tabela"
-      block: "Lista"
-      grid: "Siatka"
-      blog: "Blog"
+    models:
+      active_admin/comment:
+        few: "Komentarze"
+        many: "Komentarzy"
+        one: "Komentarz"
+        other: "Komentarze"
+      comment:
+        few: "Komentarze"
+        many: "Komentarzy"
+        one: "Komentarz"
+        other: "Komentarze"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1,143 +1,143 @@
 pt-BR:
   active_admin:
-    dashboard: "Painel Administrativo"
-    dashboard_welcome:
-      welcome: "Bem vindo ao Active Admin. Esta é a página de painéis padrão."
-      call_to_action: "Para adicionar seções ao painel, verifique 'app/admin/dashboard.rb'"
-    view: "Visualizar"
-    edit: "Editar"
-    delete: "Remover"
-    delete_confirmation: "Você tem certeza que deseja remover este item?"
-    create_another: "Criar outro %{model}"
-    new_model: "Novo(a) %{model}"
-    edit_model: "Editar %{model}"
-    delete_model: "Remover %{model}"
-    details: "Detalhes do(a) %{model}"
-    cancel: "Cancelar"
-    empty: "Vazio"
-    previous: "Anterior"
-    next: "Próximo"
-    download: "Baixar:"
-    has_many_new: "Adicionar Novo(a) %{model}"
-    has_many_delete: "Remover"
-    has_many_remove: "Remover"
-    filters:
-      buttons:
-        filter: "Filtrar"
-        clear: "Limpar Filtros"
-      predicates:
-        contains: "Contém"
-        equals: "Igual A"
-        starts_with: "Começa com"
-        ends_with: "Termina com"
-        greater_than: "Maior Que"
-        less_than: "Menor Que"
-        gteq_datetime: "Maior ou igual a"
-        lteq_datetime: "Menor ou igual a"
-        from: "A partir de"
-        to: "Até"
-    search_status:
-      headline: "Buscou:"
-      current_scope: "Em:"
-      current_filters: "Filtros escolhidos:"
-      no_current_filters: "Nenhum"
-    status_tag:
-      "yes": "Sim"
-      "no": "Não"
-      "unset": "Não"
-    main_content: "Por favor implemente %{model}#main_content para exibir conteúdo."
-    logout: "Sair"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filtros"
-      search_status: "Buscou"
-    pagination:
-      empty: "Nenhum(a) %{model} encontrado(a)"
-      one: "Exibindo <b>1</b> %{model}"
-      one_page: "Exibindo <b>todos(as) os(as) %{n}</b> %{model}"
-      multiple: "Exibindo %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> de um total de <b>%{total}</b>"
-      multiple_without_total: "Exibindo %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      per_page: "Por página: "
-      entry:
-        one: "registro"
-        other: "registros"
+    access_denied:
+      message: "Você não tem permissão para realizar o solicitado"
     any: "Qualquer"
-    blank_slate:
-      content: "Não existem %{resource_name} ainda."
-      link: "Novo"
-    dropdown_actions:
-      button_label: "Ações"
     batch_actions:
+      action_label: "%{title} Selecionado"
       button_label: "Ações em lote"
       default_confirmation: "Tem certeza que quer fazer isso?"
       delete_confirmation: "Tem certeza que deseja excluir estes %{plural_model}?"
+      labels:
+        destroy: "Excluir"
+      selection_toggle_explanation: "(Alternar Seleção)"
       succesfully_destroyed:
         one: "Excluiu com sucesso 1 %{model}"
         other: "Excluiu com sucesso %{count} %{plural_model}"
-      selection_toggle_explanation: "(Alternar Seleção)"
-      action_label: "%{title} Selecionado"
-      labels:
-        destroy: "Excluir"
+    blank_slate:
+      content: "Não existem %{resource_name} ainda."
+      link: "Novo"
+    cancel: "Cancelar"
     comments:
-      created_at: "Criado em"
-      resource_type: "Tipo de Objeto"
+      add: "Adicionar Comentário"
+      author: "Autor"
+      author_missing: "Anônimo"
       author_type: "Tipo de Autor"
       body: "Conteúdo"
-      author: "Autor"
-      add: "Adicionar Comentário"
+      created_at: "Criado em"
       delete: "Deletar comentário"
       delete_confirmation: "Tem certeza que deseja excluir este comentário?"
-      resource: "Objeto"
-      no_comments_yet: "Nenhum comentário."
-      author_missing: "Anônimo"
-      title_content: "Comentários: %{count}"
       errors:
         empty_text: "O comentário não foi salvo porque o texto estava vazio."
+      no_comments_yet: "Nenhum comentário."
+      resource: "Objeto"
+      resource_type: "Tipo de Objeto"
+      title_content: "Comentários: %{count}"
+    create_another: "Criar outro %{model}"
+    dashboard: "Painel Administrativo"
+    dashboard_welcome:
+      call_to_action: "Para adicionar seções ao painel, verifique 'app/admin/dashboard.rb'"
+      welcome: "Bem vindo ao Active Admin. Esta é a página de painéis padrão."
+    delete: "Remover"
+    delete_confirmation: "Você tem certeza que deseja remover este item?"
+    delete_model: "Remover %{model}"
+    details: "Detalhes do(a) %{model}"
     devise:
-      username:
-        title: "Nome de Usuário"
+      change_password:
+        submit: "Troque minha senha"
+        title: "Troque sua senha"
       email:
         title: "E-mail"
-      subdomain:
-        title: "Subdomínio"
+      links:
+        forgot_your_password: "Esqueceu sua senha?"
+        resend_confirmation_instructions: "Reenviar instruções de confirmação"
+        resend_unlock_instructions: "Reenviar instruções de desbloqueio"
+        sign_in: "Entrar"
+        sign_in_with_omniauth_provider: "Entre com o %{provider}"
+        sign_up: "Criar conta"
+      login:
+        remember_me: "Lembrar da senha"
+        submit: "Entrar"
+        title: "Conta"
       password:
         title: "Senha"
       password_confirmation:
         title: "Confirmação de senha"
-      sign_up:
-        title: "Cadastre-se"
-        submit: "Continuar"
-      login:
-        title: "Conta"
-        remember_me: "Lembrar da senha"
-        submit: "Entrar"
-      reset_password:
-        title: "Esqueceu sua senha?"
-        submit: "Reinicie minha senha"
-      change_password:
-        title: "Troque sua senha"
-        submit: "Troque minha senha"
-      unlock:
-        title: "Reenviar instruções de desbloqueio"
-        submit: "Reenviar instruções de desbloqueio"
       resend_confirmation_instructions:
-        title: "Reenviar instruções de confirmação"
         submit: "Reenviar instruções de confirmação"
-      links:
-        sign_up: "Criar conta"
-        sign_in: "Entrar"
-        forgot_your_password: "Esqueceu sua senha?"
-        sign_in_with_omniauth_provider: "Entre com o %{provider}"
-        resend_unlock_instructions: "Reenviar instruções de desbloqueio"
-        resend_confirmation_instructions: "Reenviar instruções de confirmação"
+        title: "Reenviar instruções de confirmação"
+      reset_password:
+        submit: "Reinicie minha senha"
+        title: "Esqueceu sua senha?"
+      sign_up:
+        submit: "Continuar"
+        title: "Cadastre-se"
+      subdomain:
+        title: "Subdomínio"
+      unlock:
+        submit: "Reenviar instruções de desbloqueio"
+        title: "Reenviar instruções de desbloqueio"
+      username:
+        title: "Nome de Usuário"
+    download: "Baixar:"
+    dropdown_actions:
+      button_label: "Ações"
+    edit: "Editar"
+    edit_model: "Editar %{model}"
+    empty: "Vazio"
+    filters:
+      buttons:
+        clear: "Limpar Filtros"
+        filter: "Filtrar"
+      predicates:
+        contains: "Contém"
+        ends_with: "Termina com"
+        equals: "Igual A"
+        from: "A partir de"
+        greater_than: "Maior Que"
+        gteq_datetime: "Maior ou igual a"
+        less_than: "Menor Que"
+        lteq_datetime: "Menor ou igual a"
+        starts_with: "Começa com"
+        to: "Até"
+    has_many_delete: "Remover"
+    has_many_new: "Adicionar Novo(a) %{model}"
+    has_many_remove: "Remover"
+    index_list:
+      block: "Lista"
+      blog: "Blog"
+      grid: "Grid"
+      table: "Tabela"
+    logout: "Sair"
+    main_content: "Por favor implemente %{model}#main_content para exibir conteúdo."
+    new_model: "Novo(a) %{model}"
+    next: "Próximo"
+    pagination:
+      empty: "Nenhum(a) %{model} encontrado(a)"
+      entry:
+        one: "registro"
+        other: "registros"
+      multiple: "Exibindo %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> de um total de <b>%{total}</b>"
+      multiple_without_total: "Exibindo %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      one: "Exibindo <b>1</b> %{model}"
+      one_page: "Exibindo <b>todos(as) os(as) %{n}</b> %{model}"
+      per_page: "Por página: "
+    powered_by: "Powered by %{active_admin} %{version}"
+    previous: "Anterior"
+    search_status:
+      current_filters: "Filtros escolhidos:"
+      current_scope: "Em:"
+      headline: "Buscou:"
+      no_current_filters: "Nenhum"
+    sidebars:
+      filters: "Filtros"
+      search_status: "Buscou"
+    status_tag:
+      "no": "Não"
+      "unset": "Não"
+      "yes": "Sim"
     unsupported_browser:
       headline: "O ActiveAdmin não oferece suporte ao Internet Explorer versão 8 ou inferior."
       recommendation: "Nós recomendamos atualizar para a última versão do <a href=\"http://windows.microsoft.com/ie\">Internet Explorer</a>, <a href=\"https://chrome.google.com/\">Google Chrome</a>, ou <a href=\"https://mozilla.org/firefox/\">Firefox</a>."
       turn_off_compatibility_view: "Se você está usando o IE 9 ou superior, <a href=\"https://support.microsoft.com/pt-br/help/17471\">desligue o \"Modo de Exibição de Compatibilidade\"</a>."
-    access_denied:
-      message: "Você não tem permissão para realizar o solicitado"
-    index_list:
-      table: "Tabela"
-      block: "Lista"
-      grid: "Grid"
-      blog: "Blog"
+    view: "Visualizar"

--- a/config/locales/pt-PT.yml
+++ b/config/locales/pt-PT.yml
@@ -1,92 +1,92 @@
 "pt-PT":
   active_admin:
-    dashboard: "Painel de Administração"
-    dashboard_welcome:
-      welcome: "Bem-vindo ao Active Admin. Esta é a página padrão."
-      call_to_action: "Se pretende adicionar seções ao painel, consulte 'app/admin/dashboard.rb'"
-    view: "Visualizar"
-    edit: "Editar"
-    delete: "Remover"
-    delete_confirmation: "Não tem a certeza de que deseja remover este ítem?"
-    new_model: "Novo(a) %{model}"
-    edit_model: "Editar %{model}"
-    delete_model: "Remover %{model}"
-    details: "Detalhes do(a) %{model}"
-    cancel: "Cancelar"
-    empty: "Vazio"
-    previous: "Anterior"
-    next: "Próximo"
-    download: "Baixar:"
-    has_many_new: "Adicionar Novo(a) %{model}"
-    has_many_delete: "Remover"
-    has_many_remove: "Remover"
-    filters:
-      buttons:
-        filter: "Filtrar"
-        clear: "Limpar Filtros"
-      predicates:
-        contains: "Contém"
-        equals: "Igual A"
-        starts_with: "Começa com"
-        ends_with: "Termina com"
-        greater_than: "Maior Que"
-        less_than: "Menor Que"
-    status_tag:
-      "yes": "Sim"
-      "no": "Não"
-      "unset": "Não"
-    main_content: "Por favor implemente %{model}#main_content para mostrar o conteúdo."
-    logout: "Sair"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filtros"
-    pagination:
-      empty: "Nenhum(a) %{model} encontrado(a)"
-      one: "Mostrando <b>1</b> %{model}"
-      one_page: "Mostrando <b>todos(as) os(as) %{n}</b> %{model}"
-      multiple: "Mostrando %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> de um total de <b>%{total}</b>"
-      multiple_without_total: "Mostrando %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      entry:
-        one: "registro"
-        other: "registros"
     any: "Qualquer"
-    blank_slate:
-      content: "Ainda não existem %{resource_name}."
-      link: "Novo"
-    dropdown_actions:
-      button_label: "Ações"
     batch_actions:
+      action_label: "%{title} Selecionado"
       button_label: "Ações em quantidade"
       default_confirmation: "Tem a certeza que quer fazer isso?"
       delete_confirmation: "Tem a certeza de que deseja excluir estes %{plural_model}?"
+      labels:
+        destroy: "Excluir"
+      selection_toggle_explanation: "(Alternar Seleção)"
       succesfully_destroyed:
         one: "Excluiu com sucesso 1 %{model}"
         other: "Excluiu com sucesso %{count} %{plural_model}"
-      selection_toggle_explanation: "(Alternar Seleção)"
-      action_label: "%{title} Selecionado"
-      labels:
-        destroy: "Excluir"
+    blank_slate:
+      content: "Ainda não existem %{resource_name}."
+      link: "Novo"
+    cancel: "Cancelar"
     comments:
-      body: "Conteúdo"
-      author: "Autor"
       add: "Adicionar Comentário"
-      resource: "Objeto"
-      no_comments_yet: "Nenhum comentário."
-      title_content: "Comentários: %{count}"
+      author: "Autor"
+      body: "Conteúdo"
       errors:
         empty_text: "O comentário não foi guardado porque o texto estava vazio."
+      no_comments_yet: "Nenhum comentário."
+      resource: "Objeto"
+      title_content: "Comentários: %{count}"
+    dashboard: "Painel de Administração"
+    dashboard_welcome:
+      call_to_action: "Se pretende adicionar seções ao painel, consulte 'app/admin/dashboard.rb'"
+      welcome: "Bem-vindo ao Active Admin. Esta é a página padrão."
+    delete: "Remover"
+    delete_confirmation: "Não tem a certeza de que deseja remover este ítem?"
+    delete_model: "Remover %{model}"
+    details: "Detalhes do(a) %{model}"
     devise:
+      change_password:
+        submit: "Trocar a minha senha"
+        title: "Troque a sua senha"
+      links:
+        forgot_your_password: "Esqueceu-se da sua senha?"
+        sign_in: "Entrar"
+        sign_in_with_omniauth_provider: "Entre com o %{provider}"
       login:
-        title: "Conta"
         remember_me: "Lembrar-me"
         submit: "Entrar"
+        title: "Conta"
       reset_password:
-        title: "Esqueceu-de da sua senha?"
         submit: "Reiniciar a minha senha"
-      change_password:
-        title: "Troque a sua senha"
-        submit: "Trocar a minha senha"
-      links:
-        sign_in: "Entrar"
-        forgot_your_password: "Esqueceu-se da sua senha?"
-        sign_in_with_omniauth_provider: "Entre com o %{provider}"
+        title: "Esqueceu-de da sua senha?"
+    download: "Baixar:"
+    dropdown_actions:
+      button_label: "Ações"
+    edit: "Editar"
+    edit_model: "Editar %{model}"
+    empty: "Vazio"
+    filters:
+      buttons:
+        clear: "Limpar Filtros"
+        filter: "Filtrar"
+      predicates:
+        contains: "Contém"
+        ends_with: "Termina com"
+        equals: "Igual A"
+        greater_than: "Maior Que"
+        less_than: "Menor Que"
+        starts_with: "Começa com"
+    has_many_delete: "Remover"
+    has_many_new: "Adicionar Novo(a) %{model}"
+    has_many_remove: "Remover"
+    logout: "Sair"
+    main_content: "Por favor implemente %{model}#main_content para mostrar o conteúdo."
+    new_model: "Novo(a) %{model}"
+    next: "Próximo"
+    pagination:
+      empty: "Nenhum(a) %{model} encontrado(a)"
+      entry:
+        one: "registro"
+        other: "registros"
+      multiple: "Mostrando %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> de um total de <b>%{total}</b>"
+      multiple_without_total: "Mostrando %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      one: "Mostrando <b>1</b> %{model}"
+      one_page: "Mostrando <b>todos(as) os(as) %{n}</b> %{model}"
+    powered_by: "Powered by %{active_admin} %{version}"
+    previous: "Anterior"
+    sidebars:
+      filters: "Filtros"
+    status_tag:
+      "no": "Não"
+      "unset": "Não"
+      "yes": "Sim"
+    view: "Visualizar"

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -1,97 +1,97 @@
 ro:
   active_admin:
-    dashboard: "Pagina Principala"
-    dashboard_welcome:
-      welcome: "Bine ati venit pe Active Admin. Aceasta este pagina principala."
-      call_to_action: "Pentru a adauga sectiuni, vedeti 'app/admin/dashboard.rb'"
-    view: "Vizualizati"
-    edit: "Modificati"
-    delete: "Stergeti"
-    delete_confirmation: "Sigur vreti sa stergeti?"
-    new_model: "Un nou %{model}"
-    edit_model: "Modificati %{model}"
-    delete_model: "Stergeti %{model}"
-    details: "Detalii %{model}"
-    cancel: "Renuntati"
-    empty: "Gol"
-    previous: "Inapoi"
-    next: "Inainte"
-    download: "Descarcati:"
-    has_many_new: "Adaugati un nou %{model}"
-    has_many_delete: "Stergeti"
-    has_many_remove: "Scoate"
-    filters:
-      buttons:
-        filter: "Cautati"
-        clear: "Stergeti filtrele"
-      predicates:
-        contains: "Conține"
-        equals: "Egal Cu"
-        starts_with: "începe cu"
-        ends_with: "se termină cu"
-        greater_than: "Mai Mare Decat"
-        less_than: "Mai Mic Decat"
-    status_tag:
-      "yes": "Da"
-      "no": "Nu"
-      "unset": "Nu"
-    main_content: "Va rugam sa implementati %{model}#main_content pentru a afisa continut."
-    logout: "Iesire"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filtre"
-    pagination:
-      empty: "Nu am gasit nici un %{model}"
-      one: "Afisare <b>1</b> %{model}"
-      one_page: "Sunt afisate <b>toate %{n}</b> inregistrarile"
-      multiple: "Sunt afisate <b>%{from}&nbsp;-&nbsp;%{to}</b> din <b>%{total}</b> inregistrari"
-      multiple_without_total: "Sunt afisate <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      entry:
-        one: "înregistrăre"
-        few: "înregistrări"
-        other: "înregistrări"
     any: "Oricare"
-    blank_slate:
-      content: "Momentan nu exista %{resource_name}."
-      link: "Creati un"
-    dropdown_actions:
-      button_label: "Actiuni"
     batch_actions:
+      action_label: "%{title} Selectat"
       button_label: "Grupare Actiuni"
       default_confirmation: "Sunteţi sigur că doriţi să faceţi acest lucru?"
       delete_confirmation: "Sunteţi sigur că doriţi să stergeţi aceste %{plural_model}?"
-      succesfully_destroyed:
-        one: "1 %{model} sters"
-        few: "%{count} %{plural_model} sterse"
-        other: "%{count} %{plural_model} sterse"
-      selection_toggle_explanation: "(Modifica Selectia)"
-      action_label: "%{title} Selectat"
       labels:
         destroy: "Sterge"
+      selection_toggle_explanation: "(Modifica Selectia)"
+      succesfully_destroyed:
+        few: "%{count} %{plural_model} sterse"
+        one: "1 %{model} sters"
+        other: "%{count} %{plural_model} sterse"
+    blank_slate:
+      content: "Momentan nu exista %{resource_name}."
+      link: "Creati un"
+    cancel: "Renuntati"
     comments:
-      body: "Text"
-      author: "Autor"
       add: "Adaugati comentariu"
-      resource: "Resursa"
-      no_comments_yet: "Nu exista comentarii."
-      title_content: "Comentarii (%{count})"
+      author: "Autor"
+      body: "Text"
       errors:
         empty_text: "Comentariul nu a fost salvat, textul lipseste."
+      no_comments_yet: "Nu exista comentarii."
+      resource: "Resursa"
+      title_content: "Comentarii (%{count})"
+    dashboard: "Pagina Principala"
+    dashboard_welcome:
+      call_to_action: "Pentru a adauga sectiuni, vedeti 'app/admin/dashboard.rb'"
+      welcome: "Bine ati venit pe Active Admin. Aceasta este pagina principala."
+    delete: "Stergeti"
+    delete_confirmation: "Sigur vreti sa stergeti?"
+    delete_model: "Stergeti %{model}"
+    details: "Detalii %{model}"
     devise:
+      change_password:
+        submit: "Schimbă parola"
+        title: "Schimbați parola"
+      links:
+        forgot_your_password: "Ați uitat parola?"
+        sign_in: "Autentificare"
+        sign_in_with_omniauth_provider: "Conectați-vă cu %{provider}"
       login:
-        title: "Autentificare"
         remember_me: "Tine-ma minte"
         submit: "Autentificare"
+        title: "Autentificare"
       reset_password:
-        title: "Ați uitat parola?"
         submit: "Reseta parola"
-      change_password:
-        title: "Schimbați parola"
-        submit: "Schimbă parola"
+        title: "Ați uitat parola?"
       unlock:
-        title: "Retrimite instrucțiunile de deblocare"
         submit: "Retrimite instrucțiunile de deblocare"
-      links:
-        sign_in: "Autentificare"
-        forgot_your_password: "Ați uitat parola?"
-        sign_in_with_omniauth_provider: "Conectați-vă cu %{provider}"
+        title: "Retrimite instrucțiunile de deblocare"
+    download: "Descarcati:"
+    dropdown_actions:
+      button_label: "Actiuni"
+    edit: "Modificati"
+    edit_model: "Modificati %{model}"
+    empty: "Gol"
+    filters:
+      buttons:
+        clear: "Stergeti filtrele"
+        filter: "Cautati"
+      predicates:
+        contains: "Conține"
+        ends_with: "se termină cu"
+        equals: "Egal Cu"
+        greater_than: "Mai Mare Decat"
+        less_than: "Mai Mic Decat"
+        starts_with: "începe cu"
+    has_many_delete: "Stergeti"
+    has_many_new: "Adaugati un nou %{model}"
+    has_many_remove: "Scoate"
+    logout: "Iesire"
+    main_content: "Va rugam sa implementati %{model}#main_content pentru a afisa continut."
+    new_model: "Un nou %{model}"
+    next: "Inainte"
+    pagination:
+      empty: "Nu am gasit nici un %{model}"
+      entry:
+        few: "înregistrări"
+        one: "înregistrăre"
+        other: "înregistrări"
+      multiple: "Sunt afisate <b>%{from}&nbsp;-&nbsp;%{to}</b> din <b>%{total}</b> inregistrari"
+      multiple_without_total: "Sunt afisate <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      one: "Afisare <b>1</b> %{model}"
+      one_page: "Sunt afisate <b>toate %{n}</b> inregistrarile"
+    powered_by: "Powered by %{active_admin} %{version}"
+    previous: "Inapoi"
+    sidebars:
+      filters: "Filtre"
+    status_tag:
+      "no": "Nu"
+      "unset": "Nu"
+      "yes": "Da"
+    view: "Vizualizati"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,141 +1,141 @@
 ru:
   active_admin:
-    dashboard: "Панель управления"
-    dashboard_welcome:
-      welcome: "Добро пожаловать в Active Admin. Это стандартная страница управления сайтом."
-      call_to_action: "Чтобы добавить сюда что-нибудь загляните в 'app/admin/dashboard.rb'"
-    view: "Открыть"
-    edit: "Изменить"
-    delete: "Удалить"
-    delete_confirmation: "Вы уверены, что хотите удалить это?"
-    new_model: "Создать %{model}"
-    edit_model: "Изменить %{model}"
-    delete_model: "Удалить %{model}"
-    details: "%{model} подробнее"
-    cancel: "Отмена"
-    empty: "Пусто"
-    previous: "Пред."
-    next: "След."
-    download: "Загрузка:"
-    has_many_new: "Добавить %{model}"
-    has_many_delete: "Удалить"
-    has_many_remove: "Убрать"
-    filters:
-      buttons:
-        filter: "Фильтровать"
-        clear: "Очистить"
-      predicates:
-        contains: "Содержит"
-        equals: "Равно"
-        starts_with: "Начинается с"
-        ends_with: "Заканчивается"
-        greater_than: "больше"
-        less_than: "меньше"
-        from: "От"
-        to: "До"
-    search_status:
-      headline: "Статус поиска:"
-      current_scope: "Область:"
-      current_filters: "Текущий фильтр:"
-      no_current_filters: "Ни один"
-    status_tag:
-      "yes": "Да"
-      "no": "Нет"
-      "unset": "Нет"
-    main_content: "Создайте %{model}#main_content для отображения содержимого."
-    logout: "Выйти"
-    powered_by: "Работает на %{active_admin} %{version}"
-    sidebars:
-      filters: "Фильтры"
-      search_status: "Статус поиска"
-    pagination:
-      empty: "%{model} не найдено"
-      one: "Результат: <b>1</b> %{model}"
-      one_page: "Результат: <b>%{n}</b> %{model}"
-      multiple: "Результат: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> из <b>%{total}</b>"
-      multiple_without_total: "Результат: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      entry:
-        one: "запись"
-        few: "записи"
-        many: "записей"
-        other: "записей"
+    access_denied:
+      message: "Вы не авторизованы для выполнения данного действия."
     any: "Любой"
-    blank_slate:
-      content: "Пока нет %{resource_name}."
-      link: "Создать"
-    dropdown_actions:
-      button_label: "Oперации"
     batch_actions:
+      action_label: "%{title} выбранное"
       button_label: "Групповые операции"
       default_confirmation: "Вы уверены, что вы хотите это сделать?"
       delete_confirmation: "Вы уверены, что хотите удалить %{plural_model}?"
-      succesfully_destroyed:
-        one: "Успешно удалено: 1 %{model}"
-        few: "Успешно удалено: %{count} %{plural_model}"
-        many: "Успешно удалено: %{count} %{plural_model}"
-        other: "Успешно удалено: %{count} %{plural_model}"
-      selection_toggle_explanation: "(Отметить всё / Снять выделение)"
-      action_label: "%{title} выбранное"
       labels:
         destroy: "Удалить"
+      selection_toggle_explanation: "(Отметить всё / Снять выделение)"
+      succesfully_destroyed:
+        few: "Успешно удалено: %{count} %{plural_model}"
+        many: "Успешно удалено: %{count} %{plural_model}"
+        one: "Успешно удалено: 1 %{model}"
+        other: "Успешно удалено: %{count} %{plural_model}"
+    blank_slate:
+      content: "Пока нет %{resource_name}."
+      link: "Создать"
+    cancel: "Отмена"
     comments:
-      created_at: "Дата создания"
-      resource_type: "Тип ресурса"
+      add: "Добавить Комментарий"
+      author: "Автор"
+      author_missing: "Аноним"
       author_type: "Тип автора"
       body: "Текст"
-      author: "Автор"
-      add: "Добавить Комментарий"
+      created_at: "Дата создания"
       delete: "Удалить Комментарий"
       delete_confirmation: "Вы уверены, что хотите удалить этот комментарий?"
-      resource: "Ресурс"
-      no_comments_yet: "Пока нет комментариев."
-      author_missing: "Аноним"
-      title_content: "Комментарии (%{count})"
       errors:
         empty_text: "Комментарий не сохранен, текст не должен быть пустым."
+      no_comments_yet: "Пока нет комментариев."
+      resource: "Ресурс"
+      resource_type: "Тип ресурса"
+      title_content: "Комментарии (%{count})"
+    dashboard: "Панель управления"
+    dashboard_welcome:
+      call_to_action: "Чтобы добавить сюда что-нибудь загляните в 'app/admin/dashboard.rb'"
+      welcome: "Добро пожаловать в Active Admin. Это стандартная страница управления сайтом."
+    delete: "Удалить"
+    delete_confirmation: "Вы уверены, что хотите удалить это?"
+    delete_model: "Удалить %{model}"
+    details: "%{model} подробнее"
     devise:
-      username:
-        title: "Имя пользователя"
+      change_password:
+        submit: "Изменение пароля"
+        title: "Изменение пароля"
       email:
         title: "Эл. почта"
-      subdomain:
-        title: "Поддомен"
-      password:
-        title: "Пароль"
-      sign_up:
-        title: "Зарегистрироваться"
-        submit: "Зарегистрироваться"
+      links:
+        forgot_your_password: "Забыли пароль?"
+        resend_confirmation_instructions: "Повторная отправка инструкций подтверждения"
+        resend_unlock_instructions: "Повторная отправка инструкций разблокировки"
+        sign_in: "Войти"
+        sign_in_with_omniauth_provider: "Войти с помощью %{provider}"
+        sign_up: "Зарегистрироваться"
       login:
-        title: "Войти"
         remember_me: "Запомнить меня"
         submit: "Войти"
-      reset_password:
-        title: "Забыли пароль?"
-        submit: "Сбросить пароль"
-      change_password:
-        title: "Изменение пароля"
-        submit: "Изменение пароля"
-      unlock:
-        title: "Повторно отправить инструкции по разблокировке"
-        submit: "Повторно отправить инструкции по разблокировке"
+        title: "Войти"
+      password:
+        title: "Пароль"
       resend_confirmation_instructions:
-        title: "Выслать повторно письмо с активацией"
         submit: "Выслать повторно письмо с активацией"
-      links:
-        sign_up: "Зарегистрироваться"
-        sign_in: "Войти"
-        forgot_your_password: "Забыли пароль?"
-        sign_in_with_omniauth_provider: "Войти с помощью %{provider}"
-        resend_unlock_instructions: "Повторная отправка инструкций разблокировки"
-        resend_confirmation_instructions: "Повторная отправка инструкций подтверждения"
+        title: "Выслать повторно письмо с активацией"
+      reset_password:
+        submit: "Сбросить пароль"
+        title: "Забыли пароль?"
+      sign_up:
+        submit: "Зарегистрироваться"
+        title: "Зарегистрироваться"
+      subdomain:
+        title: "Поддомен"
+      unlock:
+        submit: "Повторно отправить инструкции по разблокировке"
+        title: "Повторно отправить инструкции по разблокировке"
+      username:
+        title: "Имя пользователя"
+    download: "Загрузка:"
+    dropdown_actions:
+      button_label: "Oперации"
+    edit: "Изменить"
+    edit_model: "Изменить %{model}"
+    empty: "Пусто"
+    filters:
+      buttons:
+        clear: "Очистить"
+        filter: "Фильтровать"
+      predicates:
+        contains: "Содержит"
+        ends_with: "Заканчивается"
+        equals: "Равно"
+        from: "От"
+        greater_than: "больше"
+        less_than: "меньше"
+        starts_with: "Начинается с"
+        to: "До"
+    has_many_delete: "Удалить"
+    has_many_new: "Добавить %{model}"
+    has_many_remove: "Убрать"
+    index_list:
+      block: "Список"
+      blog: "Блог"
+      grid: "Сетка"
+      table: "Таблица"
+    logout: "Выйти"
+    main_content: "Создайте %{model}#main_content для отображения содержимого."
+    new_model: "Создать %{model}"
+    next: "След."
+    pagination:
+      empty: "%{model} не найдено"
+      entry:
+        few: "записи"
+        many: "записей"
+        one: "запись"
+        other: "записей"
+      multiple: "Результат: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> из <b>%{total}</b>"
+      multiple_without_total: "Результат: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      one: "Результат: <b>1</b> %{model}"
+      one_page: "Результат: <b>%{n}</b> %{model}"
+    powered_by: "Работает на %{active_admin} %{version}"
+    previous: "Пред."
+    search_status:
+      current_filters: "Текущий фильтр:"
+      current_scope: "Область:"
+      headline: "Статус поиска:"
+      no_current_filters: "Ни один"
+    sidebars:
+      filters: "Фильтры"
+      search_status: "Статус поиска"
+    status_tag:
+      "no": "Нет"
+      "unset": "Нет"
+      "yes": "Да"
     unsupported_browser:
       headline: "Пожалуйста, обратите внимание, что Active Admin больше не поддерживает старые версии Internet Explorer начиная с версии IE 8"
       recommendation: "Мы рекомендуем обновить версию вашего браузера (<a href=\"http://windows.microsoft.com/ie\">Internet Explorer</a>, <a href=\"https://chrome.google.com/\">Google Chrome</a>, или <a href=\"https://mozilla.org/firefox/\">Firefox</a>)."
       turn_off_compatibility_view: "Если вы используете IE 9 или новее, убедитесь, что <a href=\"https://support.microsoft.com/ru-ru/help/17471\">вы выключили опцию \"Просмотр в режиме совместимости\"</a>."
-    access_denied:
-      message: "Вы не авторизованы для выполнения данного действия."
-    index_list:
-      table: "Таблица"
-      block: "Список"
-      grid: "Сетка"
-      blog: "Блог"
+    view: "Открыть"

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -1,16 +1,152 @@
 sk:
+  active_admin:
+    access_denied:
+      message: "Nemáte oprávnenie k vykonaniu tejto akcie."
+    any: "Akákoľvek"
+    batch_actions:
+      action_label: "%{title}"
+      button_label: "Hromadné akcie"
+      default_confirmation: "Ste si istí, že to chcete spraviť?"
+      delete_confirmation: "Ste si istí, že chcete zmazať tieto %{plural_model}?"
+      labels:
+        destroy: "Vymazať"
+      selection_toggle_explanation: "(Zmeniť výber)"
+      succesfully_destroyed:
+        few: "Úspešne zmazané %{count} %{plural_model}"
+        one: "Úspešne zmazaný %{model}"
+        other: "Úspešne zmazaných %{count} %{plural_model}"
+        zero: "Nebol zmazaný žiaden %{model}"
+    blank_slate:
+      content: "Zatiaľ tu nie je žiadny obsah."
+      link: "Vytvoriť"
+    cancel: "Zrušiť"
+    comments:
+      add: "Pridať komentár"
+      author: "Autor"
+      author_missing: "Anonymný"
+      author_type: "Typ autora"
+      body: "Telo"
+      created_at: "Vytvorený"
+      delete: "Zmazať komentár"
+      delete_confirmation: "Naozaj chcete zmazať tento komentár?"
+      errors:
+        empty_text: "Komentár nebol uložený, je prázdny."
+      no_comments_yet: "Žiadny komentár"
+      resource: "Zdroj"
+      resource_type: "Typ zdroja"
+      title_content: "Komentáre administrátorov (%{count})"
+    create_another: "Vytvoriť ďalší %{model}"
+    dashboard: Úvod
+    dashboard_welcome:
+      call_to_action: "Pre pridanie sekcie na nástenku se pozrite do súboru 'app/admin/dashboard.rb'"
+      welcome: "Vitajte v Active Admin. Toto je nástenka."
+    delete: "Zmazať"
+    delete_confirmation: "Ste si istí, že chcete túto položku zmazať?"
+    delete_model: "Zmazať"
+    details: "Detaily"
+    devise:
+      change_password:
+        submit: "Zmeniť svoje heslo"
+        title: "Zmeniť heslo"
+      email:
+        title: "Email"
+      links:
+        forgot_your_password: "Zabudli ste heslo?"
+        resend_confirmation_instructions: "Preposlať potvrdzovacie inštrukcie"
+        resend_unlock_instructions: "Poslať znovu inštrukcie na odomknutie účtu"
+        sign_in: "Prihlásiť sa"
+        sign_in_with_omniauth_provider: "Prihlásiť sa cez %{provider}"
+        sign_up: "Registrovať sa"
+      login:
+        remember_me: "Zapamätať si ma"
+        submit: "Prihlásiť"
+        title: "Prihlásenie"
+      password:
+        title: "Heslo"
+      password_confirmation:
+        title: "Potvrdenie hesla"
+      resend_confirmation_instructions:
+        submit: "Preposlať potvrdzovacie inštrukcie"
+        title: "Preposlanie potvrdzovacie inštrukcie"
+      reset_password:
+        submit: "Obnoviť heslo"
+        title: "Zabudli ste heslo?"
+      sign_up:
+        submit: "Registrovať"
+        title: "Registrácia"
+      subdomain:
+        title: "Subdoména"
+      unlock:
+        submit: "Zaslať inštrukcií k odomknutiu účtu"
+        title: "Zaslanie inštrukcií k odomknutiu účtu"
+      username:
+        title: "Užívateľské meno"
+    download: "Stiahnúť:"
+    dropdown_actions:
+      button_label: "Akcie"
+    edit: "Upraviť"
+    edit_model: "Upraviť"
+    empty: "Prázdne"
+    filters:
+      buttons:
+        clear: "Vyčistiť filtre"
+        filter: "Filtrovať"
+      predicates:
+        contains: "Obsahuje"
+        ends_with: "Končí na"
+        equals: "Je presne"
+        from: "Od"
+        greater_than: "Väčší ako"
+        gteq_datetime: "Od"
+        less_than: "Menší ako"
+        lteq_datetime: "Do"
+        starts_with: "Začína na"
+        to: "Do"
+    has_many_delete: "Zmazať"
+    has_many_new: "Pridať nový"
+    has_many_remove: "Odstrániť"
+    index_list:
+      block: "Zoznam"
+      blog: "Blog"
+      grid: "Tabuľka"
+      table: "Tabuľka"
+    logout: "Odhlásiť"
+    main_content: "Implementujte prosím %{model}#main_content pre zobrazenie obsahu."
+    move: "Presunúť"
+    new_model: "Vytvoriť"
+    next: "Nasledujúce"
+    pagination:
+      empty: "Nenájdený."
+      entry:
+        few: "položky"
+        one: "položka"
+        other: "položky"
+      multiple: "<b>%{from}&nbsp;-&nbsp;%{to}</b> z <b>%{total}</b>"
+      multiple_without_total: "<b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      one: "Zobrazená  <b>1</b> položka"
+      one_page: "Počet zobrazených položiek %{n}"
+    powered_by: "%{active_admin} %{version}"
+    previous: "Predchádzajúce"
+    scopes:
+      all: "Všetko"
+    search_status:
+      current_filters: "Filtre:"
+      current_scope: "Scope:"
+      headline: "Stav vyhľadávania:"
+      no_current_filters: "Žiadne"
+    sidebars:
+      filters: "Filtre"
+      search_status: "Stav vyhľadávania"
+    status_tag:
+      "no": "Nie"
+      "unset": "Nie"
+      "yes": "Áno"
+    unsupported_browser:
+      headline: "ActiveAdmin nepodporuje Internet Explorer vo verzii <= 8."
+      recommendation: "Odporúčame <a href=\"http://browsehappy.com/\">aktualizovať Váš prehliadač</a>."
+      turn_off_compatibility_view: "Ak používate Internet Explorer vo verzii >= 9, uistite sa, že <a href=\"https://support.microsoft.com/en-us/help/17471\">\"režim kompatibility\" je vypnutý</a>"
+    view: "Zobraziť"
   activerecord:
-    models:
-      comment:
-        one: "Komentár"
-        few: "Komentáre"
-        many: "Komentárov"
-        other: "Komentáre"
-      active_admin/comment:
-        one: "Komentár"
-        few: "Komentáre"
-        many: "Komentárov"
-        other: "Komentáre"
     attributes:
       active_admin/comment:
         author_type: "Typ autora"
@@ -19,150 +155,14 @@ sk:
         namespace: "Namespace"
         resource_type: "Typ komentovanej položky"
         updated_at: "Upravený"
-  active_admin:
-    dashboard: Úvod
-    dashboard_welcome:
-      welcome: "Vitajte v Active Admin. Toto je nástenka."
-      call_to_action: "Pre pridanie sekcie na nástenku se pozrite do súboru 'app/admin/dashboard.rb'"
-    view: "Zobraziť"
-    edit: "Upraviť"
-    delete: "Zmazať"
-    delete_confirmation: "Ste si istí, že chcete túto položku zmazať?"
-    create_another: "Vytvoriť ďalší %{model}"
-    new_model: "Vytvoriť"
-    edit_model: "Upraviť"
-    delete_model: "Zmazať"
-    details: "Detaily"
-    cancel: "Zrušiť"
-    empty: "Prázdne"
-    previous: "Predchádzajúce"
-    next: "Nasledujúce"
-    download: "Stiahnúť:"
-    has_many_new: "Pridať nový"
-    has_many_delete: "Zmazať"
-    has_many_remove: "Odstrániť"
-    move: "Presunúť"
-    filters:
-      buttons:
-        filter: "Filtrovať"
-        clear: "Vyčistiť filtre"
-      predicates:
-        contains: "Obsahuje"
-        equals: "Je presne"
-        starts_with: "Začína na"
-        ends_with: "Končí na"
-        greater_than: "Väčší ako"
-        less_than: "Menší ako"
-        gteq_datetime: "Od"
-        lteq_datetime: "Do"
-        from: "Od"
-        to: "Do"
-    scopes:
-      all: "Všetko"
-    search_status:
-      headline: "Stav vyhľadávania:"
-      current_scope: "Scope:"
-      current_filters: "Filtre:"
-      no_current_filters: "Žiadne"
-    status_tag:
-      "yes": "Áno"
-      "no": "Nie"
-      "unset": "Nie"
-    main_content: "Implementujte prosím %{model}#main_content pre zobrazenie obsahu."
-    logout: "Odhlásiť"
-    powered_by: "%{active_admin} %{version}"
-    sidebars:
-      filters: "Filtre"
-      search_status: "Stav vyhľadávania"
-    pagination:
-      empty: "Nenájdený."
-      one: "Zobrazená  <b>1</b> položka"
-      one_page: "Počet zobrazených položiek %{n}"
-      multiple: "<b>%{from}&nbsp;-&nbsp;%{to}</b> z <b>%{total}</b>"
-      multiple_without_total: "<b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      entry:
-        one: "položka"
-        few: "položky"
-        other: "položky"
-    any: "Akákoľvek"
-    blank_slate:
-      content: "Zatiaľ tu nie je žiadny obsah."
-      link: "Vytvoriť"
-    dropdown_actions:
-      button_label: "Akcie"
-    batch_actions:
-      button_label: "Hromadné akcie"
-      default_confirmation: "Ste si istí, že to chcete spraviť?"
-      delete_confirmation: "Ste si istí, že chcete zmazať tieto %{plural_model}?"
-      succesfully_destroyed:
-        zero: "Nebol zmazaný žiaden %{model}"
-        one: "Úspešne zmazaný %{model}"
-        few: "Úspešne zmazané %{count} %{plural_model}"
-        other: "Úspešne zmazaných %{count} %{plural_model}"
-      selection_toggle_explanation: "(Zmeniť výber)"
-      action_label: "%{title}"
-      labels:
-        destroy: "Vymazať"
-    comments:
-      created_at: "Vytvorený"
-      resource_type: "Typ zdroja"
-      author_type: "Typ autora"
-      body: "Telo"
-      author: "Autor"
-      add: "Pridať komentár"
-      delete: "Zmazať komentár"
-      delete_confirmation: "Naozaj chcete zmazať tento komentár?"
-      resource: "Zdroj"
-      no_comments_yet: "Žiadny komentár"
-      author_missing: "Anonymný"
-      title_content: "Komentáre administrátorov (%{count})"
-      errors:
-        empty_text: "Komentár nebol uložený, je prázdny."
-    devise:
-      username:
-        title: "Užívateľské meno"
-      email:
-        title: "Email"
-      subdomain:
-        title: "Subdoména"
-      password:
-        title: "Heslo"
-      password_confirmation:
-        title: "Potvrdenie hesla"
-      sign_up:
-        title: "Registrácia"
-        submit: "Registrovať"
-      login:
-        title: "Prihlásenie"
-        remember_me: "Zapamätať si ma"
-        submit: "Prihlásiť"
-      reset_password:
-        title: "Zabudli ste heslo?"
-        submit: "Obnoviť heslo"
-      change_password:
-        title: "Zmeniť heslo"
-        submit: "Zmeniť svoje heslo"
-      unlock:
-        title: "Zaslanie inštrukcií k odomknutiu účtu"
-        submit: "Zaslať inštrukcií k odomknutiu účtu"
-      resend_confirmation_instructions:
-        title: "Preposlanie potvrdzovacie inštrukcie"
-        submit: "Preposlať potvrdzovacie inštrukcie"
-      links:
-        sign_in: "Prihlásiť sa"
-        sign_up: "Registrovať sa"
-        forgot_your_password: "Zabudli ste heslo?"
-        sign_in_with_omniauth_provider: "Prihlásiť sa cez %{provider}"
-        resend_unlock_instructions: "Poslať znovu inštrukcie na odomknutie účtu"
-        resend_confirmation_instructions: "Preposlať potvrdzovacie inštrukcie"
-    unsupported_browser:
-      headline: "ActiveAdmin nepodporuje Internet Explorer vo verzii <= 8."
-      recommendation: "Odporúčame <a href=\"http://browsehappy.com/\">aktualizovať Váš prehliadač</a>."
-      turn_off_compatibility_view: "Ak používate Internet Explorer vo verzii >= 9, uistite sa, že <a href=\"https://support.microsoft.com/en-us/help/17471\">\"režim kompatibility\" je vypnutý</a>"
-    access_denied:
-      message: "Nemáte oprávnenie k vykonaniu tejto akcie."
-    index_list:
-      table: "Tabuľka"
-      block: "Zoznam"
-      grid: "Tabuľka"
-      blog: "Blog"
+    models:
+      active_admin/comment:
+        few: "Komentáre"
+        many: "Komentárov"
+        one: "Komentár"
+        other: "Komentáre"
+      comment:
+        few: "Komentáre"
+        many: "Komentárov"
+        one: "Komentár"
+        other: "Komentáre"

--- a/config/locales/sv-SE.yml
+++ b/config/locales/sv-SE.yml
@@ -1,135 +1,135 @@
 "sv-SE":
   active_admin:
-    dashboard: Skrivbord
-    dashboard_welcome:
-      welcome: "Välkommen till Active Admin. Detta är ditt standardskrivbord."
-      call_to_action: "För att lägga till sektioner, gör en checkout på 'app/admin/dashboard.rb'"
-    view: "Visa"
-    edit: "Redigera"
-    delete: "Ta bort"
-    delete_confirmation: "Är du säker att du vill ta bort denna?"
-    new_model: "Ny %{model}"
-    edit_model: "Redigera %{model}"
-    delete_model: "Ta bort %{model}"
-    details: "Detaljvy för %{model}"
-    cancel: "Avbryt"
-    empty: "Tom"
-    previous: "Föregående"
-    next: "Nästa"
-    download: "Ladda ner:"
-    has_many_new: "Skapa en ny %{model}"
-    has_many_delete: "Ta bort"
-    has_many_remove: "Ta bort"
-    filters:
-      buttons:
-        filter: "Filter"
-        clear: "Rensa filter"
-      predicates:
-        contains: "Innehåller"
-        equals: "Lika med"
-        starts_with: "Börjar med"
-        ends_with: "Slutar med"
-        greater_than: "Större än"
-        less_than: "Mindre än"
-        from: "Från"
-        to: "Till"
-    search_status:
-      headline: "Sök status:"
-      current_scope: "Scope:"
-      current_filters: "Nuvarande filter:"
-      no_current_filters: "Inga"
-    status_tag:
-      "yes": "Ja"
-      "no": "Nej"
-      "unset": "Nej"
-    main_content: "Implementera %{model}#main_content för att kunna visa något."
-    logout: "Logga ut"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filter"
-      search_status: "Sök status"
-    pagination:
-      empty: "Ingen %{model} funnen"
-      one: "Visar <b>1</b> utav %{model}"
-      one_page: "Visar <b>alla %{n}</b> utav %{model}"
-      multiple: "Visar %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> av <b>%{total}</b> totalt"
-      multiple_without_total: "Visar %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      entry:
-        one: "inlägg"
-        other: "inlägg"
+    access_denied:
+      message: "Du har inte rättighet att utföra denna åtgärd."
     any: "Någon"
-    blank_slate:
-      content: "Finns inga %{resource_name} än."
-      link: "Skapa en"
-    dropdown_actions:
-      button_label: "Behandling"
     batch_actions:
+      action_label: "%{title} Markerad"
       button_label: "Batch behandling"
       default_confirmation: "Är du säker på att du vill göra detta?"
       delete_confirmation: "Är du säker på att du vill radera dessa %{plural_model}?"
+      labels:
+        destroy: "Radera"
+      selection_toggle_explanation: "(Toggle Selection)"
       succesfully_destroyed:
         one: "Lyckades radera 1 %{model}"
         other: "Lyckades radera %{count} %{plural_model}"
-      selection_toggle_explanation: "(Toggle Selection)"
-      action_label: "%{title} Markerad"
-      labels:
-        destroy: "Radera"
+    blank_slate:
+      content: "Finns inga %{resource_name} än."
+      link: "Skapa en"
+    cancel: "Avbryt"
     comments:
-      created_at: "Skapad"
-      resource_type: "Resurs typ"
+      add: "Lägg till kommentar"
+      author: "Författare"
+      author_missing: "Anonym"
       author_type: "Författar typ"
       body: "Innehåll"
-      author: "Författare"
-      add: "Lägg till kommentar"
-      resource: "Resurs"
-      no_comments_yet: "Inga kommentarer än."
-      author_missing: "Anonym"
-      title_content: "Kommentarer (%{count})"
+      created_at: "Skapad"
       errors:
         empty_text: "Kommentaren sparades inte, måste innehålla text."
+      no_comments_yet: "Inga kommentarer än."
+      resource: "Resurs"
+      resource_type: "Resurs typ"
+      title_content: "Kommentarer (%{count})"
+    dashboard: Skrivbord
+    dashboard_welcome:
+      call_to_action: "För att lägga till sektioner, gör en checkout på 'app/admin/dashboard.rb'"
+      welcome: "Välkommen till Active Admin. Detta är ditt standardskrivbord."
+    delete: "Ta bort"
+    delete_confirmation: "Är du säker att du vill ta bort denna?"
+    delete_model: "Ta bort %{model}"
+    details: "Detaljvy för %{model}"
     devise:
-      username:
-        title: "Användarnamn"
+      change_password:
+        submit: "Ändra mitt lösenord"
+        title: "Ändra ditt lösenord"
       email:
         title: "Epost"
-      subdomain:
-        title: "Subdomän"
-      password:
-        title: "Lösenord"
-      sign_up:
-        title: "Registera"
-        submit: "Registera"
+      links:
+        forgot_your_password: "Glömt ditt lösenord?"
+        resend_confirmation_instructions: "Skicka bekräftnings instruktioner"
+        resend_unlock_instructions: "Skicka upplåsnings instruktioner"
+        sign_in: "Logga in"
+        sign_in_with_omniauth_provider: "Logga in med %{provider}"
+        sign_up: "Registera"
       login:
-        title: "Inloggning"
         remember_me: "Kom ihåg mig"
         submit: "Inloggning"
-      reset_password:
-        title: "Glömt ditt lösenord?"
-        submit: "Återställa mitt lösenord"
-      change_password:
-        title: "Ändra ditt lösenord"
-        submit: "Ändra mitt lösenord"
-      unlock:
-        title: "Skicka upplåsnings instruktioner"
-        submit: "Skicka upplåsnings instruktioner"
+        title: "Inloggning"
+      password:
+        title: "Lösenord"
       resend_confirmation_instructions:
-        title: "Skicka bekräftnings instruktioner"
         submit: "Skicka bekräftnings instruktioner"
-      links:
-        sign_up: "Registera"
-        sign_in: "Logga in"
-        forgot_your_password: "Glömt ditt lösenord?"
-        sign_in_with_omniauth_provider: "Logga in med %{provider}"
-        resend_unlock_instructions: "Skicka upplåsnings instruktioner"
-        resend_confirmation_instructions: "Skicka bekräftnings instruktioner"
+        title: "Skicka bekräftnings instruktioner"
+      reset_password:
+        submit: "Återställa mitt lösenord"
+        title: "Glömt ditt lösenord?"
+      sign_up:
+        submit: "Registera"
+        title: "Registera"
+      subdomain:
+        title: "Subdomän"
+      unlock:
+        submit: "Skicka upplåsnings instruktioner"
+        title: "Skicka upplåsnings instruktioner"
+      username:
+        title: "Användarnamn"
+    download: "Ladda ner:"
+    dropdown_actions:
+      button_label: "Behandling"
+    edit: "Redigera"
+    edit_model: "Redigera %{model}"
+    empty: "Tom"
+    filters:
+      buttons:
+        clear: "Rensa filter"
+        filter: "Filter"
+      predicates:
+        contains: "Innehåller"
+        ends_with: "Slutar med"
+        equals: "Lika med"
+        from: "Från"
+        greater_than: "Större än"
+        less_than: "Mindre än"
+        starts_with: "Börjar med"
+        to: "Till"
+    has_many_delete: "Ta bort"
+    has_many_new: "Skapa en ny %{model}"
+    has_many_remove: "Ta bort"
+    index_list:
+      block: "Lista"
+      blog: "Blogg"
+      grid: "Rutnät"
+      table: "Tabell"
+    logout: "Logga ut"
+    main_content: "Implementera %{model}#main_content för att kunna visa något."
+    new_model: "Ny %{model}"
+    next: "Nästa"
+    pagination:
+      empty: "Ingen %{model} funnen"
+      entry:
+        one: "inlägg"
+        other: "inlägg"
+      multiple: "Visar %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> av <b>%{total}</b> totalt"
+      multiple_without_total: "Visar %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      one: "Visar <b>1</b> utav %{model}"
+      one_page: "Visar <b>alla %{n}</b> utav %{model}"
+    powered_by: "Powered by %{active_admin} %{version}"
+    previous: "Föregående"
+    search_status:
+      current_filters: "Nuvarande filter:"
+      current_scope: "Scope:"
+      headline: "Sök status:"
+      no_current_filters: "Inga"
+    sidebars:
+      filters: "Filter"
+      search_status: "Sök status"
+    status_tag:
+      "no": "Nej"
+      "unset": "Nej"
+      "yes": "Ja"
     unsupported_browser:
       headline: "Notera att ActiveAdmin inte längre stödjer Internet Explorer version 8 eller mindre."
       recommendation: "Vi rekommenderar dig att uppgradera till den senaste versionen av <a href=\"http://windows.microsoft.com/ie\">Internet Explorer</a>, <a href=\"https://chrome.google.com/\">Google Chrome</a>, eller <a href=\"https://mozilla.org/firefox/\">Firefox</a>."
       turn_off_compatibility_view: "Om du använder IE 9 eller senare, se till att <a href=\"https://support.microsoft.com/sv-se/help/17471\">stäng av \"Compatibility View\"</a>."
-    access_denied:
-      message: "Du har inte rättighet att utföra denna åtgärd."
-    index_list:
-      table: "Tabell"
-      block: "Lista"
-      grid: "Rutnät"
-      blog: "Blogg"
+    view: "Visa"

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -1,144 +1,144 @@
 tr:
   active_admin:
-    dashboard: "Gösterge Paneli"
-    dashboard_welcome:
-      welcome: "Active Admin'e hoş geldiniz. Burası varsayılan gösterge paneli sayfasıdır."
-      call_to_action: "Buraya bölümler eklemek için 'app/admin/dashboard.rb' dosyasına bakabilirsiniz."
-    view: "Görüntüle"
-    edit: "Düzenle"
-    delete: "Sil"
-    delete_confirmation: "Bu kaydı silmek istediğinizden emin misiniz?"
-    create_another: "Başka bir %{model} oluştur"
-    new_model: "Yeni %{model}"
-    edit_model: "%{model} Kaydını Düzenle"
-    delete_model: "%{model} Kaydını Sil"
-    details: "%{model} Ayrıntıları"
-    cancel: "İptal"
-    empty: "Boş"
-    previous: "Önceki"
-    next: "Sonraki"
-    download: "İndir:"
-    has_many_new: "Yeni %{model} Ekle"
-    has_many_delete: "Sil"
-    has_many_remove: "Çıkar"
-    move: "Taşı"
-    filters:
-      buttons:
-        filter: "Filtrele"
-        clear: "Filtreleri Temizle"
-      predicates:
-        contains: "İçerir"
-        equals: "Eşittir"
-        starts_with: "İle başlar"
-        ends_with: "İle biter"
-        greater_than: "Büyüktür"
-        less_than: "Küçüktür"
-        gteq_datetime: "Büyük yada eşit"
-        lteq_datetime: "Küçük yada eşit"
-        from: "Başlangıç"
-        to: "Bitiş"
-    search_status:
-      headline: "Arama"
-      current_scope: "Kapsam:"
-      current_filters: "Seçili filtreler:"
-      no_current_filters: "Yok"
-    status_tag:
-      "yes": "Evet"
-      "no": "Hayır"
-      "unset": "Hayır"
-    main_content: "İçeriği görüntülemek için lütfen %{model}#main_content metodunu ekleyin."
-    logout: "Çıkış Yap"
-    powered_by: "%{active_admin} %{version} tarafından desteklenmektedir."
-    sidebars:
-      filters: "Filtreler"
-      search_status: "Arama Durumu"
-    pagination:
-      empty: "Hiç %{model} yok"
-      one: "<b>1</b> %{model} görüntüleniyor"
-      one_page: "<b>%{n}</b> %{model} kaydının tamamı görüntüleniyor"
-      multiple: "<b>%{from}&nbsp;-&nbsp;%{to}</b> arası %{model} görüntüleniyor (toplam %{total} kayıt)"
-      multiple_without_total: "<b>%{from}&nbsp;-&nbsp;%{to}</b> arası %{model} görüntüleniyor"
-      per_page: "Sayfa Başına: "
-      entry:
-        one: "kayıt"
-        other: "kayıtlar"
+    access_denied:
+      message: "Bu işlemi gerçekleştirmek için yetkiniz yok."
     any: "Herhangi biri"
-    blank_slate:
-      content: "Henüz %{resource_name} yok."
-      link: "Bir tane oluşturun"
-    dropdown_actions:
-      button_label: "İşlemler"
     batch_actions:
+      action_label: "Seçilenleri %{title}"
       button_label: "Toplu İşlemler"
       default_confirmation: "Bunu yapmak istediğinizden emin misiniz?"
       delete_confirmation: "Bu %{plural_model} kayıtlarını silmek istediğinizden emin misiniz?"
+      labels:
+        destroy: "Sil"
+      selection_toggle_explanation: "(Seçimi Değiştir)"
       succesfully_destroyed:
         one: "1 %{model} başarıyla silindi"
         other: "Toplam %{count} %{plural_model} başarıyla silindi"
-      selection_toggle_explanation: "(Seçimi Değiştir)"
-      action_label: "Seçilenleri %{title}"
-      labels:
-        destroy: "Sil"
+    blank_slate:
+      content: "Henüz %{resource_name} yok."
+      link: "Bir tane oluşturun"
+    cancel: "İptal"
     comments:
-      created_at: "Oluşturma Tarihi"
-      resource_type: "Kayıt Tipi"
+      add: "Yorum Ekle"
+      author: "Yazar"
+      author_missing: "Anonim"
       author_type: "Yazar Tipi"
       body: "Ayrıntı"
-      author: "Yazar"
-      add: "Yorum Ekle"
+      created_at: "Oluşturma Tarihi"
       delete: "Yorumu Sil"
       delete_confirmation: "Bu yorumları silmek istediğinizden emin misiniz?"
-      resource: "Kayıt"
-      no_comments_yet: "Henüz yorum yok."
-      author_missing: "Anonim"
-      title_content: "Yorumlar (%{count})"
       errors:
         empty_text: "Yorum boş olarak kaydedilemez."
+      no_comments_yet: "Henüz yorum yok."
+      resource: "Kayıt"
+      resource_type: "Kayıt Tipi"
+      title_content: "Yorumlar (%{count})"
+    create_another: "Başka bir %{model} oluştur"
+    dashboard: "Gösterge Paneli"
+    dashboard_welcome:
+      call_to_action: "Buraya bölümler eklemek için 'app/admin/dashboard.rb' dosyasına bakabilirsiniz."
+      welcome: "Active Admin'e hoş geldiniz. Burası varsayılan gösterge paneli sayfasıdır."
+    delete: "Sil"
+    delete_confirmation: "Bu kaydı silmek istediğinizden emin misiniz?"
+    delete_model: "%{model} Kaydını Sil"
+    details: "%{model} Ayrıntıları"
     devise:
-      username:
-        title: "Kullanıcı adı"
+      change_password:
+        submit: "Şifremi değiştir"
+        title: "Şifrenizi değiştirin"
       email:
         title: "E-posta adresi"
-      subdomain:
-        title: "Alt alan adı"
+      links:
+        forgot_your_password: "Şifrenizi mi unuttunuz?"
+        resend_confirmation_instructions: "Onaylama talimatlarını tekrar gönder"
+        resend_unlock_instructions: "Hesap geri açma talimatlarını tekrar gönder"
+        sign_in: "Giriş yap"
+        sign_in_with_omniauth_provider: "%{provider} ile giriş yapın"
+        sign_up: "Kaydol"
+      login:
+        remember_me: "Beni hatırla"
+        submit: "Giriş yap"
+        title: "Giriş yap"
       password:
         title: "Şifre"
       password_confirmation:
         title: "Şifreyi Tekrarla"
-      sign_up:
-        title: "Kaydol"
-        submit: "Kaydol"
-      login:
-        title: "Giriş yap"
-        remember_me: "Beni hatırla"
-        submit: "Giriş yap"
-      reset_password:
-        title: "Şifrenizi mi unuttunuz?"
-        submit: "Şifremi sıfırla"
-      change_password:
-        title: "Şifrenizi değiştirin"
-        submit: "Şifremi değiştir"
-      unlock:
-        title: "Hesap geri açma talimatlarını tekrar gönder"
-        submit: "Hesap geri açma talimatlarını tekrar gönder"
       resend_confirmation_instructions:
-        title: "Onaylama talimatlarını tekrar gönder"
         submit: "Onaylama talimatlarını tekrar gönder"
-      links:
-        sign_up: "Kaydol"
-        sign_in: "Giriş yap"
-        forgot_your_password: "Şifrenizi mi unuttunuz?"
-        sign_in_with_omniauth_provider: "%{provider} ile giriş yapın"
-        resend_unlock_instructions: "Hesap geri açma talimatlarını tekrar gönder"
-        resend_confirmation_instructions: "Onaylama talimatlarını tekrar gönder"
+        title: "Onaylama talimatlarını tekrar gönder"
+      reset_password:
+        submit: "Şifremi sıfırla"
+        title: "Şifrenizi mi unuttunuz?"
+      sign_up:
+        submit: "Kaydol"
+        title: "Kaydol"
+      subdomain:
+        title: "Alt alan adı"
+      unlock:
+        submit: "Hesap geri açma talimatlarını tekrar gönder"
+        title: "Hesap geri açma talimatlarını tekrar gönder"
+      username:
+        title: "Kullanıcı adı"
+    download: "İndir:"
+    dropdown_actions:
+      button_label: "İşlemler"
+    edit: "Düzenle"
+    edit_model: "%{model} Kaydını Düzenle"
+    empty: "Boş"
+    filters:
+      buttons:
+        clear: "Filtreleri Temizle"
+        filter: "Filtrele"
+      predicates:
+        contains: "İçerir"
+        ends_with: "İle biter"
+        equals: "Eşittir"
+        from: "Başlangıç"
+        greater_than: "Büyüktür"
+        gteq_datetime: "Büyük yada eşit"
+        less_than: "Küçüktür"
+        lteq_datetime: "Küçük yada eşit"
+        starts_with: "İle başlar"
+        to: "Bitiş"
+    has_many_delete: "Sil"
+    has_many_new: "Yeni %{model} Ekle"
+    has_many_remove: "Çıkar"
+    index_list:
+      block: "Liste"
+      blog: "Blog"
+      grid: "Izgara"
+      table: "Tablo"
+    logout: "Çıkış Yap"
+    main_content: "İçeriği görüntülemek için lütfen %{model}#main_content metodunu ekleyin."
+    move: "Taşı"
+    new_model: "Yeni %{model}"
+    next: "Sonraki"
+    pagination:
+      empty: "Hiç %{model} yok"
+      entry:
+        one: "kayıt"
+        other: "kayıtlar"
+      multiple: "<b>%{from}&nbsp;-&nbsp;%{to}</b> arası %{model} görüntüleniyor (toplam %{total} kayıt)"
+      multiple_without_total: "<b>%{from}&nbsp;-&nbsp;%{to}</b> arası %{model} görüntüleniyor"
+      one: "<b>1</b> %{model} görüntüleniyor"
+      one_page: "<b>%{n}</b> %{model} kaydının tamamı görüntüleniyor"
+      per_page: "Sayfa Başına: "
+    powered_by: "%{active_admin} %{version} tarafından desteklenmektedir."
+    previous: "Önceki"
+    search_status:
+      current_filters: "Seçili filtreler:"
+      current_scope: "Kapsam:"
+      headline: "Arama"
+      no_current_filters: "Yok"
+    sidebars:
+      filters: "Filtreler"
+      search_status: "Arama Durumu"
+    status_tag:
+      "no": "Hayır"
+      "unset": "Hayır"
+      "yes": "Evet"
     unsupported_browser:
       headline: "ActiveAdmin Internet Explorer 8 ve altı artık desteklememektedir."
       recommendation: "Son sürüm <a href=\"http://windows.microsoft.com/ie\">Internet Explorer</a>, <a href=\"https://chrome.google.com/\">Google Chrome</a>, ya da <a href=\"https://mozilla.org/firefox/\">Firefox</a> tarayıcılarından birine geçmenizi tavsiye ederiz."
       turn_off_compatibility_view: "IE 9 ya da üstünü kullanıyorsanız, <a href=\"http://windows.microsoft.com/tr-tr/internet-explorer/use-compatibility-view\">\"Uyumluluk Görünümü\"</a>nü kapatmayı unutmayın."
-    access_denied:
-      message: "Bu işlemi gerçekleştirmek için yetkiniz yok."
-    index_list:
-      table: "Tablo"
-      block: "Liste"
-      grid: "Izgara"
-      blog: "Blog"
+    view: "Görüntüle"

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -1,138 +1,138 @@
 uk:
   active_admin:
-    dashboard: "Панель керування"
-    dashboard_welcome:
-      welcome: "Ласкаво просимо до Active Admin. Це стандартна сторінка керування сайтом."
-      call_to_action: "Щоб додати сюди що-небудь, зазирніть у 'app/admin/dashboard.rb'"
-    view: "Переглянути"
-    edit: "Змінити"
-    delete: "Видалити"
-    delete_confirmation: "Ви впевнені, що хочете це видалити?"
-    new_model: "Створити %{model}"
-    edit_model: "Змінити %{model}"
-    delete_model: "Видалити %{model}"
-    details: "%{model} детальніше"
-    cancel: "Скасувати"
-    empty: "Пусто"
-    previous: "Поперед."
-    next: "Наст."
-    download: "Завантаження:"
-    has_many_new: "Додати %{model}"
-    has_many_delete: "Прибрати"
-    has_many_remove: "Видалити"
-    filters:
-      buttons:
-        filter: "Фільтрувати"
-        clear: "Очистити"
-      predicates:
-        contains: "Містить"
-        equals: "="
-        starts_with: "Починається з"
-        ends_with: "Закінчується"
-        greater_than: "більше"
-        less_than: "менше"
-        from: "від"
-        to: "до"
-    search_status:
-      headline: "Статус пошуку:"
-      current_scope: "Область:"
-      current_filters: "Поточний фільтр:"
-      no_current_filters: "Жоден"
-    status_tag:
-      "yes": "Так"
-      "no": "Ні"
-      "unset": "Ні"
-    main_content: "Створіть %{model}#main_content для відображення вмісту."
-    logout: "Вийти"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Фільтри"
-      search_status: "Статус пошуку"
-    pagination:
-      empty: "%{model} не знайдено"
-      one: "Результат: <b>1</b> %{model}"
-      one_page: "Результат: <b>%{n}</b> %{model}"
-      multiple: "Результат: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> з <b>%{total}</b>"
-      multiple_without_total: "Результат: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      entry:
-        one: "запис"
-        few: "записи"
-        many: "записів"
-        other: "записів"
+    access_denied:
+      message: "Ви не авторизовані для виконання даної дії."
     any: "Будь-який"
-    blank_slate:
-      content: "Поки-що немає %{resource_name}."
-      link: "Створити"
-    dropdown_actions:
-      button_label: "Oперації"
     batch_actions:
+      action_label: "%{title} вибране"
       button_label: "Групові операції"
       default_confirmation: "Ви справді бажаєте це зробити?"
       delete_confirmation: "Ви впевнені, що хочете видалити %{plural_model}?"
-      succesfully_destroyed:
-        one: "Успішно видалено: 1 %{model}"
-        few: "Успішно видалено: %{count} %{plural_model}"
-        many: "Успішно видалено: %{count} %{plural_model}"
-        other: "Успішно видалено: %{count} %{plural_model}"
-      selection_toggle_explanation: "(Скасувати все / Зняти виділення)"
-      action_label: "%{title} вибране"
       labels:
         destroy: "Видалити"
+      selection_toggle_explanation: "(Скасувати все / Зняти виділення)"
+      succesfully_destroyed:
+        few: "Успішно видалено: %{count} %{plural_model}"
+        many: "Успішно видалено: %{count} %{plural_model}"
+        one: "Успішно видалено: 1 %{model}"
+        other: "Успішно видалено: %{count} %{plural_model}"
+    blank_slate:
+      content: "Поки-що немає %{resource_name}."
+      link: "Створити"
+    cancel: "Скасувати"
     comments:
-      resource_type: "Тип ресурса"
+      add: "Додати Коментар"
+      author: "Автор"
+      author_missing: "Анонім"
       author_type: "Тип автора"
       body: "Текст"
-      author: "Автор"
-      add: "Додати Коментар"
-      resource: "Ресурс"
-      no_comments_yet: "Поки-що немає коментарів."
-      author_missing: "Анонім"
-      title_content: "Коментарі (%{count})"
       errors:
         empty_text: "Коментар не збережено, текст не повинен бути пустим."
+      no_comments_yet: "Поки-що немає коментарів."
+      resource: "Ресурс"
+      resource_type: "Тип ресурса"
+      title_content: "Коментарі (%{count})"
+    dashboard: "Панель керування"
+    dashboard_welcome:
+      call_to_action: "Щоб додати сюди що-небудь, зазирніть у 'app/admin/dashboard.rb'"
+      welcome: "Ласкаво просимо до Active Admin. Це стандартна сторінка керування сайтом."
+    delete: "Видалити"
+    delete_confirmation: "Ви впевнені, що хочете це видалити?"
+    delete_model: "Видалити %{model}"
+    details: "%{model} детальніше"
     devise:
-      username:
-        title: "Ім'я користувача"
+      change_password:
+        submit: "Змінити пароль"
+        title: "Зміна паролю"
       email:
         title: "Електронна пошта"
-      subdomain:
-        title: "Піддомен"
-      password:
-        title: "Пароль"
-      sign_up:
-        title: "Зареєструватися"
-        submit: "Зареєструватися"
+      links:
+        forgot_your_password: "Забули пароль?"
+        resend_confirmation_instructions: "Повторна відправка інструкцій підтвердження"
+        resend_unlock_instructions: "Повторна відправка інструкцій розблокування"
+        sign_in: "Увійти"
+        sign_in_with_omniauth_provider: "Увійти з допомогою %{provider}"
+        sign_up: "Зареєструватись"
       login:
-        title: "Вхід"
         remember_me: "Запам'ятати мене"
         submit: "Увійти"
-      reset_password:
-        title: "Забули пароль?"
-        submit: "Скинути пароль"
-      change_password:
-        title: "Зміна паролю"
-        submit: "Змінити пароль"
-      unlock:
-        title: "Відправити повторно інструкції з розблокування"
-        submit: "Відправити повторно інструкції з розблокування"
+        title: "Вхід"
+      password:
+        title: "Пароль"
       resend_confirmation_instructions:
-        title: "Відправити повторно листа з активацією"
         submit: "Відправити повторно листа з активацією"
-      links:
-        sign_up: "Зареєструватись"
-        sign_in: "Увійти"
-        forgot_your_password: "Забули пароль?"
-        sign_in_with_omniauth_provider: "Увійти з допомогою %{provider}"
-        resend_unlock_instructions: "Повторна відправка інструкцій розблокування"
-        resend_confirmation_instructions: "Повторна відправка інструкцій підтвердження"
+        title: "Відправити повторно листа з активацією"
+      reset_password:
+        submit: "Скинути пароль"
+        title: "Забули пароль?"
+      sign_up:
+        submit: "Зареєструватися"
+        title: "Зареєструватися"
+      subdomain:
+        title: "Піддомен"
+      unlock:
+        submit: "Відправити повторно інструкції з розблокування"
+        title: "Відправити повторно інструкції з розблокування"
+      username:
+        title: "Ім'я користувача"
+    download: "Завантаження:"
+    dropdown_actions:
+      button_label: "Oперації"
+    edit: "Змінити"
+    edit_model: "Змінити %{model}"
+    empty: "Пусто"
+    filters:
+      buttons:
+        clear: "Очистити"
+        filter: "Фільтрувати"
+      predicates:
+        contains: "Містить"
+        ends_with: "Закінчується"
+        equals: "="
+        from: "від"
+        greater_than: "більше"
+        less_than: "менше"
+        starts_with: "Починається з"
+        to: "до"
+    has_many_delete: "Прибрати"
+    has_many_new: "Додати %{model}"
+    has_many_remove: "Видалити"
+    index_list:
+      block: "Список"
+      blog: "Блог"
+      grid: "Сітка"
+      table: "Таблиця"
+    logout: "Вийти"
+    main_content: "Створіть %{model}#main_content для відображення вмісту."
+    new_model: "Створити %{model}"
+    next: "Наст."
+    pagination:
+      empty: "%{model} не знайдено"
+      entry:
+        few: "записи"
+        many: "записів"
+        one: "запис"
+        other: "записів"
+      multiple: "Результат: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> з <b>%{total}</b>"
+      multiple_without_total: "Результат: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      one: "Результат: <b>1</b> %{model}"
+      one_page: "Результат: <b>%{n}</b> %{model}"
+    powered_by: "Powered by %{active_admin} %{version}"
+    previous: "Поперед."
+    search_status:
+      current_filters: "Поточний фільтр:"
+      current_scope: "Область:"
+      headline: "Статус пошуку:"
+      no_current_filters: "Жоден"
+    sidebars:
+      filters: "Фільтри"
+      search_status: "Статус пошуку"
+    status_tag:
+      "no": "Ні"
+      "unset": "Ні"
+      "yes": "Так"
     unsupported_browser:
       headline: "Зверніть, будь-ласка, увагу, що ActiveAdmin більше не підтримує Internet Explorer 8 версії і нижче"
       recommendation: "Ми рекомендуємо оновити версію вашого браузеру (<a href=\"http://windows.microsoft.com/ie\">Internet Explorer</a>, <a href=\"https://chrome.google.com/\">Google Chrome</a>, або <a href=\"https://mozilla.org/firefox/\">Firefox</a>)."
       turn_off_compatibility_view: "Якщо ви використовуєте IE 9 і вище, переконайтесь, що <a href=\"https://support.microsoft.com/uk-ua/help/17471\">ви вимкнули опцію \"Перегляд в режимі сумісності\"</a>."
-    access_denied:
-      message: "Ви не авторизовані для виконання даної дії."
-    index_list:
-      table: "Таблиця"
-      block: "Список"
-      grid: "Сітка"
-      blog: "Блог"
+    view: "Переглянути"

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -1,135 +1,135 @@
 vi:
   active_admin:
-    dashboard: Bảng điều khiển
-    dashboard_welcome:
-      welcome: "Chào mừng bạn đến với Active Admin. Đây là trang điều khiển mặc định."
-      call_to_action: "Để thêm thành phần cho trang điều khiển hãy chỉnh sửa 'app/admin/dashboard.rb'"
-    view: "Xem"
-    edit: "Chỉnh sửa"
-    delete: "Xóa"
-    delete_confirmation: "Bạn có chắc chắn rằng mình muốn xóa không?"
-    new_model: "Tạo mới %{model}"
-    edit_model: "Chỉnh sửa %{model}"
-    delete_model: "Xóa %{model}"
-    create_another: "Tạo thêm %{model}"
-    details: "%{model} Chi tiết"
-    cancel: "Hủy"
-    empty: "Trống"
-    previous: "Trước"
-    next: "Sau"
-    download: "Tải về:"
-    has_many_new: "Thêm mới %{model}"
-    has_many_delete: "Xóa"
-    has_many_remove: "Hủy bỏ"
-    filters:
-      buttons:
-        filter: "Lọc"
-        clear: "Xóa dữ liệu lọc"
-      predicates:
-        contains: "Có chứa"
-        equals: "Bằng"
-        starts_with: "Bắt đầu với"
-        ends_with: "Kết thúc bởi"
-        greater_than: "Lớn hơn"
-        less_than: "Nhỏ hơn"
-        gteq_datetime: "Lớn hơn hoặc bằng"
-        lteq_datetime: "Nhỏ hơn hoặc bằng"
-        from: "Từ"
-        to: "Đến"
-    search_status:
-      headline: "Danh sách tìm kiếm:"
-      current_scope: "Phạm vi:"
-      current_filters: "Bộ lộc hiện tại:"
-      no_current_filters: "Không có"
-    status_tag:
-      "yes": "Có"
-      "no": "Không Có"
-      "unset": "Không Có"
-    main_content: "Xin bổ sung %{model}#main_content để hiển thị nội dung."
-    logout: "Đăng xuất"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Bộ Lọc"
-      search_status: "Trạng thái tìm kiếm"
-    pagination:
-      empty: "Không có %{model} nào được tìm thấy"
-      one: "Đang hiển thị <b>1</b> %{model}"
-      one_page: "Đang hiển thị <b>tất cả %{n}</b> %{model}"
-      multiple: "Đang hiển thị %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> of <b>%{total}</b> trong tất cả."
-      multiple_without_total: "Đang hiển thị %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>."
-      per_page: "Mỗi trang: "
-      entry:
-        one: "entry"
-        other: "entries"
+    access_denied:
+      message: "Bạn không có quyền thực hiện tính năng này"
     any: "Bất kỳ"
-    blank_slate:
-      content: "Chưa có %{resource_name}."
-      link: "Tạo mới"
-    dropdown_actions:
-      button_label: "Hành động"
     batch_actions:
+      action_label: "%{title} được chọn"
       button_label: "Hành động hàng loạt"
       default_confirmation: "Bạn có chắc bạn muốn làm điều này?"
       delete_confirmation: "Bạn có chắc chắn muốn xóa những %{plural_model}?"
+      labels:
+        destroy: "Xóa"
+      selection_toggle_explanation: "(Thay đổi lựa chọn)"
       succesfully_destroyed:
         one: "Đã xóa thành công 1 %{model}"
         other: "Đã xóa thành công %{count} %{plural_model}"
-      selection_toggle_explanation: "(Thay đổi lựa chọn)"
-      action_label: "%{title} được chọn"
-      labels:
-        destroy: "Xóa"
+    blank_slate:
+      content: "Chưa có %{resource_name}."
+      link: "Tạo mới"
+    cancel: "Hủy"
     comments:
-      created_at: "Đã tạo"
-      resource_type: "Resource Type"
-      body: "Nội dung"
-      author: "Tác giả"
       add: "Thêm bình luận"
+      author: "Tác giả"
+      author_missing: "Vô danh"
+      body: "Nội dung"
+      created_at: "Đã tạo"
       delete: "Xoá bình luận"
       delete_confirmation: "Bạn có chắc chắn muốn xóa những bình luận này?"
-      resource: "Resource"
-      no_comments_yet: "Chưa có bình luận."
-      author_missing: "Vô danh"
-      title_content: "Bình luận (%{count})"
       errors:
         empty_text: "Lời bình luận chưa được lưu, vì nội dung còn trống."
+      no_comments_yet: "Chưa có bình luận."
+      resource: "Resource"
+      resource_type: "Resource Type"
+      title_content: "Bình luận (%{count})"
+    create_another: "Tạo thêm %{model}"
+    dashboard: Bảng điều khiển
+    dashboard_welcome:
+      call_to_action: "Để thêm thành phần cho trang điều khiển hãy chỉnh sửa 'app/admin/dashboard.rb'"
+      welcome: "Chào mừng bạn đến với Active Admin. Đây là trang điều khiển mặc định."
+    delete: "Xóa"
+    delete_confirmation: "Bạn có chắc chắn rằng mình muốn xóa không?"
+    delete_model: "Xóa %{model}"
+    details: "%{model} Chi tiết"
     devise:
-      username:
-        title: "Tên người dùng"
+      change_password:
+        submit: "Thay đổi mật khẩu của tôi"
+        title: "Thay đổi mật khẩu của bạn"
       email:
         title: "Email"
-      subdomain:
-        title: "Tên miền phụ"
+      links:
+        forgot_your_password: "Quên mật khẩu của bạn?"
+        sign_in: "Đăng nhập"
+        sign_in_with_omniauth_provider: "Đăng nhập với %{provider}"
+      login:
+        remember_me: "Ghi nhớ tôi"
+        submit: "Đăng nhập"
+        title: "Đăng nhập"
       password:
         title: "Mật khẩu"
       password_confirmation:
         title: "Mật khẩu xác nhận"
-      sign_up:
-        title: "Đăng ký"
-        submit: "Đăng ký"
-      login:
-        title: "Đăng nhập"
-        remember_me: "Ghi nhớ tôi"
-        submit: "Đăng nhập"
-      reset_password:
-        title: "Quên mật khẩu của bạn?"
-        submit: "Thiết lập lại mật khẩu của tôi"
-      change_password:
-        title: "Thay đổi mật khẩu của bạn"
-        submit: "Thay đổi mật khẩu của tôi"
-      unlock:
-        title: "Gởi lại hướng dẫn mở khoá"
-        submit: "Gởi lại hướng dẫn mở khoá"
       resend_confirmation_instructions:
-        title: "Gởi lại hướng dẫn xác nhận"
         submit: "Gởi lại hướng dẫn xác nhận"
-      links:
-        sign_in: "Đăng nhập"
-        forgot_your_password: "Quên mật khẩu của bạn?"
-        sign_in_with_omniauth_provider: "Đăng nhập với %{provider}"
-    access_denied:
-      message: "Bạn không có quyền thực hiện tính năng này"
+        title: "Gởi lại hướng dẫn xác nhận"
+      reset_password:
+        submit: "Thiết lập lại mật khẩu của tôi"
+        title: "Quên mật khẩu của bạn?"
+      sign_up:
+        submit: "Đăng ký"
+        title: "Đăng ký"
+      subdomain:
+        title: "Tên miền phụ"
+      unlock:
+        submit: "Gởi lại hướng dẫn mở khoá"
+        title: "Gởi lại hướng dẫn mở khoá"
+      username:
+        title: "Tên người dùng"
+    download: "Tải về:"
+    dropdown_actions:
+      button_label: "Hành động"
+    edit: "Chỉnh sửa"
+    edit_model: "Chỉnh sửa %{model}"
+    empty: "Trống"
+    filters:
+      buttons:
+        clear: "Xóa dữ liệu lọc"
+        filter: "Lọc"
+      predicates:
+        contains: "Có chứa"
+        ends_with: "Kết thúc bởi"
+        equals: "Bằng"
+        from: "Từ"
+        greater_than: "Lớn hơn"
+        gteq_datetime: "Lớn hơn hoặc bằng"
+        less_than: "Nhỏ hơn"
+        lteq_datetime: "Nhỏ hơn hoặc bằng"
+        starts_with: "Bắt đầu với"
+        to: "Đến"
+    has_many_delete: "Xóa"
+    has_many_new: "Thêm mới %{model}"
+    has_many_remove: "Hủy bỏ"
     index_list:
-      table: "Bảng"
       block: "Danh sách"
-      grid: "Lưới"
       blog: "Blog"
+      grid: "Lưới"
+      table: "Bảng"
+    logout: "Đăng xuất"
+    main_content: "Xin bổ sung %{model}#main_content để hiển thị nội dung."
+    new_model: "Tạo mới %{model}"
+    next: "Sau"
+    pagination:
+      empty: "Không có %{model} nào được tìm thấy"
+      entry:
+        one: "entry"
+        other: "entries"
+      multiple: "Đang hiển thị %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> of <b>%{total}</b> trong tất cả."
+      multiple_without_total: "Đang hiển thị %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>."
+      one: "Đang hiển thị <b>1</b> %{model}"
+      one_page: "Đang hiển thị <b>tất cả %{n}</b> %{model}"
+      per_page: "Mỗi trang: "
+    powered_by: "Powered by %{active_admin} %{version}"
+    previous: "Trước"
+    search_status:
+      current_filters: "Bộ lộc hiện tại:"
+      current_scope: "Phạm vi:"
+      headline: "Danh sách tìm kiếm:"
+      no_current_filters: "Không có"
+    sidebars:
+      filters: "Bộ Lọc"
+      search_status: "Trạng thái tìm kiếm"
+    status_tag:
+      "no": "Không Có"
+      "unset": "Không Có"
+      "yes": "Có"
+    view: "Xem"

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -1,143 +1,143 @@
 "zh-CN":
   active_admin:
-    dashboard: "控制面板"
-    dashboard_welcome:
-      welcome: "欢迎使用Active Admin. 这是默认的控制面板页."
-      call_to_action: "若要添加新的面板内容, 请修改 'app/admin/dashboard.rb'"
-    view: "查看"
-    edit: "编辑"
-    delete: "删除"
-    delete_confirmation: "确定删除?"
-    create_another: "新建另一个%{model}"
-    new_model: "新建%{model}"
-    edit_model: "编辑%{model}"
-    delete_model: "删除%{model}"
-    details: "%{model}详情"
-    cancel: "取消"
-    empty: "未定义"
-    previous: "上一个"
-    next: "下一个"
-    download: "下载:"
-    has_many_new: "新建一个%{model}"
-    has_many_delete: "删除"
-    has_many_remove: "清除"
-    filters:
-      buttons:
-        filter: "过滤"
-        clear: "清除条件"
-      predicates:
-        contains: "包含"
-        equals: "等于"
-        starts_with: "开头"
-        ends_with: "完与"
-        greater_than: "大于"
-        less_than: "小于"
-        gteq_datetime: "大于等于"
-        lteq_datetime: "小于等于"
-        from: "起"
-        to: "止"
-    search_status:
-      headline: "搜索条件："
-      current_scope: "搜索范围："
-      current_filters: "过滤条件："
-      no_current_filters: "无"
-    status_tag:
-      "yes": "是"
-      "no": "否"
-      "unset": "否"
-    main_content: "请执行 %{model}#main_content 来显示内容."
-    logout: "退出"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "所有条件"
-      search_status: "搜索条件"
-    pagination:
-      empty: "暂时没有%{model}"
-      one: "显示 <b>1</b> %{model}"
-      one_page: "显示 <b>所有 %{n}</b> %{model}"
-      multiple: "显示所有 <b>%{total}</b> %{model}中的<b>%{from}&nbsp;-&nbsp;%{to}</b> 条"
-      multiple_without_total: "%{model}中的<b>%{from}&nbsp;-&nbsp;%{to}</b> 条"
-      per_page: "每页："
-      entry:
-        one: "条目"
-        other: "条目"
+    access_denied:
+      message: "您无权处理此操作"
     any: "任何"
-    blank_slate:
-      content: "暂时还没有%{resource_name}."
-      link: "新建一个"
-    dropdown_actions:
-      button_label: "行动"
     batch_actions:
+      action_label: "%{title} 被选中"
       button_label: "批处理"
       default_confirmation: "你确定你要这样做？"
       delete_confirmation: "你确定要删除这些%{plural_model}?"
+      labels:
+        destroy: "删除"
+      selection_toggle_explanation: "(切换选择)"
       succesfully_destroyed:
         one: "成功删除 1 %{model}"
         other: "成功删除 %{count} %{plural_model}"
-      selection_toggle_explanation: "(切换选择)"
-      action_label: "%{title} 被选中"
-      labels:
-        destroy: "删除"
+    blank_slate:
+      content: "暂时还没有%{resource_name}."
+      link: "新建一个"
+    cancel: "取消"
     comments:
-      created_at: "创建于"
-      resource_type: "资源类型"
+      add: "添加评论"
+      author: "作者"
+      author_missing: "匿名"
       author_type: "作者类型"
       body: "内容"
-      author: "作者"
-      add: "添加评论"
+      created_at: "创建于"
       delete: "删除评论"
       delete_confirmation: "你确定删除这些评论？"
-      resource: "资源"
-      no_comments_yet: "暂时没有评论"
-      author_missing: "匿名"
-      title_content: "(%{count})条评论"
       errors:
         empty_text: "评论保存失败，内空不能为空."
+      no_comments_yet: "暂时没有评论"
+      resource: "资源"
+      resource_type: "资源类型"
+      title_content: "(%{count})条评论"
+    create_another: "新建另一个%{model}"
+    dashboard: "控制面板"
+    dashboard_welcome:
+      call_to_action: "若要添加新的面板内容, 请修改 'app/admin/dashboard.rb'"
+      welcome: "欢迎使用Active Admin. 这是默认的控制面板页."
+    delete: "删除"
+    delete_confirmation: "确定删除?"
+    delete_model: "删除%{model}"
+    details: "%{model}详情"
     devise:
-      username:
-        title: "用户名"
+      change_password:
+        submit: "修改密码"
+        title: "修改密码"
       email:
         title: "邮箱"
-      subdomain:
-        title: "子域"
+      links:
+        forgot_your_password: "忘记了密码？"
+        resend_confirmation_instructions: "重发确认邮件"
+        resend_unlock_instructions: "重发解锁邮件"
+        sign_in: "登录"
+        sign_in_with_omniauth_provider: "通过%{provider}登录"
+        sign_up: "注册"
+      login:
+        remember_me: "记住我"
+        submit: "登录"
+        title: "登录"
       password:
         title: "密码"
       password_confirmation:
         title: "确认密码"
-      sign_up:
-        title: "注册"
-        submit: "注册"
-      login:
-        title: "登录"
-        remember_me: "记住我"
-        submit: "登录"
-      reset_password:
-        title: "忘记了密码？"
-        submit: "重置我的密码"
-      change_password:
-        title: "修改密码"
-        submit: "修改密码"
-      unlock:
-        title: "重新发送送解锁命令"
-        submit: "重新发送送解锁命令"
       resend_confirmation_instructions:
-        title: " 重新发送确认指示"
         submit: " 重新发送确认指示"
-      links:
-        sign_up: "注册"
-        sign_in: "登录"
-        forgot_your_password: "忘记了密码？"
-        sign_in_with_omniauth_provider: "通过%{provider}登录"
-        resend_unlock_instructions: "重发解锁邮件"
-        resend_confirmation_instructions: "重发确认邮件"
+        title: " 重新发送确认指示"
+      reset_password:
+        submit: "重置我的密码"
+        title: "忘记了密码？"
+      sign_up:
+        submit: "注册"
+        title: "注册"
+      subdomain:
+        title: "子域"
+      unlock:
+        submit: "重新发送送解锁命令"
+        title: "重新发送送解锁命令"
+      username:
+        title: "用户名"
+    download: "下载:"
+    dropdown_actions:
+      button_label: "行动"
+    edit: "编辑"
+    edit_model: "编辑%{model}"
+    empty: "未定义"
+    filters:
+      buttons:
+        clear: "清除条件"
+        filter: "过滤"
+      predicates:
+        contains: "包含"
+        ends_with: "完与"
+        equals: "等于"
+        from: "起"
+        greater_than: "大于"
+        gteq_datetime: "大于等于"
+        less_than: "小于"
+        lteq_datetime: "小于等于"
+        starts_with: "开头"
+        to: "止"
+    has_many_delete: "删除"
+    has_many_new: "新建一个%{model}"
+    has_many_remove: "清除"
+    index_list:
+      block: "列表"
+      blog: "博客"
+      grid: "网格"
+      table: "表格"
+    logout: "退出"
+    main_content: "请执行 %{model}#main_content 来显示内容."
+    new_model: "新建%{model}"
+    next: "下一个"
+    pagination:
+      empty: "暂时没有%{model}"
+      entry:
+        one: "条目"
+        other: "条目"
+      multiple: "显示所有 <b>%{total}</b> %{model}中的<b>%{from}&nbsp;-&nbsp;%{to}</b> 条"
+      multiple_without_total: "%{model}中的<b>%{from}&nbsp;-&nbsp;%{to}</b> 条"
+      one: "显示 <b>1</b> %{model}"
+      one_page: "显示 <b>所有 %{n}</b> %{model}"
+      per_page: "每页："
+    powered_by: "Powered by %{active_admin} %{version}"
+    previous: "上一个"
+    search_status:
+      current_filters: "过滤条件："
+      current_scope: "搜索范围："
+      headline: "搜索条件："
+      no_current_filters: "无"
+    sidebars:
+      filters: "所有条件"
+      search_status: "搜索条件"
+    status_tag:
+      "no": "否"
+      "unset": "否"
+      "yes": "是"
     unsupported_browser:
       headline: "很抱歉，ActiveAdmin 已不再支持 Internet Explorer 8 以下版本的浏览器。"
       recommendation: "建议您升级到最新版本的<a href=\"http://windows.microsoft.com/ie\">Internet Explorer</a>，<a href=\"https://chrome.google.com/\">Google Chrome</a>，或是 <a href=\"https://mozilla.org/firefox/\">Firefox</a>。"
       turn_off_compatibility_view: "如果您使用的是 IE 9 或更新的版本，请确认<a href=\"https://support.microsoft.com/zh-cn/help/17472/windows-internet-explorer-11-fix-site-display-problems-compatibility-view\">已关闭“兼容性视图”</a>。"
-    access_denied:
-      message: "您无权处理此操作"
-    index_list:
-      table: "表格"
-      block: "列表"
-      grid: "网格"
-      blog: "博客"
+    view: "查看"

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -1,135 +1,135 @@
 "zh-TW":
   active_admin:
-    dashboard: 儀表板
-    dashboard_welcome:
-      welcome: "歡迎來到 Active Admin，這是預設的儀表板頁面。"
-      call_to_action: "要新增儀表板內容，請查看 'app/admin/dashboard.rb'"
-    view: "檢視"
-    edit: "編輯"
-    delete: "刪除"
-    delete_confirmation: "你確定要刪除嗎？"
-    new_model: "新增 %{model}"
-    edit_model: "編輯 %{model}"
-    delete_model: "刪除 %{model}"
-    details: "%{model} 明細"
-    cancel: "取消"
-    empty: "空的"
-    previous: "前一個"
-    next: "下一個"
-    download: "下載:"
-    has_many_new: "增加新的 %{model}"
-    has_many_delete: "刪除"
-    has_many_remove: "清除"
-    filters:
-      buttons:
-        filter: "篩選"
-        clear: "清除篩選條件"
-      predicates:
-        contains: "包含"
-        equals: "等於"
-        starts_with: "開頭為"
-        ends_with: "結尾為"
-        greater_than: "大於"
-        less_than: "小於"
-    search_status:
-      headline: "搜尋條件:"
-      current_scope: "子集："
-      current_filters: "目前篩選條件："
-      no_current_filters: "無"
-    status_tag:
-      "yes": "是"
-      "no": "否"
-      "unset": "否"
-    main_content: "請實作 %{model}#main_content 以顯示內容。"
-    logout: "登出"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "篩選條件"
-      search_status: "搜尋條件"
-    pagination:
-      empty: "找不到 %{model} "
-      one: "顯示 <b>1</b> %{model}"
-      one_page: "顯示 <b>全部 %{n}</b> %{model}"
-      multiple: "總計 <b>%{total}</b> 顯示 %{model} 中<b>%{from}&nbsp;-&nbsp;%{to}</b> 筆"
-      multiple_without_total: "顯示 %{model} 中<b>%{from}&nbsp;-&nbsp;%{to}</b> 筆"
-      entry:
-        one: "筆"
-        other: "筆"
+    access_denied:
+      message: "您沒有權限執行此項操作"
     any: "任何"
-    blank_slate:
-      content: "尚無 %{resource_name}"
-      link: "建立一筆"
-    dropdown_actions:
-      button_label: "操作"
     batch_actions:
+      action_label: "%{title} 已選取"
       button_label: "批次作業"
       default_confirmation: "你確定你要這樣做？"
       delete_confirmation: "你確定要刪除這些 %{plural_model} 嗎？"
+      labels:
+        destroy: "刪除"
+      selection_toggle_explanation: "（切換選取）"
       succesfully_destroyed:
         one: "成功刪除 1 %{model}"
         other: "成功刪除 %{count} %{plural_model}"
-      selection_toggle_explanation: "（切換選取）"
-      action_label: "%{title} 已選取"
-      labels:
-        destroy: "刪除"
+    blank_slate:
+      content: "尚無 %{resource_name}"
+      link: "建立一筆"
+    cancel: "取消"
     comments:
-      created_at: "建立"
-      resource_type: "資源種類"
+      add: "新增評論"
+      author: "作者"
+      author_missing: "匿名"
       author_type: "作者身份"
       body: "內文"
-      author: "作者"
-      add: "新增評論"
+      created_at: "建立"
       delete: "刪除評論"
       delete_confirmation: "你確定要刪除這些評論嗎？"
-      resource: "資源"
-      no_comments_yet: "尚無評論"
-      author_missing: "匿名"
-      title_content: "(%{count}) 則評論"
       errors:
         empty_text: "評論儲存失敗，不允許空白的內容。"
+      no_comments_yet: "尚無評論"
+      resource: "資源"
+      resource_type: "資源種類"
+      title_content: "(%{count}) 則評論"
+    dashboard: 儀表板
+    dashboard_welcome:
+      call_to_action: "要新增儀表板內容，請查看 'app/admin/dashboard.rb'"
+      welcome: "歡迎來到 Active Admin，這是預設的儀表板頁面。"
+    delete: "刪除"
+    delete_confirmation: "你確定要刪除嗎？"
+    delete_model: "刪除 %{model}"
+    details: "%{model} 明細"
     devise:
-      username:
-        title: "帳號"
+      change_password:
+        submit: "更改我的密碼"
+        title: "更改你的密碼"
       email:
         title: "電子郵件信箱"
-      subdomain:
-        title: "子網域"
-      password:
-        title: "密碼"
-      sign_up:
-        title: "註冊"
-        submit: "註冊"
+      links:
+        forgot_your_password: "忘記密碼？"
+        resend_confirmation_instructions: "重新發送確認信"
+        resend_unlock_instructions: "重新發送解鎖指示"
+        sign_in: "登入"
+        sign_in_with_omniauth_provider: "使用 %{provider} 登入"
+        sign_up: "註冊"
       login:
-        title: "登入"
         remember_me: "記住我"
         submit: "登入"
-      reset_password:
-        title: "忘記密碼？"
-        submit: "重置密碼"
-      change_password:
-        title: "更改你的密碼"
-        submit: "更改我的密碼"
-      unlock:
-        title: "重新發送解鎖指示"
-        submit: "重新發送解鎖指示"
+        title: "登入"
+      password:
+        title: "密碼"
       resend_confirmation_instructions:
-        title: '重新發送確認信'
         submit: '重新發送確認信'
-      links:
-        sign_up: "註冊"
-        sign_in: "登入"
-        forgot_your_password: "忘記密碼？"
-        sign_in_with_omniauth_provider: "使用 %{provider} 登入"
-        resend_unlock_instructions: "重新發送解鎖指示"
-        resend_confirmation_instructions: "重新發送確認信"
+        title: '重新發送確認信'
+      reset_password:
+        submit: "重置密碼"
+        title: "忘記密碼？"
+      sign_up:
+        submit: "註冊"
+        title: "註冊"
+      subdomain:
+        title: "子網域"
+      unlock:
+        submit: "重新發送解鎖指示"
+        title: "重新發送解鎖指示"
+      username:
+        title: "帳號"
+    download: "下載:"
+    dropdown_actions:
+      button_label: "操作"
+    edit: "編輯"
+    edit_model: "編輯 %{model}"
+    empty: "空的"
+    filters:
+      buttons:
+        clear: "清除篩選條件"
+        filter: "篩選"
+      predicates:
+        contains: "包含"
+        ends_with: "結尾為"
+        equals: "等於"
+        greater_than: "大於"
+        less_than: "小於"
+        starts_with: "開頭為"
+    has_many_delete: "刪除"
+    has_many_new: "增加新的 %{model}"
+    has_many_remove: "清除"
+    index_list:
+      block: "清單"
+      blog: "部落格"
+      grid: "格狀"
+      table: "表格"
+    logout: "登出"
+    main_content: "請實作 %{model}#main_content 以顯示內容。"
+    new_model: "新增 %{model}"
+    next: "下一個"
+    pagination:
+      empty: "找不到 %{model} "
+      entry:
+        one: "筆"
+        other: "筆"
+      multiple: "總計 <b>%{total}</b> 顯示 %{model} 中<b>%{from}&nbsp;-&nbsp;%{to}</b> 筆"
+      multiple_without_total: "顯示 %{model} 中<b>%{from}&nbsp;-&nbsp;%{to}</b> 筆"
+      one: "顯示 <b>1</b> %{model}"
+      one_page: "顯示 <b>全部 %{n}</b> %{model}"
+    powered_by: "Powered by %{active_admin} %{version}"
+    previous: "前一個"
+    search_status:
+      current_filters: "目前篩選條件："
+      current_scope: "子集："
+      headline: "搜尋條件:"
+      no_current_filters: "無"
+    sidebars:
+      filters: "篩選條件"
+      search_status: "搜尋條件"
+    status_tag:
+      "no": "否"
+      "unset": "否"
+      "yes": "是"
     unsupported_browser:
       headline: "很抱歉，ActiveAdmin 已不再支援 Internet Explorer 8 以下版本的瀏覽器。"
       recommendation: "建議您升級到最新版本的<a href=\"http://windows.microsoft.com/ie\">Internet Explorer</a>，<a href=\"https://chrome.google.com/\">Google Chrome</a>，或是 <a href=\"https://mozilla.org/firefox/\">Firefox</a>。"
       turn_off_compatibility_view: "若您是使用 IE 9 或更新的版本，請確認<a href=\"https://support.microsoft.com/zh-tw/help/17471\">「相容性檢視」是關閉的</a>。"
-    access_denied:
-      message: "您沒有權限執行此項操作"
-    index_list:
-      table: "表格"
-      block: "清單"
-      grid: "格狀"
-      blog: "部落格"
+    view: "檢視"

--- a/tasks/lint.rake
+++ b/tasks/lint.rake
@@ -107,7 +107,7 @@ class SassRailsLinter
 end
 
 desc "Lints ActiveAdmin code base"
-task lint: ["lint:rubocop", "lint:mdl", "lint:eslint", "lint:gherkin", "lint:trailing_blank_lines", "lint:missing_final_new_line", "lint:trailing_whitespace", "lint:fixme", "lint:sass_rails", "lint:rspec"]
+task lint: ["lint:rubocop", "lint:mdl", "lint:eslint", "lint:gherkin", "lint:trailing_blank_lines", "lint:missing_final_new_line", "lint:trailing_whitespace", "lint:fixme", "lint:sass_rails", "lint:rspec", "lint:yalphabetize"]
 
 namespace :lint do
   require "rubocop/rake_task"
@@ -180,5 +180,12 @@ namespace :lint do
       "bin/rspec",
       *Dir.glob("spec/*.lint.rb")
     )
+  end
+
+  desc "Check locale alphabetization using yalphabetize"
+  task :yalphabetize do
+    puts "Running yalphabetize against locales..."
+
+    sh("bundle exec yalphabetize")
   end
 end


### PR DESCRIPTION
This PR introduces [yalphabetize](https://github.com/samrjenkins/yalphabetize) to the project. I would love to hear your thoughts/feedback.

It provides us with the ability to quickly normalise/alphabetise YAML files such as locales and to maintain this normalisation into the future.

Advantages of alphabetising YAML include:
- easier to locate specific keys in large files
- easier to spot duplicate keys
- easier to compare equivalent locale YAMLs for different languages

Yalphabetize can also be integrated into CI to ensure that future PRs maintain the alphabetisation of locale files.