### PR TITLE
Backport to 3-0 stable branch make sure menu creation does not modify menu options (#8132)

### DIFF
--- a/lib/active_admin/menu.rb
+++ b/lib/active_admin/menu.rb
@@ -48,6 +48,7 @@ module ActiveAdmin
       #   menu.add parent: 'Dashboard', label: 'My Child Dashboard'
       #
       def add(options)
+        options = options.dup # Make sure parameter is not modified
         parent_chain = Array.wrap(options.delete(:parent))
 
         item = if parent = parent_chain.shift


### PR DESCRIPTION
Make sure menu creation does not modify menu options (#8078)

This is an attempt to fix/work around #8078 and related issues.

<!--

Thanks for contributing to ActiveAdmin!

You can find all the instructions for contributing at the [CONTRIBUTING file].

Before submitting your PR make sure that:

* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are splitted apart.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all github checks are passing, but feel free to ask for early feedback if you need guidance.

[CONTRIBUTING file]: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->
