### PR TITLE
Replace gemfiles rake with bundle binstub

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require "bundler/gem_tasks"
 
-import "tasks/gemfiles.rake"
 import "tasks/local.rake"
 import "tasks/test.rake"
 

--- a/bin/bundle
+++ b/bin/bundle
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+( set -x; bundle $1 )
+
+for gemfile in gemfiles/*/Gemfile; do
+  ( set -x; BUNDLE_GEMFILE="$gemfile" bundle $1 )
+done

--- a/tasks/gemfiles.rake
+++ b/tasks/gemfiles.rake
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-desc "Bundle all Gemfiles"
-task :bundle do |_t, opts|
-  ["Gemfile", *Dir.glob("gemfiles/rails_*/Gemfile")].each do |gemfile|
-    Bundler.with_original_env do
-      sh({ "BUNDLE_GEMFILE" => gemfile }, "bundle", *opts)
-    end
-  end
-end


### PR DESCRIPTION
This does the same thing but we can specify normal `bundle` CLI arguments rather than have to convert to Rake format.