### PR TITLE
Replace gsub with tr on csv_filename

### DIFF
--- a/lib/active_admin/resource_controller/streaming.rb
+++ b/lib/active_admin/resource_controller/streaming.rb
@@ -31,7 +31,7 @@ module ActiveAdmin
       end
 
       def csv_filename
-        "#{resource_collection_name.to_s.gsub('_', '-')}-#{Time.zone.now.to_date.to_formatted_s(:default)}.csv"
+        "#{resource_collection_name.to_s.tr('_', '-')}-#{Time.zone.now.to_date.to_formatted_s(:default)}.csv"
       end
 
       def stream_csv


### PR DESCRIPTION
Minor performance improvement on streaming.rb#csv_filename.
As per https://github.com/fastruby/fast-ruby/blob/main/code/string/gsub-vs-tr.rb calling `tr` is usually faster than using `gsub`.
