### PR TITLE
Provide detail in DB statement timeout error for filters

### DIFF
--- a/lib/active_admin/inputs/filters/select_input.rb
+++ b/lib/active_admin/inputs/filters/select_input.rb
@@ -43,6 +43,8 @@ module ActiveAdmin
           else
             super
           end
+        rescue ActiveRecord::QueryCanceled => error
+          raise ActiveRecord::QueryCanceled.new "#{error.message.strip} while querying the values for the ActiveAdmin :#{method} filter"
         end
 
         def pluck_column


### PR DESCRIPTION
Hello everyone! 👋

When a database timeout error occurs querying the values for a sidebar filter, the error message does not report that it is an error in the filters nor does it indicate the specific filter with the error, so I propose this change to give more information to the developer about the error so he can work on it.

Context: using a Rails application in which I use Active Admin, I accessed the view of a resource with many records and after a few seconds I got the error `PG::QueryCanceled: ERROR: canceling statement due to statement timeout`, but the error was not querying records for the table, it was querying values for a sidebar `SelectInput` filter.

<!--

Thanks for contributing to ActiveAdmin!

You can find all the instructions for contributing at the [CONTRIBUTING file].

Before submitting your PR make sure that:

* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are splitted apart.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all github checks are passing, but feel free to ask for early feedback if you need guidance.

[CONTRIBUTING file]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->
