### PR TITLE
Assume that accepting "*/*" means a request for HTML

### DIFF
--- a/lib/active_admin/resource_controller.rb
+++ b/lib/active_admin/resource_controller.rb
@@ -54,7 +54,7 @@ module ActiveAdmin
     helper_method :renderer_for
 
     def restrict_format_access!
-      unless request.format.html?
+      unless request.format.html? || request.format == "*/*"
         presenter = active_admin_config.get_page_presenter(:index)
         download_formats = (presenter || {}).fetch(:download_links, active_admin_config.namespace.download_links)
         unless build_download_formats(download_formats).include?(request.format.symbol)

--- a/spec/unit/resource_controller_spec.rb
+++ b/spec/unit/resource_controller_spec.rb
@@ -131,6 +131,30 @@ RSpec.describe "A specific resource controller", type: :controller do
     @controller = Admin::PostsController.new
   end
 
+  describe 'GET :index' do
+    context 'when accepting any content type' do
+      before do
+        request.env['HTTP_ACCEPT'] = '*/*'
+      end
+
+      it 'returns 200 OK' do
+        get :index
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when accepting HTML' do
+      before do
+        request.env['HTTP_ACCEPT'] = 'text/html'
+      end
+
+      it 'returns 200 OK' do
+        get :index
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
   describe "authenticating the user" do
     it "should do nothing when no authentication_method set" do
       namespace = controller.class.active_admin_config.namespace

--- a/spec/unit/resource_controller_spec.rb
+++ b/spec/unit/resource_controller_spec.rb
@@ -131,24 +131,24 @@ RSpec.describe "A specific resource controller", type: :controller do
     @controller = Admin::PostsController.new
   end
 
-  describe 'GET :index' do
-    context 'when accepting any content type' do
+  describe "GET :index" do
+    context "when accepting any content type" do
       before do
-        request.env['HTTP_ACCEPT'] = '*/*'
+        request.env["HTTP_ACCEPT"] = "*/*"
       end
 
-      it 'returns 200 OK' do
+      it "returns 200 OK" do
         get :index
         expect(response).to have_http_status(:ok)
       end
     end
 
-    context 'when accepting HTML' do
+    context "when accepting HTML" do
       before do
-        request.env['HTTP_ACCEPT'] = 'text/html'
+        request.env["HTTP_ACCEPT"] = "text/html"
       end
 
-      it 'returns 200 OK' do
+      it "returns 200 OK" do
         get :index
         expect(response).to have_http_status(:ok)
       end


### PR DESCRIPTION
This means that browsers like Netsurf, which specify an Accept header of `"*/*"`, will get an HTTP OK and the desired HTML content.
    
Fixes #7808.