### PR TITLE
Use `csrf_meta_tags` in place of singular version

### DIFF
--- a/app/views/layouts/active_admin_logged_out.html.erb
+++ b/app/views/layouts/active_admin_logged_out.html.erb
@@ -26,7 +26,7 @@
     <%= tag(:meta, name: name, content: content) %>
   <% end %>
 
-  <%= csrf_meta_tag %>
+  <%= csrf_meta_tags %>
 </head>
 <body class="active_admin logged_out <%= controller.action_name %>">
 <div id="wrapper">

--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -49,7 +49,7 @@ module ActiveAdmin
               text_node(favicon_tag)
             end
 
-            text_node csrf_meta_tag
+            text_node csrf_meta_tags
           end
         end
 

--- a/spec/unit/views/pages/layout_spec.rb
+++ b/spec/unit/views/pages/layout_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ActiveAdmin::Views::Pages::Layout do
     { active_admin_application: active_admin_application,
       active_admin_config: double("Config", action_items?: nil, breadcrumb: nil, sidebar_sections?: nil),
       active_admin_namespace: active_admin_namespace,
-      csrf_meta_tag: "",
+      csrf_meta_tags: "",
       current_active_admin_user: nil,
       current_active_admin_user?: false,
       current_menu: double("Menu", items: []),


### PR DESCRIPTION
This replaces `csrf_meta_tag` with `csrf_meta_tags` which [has been available since Rails 3.1](https://github.com/rails/rails/blob/main/guides/source/3_1_release_notes.md?plain=1).