### PR TITLE
Allow tables/panels to scroll horizontally when they get too wide.

### DIFF
--- a/app/assets/stylesheets/active_admin/components/_tables.scss
+++ b/app/assets/stylesheets/active_admin/components/_tables.scss
@@ -63,23 +63,30 @@ table.index_table {
 
 // --------- Tables inside Panels
 
-.panel_contents table {
-  margin-top: 5px;
-  th {
-    padding-top: 10px;
-    background: none;
-    color: $primary-color;
-    @include no-shadow;
-    @include text-shadow;
-    text-transform: uppercase;
-    border-bottom: 1px solid #ccc;
+.panel_contents {
+  overflow-x: auto;
+
+  table {
+    margin-top: 5px;
+    th {
+      padding-top: 10px;
+      background: none;
+      color: $primary-color;
+      @include no-shadow;
+      @include text-shadow;
+      text-transform: uppercase;
+      border-bottom: 1px solid #ccc;
+    }
+    tr.odd td { background: darken($table-stripe-color, 3%); }
+    tr.even td { background: $table-stripe-color; }
   }
-  tr.odd td { background: darken($table-stripe-color, 3%); }
-  tr.even td { background: $table-stripe-color; }
 }
 
 // -------------------------------------- Resource Attributes Table
-.attributes_table { overflow: hidden; }
+.attributes_table {
+  overflow: hidden;
+  overflow-x: auto;
+}
 
 .attributes_table table {
   col.even { background: $table-stripe-color; }

--- a/app/assets/stylesheets/active_admin/structure/_main_structure.scss
+++ b/app/assets/stylesheets/active_admin/structure/_main_structure.scss
@@ -4,6 +4,7 @@
 
 .index #wrapper {
   display: table;
+  table-layout: fixed;
 }
 
 #active_admin_content {


### PR DESCRIPTION
I've been using Active Admin and the only issue I've had is that while I don't necessarily need a "fully" responsive design so the app works on phones, sometimes when the index table is really wide or on tablets, the entire page is pushed off the right side of the page. I made some improvements to the CSS to just allow the tables to start to scroll horizontally when they hit that point, and would like to contribute these changes back.

To be clear, these are really the only rules I'm applying; though I put them where they seemed to make sense in context:

```css
#wrapper {
  table-layout: fixed;
  .panel_contents { overflow-x: auto; }
  .index_as_table { overflow-x: auto; }
  .attributes_table { overflow-x: auto; }
}
```

I noticed that there weren't many comments in the CSS files, but let me know if these directives should be commented to explain why they are there.

I can also revert the changes and put these grouped together somewhere or into a `_responsive.scss` if you would prefer, though that seemed to go against the design of the current CSS rules.