### PR TITLE
Require Ransack v4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       jquery-rails (~> 4.2)
       kaminari (~> 1.0, >= 1.2.1)
       railties (>= 6.1, < 7.1)
-      ransack (>= 2.1.1, < 4)
+      ransack (>= 4.0, < 5)
 
 GEM
   remote: https://rubygems.org/
@@ -320,7 +320,7 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
-    ransack (3.2.1)
+    ransack (4.0.0)
       activerecord (>= 6.1.5)
       activesupport (>= 6.1.5)
       i18n

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |s|
   s.add_dependency "jquery-rails", "~> 4.2"
   s.add_dependency "kaminari", "~> 1.0", ">= 1.2.1"
   s.add_dependency "railties", ">= 6.1", "< 7.1"
-  s.add_dependency "ransack", ">= 2.1.1", "< 4"
+  s.add_dependency "ransack", ">= 4.0", "< 5"
 end

--- a/gemfiles/rails_61/Gemfile.lock
+++ b/gemfiles/rails_61/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       jquery-rails (~> 4.2)
       kaminari (~> 1.0, >= 1.2.1)
       railties (>= 6.1, < 7.1)
-      ransack (>= 2.1.1, < 4)
+      ransack (>= 4.0, < 5)
 
 GEM
   remote: https://rubygems.org/
@@ -313,7 +313,7 @@ GEM
       thor (~> 1.0)
     rainbow (3.1.1)
     rake (13.0.6)
-    ransack (3.2.1)
+    ransack (4.0.0)
       activerecord (>= 6.1.5)
       activesupport (>= 6.1.5)
       i18n

--- a/lib/active_admin/orm/active_record/comments/comment.rb
+++ b/lib/active_admin/orm/active_record/comments/comment.rb
@@ -28,5 +28,13 @@ module ActiveAdmin
       self.resource_type = self.class.resource_type(resource)
     end
 
+    def self.ransackable_attributes(auth_object = nil)
+      authorizable_ransackable_attributes
+    end
+
+    def self.ransackable_associations(auth_object = nil)
+      authorizable_ransackable_associations
+    end
+
   end
 end

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -44,6 +44,19 @@ copy_file File.expand_path("templates/models/tagging.rb", __dir__), "app/models/
 
 copy_file File.expand_path("templates/helpers/time_helper.rb", __dir__), "app/helpers/time_helper.rb"
 
+inject_into_file "app/models/application_record.rb", before: "end" do
+  <<-RUBY
+
+  def self.ransackable_attributes(auth_object=nil)
+    authorizable_ransackable_attributes
+  end
+
+  def self.ransackable_associations(auth_object=nil)
+    authorizable_ransackable_associations
+  end
+  RUBY
+end
+
 gsub_file "config/environments/test.rb", /  config.cache_classes = true/, <<-RUBY
 
   config.cache_classes = !ENV['CLASS_RELOADING']

--- a/spec/support/templates/models/blog/post.rb
+++ b/spec/support/templates/models/blog/post.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class Blog::Post < ActiveRecord::Base
+class Blog::Post < ApplicationRecord
   belongs_to :category, foreign_key: :custom_category_id
   belongs_to :author, class_name: "User"
   has_many :taggings

--- a/spec/support/templates/models/category.rb
+++ b/spec/support/templates/models/category.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class Category < ActiveRecord::Base
+class Category < ApplicationRecord
   has_many :posts, foreign_key: :custom_category_id
   has_many :authors, through: :posts
   accepts_nested_attributes_for :posts

--- a/spec/support/templates/models/post.rb
+++ b/spec/support/templates/models/post.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class Post < ActiveRecord::Base
+class Post < ApplicationRecord
   belongs_to :category, foreign_key: :custom_category_id, optional: true
   belongs_to :author, class_name: "User", optional: true
   has_many :taggings
@@ -21,7 +21,7 @@ class Post < ActiveRecord::Base
 
   class << self
     def ransackable_scopes(_auth_object = nil)
-      [:fancy_filter]
+      super + [:fancy_filter]
     end
 
     def fancy_filter(value)

--- a/spec/support/templates/models/profile.rb
+++ b/spec/support/templates/models/profile.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
-class Profile < ActiveRecord::Base
+class Profile < ApplicationRecord
   belongs_to :user
 end

--- a/spec/support/templates/models/tag.rb
+++ b/spec/support/templates/models/tag.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class Tag < ActiveRecord::Base
+class Tag < ApplicationRecord
   has_many :taggings
   has_many :posts, through: :taggings
 end

--- a/spec/support/templates/models/tagging.rb
+++ b/spec/support/templates/models/tagging.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class Tagging < ActiveRecord::Base
+class Tagging < ApplicationRecord
   belongs_to :post, optional: true
   belongs_to :tag, optional: true
 

--- a/spec/support/templates/models/user.rb
+++ b/spec/support/templates/models/user.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   class VIP < self
   end
   has_many :posts, foreign_key: "author_id"

--- a/spec/unit/comments_spec.rb
+++ b/spec/unit/comments_spec.rb
@@ -38,6 +38,14 @@ RSpec.describe "Comments" do
       expect(comment.errors[:resource]).to eq(["can't be blank"])
     end
 
+    it "authorizes default ransackable attributes" do
+      expect(described_class.ransackable_attributes).to eq described_class.authorizable_ransackable_attributes
+    end
+
+    it "authorizes default ransackable associations" do
+      expect(described_class.ransackable_associations).to eq described_class.authorizable_ransackable_associations
+    end
+
     describe ".find_for_resource_in_namespace" do
       let(:namespace_name) { "admin" }
 


### PR DESCRIPTION
As part of a major ActiveAdmin release, we'll now require Ransack v4 which in turn requires users to declare an allowlist of attributes and associations on their models.

Closes #7809