### PR TITLE
Introduce RuboCop Performance

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ inherit_mode:
 
 require:
   - rubocop-packaging
+  - rubocop-performance
   - rubocop-rails
   - rubocop-rspec
 
@@ -98,6 +99,162 @@ Packaging/RequireHardcodingLib:
   Enabled: true
 
 Packaging/RequireRelativeHardcodingLib:
+  Enabled: true
+
+Performance:
+  Enabled: true
+
+Performance/AncestorsInclude:
+  Enabled: false
+
+Performance/ArraySemiInfiniteRangeSlice:
+  Enabled: false
+
+Performance/BigDecimalWithNumericArgument:
+  Enabled: true
+
+Performance/BindCall:
+  Enabled: true
+
+Performance/BlockGivenWithExplicitBlock:
+  Enabled: true
+
+Performance/Caller:
+  Enabled: true
+
+Performance/CaseWhenSplat:
+  Enabled: true
+
+Performance/Casecmp:
+  Enabled: false
+
+Performance/ChainArrayAllocation:
+  Enabled: false
+
+Performance/CollectionLiteralInLoop:
+  Enabled: true
+
+Performance/CompareWithBlock:
+  Enabled: true
+
+Performance/ConcurrentMonotonicTime:
+  Enabled: true
+
+Performance/ConstantRegexp:
+  Enabled: true
+
+Performance/Count:
+  Enabled: true
+
+Performance/DeletePrefix:
+  Enabled: true
+
+Performance/DeleteSuffix:
+  Enabled: true
+
+Performance/Detect:
+  Enabled: true
+
+Performance/DoubleStartEndWith:
+  Enabled: true
+  IncludeActiveSupportAliases: true
+
+Performance/EndWith:
+  Enabled: true
+
+Performance/FixedSize:
+  Enabled: true
+
+Performance/FlatMap:
+  Enabled: true
+  EnabledForFlattenWithoutParams: false
+
+Performance/InefficientHashSearch:
+  Enabled: true
+
+Performance/IoReadlines:
+  Enabled: true
+
+Performance/MapCompact:
+  Enabled: false
+
+Performance/MapMethodChain:
+  Enabled: false
+
+Performance/MethodObjectAsBlock:
+  Enabled: true
+
+Performance/OpenStruct:
+  Enabled: true
+
+Performance/RangeInclude:
+  Enabled: true
+
+Performance/RedundantBlockCall:
+  Enabled: false
+
+Performance/RedundantEqualityComparisonBlock:
+  Enabled: false
+
+Performance/RedundantMatch:
+  Enabled: true
+
+Performance/RedundantMerge:
+  Enabled: true
+  MaxKeyValuePairs: 2
+
+Performance/RedundantSortBlock:
+  Enabled: true
+
+Performance/RedundantSplitRegexpArgument:
+  Enabled: true
+
+Performance/RedundantStringChars:
+  Enabled: true
+
+Performance/RegexpMatch:
+  Enabled: true
+
+Performance/ReverseEach:
+  Enabled: true
+
+Performance/ReverseFirst:
+  Enabled: true
+
+Performance/SelectMap:
+  Enabled: false
+
+Performance/Size:
+  Enabled: true
+
+Performance/SortReverse:
+  Enabled: true
+
+Performance/Squeeze:
+  Enabled: true
+
+Performance/StartWith:
+  Enabled: true
+
+Performance/StringIdentifierArgument:
+  Enabled: true
+
+Performance/StringInclude:
+  Enabled: true
+
+Performance/StringReplacement:
+  Enabled: true
+
+Performance/Sum:
+  Enabled: false
+
+Performance/TimesMap:
+  Enabled: true
+
+Performance/UnfreezeString:
+  Enabled: true
+
+Performance/UriDefaultParser:
   Enabled: true
 
 Rails/FilePath:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -133,6 +133,8 @@ Performance/ChainArrayAllocation:
 
 Performance/CollectionLiteralInLoop:
   Enabled: true
+  Exclude:
+    - spec/**/*
 
 Performance/CompareWithBlock:
   Enabled: true
@@ -186,6 +188,9 @@ Performance/MethodObjectAsBlock:
 
 Performance/OpenStruct:
   Enabled: true
+  Exclude:
+    - features/**/*
+    - spec/**/*
 
 Performance/RangeInclude:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -188,9 +188,6 @@ Performance/MethodObjectAsBlock:
 
 Performance/OpenStruct:
   Enabled: true
-  Exclude:
-    - features/**/*
-    - spec/**/*
 
 Performance/RangeInclude:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ end
 group :rubocop do
   gem "rubocop"
   gem "rubocop-packaging"
+  gem "rubocop-performance"
   gem "rubocop-rspec"
   gem "rubocop-rails"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -394,6 +394,9 @@ GEM
       rubocop (~> 1.33)
     rubocop-packaging (0.5.2)
       rubocop (>= 1.33, < 2.0)
+    rubocop-performance (1.19.1)
+      rubocop (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
     rubocop-rails (2.21.2)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
@@ -491,6 +494,7 @@ DEPENDENCIES
   rspec-rails
   rubocop
   rubocop-packaging
+  rubocop-performance
   rubocop-rails
   rubocop-rspec
   sassc-rails

--- a/features/step_definitions/table_steps.rb
+++ b/features/step_definitions/table_steps.rb
@@ -30,7 +30,7 @@ class HtmlTableToTextHelper
       str += input_to_string(input)
     end
 
-    str += td.content.strip.gsub("\n", " ")
+    str += td.content.strip.tr("\n", " ")
   end
 
   def input_to_string(input)
@@ -78,7 +78,7 @@ module TableMatchHelper
   end
 
   def assert_cells_match(cell, expected_cell)
-    if expected_cell =~ /^\/.*\/$/
+    if /^\/.*\/$/.match?(expected_cell)
       expect(cell).to match /#{expected_cell[1..-2]}/
     else
       expect((cell || "").strip).to eq expected_cell

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -148,7 +148,7 @@ module ActiveAdmin
     #   ActiveAdmin.before_action :authenticate_admin!
     #
     AbstractController::Callbacks::ClassMethods.public_instance_methods.
-      select { |m| m.match(/_action\z/) }.each do |name|
+      select { |m| m.end_with?('_action') }.each do |name|
       define_method name do |*args, &block|
         ActiveSupport.on_load(:active_admin_controller) do
           public_send name, *args, &block

--- a/lib/active_admin/callbacks.rb
+++ b/lib/active_admin/callbacks.rb
@@ -3,6 +3,8 @@ module ActiveAdmin
   module Callbacks
     extend ActiveSupport::Concern
 
+    CALLBACK_TYPES = %i[before after].freeze
+
     private
 
     # Simple callback system. Implements before and after callbacks for
@@ -58,7 +60,7 @@ module ActiveAdmin
       #
       def define_active_admin_callbacks(*names)
         names.each do |name|
-          [:before, :after].each do |type|
+          CALLBACK_TYPES.each do |type|
             callback_name = "#{type}_#{name}_callbacks"
             callback_ivar = "@#{callback_name}"
 

--- a/lib/active_admin/dsl.rb
+++ b/lib/active_admin/dsl.rb
@@ -13,7 +13,7 @@ module ActiveAdmin
 
     # Runs the registration block inside this object
     def run_registration_block(&block)
-      instance_exec &block if block_given?
+      instance_exec &block if block
     end
 
     # The instance of ActiveAdmin::Resource that's being registered
@@ -72,7 +72,7 @@ module ActiveAdmin
     #   end
     #
     def controller(&block)
-      @config.controller.class_exec(&block) if block_given?
+      @config.controller.class_exec(&block) if block
       @config.controller
     end
 

--- a/lib/active_admin/filters/forms.rb
+++ b/lib/active_admin/filters/forms.rb
@@ -21,7 +21,7 @@ module ActiveAdmin
       # Returns the default filter type for a given attribute. If you want
       # to use a custom search method, you have to specify the type yourself.
       def default_input_type(method, options = {})
-        if method =~ /_(eq|cont|start|end)\z/
+        if /_(eq|cont|start|end)\z/.match?(method)
           :string
         elsif klass._ransackers.key?(method.to_s)
           klass._ransackers[method.to_s].type

--- a/lib/active_admin/filters/resource_extension.rb
+++ b/lib/active_admin/filters/resource_extension.rb
@@ -98,7 +98,7 @@ module ActiveAdmin
         end
 
         if @filters_to_remove
-          @filters_to_remove.each &filters.method(:delete)
+          @filters_to_remove.each { |filter| filters.delete(filter) }
         end
 
         filters
@@ -139,7 +139,7 @@ module ActiveAdmin
             end
 
             # Remove high-arity associations with no searchable column
-            high_arity = high_arity.select(&method(:searchable_column_for))
+            high_arity = high_arity.select { |r| searchable_column_for(r) }
 
             high_arity = high_arity.map { |r| r.name.to_s + "_" + searchable_column_for(r) + namespace.filter_method_for_large_association }
 

--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -161,7 +161,7 @@ module ActiveAdmin
     # Capture the ADD JS
     def js_for_has_many(class_string, &form_block)
       assoc_name = assoc_klass.model_name
-      placeholder = "NEW_#{assoc_name.to_s.underscore.upcase.gsub(/\//, '_')}_RECORD"
+      placeholder = "NEW_#{assoc_name.to_s.underscore.upcase.tr('/', '_')}_RECORD"
       opts = {
         for: [assoc, assoc_klass.new],
         class: class_string,

--- a/lib/active_admin/menu.rb
+++ b/lib/active_admin/menu.rb
@@ -64,7 +64,7 @@ module ActiveAdmin
 
       # Whether any children match the given item.
       def include?(item)
-        @children.values.include?(item) || @children.values.any? { |child| child.include?(item) }
+        @children.value?(item) || @children.values.any? { |child| child.include?(item) }
       end
 
       # Used in the UI to visually distinguish which menu item is selected.

--- a/lib/active_admin/menu_collection.rb
+++ b/lib/active_admin/menu_collection.rb
@@ -25,7 +25,7 @@ module ActiveAdmin
     end
 
     def exists?(menu_name)
-      @menus.keys.include? menu_name
+      @menus.key?(menu_name)
     end
 
     def fetch(menu_name)

--- a/lib/active_admin/namespace.rb
+++ b/lib/active_admin/namespace.rb
@@ -68,7 +68,7 @@ module ActiveAdmin
 
       # Register the resource
       register_resource_controller(config)
-      parse_registration_block(config, &block) if block_given?
+      parse_registration_block(config, &block) if block
       reset_menu!
 
       # Dispatch a registration event
@@ -83,7 +83,7 @@ module ActiveAdmin
 
       # Register the resource
       register_page_controller(config)
-      parse_page_registration_block(config, &block) if block_given?
+      parse_page_registration_block(config, &block) if block
       reset_menu!
 
       config

--- a/lib/active_admin/order_clause.rb
+++ b/lib/active_admin/order_clause.rb
@@ -29,7 +29,7 @@ module ActiveAdmin
     end
 
     def table_column
-      if (@column =~ /\./)
+      if (@column.include?('.'))
         @column
       else
         [table, active_admin_config.resource_quoted_column_name(@column)].compact.join(".")

--- a/lib/active_admin/orm/active_record/comments/views/active_admin_comments.rb
+++ b/lib/active_admin/orm/active_record/comments/views/active_admin_comments.rb
@@ -28,7 +28,7 @@ module ActiveAdmin
 
         def build_comments
           if @comments.any?
-            @comments.each(&method(:build_comment))
+            @comments.each { |comment| build_comment(comment) }
             div page_entries_info(@comments).html_safe, class: "pagination_information"
           else
             build_empty_message

--- a/lib/active_admin/resource_controller/streaming.rb
+++ b/lib/active_admin/resource_controller/streaming.rb
@@ -24,7 +24,7 @@ module ActiveAdmin
         headers["Last-Modified"] = Time.current.httpdate
 
         if ActiveAdmin.application.disable_streaming_in.include? Rails.env
-          self.response_body = block[String.new]
+          self.response_body = block[String.new] # rubocop:disable Performance/UnfreezeString to preserve encoding
         else
           self.response_body = Enumerator.new &block
         end

--- a/lib/active_admin/resource_controller/streaming.rb
+++ b/lib/active_admin/resource_controller/streaming.rb
@@ -31,7 +31,7 @@ module ActiveAdmin
       end
 
       def csv_filename
-        "#{resource_collection_name.to_s.gsub('_', '-')}-#{Time.zone.now.to_date.to_s}.csv"
+        "#{resource_collection_name.to_s.tr('_', '-')}-#{Time.zone.now.to_date.to_s}.csv"
       end
 
       def stream_csv

--- a/lib/active_admin/resource_dsl.rb
+++ b/lib/active_admin/resource_dsl.rb
@@ -192,7 +192,7 @@ module ActiveAdmin
     delegate :before_destroy, :after_destroy, to: :controller
 
     standard_rails_filters =
-      AbstractController::Callbacks::ClassMethods.public_instance_methods.select { |m| m.match(/_action\z/) }
+      AbstractController::Callbacks::ClassMethods.public_instance_methods.select { |m| m.end_with?('_action') }
     delegate *standard_rails_filters, to: :controller
 
     # Specify which actions to create in the controller

--- a/lib/active_admin/scope.rb
+++ b/lib/active_admin/scope.rb
@@ -41,7 +41,7 @@ module ActiveAdmin
       end
 
       @scope_method = nil if @scope_method == :all
-      if block_given?
+      if block
         @scope_method = nil
         @scope_block = block
       end

--- a/lib/active_admin/view_helpers/fields_for.rb
+++ b/lib/active_admin/view_helpers/fields_for.rb
@@ -2,6 +2,7 @@
 module ActiveAdmin
   module ViewHelpers
     module FormHelper
+      RESERVED_PARAMS = %w(controller action commit utf8).freeze
 
       # Flatten a params Hash to an array of fields.
       #
@@ -19,7 +20,7 @@ module ActiveAdmin
         except = Array.wrap(options[:except]).map &:to_s
 
         params.flat_map do |k, v|
-          next if namespace.nil? && %w(controller action commit utf8).include?(k.to_s)
+          next if namespace.nil? && RESERVED_PARAMS.include?(k.to_s)
           next if except.include?(k.to_s)
 
           if namespace

--- a/lib/active_admin/views/components/active_admin_form.rb
+++ b/lib/active_admin/views/components/active_admin_form.rb
@@ -37,7 +37,7 @@ module ActiveAdmin
 
         # Rails sets multipart automatically if a file field is present,
         # but the form tag has already been rendered before the block eval.
-        if multipart? && @opening_tag !~ /multipart/
+        if multipart? && !@opening_tag.include?('multipart')
           @opening_tag.sub!(/<form/, '<form enctype="multipart/form-data"')
         end
       end

--- a/lib/active_admin/views/components/active_admin_form.rb
+++ b/lib/active_admin/views/components/active_admin_form.rb
@@ -33,7 +33,7 @@ module ActiveAdmin
         end
 
         @opening_tag, @closing_tag = split_string_on(form_string, "</form>")
-        instance_eval(&block) if block_given?
+        instance_eval(&block) if block
 
         # Rails sets multipart automatically if a file field is present,
         # but the form tag has already been rendered before the block eval.
@@ -43,10 +43,10 @@ module ActiveAdmin
       end
 
       def inputs(*args, &block)
-        if block_given?
+        if block
           form_builder.template.assigns[:has_many_block] = true
         end
-        if block_given? && block.arity == 0
+        if block && block.arity == 0
           wrapped_block = proc do
             wrap_it = form_builder.already_in_an_inputs_block ? true : false
             form_builder.already_in_an_inputs_block = true
@@ -73,7 +73,7 @@ module ActiveAdmin
       end
 
       def actions(*args, &block)
-        if block_given?
+        if block
           insert_tag(SemanticActionsProxy, form_builder, *args, &block)
         else
           actions(*args) { commit_action_with_cancel_link }

--- a/lib/active_admin/views/components/active_filters_sidebar_content.rb
+++ b/lib/active_admin/views/components/active_filters_sidebar_content.rb
@@ -9,7 +9,7 @@ module ActiveAdmin
 
       def build
         active_filters = ActiveAdmin::Filters::Active.new(active_admin_config, assigns[:search])
-        active_scopes = assigns[:search].instance_variable_get("@scope_args")
+        active_scopes = assigns[:search].instance_variable_get(:@scope_args)
 
         scope_block(current_scope)
         filters_list(active_filters, active_scopes)

--- a/lib/active_admin/views/components/dropdown_menu.rb
+++ b/lib/active_admin/views/components/dropdown_menu.rb
@@ -38,7 +38,7 @@ module ActiveAdmin
 
       def item(*args, **kwargs, &block)
         within @menu do
-          if block_given?
+          if block
             li &block
           else
             li link_to(*args, **kwargs)

--- a/lib/active_admin/views/components/sidebar.rb
+++ b/lib/active_admin/views/components/sidebar.rb
@@ -7,7 +7,7 @@ module ActiveAdmin
 
       def build(sections, attributes = {})
         super(attributes)
-        sections.map(&method(:sidebar_section))
+        sections.map { |section| sidebar_section(section) }
       end
     end
   end

--- a/lib/active_admin/views/index_as_table.rb
+++ b/lib/active_admin/views/index_as_table.rb
@@ -352,12 +352,12 @@ module ActiveAdmin
             if dropdown
               dropdown_menu dropdown_name do
                 defaults(resource) if defaults
-                instance_exec(resource, &block) if block_given?
+                instance_exec(resource, &block) if block
               end
             else
               table_actions do
                 defaults(resource, css_class: :member_link) if defaults
-                if block_given?
+                if block
                   block_result = instance_exec(resource, &block)
                   text_node block_result unless block_result.is_a? Arbre::Element
                 end

--- a/lib/generators/active_admin/install/install_generator.rb
+++ b/lib/generators/active_admin/install/install_generator.rb
@@ -13,7 +13,7 @@ module ActiveAdmin
       source_root File.expand_path("templates", __dir__)
 
       def copy_initializer
-        @underscored_user_name = name.underscore.gsub("/", "_")
+        @underscored_user_name = name.underscore.tr("/", "_")
         @use_authentication_method = options[:users].present?
         @skip_comments = options[:skip_comments]
         template "active_admin.rb.erb", "config/initializers/active_admin.rb"

--- a/spec/tasks/changelog_spec.rb
+++ b/spec/tasks/changelog_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Changelog" do
 
   it "sorts contributors" do
     contributors = changelog.scan(/^\[@([^\]]+)\]: https:\/\/github\.com\/\1$/).flatten
-    expect(contributors).to eq(contributors.sort { |a, b| a.downcase <=> b.downcase })
+    expect(contributors).to eq(contributors.sort_by(&:downcase))
   end
 
   it "sorts pull requests" do

--- a/spec/unit/collection_decorator_spec.rb
+++ b/spec/unit/collection_decorator_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ActiveAdmin::CollectionDecorator do
     subject { ActiveAdmin::CollectionDecorator.decorate((1..10).to_a, with: NumberDecorator) }
 
     it "delegates them to the decorated collection" do
-      expect(subject.select(&:selectable?).count).to eq(5)
+      expect(subject.count(&:selectable?)).to eq(5)
     end
   end
 end

--- a/spec/unit/views/components/paginated_collection_spec.rb
+++ b/spec/unit/views/components/paginated_collection_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe ActiveAdmin::Views::PaginatedCollection do
 
     context "when specifying :param_name option" do
       let(:collection) do
-        posts = 10.times.map { Post.new }
+        posts = Array.new(10) { Post.new }
         Kaminari.paginate_array(posts).page(1).per(5)
       end
 
@@ -66,7 +66,7 @@ RSpec.describe ActiveAdmin::Views::PaginatedCollection do
 
     context "when specifying :params option" do
       let(:collection) do
-        posts = 10.times.map { Post.new }
+        posts = Array.new(10) { Post.new }
         Kaminari.paginate_array(posts).page(1).per(5)
       end
 
@@ -79,7 +79,7 @@ RSpec.describe ActiveAdmin::Views::PaginatedCollection do
 
     context "when specifying download_links: false option" do
       let(:collection) do
-        posts = 10.times.map { Post.new }
+        posts = Array.new(10) { Post.new }
         Kaminari.paginate_array(posts).page(1).per(5)
       end
 
@@ -249,7 +249,7 @@ RSpec.describe ActiveAdmin::Views::PaginatedCollection do
 
     context "when specifying per_page: array option" do
       let(:collection) do
-        posts = 10.times.map { Post.new }
+        posts = Array.new(10) { Post.new }
         Kaminari.paginate_array(posts).page(1).per(5)
       end
 

--- a/spec/unit/views/pages/form_spec.rb
+++ b/spec/unit/views/pages/form_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ActiveAdmin::Views::Pages::Form do
     end
 
     let(:arbre_context) do
-      OpenStruct.new(params: params, helpers: helpers, assigns: {})
+      instance_double(Arbre::Context, helpers: helpers, assigns: {})
     end
 
     context "when :title is set" do

--- a/spec/unit/views/pages/index_spec.rb
+++ b/spec/unit/views/pages/index_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ActiveAdmin::Views::Pages::Index do
     end
 
     let(:arbre_context) do
-      OpenStruct.new(params: params, helpers: helpers, assigns: {})
+      instance_double(Arbre::Context, helpers: helpers, assigns: {})
     end
 
     context "when config[:title] is assigned" do

--- a/tasks/changelog.rb
+++ b/tasks/changelog.rb
@@ -146,7 +146,7 @@ class Changelog
       new_user_references << "#{user}: https://github.com/#{user_name}"
     end
 
-    new_unique_user_references = new_user_references.sort { |a, b| a.downcase <=> b.downcase }.uniq
+    new_unique_user_references = new_user_references.sort_by(&:downcase).uniq
 
     replace_with_lines([pre_user_references, new_unique_user_references])
   end

--- a/tasks/local.rake
+++ b/tasks/local.rake
@@ -19,7 +19,7 @@ task :local do
     if %w(server s).include?(argv[0])
       command = "foreman start -f Procfile.dev"
     # If it's a rails command, auto add the rails script
-    elsif %w(generate console dbconsole g c routes runner).include?(argv[0]) || argv[0] =~ /db:/
+    elsif %w(generate console dbconsole g c routes runner).include?(argv[0]) || argv[0].include?('db:')
       argv.unshift("rails")
       command = ["bundle", "exec", *argv].join(" ")
     end

--- a/tasks/release_manager.rb
+++ b/tasks/release_manager.rb
@@ -87,7 +87,7 @@ class ReleaseManager
     phase = :looking_for_prerelease_part
 
     gem_version_segments.map do |segment|
-      if segment =~ /[a-z]/
+      if /[a-z]/.match?(segment)
         phase = :bumping_pre_release
         segment
       else


### PR DESCRIPTION
Commits are separated by scope:

- Add gem
- Autofix safe, non-production offenses
- Autofix unsafe, non-production offenses
- Autofix safe, production offenses
- Autofix unsafe, production offenses
- Manually fix remaining production offenses

Notes:
- All changed lines of code are covered by specs (required #8034)
- `Performance/EndWith` changes should be safe because minimum required ruby version is 2.7, and 2.7 also supports `Symbol#end_with?`
- `Performance/InefficientHashSearch` fixes should be safe, because both `@menus` and `@children` are hashes
- `Performance/StringInclude` fixes should be safe, because `@column` is the result of a RegExp match
- `changelog:resync` and `local` rake tasks have been tested manually