### PR TITLE
Fix form SCSS variables no longer being defined in the outermost scope, so no longer being accessible

### DIFF
--- a/app/assets/stylesheets/active_admin/_forms.scss
+++ b/app/assets/stylesheets/active_admin/_forms.scss
@@ -250,8 +250,6 @@ form {
 
 // -------------------------------------- Sidebar Forms
 
-$sidebar-inner-content-width: $sidebar-width - ($section-padding * 2);
-
 .sidebar_section {
 
   label {
@@ -273,13 +271,6 @@ $sidebar-inner-content-width: $sidebar-width - ($section-padding * 2);
 }
 
 // -------------------------------------- Filter Forms
-
-$filter-field-seperator-width: 12px;
-
-$side-by-side-filter-input-width: ($sidebar-inner-content-width * 0.5) - ($text-input-horizontal-padding * 2) - $filter-field-seperator-width;
-$side-by-side-filter-select-width: ($sidebar-inner-content-width * 0.5) - $filter-field-seperator-width;
-
-$date-range-filter-input-width: ($sidebar-inner-content-width * 0.5) - ($filter-field-seperator-width * 0.5);
 
 form.filter_form {
   .filter_form_field {

--- a/app/assets/stylesheets/active_admin/mixins/_variables.scss
+++ b/app/assets/stylesheets/active_admin/mixins/_variables.scss
@@ -45,7 +45,7 @@ $blank-slate-border: 1px dashed #DADADA !default;
 $sidebar-inner-content-width: $sidebar-width - ($section-padding * 2);
 
 // Filter Forms
-$filter-field-seperator-width: 12px;
+$filter-field-seperator-width: 12px !default;
 $side-by-side-filter-input-width: ($sidebar-inner-content-width * 0.5) - ($text-input-horizontal-padding * 2) - $filter-field-seperator-width;
 $side-by-side-filter-select-width: ($sidebar-inner-content-width * 0.5) - $filter-field-seperator-width;
 $date-range-filter-input-width: ($sidebar-inner-content-width * 0.5) - ($filter-field-seperator-width * 0.5);

--- a/app/assets/stylesheets/active_admin/mixins/_variables.scss
+++ b/app/assets/stylesheets/active_admin/mixins/_variables.scss
@@ -40,3 +40,12 @@ $text-input-horizontal-padding: 10px !default;
 $text-input-total-padding: $text-input-horizontal-padding * 2 + $border-width * 2;
 
 $blank-slate-border: 1px dashed #DADADA !default;
+
+// Sidebar Forms
+$sidebar-inner-content-width: $sidebar-width - ($section-padding * 2);
+
+// Filter Forms
+$filter-field-seperator-width: 12px;
+$side-by-side-filter-input-width: ($sidebar-inner-content-width * 0.5) - ($text-input-horizontal-padding * 2) - $filter-field-seperator-width;
+$side-by-side-filter-select-width: ($sidebar-inner-content-width * 0.5) - $filter-field-seperator-width;
+$date-range-filter-input-width: ($sidebar-inner-content-width * 0.5) - ($filter-field-seperator-width * 0.5);


### PR DESCRIPTION
- Make SCSS forms variables to be accessible in the global SCSS scope
- Allow to override $filter-field-seperator-width SCSS variable