### PR TITLE
Add csp_meta_tag to layout

### DIFF
--- a/app/views/layouts/active_admin_logged_out.html.erb
+++ b/app/views/layouts/active_admin_logged_out.html.erb
@@ -27,6 +27,7 @@
   <% end %>
 
   <%= csrf_meta_tags %>
+  <%= csp_meta_tag %>
 </head>
 <body class="active_admin logged_out <%= controller.action_name %>">
 <div id="wrapper">

--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -50,6 +50,7 @@ module ActiveAdmin
             end
 
             text_node csrf_meta_tags
+            text_node csp_meta_tag
           end
         end
 

--- a/spec/unit/views/pages/layout_spec.rb
+++ b/spec/unit/views/pages/layout_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe ActiveAdmin::Views::Pages::Layout do
       active_admin_config: double("Config", action_items?: nil, breadcrumb: nil, sidebar_sections?: nil),
       active_admin_namespace: active_admin_namespace,
       csrf_meta_tags: "",
+      csp_meta_tag: "",
       current_active_admin_user: nil,
       current_active_admin_user?: false,
       current_menu: double("Menu", items: []),


### PR DESCRIPTION
This adds the `csp_meta_tag` helper to our layout related files.