### PR TITLE
Honor load paths order when loading admin files

### DIFF
--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -126,7 +126,7 @@ module ActiveAdmin
 
     # Returns ALL the files to be loaded
     def files
-      load_paths.flatten.compact.uniq.flat_map { |path| Dir["#{path}/**/*.rb"] }.sort
+      load_paths.flatten.compact.uniq.flat_map { |path| Dir["#{path}/**/*.rb"].sort }
     end
 
     # Creates all the necessary routes for the ActiveAdmin configurations

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -144,6 +144,22 @@ RSpec.describe ActiveAdmin::Application do
         FileUtils.remove_entry_secure(test_dir, force: true)
       end
     end
+
+    it "should honor load paths order", :changes_filesystem do
+      test_dir = File.expand_path("app/other-admin", application.app_path)
+      test_file = File.expand_path("app/other-admin/posts.rb", application.app_path)
+
+      application.load_paths.unshift(test_dir)
+
+      begin
+        FileUtils.mkdir_p(test_dir)
+        FileUtils.touch(test_file)
+        expect(application.files.map { |f| File.basename(f) }).to eq(%w(posts.rb admin_users.rb dashboard.rb stores.rb))
+      ensure
+        ActiveSupport::Dependencies.clear unless ActiveAdmin::Dependency.supports_zeitwerk?
+        FileUtils.remove_entry_secure(test_dir, force: true)
+      end
+    end
   end
 
   describe "#namespace" do


### PR DESCRIPTION
[PR #6124](https://github.com/activeadmin/activeadmin/pull/6124) started sorting files when loading to ensure `ActiveAdmin.routes` has a consistent order. This order - based on admin file names - took precedence over the order of load paths.

When admins are loaded from different locations, e.g. different gems and the main application, it can be helpful to control load
order. That way the main application can override settings of admins defined in gems.

The previous behavior also made load order depend on the file system location of gems and the application since expanded paths are used when sorting. For example, in development mode, admins from a gem in `/home/user/.rvm/...` might be loaded before admins from the app in `/home/user/my_app/app/admin`, while being loaded after app admins in production when the gem lives in `/home/app/my_app/vendor/...`.

We now instead sort files of each load path individually to achieve consistent ordering while still preserving the overall order as
prescribed by the `application.load_paths` array.
