### PR TITLE
Prefer `match?` over `=~` to avoid MatchData

### DIFF
--- a/lib/active_admin/view_helpers/breadcrumb_helper.rb
+++ b/lib/active_admin/view_helpers/breadcrumb_helper.rb
@@ -2,6 +2,7 @@
 module ActiveAdmin
   module ViewHelpers
     module BreadcrumbHelper
+      ID_FORMAT_REGEXP = /\A(\d+|[a-f0-9]{24}|(?:[a-f0-9]{8}-(?:[a-f0-9]{4}-){3}[a-f0-9]{12}))\z/.freeze
 
       # Returns an array of links to use in a breadcrumb
       def breadcrumb_links(path = request.path)
@@ -13,7 +14,7 @@ module ActiveAdmin
           # 1. try using `display_name` if we can locate a DB object
           # 2. try using the model name translation
           # 3. default to calling `titlecase` on the URL fragment
-          if part =~ /\A(\d+|[a-f0-9]{24}|(?:[a-f0-9]{8}-(?:[a-f0-9]{4}-){3}[a-f0-9]{12}))\z/ && parts[index - 1]
+          if ID_FORMAT_REGEXP.match?(part) && parts[index - 1]
             parent = active_admin_config.belongs_to_config.try :target
             config = parent && parent.resource_name.route_key == parts[index - 1] ? parent : active_admin_config
             name = display_name config.find_resource part


### PR DESCRIPTION
When the specific `MatchData` object is not needed, using `regexp.match?` is preferred over `=~` as it avoids the creation of a MatchData object, resulting in improved performance and reduced memory usage.

Example:

```rb
PARTS = ["admin", "users", "2b2f0fc2-9a0d-41b8-b39d-aa21963aaee4"]

%i[ips memory].each do |benchmark|
  Benchmark.send(benchmark) do |x|
    x.report('=~') { PARTS.each { |part| part =~ ID_FORMAT_REGEXP } }
    x.report('match?') { PARTS.each { |part| ID_FORMAT_REGEXP.match?(part) } }
    x.compare!
  end
end
```

```
Comparison (IPS):
              match?:   943080.8 i/s
                  =~:   621955.5 i/s - 1.52x  (± 0.00) slower

Comparison (Memory):
              match?:          0 allocated
                  =~:        168 allocated - Infx more
```
