### PR TITLE
Force scope on default filters collection

### DIFF
--- a/lib/active_admin/filters/resource_extension.rb
+++ b/lib/active_admin/filters/resource_extension.rb
@@ -75,6 +75,7 @@ module ActiveAdmin
       def add_filter(attribute, options = {})
         raise Disabled unless filters_enabled?
 
+        options = filter_default_collection(attribute.to_sym).merge(options)
         (@filters ||= {})[attribute.to_sym] = options
       end
 
@@ -93,7 +94,7 @@ module ActiveAdmin
 
         if filters.empty? || preserve_default_filters?
           default_filters.each do |f|
-            filters[f] ||= {}
+            filters[f] ||= filter_default_collection(f)
           end
         end
 
@@ -102,6 +103,16 @@ module ActiveAdmin
         end
 
         filters
+      end
+
+      def filter_default_collection(filter)
+        association = resource_class.reflect_on_all_associations.find { |association| association.name == filter }
+        return {} unless association
+
+        scoped_collection = proc do
+          active_admin_authorization.scope_collection(association.klass.all)
+        end
+        { collection: scoped_collection }
       end
 
       # @return [Array] The array of default filters for this resource


### PR DESCRIPTION
In-repo clone of https://github.com/activeadmin/activeadmin/pull/6923.

> When we use default filters, or filter of an existing relationship without providing a collection, we enforce the collection to be scope
> It is useful when you are using authorization scope to define what resources your current user can access, even in filter values.

Fixes #6883.