### PR TITLE
Add ActionText support

### DIFF
--- a/app/assets/stylesheets/active_admin/_base.scss
+++ b/app/assets/stylesheets/active_admin/_base.scss
@@ -7,6 +7,7 @@
   @import "./typography";
   @import "./header";
   @import "./forms";
+  @import "./components/actiontext";
   @import "./components/comments";
   @import "./components/flash_messages";
   @import "./components/date_picker";

--- a/app/assets/stylesheets/active_admin/components/_actiontext.scss
+++ b/app/assets/stylesheets/active_admin/components/_actiontext.scss
@@ -1,0 +1,4 @@
+form .trix-editor-wrapper{
+  display: inline-block;
+  width: calc(80% - 22px);
+}

--- a/docs/5-forms.md
+++ b/docs/5-forms.md
@@ -176,6 +176,28 @@ end
 Datepicker also accepts the `:label` option as a string or proc to display.
 If it's a proc, it will be called each time the datepicker is rendered.
 
+## ActionText Support
+
+To use rich text input, you need install [ActionText javascript and stylesheet](https://guides.rubyonrails.org/v6.1/action_text_overview.html). Download [`trix.js`](https://github.com/basecamp/trix/releases/latest) and save it in `lib/trix.js`. Then set `active_admin.js` as following:
+```js
+//= require active_admin/base
+//= require lib/trix
+//= require actiontext
+```
+
+Import `actiontext.css` into `active_admin.css.scss`:
+```scss
+@import "./actiontext.css";
+```
+
+After ActionText installation you can use rich text input in ActiveAdmin:
+
+```ruby
+form do |f|
+  f.input :description, as: :rich_text_area
+end
+```
+
 ## Displaying Errors
 
 To display a list of all validation errors:

--- a/lib/active_admin/inputs.rb
+++ b/lib/active_admin/inputs.rb
@@ -4,6 +4,7 @@ module ActiveAdmin
     extend ActiveSupport::Autoload
 
     autoload :DatepickerInput
+    autoload :RichTextAreaInput
 
     module Filters
       extend ActiveSupport::Autoload

--- a/lib/active_admin/inputs/rich_text_area_input.rb
+++ b/lib/active_admin/inputs/rich_text_area_input.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+module ActiveAdmin
+  module Inputs
+    class RichTextAreaInput < ::Formtastic::Inputs::StringInput
+      def to_html
+        input_wrapping do
+          editor_tag = builder.rich_text_area(method, input_html_options)
+          editor = template.content_tag('div', editor_tag, class: 'trix-editor-wrapper')
+          label_html + editor
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Since ActionText is introduced in Rails 6.0,
this commit adds ActionText feature to ActiveAdmin

Related: #6106, #5643

You can demonstrate this feature in [this demo repo](https://github.com/Karoid/demo.activeadmin.info/tree/actiontext-support-demo).
I changed product description input to work as rich text field in ActionText.


![image](https://user-images.githubusercontent.com/18082991/173111931-d83d37ab-0373-4d55-8573-bf8a22f98a53.png)
![image](https://user-images.githubusercontent.com/18082991/173112038-0848317d-38cf-43bb-ae96-25e78b220e4a.png)
