### PR TITLE
Reset Codecov project threshold default

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@ coverage:
   status:
     project:
       default:
-        threshold: 0.5%
+        threshold: 0.05%
 ignore:
   - spec/**/*
   - tmp/**/*


### PR DESCRIPTION
Now that we've fixed the ignore setting we can reset this to start.
