### PR TITLE
Fix typo in package.json homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "bugs": {
     "url": "https://github.com/activeadmin/activeadmin/issues"
   },
-  "homepage": "htts://activeadmin.info",
+  "homepage": "https://activeadmin.info",
   "devDependencies": {
     "@rollup/plugin-terser": "^0.4.3",
     "eslint": "^8.52.0",


### PR DESCRIPTION
The `homepage` metadata in the `@activeadmin/activeadmin` npm package has a typo. This typo appears, for example, when running `yarn upgrade-interactive`:

```
   name                               range   from        to      url
❯◯ @activeadmin/activeadmin           latest  3.1.0    ❯  3.2.0   htts://activeadmin.info
                                                                  ^^^^
```

(Note `htts` instead of `https`.)

This PR corrects the typo.