### PR TITLE
Update Codecov ignore paths to include spec directory

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@ coverage:
   status:
     project:
       default:
-        threshold: 0.1%
+        threshold: 0.5%
 ignore:
   - spec/**/*
   - tmp/**/*

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,5 +4,6 @@ coverage:
       default:
         threshold: 0.1%
 ignore:
-  - "tmp/.*"
-  - "vendor/.*"
+  - spec/**/*
+  - tmp/**/*
+  - vendor/**/*


### PR DESCRIPTION
Use the correct format as documented by Codecov and ignore the `spec` directory.
