### PR TITLE
Minor improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /.rspec_failures
 /node_modules
 /src
+/vendor/bundle

--- a/features/step_definitions/filesystem_steps.rb
+++ b/features/step_definitions/filesystem_steps.rb
@@ -56,5 +56,4 @@ Given /^I add "([^"]*)" to the "([^"]*)" model$/ do |code, model_name|
 
   str = File.read(path).gsub /^(class .+)$/, "\\1\n  #{code}\n"
   File.open(path, "w+") { |f| f << str }
-  ActiveSupport::Dependencies.clear
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -65,10 +65,6 @@ After do
 end
 
 Before do
-  # We are caching classes, but need to manually clear references to
-  # the controllers. If they aren't clear, the router stores references
-  ActiveSupport::Dependencies.clear unless ActiveAdmin::Dependency.supports_zeitwerk?
-
   # Reload Active Admin
   ActiveAdmin.unload!
   ActiveAdmin.load!

--- a/lib/active_admin/dependency.rb
+++ b/lib/active_admin/dependency.rb
@@ -56,10 +56,6 @@ module ActiveAdmin
       Matcher.new name.to_s
     end
 
-    def self.supports_zeitwerk?
-      RUBY_ENGINE != "jruby"
-    end
-
     class Matcher
       attr_reader :name
 

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -140,7 +140,6 @@ RSpec.describe ActiveAdmin::Application do
         FileUtils.touch(test_file)
         expect(application.files).to include(test_file)
       ensure
-        ActiveSupport::Dependencies.clear unless ActiveAdmin::Dependency.supports_zeitwerk?
         FileUtils.remove_entry_secure(test_dir, force: true)
       end
     end
@@ -156,7 +155,6 @@ RSpec.describe ActiveAdmin::Application do
         FileUtils.touch(test_file)
         expect(application.files.map { |f| File.basename(f) }).to eq(%w(posts.rb admin_users.rb dashboard.rb stores.rb))
       ensure
-        ActiveSupport::Dependencies.clear unless ActiveAdmin::Dependency.supports_zeitwerk?
         FileUtils.remove_entry_secure(test_dir, force: true)
       end
     end


### PR DESCRIPTION
* Gitignore `vendor/bundle`. I often use this path locally because it matches CI, and if not gitignored it's inconvenient to use the git stash.
* Remove some dependency reloading stuff from specs no longer needed since zeitwerk is used.
* ~Fix some generated test app migrations to use standard timestamps.~ I moved this fix to #7347 since it was needed there.