### PR TITLE
Bump cucumber-rails from github master branch to 2.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ group :test do
   gem "webrick"
 
   gem "simplecov", require: false # Test coverage generator. Go to /coverage/ after running tests
-  gem "cucumber-rails", github: "cucumber/cucumber-rails", require: false
+  gem "cucumber-rails", require: false
   gem "cucumber"
   gem "database_cleaner"
   gem "jasmine"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,3 @@
-GIT
-  remote: https://github.com/cucumber/cucumber-rails.git
-  revision: 9d8f2e687d155a7da37e00d53504880b1b2ef9a8
-  specs:
-    cucumber-rails (2.4.0)
-      capybara (>= 2.18, < 4)
-      cucumber (>= 3.2, < 8)
-      mime-types (~> 3.3)
-      nokogiri (~> 1.10)
-      railties (>= 5.0, < 8)
-      rexml (~> 3.0)
-      webrick (~> 1.7)
-
 PATH
   remote: .
   specs:
@@ -149,6 +136,14 @@ GEM
     cucumber-html-formatter (17.0.0)
       cucumber-messages (~> 17.1, >= 17.1.0)
     cucumber-messages (17.1.1)
+    cucumber-rails (2.5.0)
+      capybara (>= 2.18, < 4)
+      cucumber (>= 3.2, < 8)
+      mime-types (~> 3.3)
+      nokogiri (~> 1.10)
+      railties (>= 5.0, < 8)
+      rexml (~> 3.0)
+      webrick (~> 1.7)
     cucumber-tag-expressions (4.1.0)
     cucumber-wire (6.2.0)
       cucumber-core (~> 10.1, >= 10.1.0)
@@ -489,7 +484,7 @@ DEPENDENCIES
   capybara
   chandler
   cucumber
-  cucumber-rails!
+  cucumber-rails
   cuprite
   database_cleaner
   devise

--- a/gemfiles/rails_60/Gemfile
+++ b/gemfiles/rails_60/Gemfile
@@ -28,7 +28,7 @@ group :test do
   gem "webrick"
 
   gem "simplecov", require: false # Test coverage generator. Go to /coverage/ after running tests
-  gem "cucumber-rails", github: "cucumber/cucumber-rails", require: false
+  gem "cucumber-rails", require: false
   gem "cucumber"
   gem "database_cleaner"
   gem "jasmine"

--- a/gemfiles/rails_60/Gemfile.lock
+++ b/gemfiles/rails_60/Gemfile.lock
@@ -1,16 +1,3 @@
-GIT
-  remote: https://github.com/cucumber/cucumber-rails.git
-  revision: 9d8f2e687d155a7da37e00d53504880b1b2ef9a8
-  specs:
-    cucumber-rails (2.4.0)
-      capybara (>= 2.18, < 4)
-      cucumber (>= 3.2, < 8)
-      mime-types (~> 3.3)
-      nokogiri (~> 1.10)
-      railties (>= 5.0, < 8)
-      rexml (~> 3.0)
-      webrick (~> 1.7)
-
 PATH
   remote: ../..
   specs:
@@ -140,6 +127,14 @@ GEM
     cucumber-html-formatter (17.0.0)
       cucumber-messages (~> 17.1, >= 17.1.0)
     cucumber-messages (17.1.1)
+    cucumber-rails (2.5.0)
+      capybara (>= 2.18, < 4)
+      cucumber (>= 3.2, < 8)
+      mime-types (~> 3.3)
+      nokogiri (~> 1.10)
+      railties (>= 5.0, < 8)
+      rexml (~> 3.0)
+      webrick (~> 1.7)
     cucumber-tag-expressions (4.1.0)
     cucumber-wire (6.2.0)
       cucumber-core (~> 10.1, >= 10.1.0)
@@ -390,7 +385,7 @@ DEPENDENCIES
   cancancan
   capybara
   cucumber
-  cucumber-rails!
+  cucumber-rails
   cuprite
   database_cleaner
   devise

--- a/gemfiles/rails_61_turbolinks/Gemfile
+++ b/gemfiles/rails_61_turbolinks/Gemfile
@@ -30,7 +30,7 @@ group :test do
   gem "webrick"
 
   gem "simplecov", require: false # Test coverage generator. Go to /coverage/ after running tests
-  gem "cucumber-rails", github: "cucumber/cucumber-rails", require: false
+  gem "cucumber-rails", require: false
   gem "cucumber"
   gem "database_cleaner"
   gem "jasmine"

--- a/gemfiles/rails_61_turbolinks/Gemfile.lock
+++ b/gemfiles/rails_61_turbolinks/Gemfile.lock
@@ -1,16 +1,3 @@
-GIT
-  remote: https://github.com/cucumber/cucumber-rails.git
-  revision: 9d8f2e687d155a7da37e00d53504880b1b2ef9a8
-  specs:
-    cucumber-rails (2.4.0)
-      capybara (>= 2.18, < 4)
-      cucumber (>= 3.2, < 8)
-      mime-types (~> 3.3)
-      nokogiri (~> 1.10)
-      railties (>= 5.0, < 8)
-      rexml (~> 3.0)
-      webrick (~> 1.7)
-
 PATH
   remote: ../..
   specs:
@@ -144,6 +131,14 @@ GEM
     cucumber-html-formatter (17.0.0)
       cucumber-messages (~> 17.1, >= 17.1.0)
     cucumber-messages (17.1.1)
+    cucumber-rails (2.5.0)
+      capybara (>= 2.18, < 4)
+      cucumber (>= 3.2, < 8)
+      mime-types (~> 3.3)
+      nokogiri (~> 1.10)
+      railties (>= 5.0, < 8)
+      rexml (~> 3.0)
+      webrick (~> 1.7)
     cucumber-tag-expressions (4.1.0)
     cucumber-wire (6.2.0)
       cucumber-core (~> 10.1, >= 10.1.0)
@@ -395,7 +390,7 @@ DEPENDENCIES
   cancancan
   capybara
   cucumber
-  cucumber-rails!
+  cucumber-rails
   cuprite
   database_cleaner
   devise

--- a/gemfiles/rails_61_webpacker/Gemfile
+++ b/gemfiles/rails_61_webpacker/Gemfile
@@ -27,7 +27,7 @@ group :test do
   gem "webrick"
 
   gem "simplecov", require: false # Test coverage generator. Go to /coverage/ after running tests
-  gem "cucumber-rails", github: "cucumber/cucumber-rails", require: false
+  gem "cucumber-rails", require: false
   gem "cucumber"
   gem "database_cleaner"
   gem "jasmine"

--- a/gemfiles/rails_61_webpacker/Gemfile.lock
+++ b/gemfiles/rails_61_webpacker/Gemfile.lock
@@ -1,16 +1,3 @@
-GIT
-  remote: https://github.com/cucumber/cucumber-rails.git
-  revision: 9d8f2e687d155a7da37e00d53504880b1b2ef9a8
-  specs:
-    cucumber-rails (2.4.0)
-      capybara (>= 2.18, < 4)
-      cucumber (>= 3.2, < 8)
-      mime-types (~> 3.3)
-      nokogiri (~> 1.10)
-      railties (>= 5.0, < 8)
-      rexml (~> 3.0)
-      webrick (~> 1.7)
-
 PATH
   remote: ../..
   specs:
@@ -144,6 +131,14 @@ GEM
     cucumber-html-formatter (17.0.0)
       cucumber-messages (~> 17.1, >= 17.1.0)
     cucumber-messages (17.1.1)
+    cucumber-rails (2.5.0)
+      capybara (>= 2.18, < 4)
+      cucumber (>= 3.2, < 8)
+      mime-types (~> 3.3)
+      nokogiri (~> 1.10)
+      railties (>= 5.0, < 8)
+      rexml (~> 3.0)
+      webrick (~> 1.7)
     cucumber-tag-expressions (4.1.0)
     cucumber-wire (6.2.0)
       cucumber-core (~> 10.1, >= 10.1.0)
@@ -391,7 +386,7 @@ DEPENDENCIES
   cancancan
   capybara
   cucumber
-  cucumber-rails!
+  cucumber-rails
   cuprite
   database_cleaner
   devise


### PR DESCRIPTION
Related to #7366 

cucumber-rails 2.5 with Rails 7 support has been released.