### PR TITLE
Move general lint to new workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,85 +1,12 @@
----
-
 name: ci
 
 on:
   pull_request:
-
   push:
     branches:
       - master
 
 jobs:
-  jruby:
-    name: Check Gemfile installs fine on JRuby
-    runs-on: ubuntu-latest
-
-    timeout-minutes: 15
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: jruby-9.3.4.0
-
-      - name: Run bug report template
-        run: ACTIVE_ADMIN_PATH=. ruby tasks/bug_report_template.rb
-
-  lint:
-    name: lint (${{ matrix.ruby }})
-    runs-on: ${{ matrix.os }}
-
-    timeout-minutes: 15
-
-    strategy:
-      fail-fast: false
-
-      matrix:
-        ruby: [3.1]
-        os: [ubuntu-latest]
-
-    env:
-      COVERAGE: true
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Configure bundler
-        run: |
-          echo "BUNDLE_GEMFILE=Gemfile" >> $GITHUB_ENV
-          echo "BUNDLE_PATH=$(pwd)/vendor/bundle" >> $GITHUB_ENV
-
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
-
-      - name: Generate docs
-        run: bin/rake docs:build
-
-      - name: Setup git
-        run: |
-          git config --global user.email activeadmin@ci.dummy
-          git config --global user.name ActiveAdmin
-
-      - name: Run lints
-        run: bin/rake lint
-
-      # - name: Run bug report template
-      #   run: ACTIVE_ADMIN_PATH=. ruby tasks/bug_report_template.rb
-
-      - name: Format coverage
-        run: |
-          bin/prepare_coverage
-          mv coverage/.resultset.json coverage/raw.lint.json
-
-      - name: Save partial coverage as an artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: coverage
-          path: coverage/raw.lint.json
-
   test:
     name: test (${{ matrix.ruby }}, ${{ matrix.deps }})
     runs-on: ${{ matrix.os }}
@@ -177,7 +104,6 @@ jobs:
     runs-on: ubuntu-latest
 
     needs:
-      - lint
       - test
 
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,42 @@
+name: General Lint
+
+on:
+  pull_request:
+
+env:
+  JRUBY_VERSION: jruby-9.3.4.0
+  RUBY_VERSION: 3.1
+
+jobs:
+  jruby:
+    name: Check Gemfile installs fine on JRuby
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.JRUBY_VERSION }}
+      - name: Run bug report template
+        run: ACTIVE_ADMIN_PATH=. ruby tasks/bug_report_template.rb
+
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
+      - name: Generate docs
+        run: bin/rake docs:build
+      - name: Setup git
+        run: |
+          git config --global user.email activeadmin@ci.dummy
+          git config --global user.name ActiveAdmin
+      - name: Run lints
+        run: bin/rake lint
+      # - name: Run bug report template
+      #   run: ACTIVE_ADMIN_PATH=. ruby tasks/bug_report_template.rb

--- a/gemfiles/rails_61_webpacker/Gemfile.lock
+++ b/gemfiles/rails_61_webpacker/Gemfile.lock
@@ -219,7 +219,6 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.1)
     minitest (5.18.0)
     multi_test (1.1.0)
     net-protocol (0.1.3)
@@ -228,14 +227,11 @@ GEM
       net-protocol
     nio4r (2.5.8)
     nio4r (2.5.8-java)
-    nokogiri (1.13.10)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.14.2-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.10-arm64-darwin)
+    nokogiri (1.14.2-java)
       racc (~> 1.4)
-    nokogiri (1.13.10-java)
-      racc (~> 1.4)
-    nokogiri (1.13.10-x86_64-linux)
+    nokogiri (1.14.2-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.22.1)
@@ -325,10 +321,8 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.6.1)
-      mini_portile2 (~> 2.8.0)
-    sqlite3 (1.5.4-arm64-darwin)
-    sqlite3 (1.5.4-x86_64-linux)
+    sqlite3 (1.6.1-arm64-darwin)
+    sqlite3 (1.6.1-x86_64-linux)
     sys-uname (1.2.2)
       ffi (~> 1.1)
     thor (1.2.1)
@@ -354,8 +348,8 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   java
-  ruby
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Isolate the general lint jobs to a new workflow as this only needs to run on pull request, not both pull request and push like tests. This often fails on push (post merge PR) but it doesn't need to run there anyway. Only tests do.