### PR TITLE
Drop support for Ruby 2.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,7 +91,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        ruby: [{ name: 2.7, value: 2.7.5 }, { name: 2.6, value: 2.6.9 }]
+        ruby: [{ name: 2.7, value: 2.7.5 }]
 
         os: [ubuntu-20.04]
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ require:
 
 AllCops:
   DisabledByDefault: true
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
 
   Exclude:
     - tmp/development_apps/**/*

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.extra_rdoc_files = %w[CHANGELOG.md CODE_OF_CONDUCT.md CONTRIBUTING.md README.md]
 
-  s.required_ruby_version = ">= 2.6"
+  s.required_ruby_version = ">= 2.7"
 
   s.add_dependency "arbre", "~> 1.2", ">= 1.2.1"
   s.add_dependency "formtastic", ">= 3.1", "< 5.0"


### PR DESCRIPTION
Ruby 2.6 is going to be unsupported soon, one month left for arriving to its EOL.

Maybe could be the moment to drop the support also for ActiveAdmin.