### PR TITLE
Add more documentation about PORO decorator requirements

### DIFF
--- a/docs/11-decorators.md
+++ b/docs/11-decorators.md
@@ -53,8 +53,8 @@ class PostDecorator
 end
 ```
 
-If you include comments on resources, your decorator class must respond to
-`model` returning a resource, and `decorated?` returning true.
+If a given resource uses ActiveAdmin's Comments feature, then that resource's decorator class must respond to
+`model` where it returns the model instance and `decorated?` returns `true`.
 
 ```ruby
 # app/decorators/post_decorator.rb

--- a/docs/11-decorators.md
+++ b/docs/11-decorators.md
@@ -53,6 +53,48 @@ class PostDecorator
 end
 ```
 
+If you include comments on resources, your decorator class must respond to
+`model` returning a resource, and `decorated?` returning true.
+
+```ruby
+# app/decorators/post_decorator.rb
+class PostDecorator
+  attr_reader :post
+  delegate_missing_to :post
+
+  def initialize(post)
+    @post = post
+  end
+
+  def decorated?
+    true
+  end
+
+  def model
+    post
+  end
+end
+```
+
+If you use any actions with param(e.g. show, edit, destroy), your decorator
+class must respond to `to_param`.
+
+```ruby
+# app/decorators/post_decorator.rb
+class PostDecorator
+  attr_reader :post
+  delegate_missing_to :post
+
+  def initialize(post)
+    @post = post
+  end
+
+  def to_param
+    post.id
+  end
+end
+```
+
 ## Forms
 
 By default, ActiveAdmin does *not* decorate the resource used to render forms.

--- a/docs/11-decorators.md
+++ b/docs/11-decorators.md
@@ -77,20 +77,17 @@ end
 ```
 
 If you use any actions with param(e.g. show, edit, destroy), your decorator
-class must respond to `to_param`.
+class must explicitly delegate `to_param` to the decorated model.
 
 ```ruby
 # app/decorators/post_decorator.rb
 class PostDecorator
   attr_reader :post
   delegate_missing_to :post
+  delegate :to_param, to: :post
 
   def initialize(post)
     @post = post
-  end
-
-  def to_param
-    post.id
   end
 end
 ```


### PR DESCRIPTION
Some methods need to be implemented in the following cases when using PORO decorator, but documentation did not mention it.

- use any actions with param(e.g. `show`, `edit`, `destroy` )
  - If the condition is not satisfied, there will be a problem so that decorator doesn't respond to param(by default, param is id)
- includes comments on resources
  - If the condition is not satisfied, there will be a problem with `ActiveAdmin::ResourceController::Decorators.undecorate` .

So I add explanation of the above cases.