### PR TITLE
Add additional metadata to activeadmin.gemspec

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -18,7 +18,16 @@ Gem::Specification.new do |s|
 
   s.extra_rdoc_files = %w[CHANGELOG.md CODE_OF_CONDUCT.md CONTRIBUTING.md README.md]
 
-  s.metadata = { "rubygems_mfa_required" => "true" }
+  s.metadata = {
+    "bug_tracker_uri" => "https://github.com/activeadmin/activeadmin/issues",
+    "changelog_uri" => "https://github.com/activeadmin/activeadmin/blob/master/CHANGELOG.md",
+    "documentation_uri" => "https://activeadmin.info",
+    "homepage_uri" => "https://activeadmin.info",
+    "mailing_list_uri" => "https://groups.google.com/group/activeadmin",
+    "rubygems_mfa_required" => "true",
+    "source_code_uri" => "https://github.com/activeadmin/activeadmin",
+    "wiki_uri" => "https://github.com/activeadmin/activeadmin/wiki"
+  }
 
   s.required_ruby_version = ">= 2.7"
 


### PR DESCRIPTION
This commits adds additional metadata to `activeadmin.gemspec` based on the [rubygems specification](https://guides.rubygems.org/specification-reference/#metadata). This should add a few additional links to the sidebar on rubygems.org, namely Changelog, and also improve discoverability with other tools using the rubygems ecosystem.