### PR TITLE
Add Load Paths docs to the active_admin.rb template

### DIFF
--- a/lib/generators/active_admin/install/templates/active_admin.rb.erb
+++ b/lib/generators/active_admin/install/templates/active_admin.rb.erb
@@ -18,6 +18,21 @@ ActiveAdmin.setup do |config|
   #
   # config.site_title_image = "logo.png"
 
+  # == Load Paths
+  #
+  # By default Active Admin files go inside app/admin/.
+  # You can change this directory.
+  # eg:
+  # config.load_paths = [File.join(Rails.root, 'app', 'ui')]
+  #
+  # Or, you can also load more directories.
+  # Useful when setting namespaces with users that are not your main AdminUser entitiy.
+  # eg:
+  # config.load_paths = [
+  #   File.join(Rails.root, 'app', 'admin'),
+  #   File.join(Rails.root, 'app', 'cashier')
+  # ]
+
   # == Default Namespace
   #
   # Set the default namespace each administration resource

--- a/lib/generators/active_admin/install/templates/active_admin.rb.erb
+++ b/lib/generators/active_admin/install/templates/active_admin.rb.erb
@@ -22,16 +22,18 @@ ActiveAdmin.setup do |config|
   #
   # By default Active Admin files go inside app/admin/.
   # You can change this directory.
+  #
   # eg:
-  # config.load_paths = [File.join(Rails.root, 'app', 'ui')]
+  #   config.load_paths = [File.join(Rails.root, 'app', 'ui')]
   #
   # Or, you can also load more directories.
-  # Useful when setting namespaces with users that are not your main AdminUser entitiy.
+  # Useful when setting namespaces with users that are not your main AdminUser entity.
+  #
   # eg:
-  # config.load_paths = [
-  #   File.join(Rails.root, 'app', 'admin'),
-  #   File.join(Rails.root, 'app', 'cashier')
-  # ]
+  #   config.load_paths = [
+  #     File.join(Rails.root, 'app', 'admin'),
+  #     File.join(Rails.root, 'app', 'cashier')
+  #   ]
 
   # == Default Namespace
   #


### PR DESCRIPTION
It would be nice to have this piece of doc in the `active_admin.rb` template, I know it's already in the [doc site](https://activeadmin.info/1-general-configuration.html#load-paths), but sometimes we take a look directly at the initializer comments to look for useful examples. 

<!--

Thanks for contributing to ActiveAdmin!

You can find all the instructions for contributing at the [CONTRIBUTING file].

Before submitting your PR make sure that:

* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are splitted apart.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all github checks are passing, but feel free to ask for early feedback if you need guidance.

[CONTRIBUTING file]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->
