### PR TITLE
Targeting minimum Ruby version to 3.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ require:
 
 AllCops:
   DisabledByDefault: true
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
 
   Exclude:
     - tmp/development_apps/**/*

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
     "wiki_uri" => "https://github.com/activeadmin/activeadmin/wiki"
   }
 
-  s.required_ruby_version = ">= 2.7"
+  s.required_ruby_version = ">= 3.0"
 
   s.add_dependency "arbre", "~> 1.2", ">= 1.2.1"
   s.add_dependency "formtastic", ">= 3.1"

--- a/tasks/release_manager.rb
+++ b/tasks/release_manager.rb
@@ -61,9 +61,9 @@ class ReleaseManager
   private
 
   def assert_compatible_ruby!
-    incompatible_ruby = Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.7.0")
+    incompatible_ruby = Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.0.0")
 
-    raise "Unsupported ruby version. Use ruby 2.7.0 or higher to release" if incompatible_ruby
+    raise "Unsupported ruby version. Use ruby 3.0.0 or higher to release" if incompatible_ruby
   end
 
   def assert_synced_versioning!


### PR DESCRIPTION
Some time ago Ruby 2.7 support was dropped, removing it from the CI but some references remained in the code.

I think we can target the minimum Ruby version to 3.0.

Let me know if you think something different!