### PR TITLE
Get ready for 3.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+## 3.1.0 [☰](https://github.com/activeadmin/activeadmin/compare/v3.0.0..v3.1.0)
+
+### Enhancements
+
+* Support Rails 7.1. [#8102] by [@mgrunberg]
+* Remove deprecated usage of ActiveSupport::Deprecation singleton. [#8106] by [@mgrunberg]
+* Replace to_formatted_s with to_s to convert date to string. [#8105] by [@mgrunberg]
+* Remove upper bound dependency limits from gemspec. [#8098] by [@javierjulio]
+
 ## 3.0.0 [☰](https://github.com/activeadmin/activeadmin/compare/v2.14.0..v3.0.0)
 
 ### Breaking Changes
@@ -864,6 +873,10 @@ Please check [0-6-stable] for previous changes.
 [#7993]: https://github.com/activeadmin/activeadmin/pull/7993
 [#8009]: https://github.com/activeadmin/activeadmin/pull/8009
 [#8010]: https://github.com/activeadmin/activeadmin/pull/8010
+[#8098]: https://github.com/activeadmin/activeadmin/pull/8098
+[#8102]: https://github.com/activeadmin/activeadmin/pull/8102
+[#8105]: https://github.com/activeadmin/activeadmin/pull/8105
+[#8106]: https://github.com/activeadmin/activeadmin/pull/8106
 
 [@1000ship]: https://github.com/1000ship
 [@5t111111]: https://github.com/5t111111

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: .
   specs:
-    activeadmin (3.0.0)
+    activeadmin (3.1.0)
       arbre (~> 1.2, >= 1.2.1)
       formtastic (>= 3.1)
       formtastic_i18n (>= 0.4)

--- a/gemfiles/rails_61/Gemfile.lock
+++ b/gemfiles/rails_61/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    activeadmin (3.0.0)
+    activeadmin (3.1.0)
       arbre (~> 1.2, >= 1.2.1)
       formtastic (>= 3.1)
       formtastic_i18n (>= 0.4)

--- a/gemfiles/rails_70/Gemfile.lock
+++ b/gemfiles/rails_70/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    activeadmin (3.0.0)
+    activeadmin (3.1.0)
       arbre (~> 1.2, >= 1.2.1)
       formtastic (>= 3.1)
       formtastic_i18n (>= 0.4)

--- a/lib/active_admin/version.rb
+++ b/lib/active_admin/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ActiveAdmin
-  VERSION = "3.0.0"
+  VERSION = "3.1.0"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activeadmin/activeadmin",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "The administration framework for Ruby on Rails.",
   "main": "app/assets/javascripts/active_admin/base.js",
   "type": "module",


### PR DESCRIPTION
The default branch is running v4 development with an ongoing Tailwind CSS migration. The priority with a 3.x release is to remove the upper bound limits on most dependencies to ease the maintenance burden.