### PR TITLE
Replace to_formatted_s with to_s to convert date to string

### DIFF
--- a/lib/active_admin/resource_controller/streaming.rb
+++ b/lib/active_admin/resource_controller/streaming.rb
@@ -31,7 +31,7 @@ module ActiveAdmin
       end
 
       def csv_filename
-        "#{resource_collection_name.to_s.gsub('_', '-')}-#{Time.zone.now.to_date.to_formatted_s(:default)}.csv"
+        "#{resource_collection_name.to_s.gsub('_', '-')}-#{Time.zone.now.to_date.to_s}.csv"
       end
 
       def stream_csv


### PR DESCRIPTION
Solves the following deprecation warning in Rails 7.1:
```
DEPRECATION WARNING: to_default_s is deprecated and will be removed from Rails 7.2 (use to_s instead)
```

Check deprecation
[here](https://github.com/rails/rails/blob/v7.1.1/activesupport/lib/active_support/core_ext/date/conversions.rb#L59)

It shouldn't be a problem in [Rails 6.1](https://github.com/rails/rails/blob/v6.1.7.6/activesupport/lib/active_support/core_ext/date/conversions.rb#L59 ) or [Rails 7.0](https://github.com/rails/rails/blob/v7.0.8/activesupport/lib/active_support/core_ext/date/conversions.rb#L59 )

### Background

This commit was extracted from #8102. 

Rails 7.1 is technically supported in 3-0-stable because #8098 got merged. We can't run test against Rails 7.1 yet (#8102) but makes sense to me to merge the required changes while waiting.