### PR TITLE
Replace eslint rake task with CI workflow

### DIFF
--- a/.github/workflows/eslint-none.yml
+++ b/.github/workflows/eslint-none.yml
@@ -1,0 +1,20 @@
+name: JS Lint
+
+on:
+  pull_request:
+    # If updating `paths-ignore` then update eslint.yml to match
+    paths-ignore:
+      - '.eslintignore'
+      - '.eslintrc.yml'
+      - '.github/workflows/eslint.yml'
+      - 'package*.json'
+      - 'yarn.lock'
+      - '**.js'
+
+jobs:
+  eslint:
+    name: Run eslint
+    if: false
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Do nothing"

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,0 +1,32 @@
+name: JS Lint
+
+on:
+  pull_request:
+    # If updating `paths` then update eslint-none.yml to match
+    paths:
+      - '.eslintignore'
+      - '.eslintrc.yml'
+      - '.github/workflows/eslint.yml'
+      - 'package*.json'
+      - 'yarn.lock'
+      - '**.js'
+
+env:
+  NODE_VERSION: 18.x
+
+jobs:
+  eslint:
+    name: Run eslint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - uses: reviewdog/action-eslint@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          filter_mode: nofilter # added (default), diff_context, file, nofilter
+          fail_on_error: true
+          reporter: github-pr-check

--- a/tasks/lint.rake
+++ b/tasks/lint.rake
@@ -107,7 +107,7 @@ class SassRailsLinter
 end
 
 desc "Lints ActiveAdmin code base"
-task lint: ["lint:rubocop", "lint:mdl", "lint:eslint", "lint:gherkin", "lint:trailing_blank_lines", "lint:missing_final_new_line", "lint:trailing_whitespace", "lint:fixme", "lint:sass_rails", "lint:rspec"]
+task lint: ["lint:rubocop", "lint:mdl", "lint:gherkin", "lint:trailing_blank_lines", "lint:missing_final_new_line", "lint:trailing_whitespace", "lint:fixme", "lint:sass_rails", "lint:rspec"]
 
 namespace :lint do
   require "rubocop/rake_task"
@@ -119,14 +119,6 @@ namespace :lint do
     puts "Running mdl..."
 
     sh("mdl", "--git-recurse", ".")
-  end
-
-  desc "Checks JS code style with eslint"
-  task :eslint do
-    puts "Linting JS code..."
-
-    sh("bin/yarn", "install")
-    sh("bin/yarn", "eslint")
   end
 
   desc "Checks gherkin code style"


### PR DESCRIPTION
This runs eslint using reviewdog so any warnings appear as inline annotations in the "Files changed" tab. The workflow is optimized so it can be required but only runs if applicable files are changed.