### PR TITLE
Inline more styles into extracted partials

### DIFF
--- a/app/javascript/active_admin/features/dark_mode_toggle.js
+++ b/app/javascript/active_admin/features/dark_mode_toggle.js
@@ -32,10 +32,10 @@ window.addEventListener("storage", (event) => {
 });
 
 const toggleDarkMode = () => {
-  if (localStorage.getItem(THEME_KEY) === 'light') {
-    localStorage.setItem(THEME_KEY, 'dark');
-  } else {
+  if (localStorage.getItem(THEME_KEY) === 'dark' || (!(THEME_KEY in localStorage) && darkModeMedia.matches)) {
     localStorage.setItem(THEME_KEY, 'light');
+  } else {
+    localStorage.setItem(THEME_KEY, 'dark');
   }
   setTheme();
 };

--- a/app/javascript/active_admin/features/dark_mode_toggle.js
+++ b/app/javascript/active_admin/features/dark_mode_toggle.js
@@ -9,12 +9,12 @@ const setTheme = () => {
   // On page load or when changing themes, best to add inline in `head` to avoid FOUC
   if (localStorage.getItem(THEME_KEY) === 'dark' || (!(THEME_KEY in localStorage) && darkModeMedia.matches)) {
     document.documentElement.classList.add('dark');
-    lightIcon.classList.add('hidden');
-    darkIcon.classList.remove('hidden');
+    lightIcon?.classList.add('hidden');
+    darkIcon?.classList.remove('hidden');
   } else {
     document.documentElement.classList.remove('dark');
-    darkIcon.classList.add('hidden');
-    lightIcon.classList.remove('hidden');
+    darkIcon?.classList.add('hidden');
+    lightIcon?.classList.remove('hidden');
   }
 }
 

--- a/app/views/active_admin/_sidebar.html.erb
+++ b/app/views/active_admin/_sidebar.html.erb
@@ -1,5 +1,5 @@
 <% unless skip_sidebar? || sidebar_sections_for_action.blank? %>
-  <div id="sidebar" class="sidebar">
+  <div class="sidebar">
     <% sidebar_sections_for_action.each do |section| %>
       <%= content_tag :div, id: section.id, class: section.custom_class do %>
         <% if section.block %>

--- a/app/views/active_admin/devise/confirmations/new.html.erb
+++ b/app/views/active_admin/devise/confirmations/new.html.erb
@@ -1,5 +1,5 @@
-<div class="devise-form-container">
-  <h2 class="devise-form-title">
+<div class="p-6 sm:p-8 space-y-4 md:space-y-6 w-full sm:max-w-md bg-white sm:rounded-md shadow dark:border dark:bg-gray-800 dark:border-gray-700">
+  <h2 class="text-xl font-bold leading-tight tracking-tight text-gray-900 md:text-2xl dark:text-white">
     <%= active_admin_application.site_title(self) %> <%= set_page_title t('active_admin.devise.resend_confirmation_instructions.title') %>
   </h2>
 
@@ -9,11 +9,9 @@
       f.input :email
     end
     f.actions do
-      f.action :submit, label: t('active_admin.devise.resend_confirmation_instructions.submit'), button_html: { class: "devise-form-button", value: t('active_admin.devise.resend_confirmation_instructions.submit') }
+      f.action :submit, label: t('active_admin.devise.resend_confirmation_instructions.submit'), button_html: { class: "w-full", value: t('active_admin.devise.resend_confirmation_instructions.submit') }
     end
   end %>
 
-  <div class="devise-shared-links">
-    <%= render partial: "active_admin/devise/shared/links" %>
-  </div>
+  <%= render partial: "active_admin/devise/shared/links" %>
 </div>

--- a/app/views/active_admin/devise/passwords/edit.html.erb
+++ b/app/views/active_admin/devise/passwords/edit.html.erb
@@ -1,5 +1,5 @@
-<div class="devise-form-container">
-  <h2 class="devise-form-title">
+<div class="p-6 sm:p-8 space-y-4 md:space-y-6 w-full sm:max-w-md bg-white sm:rounded-md shadow dark:border dark:bg-gray-800 dark:border-gray-700">
+  <h2 class="text-xl font-bold leading-tight tracking-tight text-gray-900 md:text-2xl dark:text-white">
     <%= active_admin_application.site_title(self) %> <%= set_page_title t('active_admin.devise.change_password.title') %>
   </h2>
 
@@ -11,12 +11,10 @@
       f.input :reset_password_token, as: :hidden, input_html: { value: resource.reset_password_token }
     end
     f.actions do
-      f.action :submit, label: t('active_admin.devise.change_password.submit'), button_html: { class: "devise-form-button", value: t('active_admin.devise.change_password.submit') }
+      f.action :submit, label: t('active_admin.devise.change_password.submit'), button_html: { class: "w-full", value: t('active_admin.devise.change_password.submit') }
     end
   end
   %>
 
-  <div class="devise-shared-links">
-    <%= render 'active_admin/devise/shared/links' %>
-  </div>
+  <%= render 'active_admin/devise/shared/links' %>
 </div>

--- a/app/views/active_admin/devise/passwords/new.html.erb
+++ b/app/views/active_admin/devise/passwords/new.html.erb
@@ -1,5 +1,5 @@
-<div class="devise-form-container">
-  <h2 class="devise-form-title">
+<div class="p-6 sm:p-8 space-y-4 md:space-y-6 w-full sm:max-w-md bg-white sm:rounded-md shadow dark:border dark:bg-gray-800 dark:border-gray-700">
+  <h2 class="text-xl font-bold leading-tight tracking-tight text-gray-900 md:text-2xl dark:text-white">
     <%= active_admin_application.site_title(self) %> <%= set_page_title t('active_admin.devise.reset_password.title') %>
   </h2>
 
@@ -8,11 +8,9 @@
       f.input :email
     end
     f.actions do
-      f.action :submit, label: t('active_admin.devise.reset_password.submit'), button_html: { class: "devise-form-button", value: t('active_admin.devise.reset_password.submit') }
+      f.action :submit, label: t('active_admin.devise.reset_password.submit'), button_html: { class: "w-full", value: t('active_admin.devise.reset_password.submit') }
     end
   end %>
 
-  <div class="devise-shared-links">
-    <%= render partial: "active_admin/devise/shared/links" %>
-  </div>
+  <%= render partial: "active_admin/devise/shared/links" %>
 </div>

--- a/app/views/active_admin/devise/registrations/new.html.erb
+++ b/app/views/active_admin/devise/registrations/new.html.erb
@@ -1,5 +1,5 @@
-<div class="devise-form-container">
-  <h2 class="devise-form-title">
+<div class="p-6 sm:p-8 space-y-4 md:space-y-6 w-full sm:max-w-md bg-white sm:rounded-md shadow dark:border dark:bg-gray-800 dark:border-gray-700">
+  <h2 class="text-xl font-bold leading-tight tracking-tight text-gray-900 md:text-2xl dark:text-white">
     <%= active_admin_application.site_title(self) %> <%= set_page_title t('active_admin.devise.sign_up.title') %>
   </h2>
 
@@ -14,12 +14,10 @@
       f.input :password_confirmation, label: t('active_admin.devise.password_confirmation.title')
     end
     f.actions do
-      f.action :submit, label: t('active_admin.devise.login.submit'), button_html: { class: "devise-form-button", value: t('active_admin.devise.sign_up.submit') }
+      f.action :submit, label: t('active_admin.devise.login.submit'), button_html: { class: "w-full", value: t('active_admin.devise.sign_up.submit') }
     end
   end
   %>
 
-  <div class="devise-shared-links">
-    <%= render partial: "active_admin/devise/shared/links" %>
-  </div>
+  <%= render partial: "active_admin/devise/shared/links" %>
 </div>

--- a/app/views/active_admin/devise/sessions/new.html.erb
+++ b/app/views/active_admin/devise/sessions/new.html.erb
@@ -1,5 +1,5 @@
-<div class="devise-form-container">
-  <h2 class="devise-form-title">
+<div class="p-6 sm:p-8 space-y-4 md:space-y-6 w-full sm:max-w-md bg-white sm:rounded-md shadow dark:border dark:bg-gray-800 dark:border-gray-700">
+  <h2 class="text-xl font-bold leading-tight tracking-tight text-gray-900 md:text-2xl dark:text-white">
     <%= site_title %> <%= set_page_title t('active_admin.devise.login.title') %>
   </h2>
 
@@ -13,12 +13,10 @@
       f.input :remember_me, label: t('active_admin.devise.login.remember_me'), as: :boolean if devise_mapping.rememberable?
     end
     f.actions do
-      f.action :submit, label: t('active_admin.devise.login.submit'), wrapper_html: { class: "grow" }, button_html: { class: "devise-form-button", value: t('active_admin.devise.login.submit') }
+      f.action :submit, label: t('active_admin.devise.login.submit'), wrapper_html: { class: "grow" }, button_html: { class: "w-full", value: t('active_admin.devise.login.submit') }
     end
   end
   %>
 
-  <div class="devise-shared-links">
-    <%= render partial: "active_admin/devise/shared/links" %>
-  </div>
+  <%= render partial: "active_admin/devise/shared/links" %>
 </div>

--- a/app/views/active_admin/devise/shared/_links.erb
+++ b/app/views/active_admin/devise/shared/_links.erb
@@ -1,3 +1,4 @@
+<div class="mt-6 text-sm link-default">
 <%- if controller_name != 'sessions' %>
   <% scope = Devise::Mapping.find_scope!(resource_name) %>
   <%= link_to t('active_admin.devise.links.sign_in'), send(:"new_#{scope}_session_path") %>
@@ -31,3 +32,4 @@
     <br>
   <% end -%>
 <% end -%>
+</div>

--- a/app/views/active_admin/devise/unlocks/new.html.erb
+++ b/app/views/active_admin/devise/unlocks/new.html.erb
@@ -1,5 +1,5 @@
-<div class="devise-form-container">
-  <h2 class="devise-form-title">
+<div class="p-6 sm:p-8 space-y-4 md:space-y-6 w-full sm:max-w-md bg-white sm:rounded-md shadow dark:border dark:bg-gray-800 dark:border-gray-700">
+  <h2 class="text-xl font-bold leading-tight tracking-tight text-gray-900 md:text-2xl dark:text-white">
     <%= site_title %> <%= set_page_title t('active_admin.devise.unlock.title') %>
   </h2>
 
@@ -9,11 +9,9 @@
       f.input :email
     end
     f.actions do
-      f.action :submit, label: t('active_admin.devise.unlock.submit'), button_html: { class: "devise-form-button", value: t('active_admin.devise.unlock.submit') }
+      f.action :submit, label: t('active_admin.devise.unlock.submit'), button_html: { class: "w-full", value: t('active_admin.devise.unlock.submit') }
     end
   end %>
 
-  <div class="devise-shared-links">
-    <%= render partial: "active_admin/devise/shared/links" %>
-  </div>
+  <%= render partial: "active_admin/devise/shared/links" %>
 </div>

--- a/app/views/active_admin/html_head/_stylesheets.html.erb
+++ b/app/views/active_admin/html_head/_stylesheets.html.erb
@@ -1,1 +1,1 @@
-<%= stylesheet_link_tag "active_admin", media: "all" %>
+<%= stylesheet_link_tag "active_admin" %>

--- a/app/views/kaminari/active_admin/_first_page.html.erb
+++ b/app/views/kaminari/active_admin/_first_page.html.erb
@@ -7,4 +7,4 @@
     remote:        data-remote
 -%>
 
-<%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote, class: "pagination-link" %>
+<%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote, class: "flex items-center justify-center px-2.5 py-3 h-8 leading-tight text-gray-500 bg-white dark:bg-gray-800 dark:text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-700 dark:hover:text-white rounded no-underline" %>

--- a/app/views/kaminari/active_admin/_gap.html.erb
+++ b/app/views/kaminari/active_admin/_gap.html.erb
@@ -5,4 +5,6 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="pagination-gap"><%= t('views.pagination.truncate').html_safe %></span>
+<span class="flex items-center justify-center px-2.5 py-3 h-8 leading-tight text-gray-500 bg-white dark:bg-gray-800 dark:text-gray-400">
+  <%= t('views.pagination.truncate').html_safe %>
+</span>

--- a/app/views/kaminari/active_admin/_last_page.html.erb
+++ b/app/views/kaminari/active_admin/_last_page.html.erb
@@ -6,4 +6,4 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote, class: "pagination-link" %>
+<%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote, class: "flex items-center justify-center px-2.5 py-3 h-8 leading-tight text-gray-500 bg-white dark:bg-gray-800 dark:text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-700 dark:hover:text-white rounded no-underline" %>

--- a/app/views/kaminari/active_admin/_next_page.html.erb
+++ b/app/views/kaminari/active_admin/_next_page.html.erb
@@ -7,9 +7,9 @@
     remote:        data-remote
 -%>
 <% unless current_page.last? %>
-  <%= link_to url, rel: 'next', remote: remote, class: "pagination-link" do %>
+  <%= link_to url, rel: 'next', remote: remote, class: "flex items-center justify-center px-2.5 py-3 h-8 leading-tight text-gray-500 bg-white dark:bg-gray-800 dark:text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-700 dark:hover:text-white rounded no-underline" do %>
     <span class="sr-only"><%= t('views.pagination.next').html_safe %></span>
-    <svg class="pagination-icon-arrow" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 6 10">
+    <svg class="w-2.5 h-2.5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 6 10">
       <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 9 4-4-4-4"/>
     </svg>
   <% end %>

--- a/app/views/kaminari/active_admin/_page.html.erb
+++ b/app/views/kaminari/active_admin/_page.html.erb
@@ -8,7 +8,7 @@
     remote:        data-remote
 -%>
 <% if page.current? %>
-  <%= link_to page, url, { remote: remote, rel: page.rel, class: "pagination-link pagination-link-active" } %>
+  <%= link_to page, url, { remote: remote, rel: page.rel, class: "flex items-center justify-center px-2.5 py-3 h-8 leading-tight text-white bg-blue-500 dark:text-white dark:bg-blue-500 hover:bg-blue-500 hover:text-white dark:hover:bg-blue-500 dark:hover:text-white rounded no-underline" } %>
 <% else %>
-  <%= link_to page, url, { remote: remote, rel: page.rel, class: "pagination-link" } %>
+  <%= link_to page, url, { remote: remote, rel: page.rel, class: "flex items-center justify-center px-2.5 py-3 h-8 leading-tight text-gray-500 bg-white dark:bg-gray-800 dark:text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-700 dark:hover:text-white rounded no-underline" } %>
 <% end %>

--- a/app/views/kaminari/active_admin/_paginator.html.erb
+++ b/app/views/kaminari/active_admin/_paginator.html.erb
@@ -7,7 +7,7 @@
     paginator:     the paginator that renders the pagination tags inside
 -%>
 <%= paginator.render do -%>
-  <nav class="pagination">
+  <nav data-test-pagination class="inline-flex flex-wrap -space-x-px text-sm gap-1">
     <%= prev_page_tag unless current_page.first? %>
     <% each_page do |page| -%>
       <% if page.display_tag? -%>

--- a/app/views/kaminari/active_admin/_prev_page.html.erb
+++ b/app/views/kaminari/active_admin/_prev_page.html.erb
@@ -7,9 +7,9 @@
     remote:        data-remote
 -%>
 <% unless current_page.first? %>
-  <%= link_to url, rel: 'prev', remote: remote, class: "pagination-link" do %>
+  <%= link_to url, rel: 'prev', remote: remote, class: "flex items-center justify-center px-2.5 py-3 h-8 leading-tight text-gray-500 bg-white dark:bg-gray-800 dark:text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-700 dark:hover:text-white rounded no-underline" do %>
     <span class="sr-only"><%= t('views.pagination.previous').html_safe %></span>
-    <svg class="pagination-icon-arrow" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 6 10">
+    <svg class="w-2.5 h-2.5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 6 10">
       <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 1 1 5l4 4"/>
     </svg>
   <% end %>

--- a/app/views/layouts/active_admin.html.erb
+++ b/app/views/layouts/active_admin.html.erb
@@ -9,7 +9,7 @@
     <%= render "active_admin/site_header", title: site_title %>
     <%= render "active_admin/page_header", title: @page_title || page_title %>
     <%= render "active_admin/flash_messages" %>
-    <div class="page-content-container">
+    <div data-test-page-content class="link-default px-2.5 lg:px-5 grid grid-cols-1 gap-4 lg:gap-6 lg:grid-flow-col lg:auto-cols-[minmax(0,250px)]">
       <%= yield %>
       <%= render "active_admin/sidebar" %>
     </div>

--- a/app/views/layouts/active_admin_logged_out.html.erb
+++ b/app/views/layouts/active_admin_logged_out.html.erb
@@ -4,8 +4,8 @@
   <%= render "active_admin/html_head/title", title: html_head_site_title %>
   <%= render "active_admin/html_head/defaults" %>
 </head>
-<body class="devise-body">
-  <div class="devise-page-container">
+<body class="bg-gray-50 dark:bg-gray-900">
+  <div class="flex flex-col items-center justify-center min-h-screen py-4 sm:px-6 sm:py-8 mx-auto">
     <%= render "active_admin/flash_messages" %>
     <%= yield %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,7 +5,6 @@ en:
       last: "Last"
       previous: "Previous"
       next: "Next"
-      # truncate: "&hellip;"
   activerecord:
     models:
       comment:

--- a/features/step_definitions/additional_web_steps.rb
+++ b/features/step_definitions/additional_web_steps.rb
@@ -67,7 +67,7 @@ Then /^the "([^"]*)" field should contain the option "([^"]*)"$/ do |field, opti
 end
 
 Then /^I should see the content "([^"]*)"$/ do |content|
-  expect(page).to have_css ".page-content-container", text: content
+  expect(page).to have_css "[data-test-page-content]", text: content
 end
 
 Then /^I should see a validation error "([^"]*)"$/ do |error_message|

--- a/features/step_definitions/pagination_steps.rb
+++ b/features/step_definitions/pagination_steps.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 Then /^I should not see pagination$/ do
-  expect(page).to_not have_css ".pagination"
+  expect(page).to_not have_css "[data-test-pagination]"
 end
 
 Then /^I should see pagination page (\d+) link$/ do |num|
-  expect(page).to have_css ".pagination a", text: num, count: 1
+  expect(page).to have_css "[data-test-pagination] a", text: num, count: 1
 end
 
 Then /^I should see the pagination "Next" link/ do
-  expect(page).to have_css "a", text: "Next"
+  expect(page).to have_css "[data-test-pagination] a", text: "Next"
 end
 
 Then /^I should not see the pagination "Next" link/ do
-  expect(page).to_not have_css "a", text: "Next"
+  expect(page).to_not have_css "[data-test-pagination] a", text: "Next"
 end

--- a/lib/generators/active_admin/assets/templates/tailwind.config.js
+++ b/lib/generators/active_admin/assets/templates/tailwind.config.js
@@ -6,9 +6,9 @@ module.exports = {
     './node_modules/flowbite/**/*.js',
     `${gemPath}/plugin.js`,
     `${gemPath}/app/views/**/*.{arb,erb,html,rb}`,
+    `${gemPath}/lib/active_admin/**/*.rb`,
     './app/admin/**/*.{arb,erb,html,rb}',
     './app/views/**/*.{arb,erb,html,rb}',
-    './app/helpers/**/*.rb',
     './app/assets/stylesheets/**/*.css',
     './app/javascript/**/*.js'
   ],

--- a/lib/generators/active_admin/install/templates/active_admin.rb.erb
+++ b/lib/generators/active_admin/install/templates/active_admin.rb.erb
@@ -2,14 +2,9 @@ ActiveAdmin.setup do |config|
   # == Site Title
   #
   # Set the title that is displayed on the main layout
-  # for each of the active admin pages.
-  #
-  # Can also be customized with a block or by extracting a partial.
-  #
-  #   config.site_title = proc { "<%= Rails.application.class.name.split("::").first.titlecase %>" }
-  #
-  # Extract the app/views/active_admin/_site_header_title.html.erb partial into
-  # your project to override the output to use your own logo, styles, etc.
+  # for each of the active admin pages. Can also be customized
+  # by extracting the _site_header partial into your project
+  # to use your own logo, styles, etc.
   #
   config.site_title = "<%= Rails.application.class.name.split("::").first.titlecase %>"
 

--- a/plugin.js
+++ b/plugin.js
@@ -329,10 +329,7 @@ module.exports = plugin(
       '.inner-body-container': {
         '@apply xl:ms-64': {}
       },
-      '.page-content-container': {
-        '@apply px-2.5 lg:px-5 grid grid-cols-1 gap-4 lg:gap-6 lg:grid-flow-col lg:auto-cols-[minmax(0,250px)]': {}
-      },
-      '.page-content-container :where(a)': {
+      '.link-default :where(a)': {
         '@apply text-blue-600 dark:text-blue-500 underline underline-offset-[.2rem]': {}
       },
       '.index-data-table-toolbar': {

--- a/plugin.js
+++ b/plugin.js
@@ -557,24 +557,6 @@ module.exports = plugin(
       '.formtastic :where(.has_many_fields)': {
         '@apply my-5 border-s-2 border-s-gray-700 ps-3': {}
       },
-      '.devise-body': {
-        '@apply bg-gray-50 dark:bg-gray-900': {}
-      },
-      '.devise-page-container': {
-        '@apply flex flex-col items-center justify-center min-h-screen py-4 sm:px-6 sm:py-8 mx-auto': {}
-      },
-      '.devise-form-container': {
-        '@apply p-6 sm:p-8 space-y-4 md:space-y-6 w-full sm:max-w-md bg-white sm:rounded-md shadow dark:border dark:bg-gray-800 dark:border-gray-700': {}
-      },
-      '.devise-form-title': {
-        '@apply text-xl font-bold leading-tight tracking-tight text-gray-900 md:text-2xl dark:text-white': {}
-      },
-      '.devise-form-button': {
-        '@apply w-full': {}
-      },
-      '.devise-shared-links': {
-        '@apply mt-6 text-sm': {}
-      },
       '.blank-slate': {
         '@apply relative block w-full rounded-lg border-2 border-dashed border-gray-300 hover:border-gray-400 dark:border-gray-700 dark:hover:border-gray-600 px-6 py-12 text-center': {}
       },

--- a/plugin.js
+++ b/plugin.js
@@ -1,13 +1,11 @@
 const plugin = require('tailwindcss/plugin')
 const defaultTheme = require('tailwindcss/defaultTheme');
 const colors = require('tailwindcss/colors');
-const [baseFontSize, { lineHeight: baseLineHeight }] = defaultTheme.fontSize.base;
 const { spacing, borderWidth, borderRadius } = defaultTheme;
 
 // https://github.com/tailwindlabs/tailwindcss/discussions/9336
 // https://github.com/tailwindlabs/tailwindcss/discussions/2049
 // https://github.com/tailwindlabs/tailwindcss/discussions/2049#discussioncomment-45546
-// console.log('activeadmin tailwind plugin loaded')
 
 const svgToTinyDataUri = (() => {
 	// Source: https://github.com/tigt/mini-svg-data-uri
@@ -585,19 +583,7 @@ module.exports = plugin(
       },
       '.blank-slate-title': {
         '@apply block mb-4 only:mb-0 font-semibold leading-6 text-gray-900 dark:text-gray-200': {}
-      },
-      // '': {
-      //   '': {}
-      // },
-      // '': {
-      //   '': {}
-      // },
-      // '': {
-      //   '': {}
-      // },
-      // '': {
-      //   '': {}
-      // },
+      }
     });
   }
 )

--- a/plugin.js
+++ b/plugin.js
@@ -8,24 +8,24 @@ const { spacing, borderWidth, borderRadius } = defaultTheme;
 // https://github.com/tailwindlabs/tailwindcss/discussions/2049#discussioncomment-45546
 
 const svgToTinyDataUri = (() => {
-	// Source: https://github.com/tigt/mini-svg-data-uri
-	const reWhitespace = /\s+/g,
-		reUrlHexPairs = /%[\dA-F]{2}/g,
-		hexDecode = {'%20': ' ', '%3D': '=', '%3A': ':', '%2F': '/'},
-		specialHexDecode = match => hexDecode[match] || match.toLowerCase(),
-		svgToTinyDataUri = svg => {
-			svg = String(svg);
-			if(svg.charCodeAt(0) === 0xfeff) svg = svg.slice(1);
-			svg = svg
-				.trim()
-				.replace(reWhitespace, ' ')
-				.replaceAll('"', '\'');
-			svg = encodeURIComponent(svg);
-			svg = svg.replace(reUrlHexPairs, specialHexDecode);
-			return 'data:image/svg+xml,' + svg;
-		};
-	svgToTinyDataUri.toSrcset = svg => svgToTinyDataUri(svg).replace(/ /g, '%20');
-	return svgToTinyDataUri;
+  // Source: https://github.com/tigt/mini-svg-data-uri
+  const reWhitespace = /\s+/g,
+    reUrlHexPairs = /%[\dA-F]{2}/g,
+    hexDecode = { '%20': ' ', '%3D': '=', '%3A': ':', '%2F': '/' },
+    specialHexDecode = match => hexDecode[match] || match.toLowerCase(),
+    svgToTinyDataUri = svg => {
+      svg = String(svg);
+      if (svg.charCodeAt(0) === 0xfeff) svg = svg.slice(1);
+      svg = svg
+        .trim()
+        .replace(reWhitespace, ' ')
+        .replaceAll('"', '\'');
+      svg = encodeURIComponent(svg);
+      svg = svg.replace(reUrlHexPairs, specialHexDecode);
+      return 'data:image/svg+xml,' + svg;
+    };
+  svgToTinyDataUri.toSrcset = svg => svgToTinyDataUri(svg).replace(/ /g, '%20');
+  return svgToTinyDataUri;
 })();
 
 module.exports = plugin(
@@ -102,11 +102,8 @@ module.exports = plugin(
       ['select']: {
         'background-image': `url("${svgToTinyDataUri(
           `<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">
-    <path stroke="${theme(
-            'colors.gray.500',
-            colors.gray[500]
-          )}" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 4 4 4-4"/>
-    </svg>`
+            <path stroke="${theme('colors.gray.500', colors.gray[500])}" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 4 4 4-4"/>
+          </svg>`
         )}")`,
         'background-position': `right ${spacing[3]} center`,
         'background-repeat': `no-repeat`,

--- a/plugin.js
+++ b/plugin.js
@@ -369,24 +369,6 @@ module.exports = plugin(
       '.paginated-collection-footer': {
         '@apply p-3 flex gap-2 items-center justify-between text-sm border-t border-gray-200 dark:border-gray-700': {}
       },
-      '.pagination': {
-        '@apply inline-flex flex-wrap -space-x-px text-sm gap-1': {}
-      },
-      '.pagination-link, .pagination-gap': {
-        '@apply flex items-center justify-center px-2.5 py-3 h-8 leading-tight text-gray-500 bg-white dark:bg-gray-800 dark:text-gray-400': {}
-      },
-      '.pagination-gap': {
-        '@apply p-0': {}
-      },
-      '.pagination-link': {
-        '@apply hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-700 dark:hover:text-white rounded no-underline': {}
-      },
-      '.pagination-link-active': {
-        '@apply text-white bg-blue-500 hover:bg-blue-500 hover:text-white dark:text-white dark:bg-blue-500 dark:hover:bg-blue-500': {}
-      },
-      '.pagination-icon-arrow': {
-        '@apply w-2.5 h-2.5': {}
-      },
       '.pagination-per-page': {
         '@apply text-sm py-1 pe-7 w-auto w-min': {}
       },


### PR DESCRIPTION
Now that we've extracted the initial set of customizable templates, we can inline more Tailwind styles in those templates for users to customize without having to change CSS. Some styles will have to remain as components. In the future, it would be nice to extract more partials, for example, a default for comments or other components. This also includes some bug fixes for the dark mode toggle JS.