### PR TITLE
Use remove_record option as checkbox label for removing records in has_many forms

### DIFF
--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -113,10 +113,8 @@ module ActiveAdmin
           template.link_to remove_text, "#", class: "button has_many_remove"
         end
       elsif allow_destroy?(form_builder.object)
-        form_builder.input(
-          :_destroy, as: :boolean,
-                     wrapper_html: { class: "has_many_delete" },
-                     label: I18n.t("active_admin.has_many_delete"))
+        remove_text = remove_record.is_a?(String) ? remove_record : I18n.t("active_admin.has_many_delete")
+        form_builder.input(:_destroy, as: :boolean, wrapper_html: { class: "has_many_delete" }, label: remove_text)
       end
 
       if sortable_column


### PR DESCRIPTION
Currently, the `remove_record` in the example below (taken from [the "Nested Resources" section of the doc](https://activeadmin.info/5-forms.html#nested-resources)), the `remove_record` will only be used for the button that removes _new_ records. It will not be used as a label for the checkbox that lets the user select which _existing_ records should be destroyed.

```rb
ActiveAdmin.register Post do
  permit_params comment_attributes: [:id, :body, :_destroy]

  form do |f|
    f.inputs do
      f.has_many :comments, remove_record: 'Remove Comment' do |b|
        b.input :body
      end
    end
    f.actions
  end
end
```

This PR makes Active Admin use the same option for both the button that removes new records and for the checkbox that selects which existing records to destroy.

I could use this change, but would other users find it useful? If so, I'm happy to add some tests. I could use the `I18n` translations instead. I also found the documentation to be a bit misleading, as I initially thought the same setting should apply to both types of records. Happy to update the doc instead!

It also raises some questions:

- It's not a big breaking change, but it might change the UI of applications which rely on translations for existing records while using the `remove_record` option for new records. If we need to make it backward-compatible, then an opt-in option could work.
- Should there be two different options for new and existing records?