### PR TITLE
Drop support for Ruby 2.6

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ require:
 
 AllCops:
   DisabledByDefault: true
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
 
   Exclude:
     - tmp/development_apps/**/*

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.metadata = { "rubygems_mfa_required" => "true" }
 
-  s.required_ruby_version = ">= 2.6"
+  s.required_ruby_version = ">= 2.7"
 
   s.add_dependency "arbre", "~> 1.2", ">= 1.2.1"
   s.add_dependency "formtastic", ">= 3.1", "< 5.0"


### PR DESCRIPTION
Ransack 4 requires Ruby 2.7, so ActiveAdmin 3.x series does not support
Ruby 2.6 already and this commit fixes the misleading gemspec version

It has been decided not to run CI tests against 2.7 because it is in EOL

Close #8022