### PR TITLE
Sanitize HTML in page title (remove HTML tags)

### DIFF
--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -25,7 +25,7 @@ module ActiveAdmin
 
         def build_active_admin_head
           within head do
-            html_title [title, helpers.active_admin_namespace.site_title(self)].compact.join(" | ")
+            html_title sanitize([title, helpers.active_admin_namespace.site_title(self)].compact.join(" | "), tags: [])
 
             text_node(active_admin_namespace.head)
 


### PR DESCRIPTION
This change removes the HTML from the title before it's added to the document `<head>`.

It allows to use links as return values from `#name` methods of decorators without causing weird HTML tags in the browsers or title tab bar. 