### PR TITLE
Remove multiline ternary operator

### DIFF
--- a/lib/active_admin/order_clause.rb
+++ b/lib/active_admin/order_clause.rb
@@ -29,8 +29,11 @@ module ActiveAdmin
     end
 
     def table_column
-      (@column =~ /\./) ? @column :
+      if (@column =~ /\./)
+        @column
+      else
         [table, active_admin_config.resource_quoted_column_name(@column)].compact.join(".")
+      end
     end
 
     def sql

--- a/lib/active_admin/views/components/active_admin_form.rb
+++ b/lib/active_admin/views/components/active_admin_form.rb
@@ -73,9 +73,11 @@ module ActiveAdmin
       end
 
       def actions(*args, &block)
-        block_given? ?
-          insert_tag(SemanticActionsProxy, form_builder, *args, &block) :
+        if block_given?
+          insert_tag(SemanticActionsProxy, form_builder, *args, &block)
+        else
           actions(*args) { commit_action_with_cancel_link }
+        end
       end
 
       def commit_action_with_cancel_link

--- a/lib/active_admin/views/pages/index.rb
+++ b/lib/active_admin/views/pages/index.rb
@@ -113,8 +113,11 @@ module ActiveAdmin
         # Returns the actual class for renderering the main content on the index
         # page. To set this, use the :as option in the page_presenter block.
         def find_index_renderer_class(klass)
-          klass.is_a?(Class) ? klass :
+          if klass.is_a?(Class)
+            klass
+          else
             ::ActiveAdmin::Views.const_get("IndexAs" + klass.to_s.camelcase)
+          end
         end
 
         def render_blank_slate

--- a/spec/unit/order_clause_spec.rb
+++ b/spec/unit/order_clause_spec.rb
@@ -28,6 +28,15 @@ RSpec.describe ActiveAdmin::OrderClause do
     end
   end
 
+  describe "posts.id_asc" do
+    let(:clause) { "posts.id_asc" }
+
+    describe "#table_column" do
+      subject { super().table_column }
+      it { is_expected.to eq("posts.id") }
+    end
+  end
+
   describe "virtual_column_asc" do
     let(:clause) { "virtual_column_asc" }
 


### PR DESCRIPTION
Replace multiline ternary operator with a standard `if...else` for readability and better code coverage

### master

Fake Coverage 100%

<img width="742" alt="image" src="https://github.com/activeadmin/activeadmin/assets/556268/d77eeee7-4b3c-46ca-9e5f-9beb0fd51cf2">


### this branch

Real Coverage 96.43%

<img width="737" alt="image" src="https://github.com/activeadmin/activeadmin/assets/556268/b4d5818a-28e3-47a1-8e07-21b0aedf84a0">

