### PR TITLE
Fix CSV responses when index overriding with the call alias method

### DIFF
--- a/app/controllers/active_admin/resource_controller/streaming.rb
+++ b/app/controllers/active_admin/resource_controller/streaming.rb
@@ -15,6 +15,7 @@ module ActiveAdmin
           yield(format) if block_given?
         end
       end
+      alias :index! :index
 
       protected
 

--- a/spec/unit/authorization/index_overriding_spec.rb
+++ b/spec/unit/authorization/index_overriding_spec.rb
@@ -5,19 +5,44 @@ RSpec.describe "Index overriding", type: :controller do
   before do
     load_resources { ActiveAdmin.register Post }
     @controller = Admin::PostsController.new
+  end
 
-    @controller.instance_eval do
-      def index
-        super do
-          render body: "Rendered from passed block"
-          return
+  context "with the call super" do
+    before do
+      @controller.instance_eval do
+        def index
+          super do |format|
+            format.html { render body: "Rendered from passed block" }
+          end
         end
       end
     end
+
+    it "should call block passed to overridden index" do
+      get :index
+      expect(response.body).to eq "Rendered from passed block"
+    end
+
+    it "can CSV responses" do
+      get :index, format: :csv
+      expect(response.header["Content-Type"]).to eq "text/csv; charset=utf-8"
+    end
   end
 
-  it "should call block passed to overridden index" do
-    get :index
-    expect(response.body).to eq "Rendered from passed block"
+  context "with the call alias method" do
+    before do
+      @controller.instance_eval do
+        def index
+          index! do
+            # Do nothing
+          end
+        end
+      end
+    end
+
+    it "can CSV responses" do
+      get :index, format: :csv
+      expect(response.header["Content-Type"]).to eq "text/csv; charset=utf-8"
+    end
   end
 end

--- a/spec/unit/resource_controller_spec.rb
+++ b/spec/unit/resource_controller_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe ActiveAdmin::ResourceController, type: :controller do
 
     it "should have actual action methods" do
       controller.class.clear_action_methods! # make controller recalculate :action_methods on the next call
-      expect(controller.action_methods.sort).to eq ["batch_action", "create", "destroy", "edit", "index", "new", "show", "update"]
+      expect(controller.action_methods.sort).to eq ["batch_action", "create", "destroy", "edit", "index", "index!", "new", "show", "update"]
     end
   end
 end


### PR DESCRIPTION
<!--

Thanks for contributing to ActiveAdmin!

You can find all the instructions for contributing at the [CONTRIBUTING file].

Before submitting your PR make sure that:

* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are splitted apart.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all github checks are passing, but feel free to ask for early feedback if you need guidance.

[CONTRIBUTING file]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->

CSV responses are implemented by overriding the index as below.

<https://github.com/activeadmin/activeadmin/blob/2692838b7520a6b78478beeda9e0adb8179e2f39/lib/active_admin/resource_controller/streaming.rb#L12-L17>

If a user overrides the index using the alias method instead of the super, this implementation is ignored and CSV responses are not working.

```rb
controller do
  def index
    index! do |format| # Cause "No renderer defined for format: csv"
      ...
    end
  end
end
```

I add an alias method to make this implementation work anytime.