### PR TITLE
Improve SimpleCov configuration

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,8 +1,15 @@
 # frozen_string_literal: true
+
 SimpleCov.start do
-  add_filter %r{^/spec/}
+  load_profile "test_frameworks"
+
   add_filter "tmp/development_apps/"
   add_filter "tmp/test_apps/"
+
+  add_group 'Libraries', 'lib/'
+  add_group 'Tasks', 'tasks/'
+
+  track_files "lib/**/*.rb" # TODO: track "tasks/**/*.rb"
 end
 
 if ENV["COVERAGE"] == "true"

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,6 +4,7 @@ coverage:
       default:
         threshold: 0.1%
 ignore:
+  - features/**/*
   - spec/**/*
   - tmp/**/*
   - vendor/**/*


### PR DESCRIPTION
- Track all files in `/lib` for accurate coverage
- Use `test_frameworks` profile to exclude test folders
- Add `Libraries` and `Tasks` groups for HTML export

Note: `/tasks` files not yet covered

---

Other notes:

- You can see at https://app.codecov.io/gh/activeadmin/activeadmin that `features` is included and `tasks` only shows a single file
- I've deliberately ignored tasks files to avoid decreasing coverage too much and because I understand that tasks are tested in a way that coverage can't be checked
- In order to see the effects of `track_files`, you can run
   ```
   COVERAGE=true bin/rspec spec/unit/view_factory_spec.rb --seed 1
   ```
   on this branch (`2149 / 4785 LOC (44.91%)`) and against master (`2149 / 3954 LOC (54.35%)`)

