### PR TITLE
Remove `insert_tag` from Form-Partial docs

### DIFF
--- a/docs/5-forms.md
+++ b/docs/5-forms.md
@@ -56,7 +56,7 @@ Which looks for something like this:
 
 ```ruby
 # app/views/admin/posts/_form.html.arb
-insert_tag active_admin_form_for resource do |f|
+active_admin_form_for [:admin, resource] do |f|
   inputs :title, :body
   actions
 end


### PR DESCRIPTION
This PR contains only documentation changes. It references #3910, which was closed due to inactivity.

This removes the use of `insert_tag` in the documentation for form-partials. 

As discussed in #3910, using `insert_tag active_admin_form_for resource` in a form-partial raises the following error (where `post` is the name of the resource):

```ruby
undefined method 'posts_path' for #<#Class:0x007f9980312588:0x007f9981f96358>
```

The commonly accepted solution in #3910 is the usage of  `active_admin_form_for[:admin, resource]` instead. This is the solution that worked for me as well. I'm uncertain if this requires any additional explanations regarding the namespace of the resource.