### PR TITLE
Backport to 3-0 stable branch provide detail in DB statement timeout error for filters (#8117)

### DIFF
--- a/lib/active_admin/inputs/filters/select_input.rb
+++ b/lib/active_admin/inputs/filters/select_input.rb
@@ -43,6 +43,8 @@ module ActiveAdmin
           else
             super
           end
+        rescue ActiveRecord::QueryCanceled => error
+          raise ActiveRecord::QueryCanceled.new "#{error.message.strip} while querying the values for the ActiveAdmin :#{method} filter"
         end
 
         def pluck_column


### PR DESCRIPTION
Give more info about db timeout error in filters

When a database timeout error occurs querying the values for a filter, the error message does not give the filter information

<!--

Thanks for contributing to ActiveAdmin!

You can find all the instructions for contributing at the [CONTRIBUTING file].

Before submitting your PR make sure that:

* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are splitted apart.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all github checks are passing, but feel free to ask for early feedback if you need guidance.

[CONTRIBUTING file]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->
