### PR TITLE
Allow `config.paginate` to be a block

### DIFF
--- a/lib/active_admin/resource/pagination.rb
+++ b/lib/active_admin/resource/pagination.rb
@@ -20,8 +20,12 @@ module ActiveAdmin
         @max_per_page = namespace.max_per_page
       end
 
-      def paginate
-        @paginate.is_a?(Proc) ? instance_eval(&@paginate) : @paginate
+      def paginate(controller: nil)
+        if @paginate.is_a?(Proc)
+          controller ? controller.instance_eval(&@paginate) : @paginate.call
+        else
+          @paginate
+        end
       end
     end
   end

--- a/lib/active_admin/resource/pagination.rb
+++ b/lib/active_admin/resource/pagination.rb
@@ -11,13 +11,17 @@ module ActiveAdmin
       attr_accessor :max_per_page
 
       # Enable / disable pagination (defaults to true)
-      attr_accessor :paginate
+      attr_writer :paginate
 
       def initialize(*args)
         super
         @paginate = true
         @per_page = namespace.default_per_page
         @max_per_page = namespace.max_per_page
+      end
+
+      def paginate
+        @paginate.is_a?(Proc) ? instance_eval(&@paginate) : @paginate
       end
     end
   end

--- a/lib/active_admin/resource_controller/data_access.rb
+++ b/lib/active_admin/resource_controller/data_access.rb
@@ -277,7 +277,7 @@ module ActiveAdmin
       end
 
       def per_page
-        if active_admin_config.paginate
+        if active_admin_config.paginate(controller: self)
           dynamic_per_page || configured_per_page
         else
           active_admin_config.max_per_page

--- a/spec/unit/resource/pagination_spec.rb
+++ b/spec/unit/resource/pagination_spec.rb
@@ -19,6 +19,11 @@ module ActiveAdmin
         config.paginate = false
         expect(config.paginate).to eq false
       end
+
+      it "should be settable to executable Proc" do
+        config.paginate = proc { false }
+        expect(config.paginate).to eq false
+      end
     end
 
     describe "#per_page" do


### PR DESCRIPTION
Hello, everyone!

I propose this change to allow `config.paginate` option to be set as a block that will return a value based on resource configuration.

In my case, I have a Sessions resource with an index that can be displayed as a table (default view) and as a calendar. With the calendar view, the pagination is replaced by the start/end time filter.

Using this change I can initialize resources in the following way:
```ruby
ActiveAdmin.register Session, as: "All Sessions" do
  config.paginate = proc { params[:as] != "calendar" }
  index(as: :calendar)
end
```
which will allow `ActiveAdmin::Views::IndexAsCalendar` will handle filtering instead of pagination.

Thank you for your attention! Please, tell me what you think about it.