### PR TITLE
Backport to 3-0 stable branch ransack error with filters when ActiveStorage is used (#8137)

### DIFF
--- a/lib/active_admin/filters/formtastic_addons.rb
+++ b/lib/active_admin/filters/formtastic_addons.rb
@@ -47,7 +47,7 @@ module ActiveAdmin
       #
 
       def searchable_has_many_through?
-        if reflection && reflection.options[:through]
+        if klass.ransackable_associations.include?(method.to_s) && reflection && reflection.options[:through]
           reflection.through_reflection.klass.ransackable_attributes.include? reflection.foreign_key
         else
           false


### PR DESCRIPTION
feat: check ransackable_associations when checking searchable_has_many_through

<!--

Thanks for contributing to ActiveAdmin!

You can find all the instructions for contributing at the [CONTRIBUTING file].

Before submitting your PR make sure that:

* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are splitted apart.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all github checks are passing, but feel free to ask for early feedback if you need guidance.

[CONTRIBUTING file]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->
