### PR TITLE
Support loading site title image from Webpacker assets

### DIFF
--- a/app/views/layouts/active_admin_logged_out.html.erb
+++ b/app/views/layouts/active_admin_logged_out.html.erb
@@ -20,7 +20,11 @@
     <% end %>
   <% end %>
 
-  <%= favicon_link_tag ActiveAdmin.application.favicon if ActiveAdmin.application.favicon %>
+  <% if ActiveAdmin.application.use_webpacker %>
+    <%= favicon_pack_tag ActiveAdmin.application.favicon if ActiveAdmin.application.favicon %>
+  <% else %>
+    <%= favicon_link_tag ActiveAdmin.application.favicon if ActiveAdmin.application.favicon %>
+  <% end %>
 
   <% ActiveAdmin.application.meta_tags_for_logged_out_pages.each do |name, content| %>
     <%= tag(:meta, name: name, content: content) %>

--- a/app/views/layouts/active_admin_logged_out.html.erb
+++ b/app/views/layouts/active_admin_logged_out.html.erb
@@ -20,10 +20,12 @@
     <% end %>
   <% end %>
 
-  <% if ActiveAdmin.application.use_webpacker %>
-    <%= favicon_pack_tag ActiveAdmin.application.favicon if ActiveAdmin.application.favicon %>
-  <% else %>
-    <%= favicon_link_tag ActiveAdmin.application.favicon if ActiveAdmin.application.favicon %>
+  <% if ActiveAdmin.application.favicon %>
+    <% if ActiveAdmin.application.use_webpacker %>
+      <%= favicon_pack_tag ActiveAdmin.application.favicon %>
+    <% else %>
+      <%= favicon_link_tag ActiveAdmin.application.favicon %>
+    <% end %>
   <% end %>
 
   <% ActiveAdmin.application.meta_tags_for_logged_out_pages.each do |name, content| %>

--- a/features/favicon.feature
+++ b/features/favicon.feature
@@ -6,7 +6,7 @@ Feature: Favicon
     Given a configuration of:
     """
       ActiveAdmin.register Post
-      ActiveAdmin.application.favicon = "a/favicon.ico"
+      ActiveAdmin.application.favicon = "favicon.ico"
     """
 
   Scenario: Logged out views show Favicon

--- a/features/site_title.feature
+++ b/features/site_title.feature
@@ -13,6 +13,7 @@ Feature: Site title
     """
       ActiveAdmin.application.site_title = "My Great Site"
       ActiveAdmin.application.site_title_link = "/admin"
+      ActiveAdmin.application.site_title_image = ""
     """
     When I am on the dashboard
     And I should see the site title "My Great Site"
@@ -22,26 +23,27 @@ Feature: Site title
   Scenario: Set the site title image
     Given a configuration of:
     """
-      ActiveAdmin.application.site_title_image = "http://railscasts.com/assets/episodes/stills/284-active-admin.png?1316476106"
+      ActiveAdmin.application.site_title_image = "logo.png"
     """
     When I am on the dashboard
     And I should not see the site title "My Great Site"
-    And I should see the site title image "http://railscasts.com/assets/episodes/stills/284-active-admin.png?1316476106"
+    And I should see the site title image "logo.png"
 
   Scenario: Set the site title image with link
     Given a configuration of:
     """
       ActiveAdmin.application.site_title_link = "http://www.google.com"
-      ActiveAdmin.application.site_title_image = "http://railscasts.com/assets/episodes/stills/284-active-admin.png?1316476106"
+      ActiveAdmin.application.site_title_image = "logo.png"
     """
     When I am on the dashboard
-    And I should see the site title image "http://railscasts.com/assets/episodes/stills/284-active-admin.png?1316476106"
+    And I should see the site title image "logo.png"
     And I should see the site title image linked to "http://www.google.com"
 
   Scenario: Set the site title to a proc
     Given a configuration of:
     """
       ActiveAdmin.application.site_title = proc { "Hello #{controller.current_admin_user.try(:email) || 'you!'}" }
+      ActiveAdmin.application.site_title_image = ""
     """
     When I am on the dashboard
     And I should see the site title "Hello admin@example.com"

--- a/features/step_definitions/site_title_steps.rb
+++ b/features/step_definitions/site_title_steps.rb
@@ -23,7 +23,13 @@ end
 
 Then /^I should see the site title image "([^"]*)"$/ do |image|
   img = page.find("h1#site_title img")
-  expect(img[:src]).to eq(image)
+  if ActiveAdmin.application.use_webpacker
+    result = image.match(/^(?<filename>.+)\.(?<suffix>[A-z0-9]+)$/)
+    expect(img[:src]).to match(%r{^/packs-test/media/images/#{result[:filename]}-[a-z0-9]+.#{result[:suffix]}$})
+  else
+    result = image.match(/^(?<filename>.+)\.(?<suffix>[A-z0-9]+)$/)
+    expect(img[:src]).to match(%r{^/assets/#{result[:filename]}-[a-z0-9]+.#{result[:suffix]}$})
+  end
 end
 
 Then /^I should see the site title image linked to "([^"]*)"$/ do |url|

--- a/lib/active_admin/views/components/site_title.rb
+++ b/lib/active_admin/views/components/site_title.rb
@@ -46,7 +46,11 @@ module ActiveAdmin
       end
 
       def title_image
-        helpers.image_tag(site_title_image, id: "site_title_image", alt: title_text)
+        if active_admin_namespace.use_webpacker
+          helpers.image_pack_tag(site_title_image, id: "site_title_image", alt: title_text)
+        else
+          helpers.image_tag(site_title_image, id: "site_title_image", alt: title_text)
+        end
       end
 
     end

--- a/lib/active_admin/views/components/site_title.rb
+++ b/lib/active_admin/views/components/site_title.rb
@@ -46,7 +46,7 @@ module ActiveAdmin
       end
 
       def title_image
-        if active_admin_namespace.use_webpacker
+        if @namespace.use_webpacker
           helpers.image_pack_tag(site_title_image, id: "site_title_image", alt: title_text)
         else
           helpers.image_tag(site_title_image, id: "site_title_image", alt: title_text)

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -6,13 +6,13 @@ webpacker_app = ENV["BUNDLE_GEMFILE"] == File.expand_path("../../gemfiles/rails_
 if webpacker_app
   create_file "app/javascript/packs/some-random-css.css"
   create_file "app/javascript/packs/some-random-js.js"
-  create_file "app/javascript/images/a/favicon.ico"
-  create_file "app/javascript/packs/images.js"
-  append_file "app/javascript/packs/images.js", "import '../images/a/favicon.ico';"
+  create_file "app/javascript/images/favicon.ico"
+  create_file "app/javascript/images/logo.png"
 else
   create_file "app/assets/stylesheets/some-random-css.css"
   create_file "app/assets/javascripts/some-random-js.js"
-  create_file "app/assets/images/a/favicon.ico"
+  create_file "app/assets/images/favicon.ico"
+  create_file "app/assets/images/logo.png"
 end
 
 initial_timestamp = Time.now.strftime("%Y%M%d%H%M%S").to_i
@@ -65,7 +65,7 @@ RUBY
 
 unless webpacker_app
   inject_into_file "config/environments/test.rb", after: "  config.action_mailer.default_url_options = {host: 'example.com'}" do
-    "\n  config.assets.precompile += %w( some-random-css.css some-random-js.js a/favicon.ico )\n"
+    "\n  config.assets.precompile += %w( some-random-css.css some-random-js.js )\n"
   end
 end
 
@@ -77,10 +77,22 @@ RUBY
 if webpacker_app
   rails_command "webpacker:install"
   gsub_file "config/webpacker.yml", /^(.*)extract_css.*$/, '\1extract_css: true' if ENV["RAILS_ENV"] == "test"
+
+  inject_into_file "app/javascript/packs/application.js", after: "import \"channels\"" do
+    "\n\nrequire.context('../images', true)\n"
+  end
 end
 
 # Setup Active Admin
 generate "active_admin:install#{" --use-webpacker" if webpacker_app}"
+
+# Setup title image and favicon
+inject_into_file "config/initializers/active_admin.rb", after: "  # config.site_title_image = \"logo.png\"" do
+  "\n  config.site_title_image = 'logo.png'\n"
+end
+inject_into_file "config/initializers/active_admin.rb", after: "  # config.favicon = 'favicon.ico'" do
+  "\n  config.favicon = 'favicon.ico'\n"
+end
 
 # Force strong parameters to raise exceptions
 inject_into_file "config/application.rb", after: "class Application < Rails::Application" do

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe ActiveAdmin::Application do
   end
 
   it "should set the site's title image" do
-    application.site_title_image = "http://railscasts.com/assets/episodes/stills/284-active-admin.png?1316476106"
-    expect(application.site_title_image).to eq "http://railscasts.com/assets/episodes/stills/284-active-admin.png?1316476106"
+    application.site_title_image = "logo.png"
+    expect(application.site_title_image).to eq "logo.png"
   end
 
   it "should store the site's favicon" do
@@ -58,8 +58,8 @@ RSpec.describe ActiveAdmin::Application do
   end
 
   it "should set the site's favicon" do
-    application.favicon = "/a/favicon.ico"
-    expect(application.favicon).to eq "/a/favicon.ico"
+    application.favicon = "favicon.ico"
+    expect(application.favicon).to eq "favicon.ico"
   end
 
   it "should store meta tags" do

--- a/spec/unit/views/components/site_title_spec.rb
+++ b/spec/unit/views/components/site_title_spec.rb
@@ -2,74 +2,75 @@
 require "rails_helper"
 
 RSpec.describe ActiveAdmin::Views::SiteTitle do
-  let(:helpers) { mock_action_view }
-  let(:settings) { ActiveAdmin::SettingsNode.build(ActiveAdmin::NamespaceSettings) }
-
-  def build_title(namespace)
+  subject do
     render_arbre_component({ namespace: namespace }, helpers) do
       insert_tag ActiveAdmin::Views::SiteTitle, assigns[:namespace]
     end
   end
 
-  def double(params)
-    params.each { |key, value| settings.send "#{key}=", value }
+  let(:helpers) { mock_action_view }
+  let(:namespace) do
+    settings = ActiveAdmin::SettingsNode.build(ActiveAdmin::NamespaceSettings)
+    settings.use_webpacker = use_webpacker
+    settings.site_title = site_title
+    settings.site_title_image = site_title_image
+    settings.site_title_link = site_title_link
     settings
   end
+  let(:use_webpacker) { ActiveAdmin.application.use_webpacker }
+  let(:site_title) { nil }
+  let(:site_title_image) { nil }
+  let(:site_title_link) { nil }
 
   context "when a value" do
-    it "renders the string when a string is passed in" do
-      namespace = double site_title: "Hello World",
-                         site_title_image: nil,
-                         site_title_link: nil
+    context "is a string" do
+      let(:site_title) { "Hello World" }
 
-      site_title = build_title(namespace)
-      expect(site_title.content).to eq "Hello World"
+      it "renders the string" do
+        expect(subject.content).to eq "Hello World"
+      end
     end
 
-    it "renders the return value of a method when a symbol" do
-      expect(helpers).to receive(:hello_world).and_return("Hello World")
+    context "is a symbol" do
+      let(:site_title) { :hello_world }
 
-      namespace = double site_title: :hello_world,
-                         site_title_image: nil,
-                         site_title_link: nil
-
-      site_title = build_title(namespace)
-      expect(site_title.content).to eq "Hello World"
+      it "renders the return value of a method" do
+        expect(helpers).to receive(:hello_world).and_return("Hello World")
+        expect(subject.content).to eq "Hello World"
+      end
     end
 
-    it "renders the return value of a proc" do
-      namespace = double site_title: proc { "Hello World" },
-                         site_title_image: nil,
-                         site_title_link: nil
+    context "is a proc" do
+      let(:site_title) { proc { "Hello World" } }
 
-      site_title = build_title(namespace)
-      expect(site_title.content).to eq "Hello World"
+      it "renders the return value of the proc" do
+        expect(subject.content).to eq "Hello World"
+      end
     end
   end
 
   context "when an image" do
-    it "renders the string when a string is passed in" do
-      expect(helpers).to receive(:image_tag).
-        with("an/image.png", alt: nil, id: "site_title_image").
-        and_return '<img src="/assets/an/image.png" />'.html_safe
+    context "when a string is passed in" do
+      let(:site_title_image) { "logo.png" }
 
-      namespace = double site_title: nil,
-                         site_title_image: "an/image.png",
-                         site_title_link: nil
-
-      site_title = build_title(namespace)
-      expect(site_title.content.strip).to eq '<img src="/assets/an/image.png" />'
+      it "renders the string when a string is passed in" do
+        if use_webpacker
+          expect(helpers).to receive(:image_pack_tag).once.and_call_original
+          expect(subject.content).to match %r{<img id="site_title_image" src="/packs-test/media/images/logo-[a-z0-9]+.png" />}
+        else
+          expect(helpers).to receive(:image_tag).once.and_call_original
+          expect(subject.content).to match %r{<img id="site_title_image" src="/assets/logo-[a-z0-9]+.png" />}
+        end
+      end
     end
   end
 
   context "when a link is present" do
-    it "renders the string when a string is passed in" do
-      namespace = double site_title: "Hello World",
-                         site_title_image: nil,
-                         site_title_link: "/"
+    let(:site_title) { "Hello Wrold" }
+    let(:site_title_link) { "/" }
 
-      site_title = build_title(namespace)
-      expect(site_title.content).to eq '<a href="/">Hello World</a>'
+    it "renders the string when a string is passed in" do
+      expect(subject.content).to eq "<a href=\"#{site_title_link}\">#{site_title}</a>"
     end
   end
 end


### PR DESCRIPTION
When `config.use_webpacker` is true, ActiveAdmin will now generate the title_image tag using Webpacker's `image_pack_tag` instead of `image_tag` (which uses the asset pipeline). This change makes it possible to use Webpacker to provide the title image asset.

I managed to get both Webpacker and Sprockets tests to work by making the title image path consistent between the two types of test projects.


Fixes [#6898](https://github.com/activeadmin/activeadmin/issues/6898)

<!--

Thanks for contributing to ActiveAdmin!

You can find all the instructions for contributing at the [CONTRIBUTING file].

Before submitting your PR make sure that:

* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are splitted apart.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all github checks are passing, but feel free to ask for early feedback if you need guidance.

[CONTRIBUTING file]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->
