### PR TITLE
Fix pundit performance

### DIFF
--- a/lib/active_admin/pundit_adapter.rb
+++ b/lib/active_admin/pundit_adapter.rb
@@ -89,7 +89,7 @@ module ActiveAdmin
     end
 
     def namespace(object)
-      if default_policy_namespace && !object.class.to_s.match?(/^#{default_policy_module}::/)
+      if default_policy_namespace && !object.class.to_s.start_with?("#{default_policy_module}::")
         [default_policy_namespace.to_sym, object]
       else
         object

--- a/lib/active_admin/pundit_adapter.rb
+++ b/lib/active_admin/pundit_adapter.rb
@@ -71,10 +71,11 @@ module ActiveAdmin
     # This fallback might be removed in future versions of ActiveAdmin, so
     # pundit_adapter search will work consistently with provided namespaces
     def compat_policy(subject)
+      return unless default_policy_namespace
+
       target = policy_target(subject)
 
-      return unless default_policy_namespace &&
-        target.class.to_s.include?(default_policy_module) &&
+      return unless target.class.to_s.include?(default_policy_module) &&
         (policy = Pundit.policy(user, target))
 
       policy_name = policy.class.to_s

--- a/lib/active_admin/pundit_adapter.rb
+++ b/lib/active_admin/pundit_adapter.rb
@@ -36,7 +36,7 @@ module ActiveAdmin
       if (policy = compat_policy(subject))
         policy
       elsif default_policy_class
-        default_policy(user, subject)
+        default_policy(subject)
       else
         raise e
       end
@@ -100,7 +100,7 @@ module ActiveAdmin
       ActiveAdmin.application.pundit_default_policy && ActiveAdmin.application.pundit_default_policy.constantize
     end
 
-    def default_policy(user, subject)
+    def default_policy(subject)
       default_policy_class.new(user, subject)
     end
 

--- a/lib/active_admin/pundit_adapter.rb
+++ b/lib/active_admin/pundit_adapter.rb
@@ -31,14 +31,13 @@ module ActiveAdmin
     end
 
     def retrieve_policy(subject)
-      Pundit.policy!(user, namespace(policy_target(subject)))
-    rescue Pundit::NotDefinedError => e
-      if (policy = compat_policy(subject))
+      target = policy_target(subject)
+      if (policy = Pundit.policy(user, namespace(target)) || compat_policy(subject))
         policy
       elsif default_policy_class
         default_policy(subject)
       else
-        raise e
+        raise Pundit::NotDefinedError, "unable to find a compatible policy for `#{target}`"
       end
     end
 

--- a/lib/active_admin/pundit_adapter.rb
+++ b/lib/active_admin/pundit_adapter.rb
@@ -32,7 +32,7 @@ module ActiveAdmin
 
     def retrieve_policy(subject)
       target = policy_target(subject)
-      if (policy = Pundit.policy(user, namespace(target)) || compat_policy(subject))
+      if (policy = policy(namespace(target)) || compat_policy(subject))
         policy
       elsif default_policy_class
         default_policy(subject)
@@ -75,7 +75,7 @@ module ActiveAdmin
       target = policy_target(subject)
 
       return unless target.class.to_s.include?(default_policy_module) &&
-        (policy = Pundit.policy(user, target))
+        (policy = policy(target))
 
       policy_name = policy.class.to_s
 
@@ -110,6 +110,14 @@ module ActiveAdmin
 
     def default_policy_module
       default_policy_namespace.to_s.camelize
+    end
+
+    def policy(target)
+      policies[target] ||= Pundit.policy(user, target)
+    end
+
+    def policies
+      @policies ||= {}
     end
 
   end

--- a/spec/unit/pundit_adapter_spec.rb
+++ b/spec/unit/pundit_adapter_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe ActiveAdmin::PunditAdapter do
       end
 
       it "looks for a namespaced policy" do
-        expect(Pundit).to receive(:policy!).with(anything, [:foobar, Post]).and_return(DefaultPolicy.new(double, double))
+        expect(Pundit).to receive(:policy).with(anything, [:foobar, Post]).and_return(DefaultPolicy.new(double, double))
         auth.authorized?(:read, Post)
       end
 
@@ -81,13 +81,13 @@ RSpec.describe ActiveAdmin::PunditAdapter do
       end
 
       it "uses the resource when no subject given" do
-        expect(Pundit).to receive(:policy!).with(anything, [:foobar, resource]).and_return(DefaultPolicy::Scope.new(double, double))
+        expect(Pundit).to receive(:policy).with(anything, [:foobar, resource]).and_return(DefaultPolicy::Scope.new(double, double))
         auth.authorized?(:index)
       end
     end
 
     it "uses the resource when no subject given" do
-      expect(Pundit).to receive(:policy!).with(anything, resource).and_return(DefaultPolicy::Scope.new(double, double))
+      expect(Pundit).to receive(:policy).with(anything, resource).and_return(DefaultPolicy::Scope.new(double, double))
       auth.authorized?(:index)
     end
 
@@ -105,12 +105,12 @@ RSpec.describe ActiveAdmin::PunditAdapter do
       end
 
       it "looks for a namespaced policy" do
-        expect(Pundit).to receive(:policy!).with(anything, [:pub, Publisher]).and_return(DefaultPolicy.new(double, double))
+        expect(Pundit).to receive(:policy).with(anything, [:pub, Publisher]).and_return(DefaultPolicy.new(double, double))
         auth.authorized?(:read, Publisher)
       end
 
       it "fallbacks to the policy without namespace" do
-        expect(Pundit).to receive(:policy!).with(anything, [:pub, Publisher]).and_raise(Pundit::NotDefinedError)
+        expect(Pundit).to receive(:policy).with(anything, [:pub, Publisher]).and_return(nil)
         expect(Pundit).to receive(:policy).with(anything, Publisher).and_return(DefaultPolicy.new(double, double))
 
         auth.authorized?(:read, Publisher)
@@ -146,7 +146,7 @@ RSpec.describe ActiveAdmin::PunditAdapter do
 
       before do
         allow(ActiveAdmin.application).to receive(:pundit_default_policy).and_return default_policy_klass_name
-        allow(Pundit).to receive(:policy!) { raise Pundit::NotDefinedError.new }
+        allow(Pundit).to receive(:policy) { nil }
       end
 
       it("should return default policy instance") { is_expected.to be_instance_of(default_policy_klass) }


### PR DESCRIPTION
Our fallback behavior introduced at #7144 to keep backwards compatibility when looking for compatible Pundit policies introduced severe performance degradation.

This PR fixes the issue by introducing a cache of Pundit policies. It also introduces other minor improvements but the performance culprit should hopefully be fixed by 63e3f5f850a364faf58979637a7b70431630442c.

Fixes #7477.