### PR TITLE
Fix passing expected hash payload argument

### DIFF
--- a/features/step_definitions/configuration_steps.rb
+++ b/features/step_definitions/configuration_steps.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 module ActiveAdminReloading
   def load_aa_config(config_content)
-    ActiveSupport::Notifications.instrument ActiveAdmin::Application::BeforeLoadEvent, ActiveAdmin.application
+    ActiveSupport::Notifications.instrument ActiveAdmin::Application::BeforeLoadEvent, { active_admin_application: ActiveAdmin.application }
     eval(config_content)
-    ActiveSupport::Notifications.instrument ActiveAdmin::Application::AfterLoadEvent, ActiveAdmin.application
+    ActiveSupport::Notifications.instrument ActiveAdmin::Application::AfterLoadEvent, { active_admin_application: ActiveAdmin.application }
     Rails.application.reload_routes!
     ActiveAdmin.application.namespaces.each &:reset_menu!
   end

--- a/lib/active_admin.rb
+++ b/lib/active_admin.rb
@@ -113,7 +113,7 @@ module ActiveAdmin
     private
 
     def wrap_block_for_active_support_notifications block
-      proc { |_name, _start, _finish, _id, payload| block.call payload }
+      proc { |_name, _start, _finish, _id, payload| block.call payload[:active_admin_application] }
     end
 
   end

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -76,7 +76,7 @@ module ActiveAdmin
 
       namespace = namespaces[name.to_sym] ||= begin
         namespace = Namespace.new(self, name)
-        ActiveSupport::Notifications.instrument ActiveAdmin::Namespace::RegisterEvent, namespace
+        ActiveSupport::Notifications.instrument ActiveAdmin::Namespace::RegisterEvent, { active_admin_namespace: namespace }
         namespace
       end
 
@@ -112,10 +112,10 @@ module ActiveAdmin
     # To reload everything simply call `ActiveAdmin.unload!`
     def load!
       unless loaded?
-        ActiveSupport::Notifications.instrument BeforeLoadEvent, self # before_load hook
+        ActiveSupport::Notifications.instrument BeforeLoadEvent, { active_admin_application: self } # before_load hook
         files.each { |file| load file } # load files
         namespace(default_namespace) # init AA resources
-        ActiveSupport::Notifications.instrument AfterLoadEvent, self # after_load hook
+        ActiveSupport::Notifications.instrument AfterLoadEvent, { active_admin_application: self } # after_load hook
         @@loaded = true
       end
     end

--- a/lib/active_admin/namespace.rb
+++ b/lib/active_admin/namespace.rb
@@ -60,7 +60,7 @@ module ActiveAdmin
       settings.respond_to?(method) ? settings.send(method, *args) : super
     end
 
-    # Register a resource into this namespace. The preffered method to access this is to
+    # Register a resource into this namespace. The preferred method to access this is to
     # use the global registration ActiveAdmin.register which delegates to the proper
     # namespace instance.
     def register(resource_class, options = {}, &block)
@@ -72,7 +72,7 @@ module ActiveAdmin
       reset_menu!
 
       # Dispatch a registration event
-      ActiveSupport::Notifications.instrument ActiveAdmin::Resource::RegisterEvent, config
+      ActiveSupport::Notifications.instrument ActiveAdmin::Resource::RegisterEvent, { active_admin_resource: config }
 
       # Return the config
       config

--- a/spec/unit/resource_registration_spec.rb
+++ b/spec/unit/resource_registration_spec.rb
@@ -18,7 +18,13 @@ RSpec.describe "Registering an object to administer" do
     end
 
     it "should dispatch a Resource::RegisterEvent" do
-      expect(ActiveSupport::Notifications).to receive(:instrument).with(ActiveAdmin::Resource::RegisterEvent, an_instance_of(ActiveAdmin::Resource))
+      expect(ActiveSupport::Notifications).to(
+        receive(:instrument)
+          .with(
+            ActiveAdmin::Resource::RegisterEvent,
+            hash_including(active_admin_resource: an_instance_of(ActiveAdmin::Resource))
+          )
+      )
 
       application.register Category
     end
@@ -34,8 +40,20 @@ RSpec.describe "Registering an object to administer" do
     end
 
     it "should generate a Namespace::RegisterEvent and a Resource::RegisterEvent" do
-      expect(ActiveSupport::Notifications).to receive(:instrument).with(ActiveAdmin::Namespace::RegisterEvent, an_instance_of(ActiveAdmin::Namespace))
-      expect(ActiveSupport::Notifications).to receive(:instrument).with(ActiveAdmin::Resource::RegisterEvent, an_instance_of(ActiveAdmin::Resource))
+      expect(ActiveSupport::Notifications).to(
+        receive(:instrument)
+          .with(
+            ActiveAdmin::Namespace::RegisterEvent,
+            hash_including(active_admin_namespace: an_instance_of(ActiveAdmin::Namespace))
+          )
+      )
+      expect(ActiveSupport::Notifications).to(
+        receive(:instrument)
+          .with(
+            ActiveAdmin::Resource::RegisterEvent,
+            hash_including(active_admin_resource: an_instance_of(ActiveAdmin::Resource))
+          )
+      )
       application.register Category, namespace: :not_yet_created
     end
   end


### PR DESCRIPTION
Passing non hash objects as payload arguments to an event instrumenter breaks subscribers implemented by other libraries like Sentry.

https://api.rubyonrails.org/v6.1.5.1/classes/ActiveSupport/Notifications.html
https://api.rubyonrails.org/classes/ActiveSupport/Notifications.html

Fixes #7342 

<!--

Thanks for contributing to ActiveAdmin!

You can find all the instructions for contributing at the [CONTRIBUTING file].

Before submitting your PR make sure that:

* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are splitted apart.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all github checks are passing, but feel free to ask for early feedback if you need guidance.

[CONTRIBUTING file]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->
