### PR TITLE
Fix Ransack error with filters when ActiveStorage is used

### DIFF
--- a/lib/active_admin/filters/formtastic_addons.rb
+++ b/lib/active_admin/filters/formtastic_addons.rb
@@ -47,7 +47,7 @@ module ActiveAdmin
       #
 
       def searchable_has_many_through?
-        if reflection && reflection.options[:through]
+        if klass.ransackable_associations.include?(method.to_s) && reflection && reflection.options[:through]
           reflection.through_reflection.klass.ransackable_attributes.include? reflection.foreign_key
         else
           false


### PR DESCRIPTION
this should fix errors when using models with activestorage in https://github.com/activeadmin/activeadmin/issues/8076

The problem was that formtastic will treat the association as searchable and try to call `ransackable_attributes` on the active storage model even though you define `ransackable_associations` in the model