### PR TITLE
Replace lint rake task with rubocop CI workflow

### DIFF
--- a/.github/workflows/rubocop-none.yml
+++ b/.github/workflows/rubocop-none.yml
@@ -1,0 +1,24 @@
+name: Rubocop
+
+on:
+  pull_request:
+    # If updating `paths-ignore` then update rubocop.yml to match
+    paths-ignore:
+      - '.github/workflows/rubocop.yml'
+      - 'config/rubocop/**/*.yml'
+      - '.rubocop.yml'
+      - '**.arb'
+      - '**.rake'
+      - '**.rb'
+      - '*.gemspec'
+      - 'gemfiles/**/Gemfile*'
+      - 'Gemfile*'
+      - 'Rakefile'
+
+jobs:
+  rubocop:
+    name: Run rubocop
+    if: false
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Do nothing"

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,39 @@
+name: Rubocop
+
+on:
+  pull_request:
+    # If updating `paths` then update rubocop-none.yml to match
+    paths:
+      - '.github/workflows/rubocop.yml'
+      - 'config/rubocop/**/*.yml'
+      - '.rubocop.yml'
+      - '**.arb'
+      - '**.rake'
+      - '**.rb'
+      - '*.gemspec'
+      - 'gemfiles/**/Gemfile*'
+      - 'Gemfile*'
+      - 'Rakefile'
+
+env:
+  RUBY_VERSION: "3.1"
+
+jobs:
+  rubocop:
+    name: Run rubocop
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_WITHOUT: default development test release docs
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
+      - uses: reviewdog/action-rubocop@v2
+        with:
+          fail_on_error: true
+          filter_mode: nofilter # added (default), diff_context, file, nofilter
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          skip_install: true
+          use_bundler: true

--- a/tasks/lint.rake
+++ b/tasks/lint.rake
@@ -107,13 +107,9 @@ class SassRailsLinter
 end
 
 desc "Lints ActiveAdmin code base"
-task lint: ["lint:rubocop", "lint:gherkin", "lint:trailing_blank_lines", "lint:missing_final_new_line", "lint:trailing_whitespace", "lint:fixme", "lint:sass_rails", "lint:rspec"]
+task lint: ["lint:gherkin", "lint:trailing_blank_lines", "lint:missing_final_new_line", "lint:trailing_whitespace", "lint:fixme", "lint:sass_rails", "lint:rspec"]
 
 namespace :lint do
-  require "rubocop/rake_task"
-  desc "Checks ruby code style with RuboCop"
-  RuboCop::RakeTask.new
-
   desc "Checks gherkin code style"
   task :gherkin do
     puts "Linting gherkin code..."


### PR DESCRIPTION
This runs Rubocop using Reviewdog so any warnings appear as inline annotations in the "Files changed" tab. The workflow is optimized so it can be required but only runs if applicable files are changed.