### PR TITLE
Apply `box-sizing: border-box` globally

### DIFF
--- a/app/assets/stylesheets/active_admin/_base.scss
+++ b/app/assets/stylesheets/active_admin/_base.scss
@@ -33,6 +33,12 @@
   @import "./structure/main_structure";
   @import "./structure/title_bar";
 
+  *,
+  *:before,
+  *:after {
+    box-sizing: border-box;
+  }
+
   body {
     @include sans-family;
     line-height: 1.5;

--- a/app/assets/stylesheets/active_admin/_base.scss
+++ b/app/assets/stylesheets/active_admin/_base.scss
@@ -33,10 +33,14 @@
   @import "./structure/main_structure";
   @import "./structure/title_bar";
 
+  html {
+    box-sizing: border-box;
+  }
+
   *,
   *:before,
   *:after {
-    box-sizing: border-box;
+    box-sizing: inherit;
   }
 
   body {

--- a/app/assets/stylesheets/active_admin/_forms.scss
+++ b/app/assets/stylesheets/active_admin/_forms.scss
@@ -313,7 +313,6 @@ form.filter_form {
 
     &.filter_date_range {
       input[type=text] {
-        box-sizing: border-box;
         width: $date-range-filter-input-width;
 
         + input {

--- a/app/assets/stylesheets/active_admin/components/_date_picker.scss
+++ b/app/assets/stylesheets/active_admin/components/_date_picker.scss
@@ -17,11 +17,10 @@
   }
 
   .ui-datepicker-header {
-    height: 14px;
     @include primary-gradient;
     padding: 12px 5px 7px 4px;
     margin: 0px 0px 2px 2px;
-    width: 147px;
+    width: 156px;
     border-top-left-radius: 7px;
     border-top-right-radius: 7px;
     position: relative;

--- a/app/assets/stylesheets/active_admin/components/_dropdown_menu.scss
+++ b/app/assets/stylesheets/active_admin/components/_dropdown_menu.scss
@@ -106,7 +106,6 @@
       li {
         display: block;
         border-bottom: solid 1px #ebebeb;
-        box-sizing: border-box;
 
         a {
           display: block;

--- a/app/assets/stylesheets/active_admin/structure/_title_bar.scss
+++ b/app/assets/stylesheets/active_admin/structure/_title_bar.scss
@@ -1,7 +1,6 @@
 #title_bar {
   @include section-header;
   @include clearfix;
-  box-sizing: border-box;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.37);
   display: table;
   border-bottom-color: #EEE;


### PR DESCRIPTION
This is extracted from #3862. I think it shouldn't change the default appearance but should make it easier to customize it.

I slightly changed the original commit to propose the best practice recommended here: https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/.