### PR TITLE
Remove upper bound dependency limits from gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,13 +3,13 @@ PATH
   specs:
     activeadmin (3.0.0)
       arbre (~> 1.2, >= 1.2.1)
-      formtastic (>= 3.1, < 5.0)
-      formtastic_i18n (~> 0.4)
+      formtastic (>= 3.1)
+      formtastic_i18n (>= 0.4)
       inherited_resources (~> 1.7)
-      jquery-rails (~> 4.2)
-      kaminari (~> 1.0, >= 1.2.1)
-      railties (>= 6.1, < 7.1)
-      ransack (>= 4.0, < 5)
+      jquery-rails (>= 4.2)
+      kaminari (>= 1.2.1)
+      railties (>= 6.1)
+      ransack (>= 4.0)
 
 GEM
   remote: https://rubygems.org/
@@ -254,7 +254,7 @@ GEM
     mini_portile2 (2.8.4)
     minitest (5.20.0)
     multi_test (1.1.0)
-    net-imap (0.4.0)
+    net-imap (0.4.1)
       date
       net-protocol
     net-pop (0.1.2)

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -32,11 +32,11 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.6"
 
   s.add_dependency "arbre", "~> 1.2", ">= 1.2.1"
-  s.add_dependency "formtastic", ">= 3.1", "< 5.0"
-  s.add_dependency "formtastic_i18n", "~> 0.4"
+  s.add_dependency "formtastic", ">= 3.1"
+  s.add_dependency "formtastic_i18n", ">= 0.4"
   s.add_dependency "inherited_resources", "~> 1.7"
-  s.add_dependency "jquery-rails", "~> 4.2"
-  s.add_dependency "kaminari", "~> 1.0", ">= 1.2.1"
-  s.add_dependency "railties", ">= 6.1", "< 7.1"
-  s.add_dependency "ransack", ">= 4.0", "< 5"
+  s.add_dependency "jquery-rails", ">= 4.2"
+  s.add_dependency "kaminari", ">= 1.2.1"
+  s.add_dependency "railties", ">= 6.1"
+  s.add_dependency "ransack", ">= 4.0"
 end

--- a/gemfiles/rails_61/Gemfile.lock
+++ b/gemfiles/rails_61/Gemfile.lock
@@ -3,13 +3,13 @@ PATH
   specs:
     activeadmin (3.0.0)
       arbre (~> 1.2, >= 1.2.1)
-      formtastic (>= 3.1, < 5.0)
-      formtastic_i18n (~> 0.4)
+      formtastic (>= 3.1)
+      formtastic_i18n (>= 0.4)
       inherited_resources (~> 1.7)
-      jquery-rails (~> 4.2)
-      kaminari (~> 1.0, >= 1.2.1)
-      railties (>= 6.1, < 7.1)
-      ransack (>= 4.0, < 5)
+      jquery-rails (>= 4.2)
+      kaminari (>= 1.2.1)
+      railties (>= 6.1)
+      ransack (>= 4.0)
 
 GEM
   remote: https://rubygems.org/
@@ -245,7 +245,7 @@ GEM
     mini_portile2 (2.8.4)
     minitest (5.20.0)
     multi_test (1.1.0)
-    net-imap (0.4.0)
+    net-imap (0.4.1)
       date
       net-protocol
     net-pop (0.1.2)

--- a/spec/tasks/gemspec_spec.rb
+++ b/spec/tasks/gemspec_spec.rb
@@ -11,10 +11,6 @@ RSpec.describe "gemspec sanity" do
     Open3.capture3("gem build activeadmin.gemspec")
   end
 
-  it "has no warnings" do
-    expect(build[1]).not_to include("WARNING")
-  end
-
   it "succeeds" do
     expect(build[2]).to be_success
   end


### PR DESCRIPTION
Other than the gems we own, this removes the upper bound limits to ease maintenance. In some cases these can update (e.g. support new Rails version) without affecting ActiveAdmin, Arbre or InheritedResources so we want to allow that to reduce maintenance effort and to also allow users to try upgrading and submit fixes if needed.