### PR TITLE
Use Node 16 in webpacker

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,9 +27,9 @@ jobs:
         deps: [rails_61, rails_70]
 
         include:
-          # - ruby: 3.1
-          #   os: ubuntu-latest
-          #   deps: rails_61_webpacker
+          - ruby: 3.1
+            os: ubuntu-latest
+            deps: rails_61_webpacker
           - ruby: 3.1
             os: ubuntu-latest
             deps: rails_61_turbolinks
@@ -54,6 +54,11 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+        if: matrix.deps == 'rails_61_webpacker'
 
       - name: Setup git
         run: |


### PR DESCRIPTION
There is an issue with the Node 18 version installed on the CI that prevents webpacker to run correctly

```
Run tmp/test_apps/rails_61_webpacker/bin/webpack
node:internal/crypto/hash:71
  this[kHandle] = new _Hash(algorithm, xofLen);
```

Ref: activeadmin/activeadmin#7290

<!--

Thanks for contributing to ActiveAdmin!

You can find all the instructions for contributing at the [CONTRIBUTING file].

Before submitting your PR make sure that:

* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are splitted apart.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all github checks are passing, but feel free to ask for early feedback if you need guidance.

[CONTRIBUTING file]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->

---

I think that the failure is not related. It should be because secrets are not available in forks and in PRs originating from a fork?

https://securitylab.github.com/research/github-actions-preventing-pwn-requests/