### PR TITLE
Fix typo in Vietnamese locale for filter text

### DIFF
--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -39,7 +39,7 @@ vi:
     search_status:
       headline: "Danh sách tìm kiếm:"
       current_scope: "Phạm vi:"
-      current_filters: "Bộ lộc hiện tại:"
+      current_filters: "Bộ lọc hiện tại:"
       no_current_filters: "Không có"
     status_tag:
       "yes": "Có"


### PR DESCRIPTION
Fixed a typo in the Vietnamese locale: "fortune" instead of "filter".