### PR TITLE
Add 'has_nested' class to menu only if at least one child is visible

### DIFF
--- a/lib/active_admin/views/components/menu_item.rb
+++ b/lib/active_admin/views/components/menu_item.rb
@@ -24,7 +24,7 @@ module ActiveAdmin
           span label, item.html_options
         end
 
-        if item.items.any?
+        if item.items.map { |itm| helpers.render_in_context self, itm.should_display }.any?(true)
           add_class "has_nested"
           @submenu = menu(item)
         end

--- a/spec/unit/views/components/menu_spec.rb
+++ b/spec/unit/views/components/menu_spec.rb
@@ -118,6 +118,25 @@ RSpec.describe ActiveAdmin::Views::Menu do
     end
   end
 
+  describe "marking 'has_nested'" do
+    it "should not add 'has_nested' when all menu items with an if block return false" do
+      menu.add label: "Workspaces", url: "/workspaces" do |workspaces|
+        workspaces.add label: "Don't Show 1", url: "/", if: proc { false }
+        workspaces.add label: "Don't Show 2", url: "/", if: proc { false }
+      end
+      expect(html).not_to have_selector("li#workspaces.has_nested")
+    end
+
+    it "should add 'has_nested' when any menu item with an if block returns true" do
+      menu.add label: "Workspaces", url: "/workspaces" do |workspaces|
+        workspaces.add label: "Don't Show 1", url: "/", if: proc { false }
+        workspaces.add label: "Don't Show 2", url: "/", if: proc { true }
+      end
+      expect(menu_component.children).not_to be_empty
+      expect(html).to have_selector("li#workspaces.has_nested")
+    end
+  end
+
   describe "returning the menu items to display" do
     it "should return one item with no if block" do
       menu.add label: "Hello World", url: "/"


### PR DESCRIPTION
`has_nested` class is applied to any menu item that has children without checking if those should be displayed or not. This results an empty dropdown in case where a menu item has no visible children.

<img width="378" alt="image" src="https://user-images.githubusercontent.com/556445/193637351-7c3b7c07-bce6-45c7-abcd-6fbf4b9087bb.png">
