### PR TITLE
Enable Pundit authorization with namespaced decorators

### DIFF
--- a/lib/active_admin/pundit_adapter.rb
+++ b/lib/active_admin/pundit_adapter.rb
@@ -56,7 +56,7 @@ module ActiveAdmin
       case subject
       when nil then resource
       when Class then subject.new
-      else subject
+      else undecorate(subject)
       end
     end
 
@@ -118,6 +118,9 @@ module ActiveAdmin
       @policies ||= {}
     end
 
+    def undecorate(subject)
+      ResourceController::Decorators.undecorate(subject)
+    end
   end
 
 end


### PR DESCRIPTION
I guess the testing could do with some love, and perhaps we should add tests for both namespaced and non-namespaced decorators. Am I on the right track here?

# What

When retrieving auth policies and the subject is wrapped in a namespaced decorator, Pundit is not able to find the policy. My original issue with full  description and code to reproduce is in issue #7933.

# How

This fix makes use of `ResourceController::Decorators.undecorate` to undecorate the target before asking pundit to fetch the policy.

It does this in `PunditAdaper#policy_target`, so as to have the fix affect `PunditAdapter#retrieve_policy` which in turn is used by  `PunditAdapter#authorized`.

Unless I'm missing something the remaining public methods are not affected by the issue at hand.

---

Fixes #7933