### PR TITLE
Use squash merge strategy for mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -8,4 +8,4 @@ pull_request_rules:
 
     actions:
       merge:
-        method: merge
+        method: squash


### PR DESCRIPTION
This matches how we usually merge other PRs: merge strategy in general, except for single commit PRs, where we use squash. Dependabot PRs are single commit, so we should use squash for them too.