### PR TITLE
Make sure menu creation does not modify menu options

### DIFF
--- a/lib/active_admin/menu.rb
+++ b/lib/active_admin/menu.rb
@@ -48,6 +48,7 @@ module ActiveAdmin
       #   menu.add parent: 'Dashboard', label: 'My Child Dashboard'
       #
       def add(options)
+        options = options.dup # Make sure parameter is not modified
         parent_chain = Array.wrap(options.delete(:parent))
 
         item = if parent = parent_chain.shift


### PR DESCRIPTION
This is an attempt to fix/work around #8078 and related issues.

If you look at the mentioned and related tickets, the problem is that sometimes nested menu items are rendered on the top-level, without a parent. I'm not 100% sure this PR fixes the problem, as it is difficult to reproduce, but this is a place in the code where the parent property of the menu items is modified unnecessarily.

fixes #8078 