### PR TITLE
Update templates and dark mode styles

### DIFF
--- a/app/views/active_admin/_html_head.html.erb
+++ b/app/views/active_admin/_html_head.html.erb
@@ -1,5 +1,9 @@
+<%= stylesheet_link_tag "active_admin" %>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<%= csrf_meta_tags %>
+<%= csp_meta_tag %>
+<% # On page load or when changing themes, best to add inline in `head` to avoid FOUC %>
 <%= javascript_tag nonce: true do %>
-  // On page load or when changing themes, best to add inline in `head` to avoid FOUC
   if (localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
     document.documentElement.classList.add('dark')
   } else {

--- a/app/views/active_admin/_main_navigation.html.erb
+++ b/app/views/active_admin/_main_navigation.html.erb
@@ -1,24 +1,24 @@
-<div id="main-menu" class="fixed top-14 left-0 z-40 w-60 h-screen p-4 overflow-y-auto transition-transform duration-200 -translate-x-full xl:translate-x-0 xl:border-r xl:border-gray-200 xl:dark:border-gray-700 bg-white dark:bg-gray-800" tabindex="-1" aria-labelledby="drawer-navigation-label">
+<div id="main-menu" class="fixed xl:top-16 left-0 z-40 w-72 xl:w-60 h-screen p-4 overflow-y-auto transition-transform duration-200 -translate-x-full xl:translate-x-0 bg-white dark:bg-gray-950 xl:border-r xl:border-gray-200 xl:dark:border-white/10" tabindex="-1" aria-labelledby="drawer-navigation-label">
   <ul role="list" class="flex flex-1 flex-col space-y-1.5">
     <% current_menu.items(self).each do |item| %>
       <% children = item.items(self).presence %>
       <li <%= current_menu_item?(item) && "data-open" %> data-item-id="<%= item.id %>">
         <% if children %>
-          <button data-menu-button class="hover:bg-gray-50 flex items-center w-full text-left rounded-md p-2 gap-x-3 text-sm leading-6 font-semibold text-gray-700">
+          <button data-menu-button class="text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white flex items-center w-full text-left rounded-md p-2 gap-x-2 text-sm">
             <%= item.label(self) %>
-            <svg data-menu-icon class="ms-auto text-gray-500 h-5 w-5 shrink-0 <%= current_menu_item?(item) && "rotate-90" %>" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <svg data-menu-icon class="ms-auto h-5 w-5 shrink-0 <%= current_menu_item?(item) && "rotate-90" %>" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
               <path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" />
             </svg>
           </button>
           <ul data-menu-list role="list" class="mt-1 space-y-1 <%= current_menu_item?(item) ? "" : "hidden" %>">
             <% children.each do |j| %>
               <li data-item-id="<%= j.id %>">
-                <%= link_to j.label(self), j.url(self), j.html_options.merge(class: "hover:bg-gray-50 block rounded-md py-1.5 px-2 text-sm leading-6 text-gray-700 #{(current_menu_item?(j) ? "bg-gray-50 selected" : "")}") %>
+                <%= link_to j.label(self), j.url(self), j.html_options.merge(class: "text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white block rounded-md py-1.5 px-2 text-sm #{(current_menu_item?(j) ? "bg-gray-100 dark:bg-white/5 text-gray-900 dark:text-white selected" : "")}") %>
               </li>
             <% end %>
           </ul>
         <% elsif url = item.url(self) %>
-          <%= link_to item.label(self), url, item.html_options.merge(class: "hover:bg-gray-50 group flex gap-x-3 rounded-md p-2 text-sm leading-6 font-semibold text-gray-700 #{(current_menu_item?(item) ? "bg-gray-50 selected" : "")}") %>
+          <%= link_to item.label(self), url, item.html_options.merge(class: "text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white flex items-center w-full text-left rounded-md p-2 gap-x-2 text-sm #{(current_menu_item?(item) ? "bg-gray-100 dark:bg-white/5 text-gray-900 dark:text-white selected" : "")}") %>
         <% else %>
           <%= item.label(self) %>
         <% end %>

--- a/app/views/active_admin/_main_navigation.html.erb
+++ b/app/views/active_admin/_main_navigation.html.erb
@@ -1,0 +1,28 @@
+<div id="main-menu" class="fixed top-14 left-0 z-40 w-60 h-screen p-4 overflow-y-auto transition-transform duration-200 -translate-x-full xl:translate-x-0 xl:border-r xl:border-gray-200 xl:dark:border-gray-700 bg-white dark:bg-gray-800" tabindex="-1" aria-labelledby="drawer-navigation-label">
+  <ul role="list" class="flex flex-1 flex-col space-y-1.5">
+    <% current_menu.items(self).each do |item| %>
+      <% children = item.items(self).presence %>
+      <li <%= current_menu_item?(item) && "data-open" %> data-item-id="<%= item.id %>">
+        <% if children %>
+          <button data-menu-button class="hover:bg-gray-50 flex items-center w-full text-left rounded-md p-2 gap-x-3 text-sm leading-6 font-semibold text-gray-700">
+            <%= item.label(self) %>
+            <svg data-menu-icon class="ms-auto text-gray-500 h-5 w-5 shrink-0 <%= current_menu_item?(item) && "rotate-90" %>" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" />
+            </svg>
+          </button>
+          <ul data-menu-list role="list" class="mt-1 space-y-1 <%= current_menu_item?(item) ? "" : "hidden" %>">
+            <% children.each do |j| %>
+              <li data-item-id="<%= j.id %>">
+                <%= link_to j.label(self), j.url(self), j.html_options.merge(class: "hover:bg-gray-50 block rounded-md py-1.5 px-2 text-sm leading-6 text-gray-700 #{(current_menu_item?(j) ? "bg-gray-50 selected" : "")}") %>
+              </li>
+            <% end %>
+          </ul>
+        <% elsif url = item.url(self) %>
+          <%= link_to item.label(self), url, item.html_options.merge(class: "hover:bg-gray-50 group flex gap-x-3 rounded-md p-2 text-sm leading-6 font-semibold text-gray-700 #{(current_menu_item?(item) ? "bg-gray-50 selected" : "")}") %>
+        <% else %>
+          <%= item.label(self) %>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/active_admin/_main_navigation.html.erb
+++ b/app/views/active_admin/_main_navigation.html.erb
@@ -1,4 +1,4 @@
-<div id="main-menu" class="fixed xl:top-16 left-0 z-40 w-72 xl:w-60 h-screen p-4 overflow-y-auto transition-transform duration-200 -translate-x-full xl:translate-x-0 bg-white dark:bg-gray-950 xl:border-r xl:border-gray-200 xl:dark:border-white/10" tabindex="-1" aria-labelledby="drawer-navigation-label">
+<div id="main-menu" class="fixed top-0 xl:top-16 bottom-0 left-0 z-40 w-72 xl:w-60 p-4 overflow-y-auto transition-transform duration-200 -translate-x-full xl:translate-x-0 bg-white dark:bg-gray-950 xl:border-r xl:border-gray-200 xl:dark:border-white/10" tabindex="-1" aria-labelledby="drawer-navigation-label">
   <ul role="list" class="flex flex-1 flex-col space-y-1.5">
     <% current_menu.items(self).each do |item| %>
       <% children = item.items(self).presence %>

--- a/app/views/active_admin/_page_header.html.erb
+++ b/app/views/active_admin/_page_header.html.erb
@@ -1,12 +1,13 @@
 <div data-test-page-header class="bg-gray-50 border-b p-4 mb-8 flex flex-col gap-4 md:flex-row md:items-center justify-between dark:border-gray-700 dark:bg-gray-800">
   <div class="flex flex-col gap-3 pt-1">
+    <% breadcrumb_links = build_breadcrumb_links(request.path, class: "text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200") %>
     <% if breadcrumb_links.present? %>
       <nav aria-label="breadcrumb">
-        <ol class="breadcrumbs flex flex-wrap text-xs">
+        <ol class="flex flex-wrap gap-1 text-sm">
           <% breadcrumb_links.each_with_index do |link, index| %>
-            <li class="inline-flex items-center h-5" data-test-breadcrumb>
+            <li class="inline-flex items-center h-5 gap-1">
               <% if index > 0 %>
-                <svg class="h-5 w-5 flex-shrink-0 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <svg class="h-5 w-5 text-gray-300 dark:text-gray-700 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                   <path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd"/>
                 </svg>
               <% end %>

--- a/app/views/active_admin/_page_header.html.erb
+++ b/app/views/active_admin/_page_header.html.erb
@@ -1,4 +1,4 @@
-<div data-test-page-header class="bg-gray-50 border-b p-4 mb-8 flex flex-col gap-4 md:flex-row md:items-center justify-between dark:border-gray-700 dark:bg-gray-800">
+<div data-test-page-header class="bg-gray-50 border-b p-4 mb-8 flex flex-col gap-4 md:flex-row md:items-center justify-between dark:border-gray-800/50 dark:bg-inherit">
   <div class="flex flex-col gap-3 pt-1">
     <% breadcrumb_links = build_breadcrumb_links(request.path, class: "text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200") %>
     <% if breadcrumb_links.present? %>

--- a/app/views/active_admin/_site_footer.html.erb
+++ b/app/views/active_admin/_site_footer.html.erb
@@ -1,4 +1,4 @@
-<div class="text-sm text-center mt-16 mx-8 pt-9 pb-12 text-gray-500 border-t dark:border-gray-700">
+<div class="text-sm text-center mt-16 mx-8 pt-9 pb-12 text-gray-500 border-t dark:border-gray-800">
   <%= I18n.t(
         "active_admin.powered_by",
         active_admin: link_to("Active Admin", "https://activeadmin.info", class: "hover:text-gray-900 dark:hover:text-gray-400"),

--- a/app/views/active_admin/_site_header.html.erb
+++ b/app/views/active_admin/_site_header.html.erb
@@ -1,6 +1,6 @@
-<div data-test-site-header id="header" class="border-b border-gray-200 dark:border-gray-700 dark:bg-gray-800 px-4 py-2 flex items-center">
+<div data-test-site-header class="border-b border-gray-200 dark:border-gray-700 dark:bg-gray-800 px-4 py-2 flex items-center sticky top-0 z-20 h-14 w-full backdrop-blur bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
 
-  <button class="xl:hidden me-3 inline-flex items-center p-2 w-10 h-10 justify-center text-sm text-gray-500 rounded-lg hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-200 dark:text-gray-400 dark:hover:bg-gray-700 dark:focus:ring-gray-600" data-drawer-target="main-menu" data-drawer-show="main-menu" aria-controls="drawer-navigation">
+  <button class="xl:hidden pe-3 inline-flex items-center w-8 h-8 justify-center text-sm text-gray-500 dark:text-gray-400 focus-visible:outline-none focus-visible:ring-ring focus-visible:bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0" data-drawer-target="main-menu" data-drawer-show="main-menu" aria-controls="drawer-navigation">
     <svg class="w-5 h-5 text-gray-800 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 17 14"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M1 1h15M1 7h15M1 13h15"/></svg>
   </button>
 
@@ -10,45 +10,16 @@
     </h1>
   </div>
 
-  <button type="button" class="dark-mode-toggle flex items-center me-2 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 rounded-lg text-sm p-2.5">
+  <button type="button" class="dark-mode-toggle flex items-center w-9 h-9 justify-center me-1 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400 focus:outline-none text-sm">
     <svg class="hidden dark:block w-5 h-5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 18 20"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.509 5.75c0-1.493.394-2.96 1.144-4.25h-.081a8.5 8.5 0 1 0 7.356 12.746A8.5 8.5 0 0 1 8.509 5.75Z"/></svg>
     <svg class="dark:hidden w-5 h-5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 3V1m0 18v-2M5.05 5.05 3.636 3.636m12.728 12.728L14.95 14.95M3 10H1m18 0h-2M5.05 14.95l-1.414 1.414M16.364 3.636 14.95 5.05M14 10a4 4 0 1 1-8 0 4 4 0 0 1 8 0Z"/></svg>
   </button>
 
-  <button id="user-menu-button" class="flex items-center w-8 h-8 justify-center text-sm text-gray-500 focus:outline-none dark:text-gray-200" data-dropdown-toggle="user-menu" data-dropdown-offset-distance="3" data-dropdown-placement="bottom-end">
+  <button id="user-menu-button" class="flex items-center w-9 h-9 justify-center text-sm text-gray-500 focus:outline-none dark:text-gray-200" data-dropdown-toggle="user-menu" data-dropdown-offset-distance="3" data-dropdown-placement="bottom-end">
     <svg class="w-7 h-7" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20"><path d="M10 0a10 10 0 1 0 10 10A10.011 10.011 0 0 0 10 0Zm0 5a3 3 0 1 1 0 6 3 3 0 0 1 0-6Zm0 13a8.949 8.949 0 0 1-4.951-1.488A3.987 3.987 0 0 1 9 13h2a3.987 3.987 0 0 1 3.951 3.512A8.949 8.949 0 0 1 10 18Z"/></svg>
   </button>
 
-  <div id="main-menu" class="fixed top-0 left-0 z-40 w-64 h-screen p-4 overflow-y-auto transition-transform duration-200 -translate-x-full xl:translate-x-0 xl:border-r xl:border-gray-200 xl:dark:border-gray-700 bg-white dark:bg-gray-800" tabindex="-1" aria-labelledby="drawer-navigation-label">
-    <ul role="list" class="flex flex-1 flex-col space-y-1.5">
-      <% current_menu.items(self).each do |item| %>
-        <% children = item.items(self).presence %>
-        <li <%= current_menu_item?(item) && "data-open" %> data-item-id="<%= item.id %>">
-          <% if children %>
-            <button data-menu-button class="hover:bg-gray-50 flex items-center w-full text-left rounded-md p-2 gap-x-3 text-sm leading-6 font-semibold text-gray-700">
-              <%= item.label(self) %>
-              <svg data-menu-icon class="ms-auto text-gray-500 h-5 w-5 shrink-0 <%= current_menu_item?(item) && "rotate-90" %>" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                <path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" />
-              </svg>
-            </button>
-            <ul data-menu-list role="list" class="mt-1 space-y-1.5 <%= current_menu_item?(item) ? "" : "hidden" %>">
-              <% children.each do |j| %>
-                <li data-item-id="<%= j.id %>">
-                  <%= link_to j.label(self), j.url(self), j.html_options.merge(class: "hover:bg-gray-50 block rounded-md p-2 text-sm leading-6 text-gray-700 #{(current_menu_item?(j) ? "bg-gray-50 selected" : "")}") %>
-                </li>
-              <% end %>
-            </ul>
-          <% elsif url = item.url(self) %>
-            <%= link_to item.label(self), url, item.html_options.merge(class: "hover:bg-gray-50 group flex gap-x-3 rounded-md p-2 text-sm leading-6 font-semibold text-gray-700 #{(current_menu_item?(item) ? "bg-gray-50 selected" : "")}") %>
-          <% else %>
-            <%= item.label(self) %>
-          <% end %>
-        </li>
-      <% end %>
-    </ul>
-  </div>
-
-  <div id="user-menu" class="z-10 hidden min-w-max bg-white rounded shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-gray-700 py-1 text-sm text-gray-700 dark:text-gray-200" aria-labelledby="user-menu-button">
+  <div id="user-menu" class="z-50 hidden min-w-max bg-white rounded shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-gray-700 py-1 text-sm text-gray-700 dark:text-gray-200" aria-labelledby="user-menu-button">
     <ul>
       <% if current_active_admin_user? %>
         <li><%= auto_link current_active_admin_user, class: "block px-2.5 py-2 no-underline text-gray-700 hover:bg-gray-100 hover:text-gray-900 dark:text-white dark:hover:bg-gray-600 dark:hover:text-white" %></li>

--- a/app/views/active_admin/_site_header.html.erb
+++ b/app/views/active_admin/_site_header.html.erb
@@ -1,5 +1,4 @@
-<div data-test-site-header class="border-b border-gray-200 dark:border-gray-700 dark:bg-gray-800 px-4 py-2 flex items-center sticky top-0 z-20 h-14 w-full backdrop-blur bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-
+<div class="border-b border-gray-200 dark:border-white/10 dark:bg-gray-950/75 px-4 py-2 flex items-center sticky top-0 z-20 h-16 w-full backdrop-blur-md">
   <button class="xl:hidden pe-3 inline-flex items-center w-8 h-8 justify-center text-sm text-gray-500 dark:text-gray-400 focus-visible:outline-none focus-visible:ring-ring focus-visible:bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0" data-drawer-target="main-menu" data-drawer-show="main-menu" aria-controls="drawer-navigation">
     <svg class="w-5 h-5 text-gray-800 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 17 14"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M1 1h15M1 7h15M1 13h15"/></svg>
   </button>

--- a/app/views/active_admin/html_head/_defaults.html.erb
+++ b/app/views/active_admin/html_head/_defaults.html.erb
@@ -1,3 +1,0 @@
-<%= render "active_admin/html_head/stylesheets" %>
-<%= render "active_admin/html_head/meta_tags" %>
-<%= render "active_admin/html_head/javascripts" %>

--- a/app/views/active_admin/html_head/_meta_tags.html.erb
+++ b/app/views/active_admin/html_head/_meta_tags.html.erb
@@ -1,3 +1,0 @@
-<meta name="viewport" content="width=device-width,initial-scale=1">
-<%= csrf_meta_tags %>
-<%= csp_meta_tag %>

--- a/app/views/active_admin/html_head/_stylesheets.html.erb
+++ b/app/views/active_admin/html_head/_stylesheets.html.erb
@@ -1,1 +1,0 @@
-<%= stylesheet_link_tag "active_admin" %>

--- a/app/views/active_admin/html_head/_title.html.erb
+++ b/app/views/active_admin/html_head/_title.html.erb
@@ -1,1 +1,0 @@
-<title><%= sanitize(title, tags: []) %></title>

--- a/app/views/kaminari/active_admin/_first_page.html.erb
+++ b/app/views/kaminari/active_admin/_first_page.html.erb
@@ -6,5 +6,4 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-
-<%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote, class: "flex items-center justify-center px-2.5 py-3 h-8 leading-tight text-gray-500 bg-white dark:bg-gray-800 dark:text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-700 dark:hover:text-white rounded no-underline" %>
+<%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote, class: "flex items-center justify-center px-2.5 py-3 h-8 leading-tight text-gray-500 dark:text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-800 dark:hover:text-white rounded no-underline" %>

--- a/app/views/kaminari/active_admin/_first_page.html.erb
+++ b/app/views/kaminari/active_admin/_first_page.html.erb
@@ -1,9 +1,0 @@
-<%# Link to the "First" page
-  - available local variables
-    url:           url to the first page
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
-<%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote, class: "flex items-center justify-center px-2.5 py-3 h-8 leading-tight text-gray-500 dark:text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-800 dark:hover:text-white rounded no-underline" %>

--- a/app/views/kaminari/active_admin/_gap.html.erb
+++ b/app/views/kaminari/active_admin/_gap.html.erb
@@ -5,6 +5,6 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="flex items-center justify-center px-2.5 py-3 h-8 leading-tight text-gray-500 bg-white dark:bg-gray-800 dark:text-gray-400">
+<span class="flex items-center justify-center px-2.5 py-3 h-8 leading-tight text-gray-500 dark:text-gray-400">
   <%= t('views.pagination.truncate').html_safe %>
 </span>

--- a/app/views/kaminari/active_admin/_last_page.html.erb
+++ b/app/views/kaminari/active_admin/_last_page.html.erb
@@ -6,4 +6,4 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote, class: "flex items-center justify-center px-2.5 py-3 h-8 leading-tight text-gray-500 bg-white dark:bg-gray-800 dark:text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-700 dark:hover:text-white rounded no-underline" %>
+<%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote, class: "flex items-center justify-center px-2.5 py-3 h-8 leading-tight text-gray-500 dark:text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-800 dark:hover:text-white rounded no-underline" %>

--- a/app/views/kaminari/active_admin/_last_page.html.erb
+++ b/app/views/kaminari/active_admin/_last_page.html.erb
@@ -1,9 +1,0 @@
-<%# Link to the "Last" page
-  - available local variables
-    url:           url to the last page
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
-<%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote, class: "flex items-center justify-center px-2.5 py-3 h-8 leading-tight text-gray-500 dark:text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-800 dark:hover:text-white rounded no-underline" %>

--- a/app/views/kaminari/active_admin/_next_page.html.erb
+++ b/app/views/kaminari/active_admin/_next_page.html.erb
@@ -7,7 +7,7 @@
     remote:        data-remote
 -%>
 <% unless current_page.last? %>
-  <%= link_to url, rel: 'next', remote: remote, class: "flex items-center justify-center px-2.5 py-3 h-8 leading-tight text-gray-500 bg-white dark:bg-gray-800 dark:text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-700 dark:hover:text-white rounded no-underline" do %>
+  <%= link_to url, rel: 'next', remote: remote, class: "flex items-center justify-center px-2.5 py-3 h-8 leading-tight text-gray-500 dark:text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-800 dark:hover:text-white rounded no-underline" do %>
     <span class="sr-only"><%= t('views.pagination.next').html_safe %></span>
     <svg class="w-2.5 h-2.5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 6 10">
       <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 9 4-4-4-4"/>

--- a/app/views/kaminari/active_admin/_page.html.erb
+++ b/app/views/kaminari/active_admin/_page.html.erb
@@ -8,7 +8,7 @@
     remote:        data-remote
 -%>
 <% if page.current? %>
-  <%= link_to page, url, { remote: remote, rel: page.rel, class: "flex items-center justify-center px-2.5 py-3 h-8 leading-tight text-white bg-blue-500 dark:text-white dark:bg-blue-500 hover:bg-blue-500 hover:text-white dark:hover:bg-blue-500 dark:hover:text-white rounded no-underline" } %>
+  <%= link_to page, url, { remote: remote, rel: page.rel, class: "flex items-center justify-center px-2.5 py-3 h-8 leading-tight text-white bg-blue-500 dark:text-white dark:bg-blue-600 hover:bg-blue-500 hover:text-white dark:hover:bg-blue-600 dark:hover:text-white rounded no-underline" } %>
 <% else %>
-  <%= link_to page, url, { remote: remote, rel: page.rel, class: "flex items-center justify-center px-2.5 py-3 h-8 leading-tight text-gray-500 bg-white dark:bg-gray-800 dark:text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-700 dark:hover:text-white rounded no-underline" } %>
+  <%= link_to page, url, { remote: remote, rel: page.rel, class: "flex items-center justify-center px-2.5 py-3 h-8 leading-tight text-gray-500 dark:text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-800 dark:hover:text-white rounded no-underline" } %>
 <% end %>

--- a/app/views/kaminari/active_admin/_prev_page.html.erb
+++ b/app/views/kaminari/active_admin/_prev_page.html.erb
@@ -7,7 +7,7 @@
     remote:        data-remote
 -%>
 <% unless current_page.first? %>
-  <%= link_to url, rel: 'prev', remote: remote, class: "flex items-center justify-center px-2.5 py-3 h-8 leading-tight text-gray-500 bg-white dark:bg-gray-800 dark:text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-700 dark:hover:text-white rounded no-underline" do %>
+  <%= link_to url, rel: 'prev', remote: remote, class: "flex items-center justify-center px-2.5 py-3 h-8 leading-tight text-gray-500 dark:text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-800 dark:hover:text-white rounded no-underline" do %>
     <span class="sr-only"><%= t('views.pagination.previous').html_safe %></span>
     <svg class="w-2.5 h-2.5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 6 10">
       <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 1 1 5l4 4"/>

--- a/app/views/layouts/active_admin.html.erb
+++ b/app/views/layouts/active_admin.html.erb
@@ -4,7 +4,7 @@
   <%= render "active_admin/html_head/title", title: html_head_site_title %>
   <%= render "active_admin/html_head/defaults" %>
 </head>
-<body>
+<body class="bg-white dark:bg-gray-950/95 text-gray-950 dark:text-gray-100 antialiased">
   <%= render "active_admin/site_header", title: site_title %>
   <div class="xl:ms-60">
     <%= render "active_admin/main_navigation" %>

--- a/app/views/layouts/active_admin.html.erb
+++ b/app/views/layouts/active_admin.html.erb
@@ -1,8 +1,8 @@
 <!doctype html>
 <html lang="<%= I18n.locale %>">
 <head>
-  <%= render "active_admin/html_head/title", title: html_head_site_title %>
-  <%= render "active_admin/html_head/defaults" %>
+  <title><%= html_head_site_title %></title>
+  <%= render "active_admin/html_head" %>
 </head>
 <body class="bg-white dark:bg-gray-950/95 text-gray-950 dark:text-gray-100 antialiased">
   <%= render "active_admin/site_header", title: site_title %>

--- a/app/views/layouts/active_admin.html.erb
+++ b/app/views/layouts/active_admin.html.erb
@@ -5,8 +5,9 @@
   <%= render "active_admin/html_head/defaults" %>
 </head>
 <body>
-  <div class="inner-body-container">
-    <%= render "active_admin/site_header", title: site_title %>
+  <%= render "active_admin/site_header", title: site_title %>
+  <div class="xl:ms-60">
+    <%= render "active_admin/main_navigation" %>
     <%= render "active_admin/page_header", title: @page_title || page_title %>
     <%= render "active_admin/flash_messages" %>
     <div data-test-page-content class="link-default px-2.5 lg:px-5 grid grid-cols-1 gap-4 lg:gap-6 lg:grid-flow-col lg:auto-cols-[minmax(0,250px)]">

--- a/app/views/layouts/active_admin_logged_out.html.erb
+++ b/app/views/layouts/active_admin_logged_out.html.erb
@@ -1,8 +1,8 @@
 <!doctype html>
 <html lang="<%= I18n.locale %>">
 <head>
-  <%= render "active_admin/html_head/title", title: html_head_site_title %>
-  <%= render "active_admin/html_head/defaults" %>
+  <title><%= html_head_site_title %></title>
+  <%= render "active_admin/html_head" %>
 </head>
 <body class="bg-gray-50 dark:bg-gray-900 text-gray-950 dark:text-gray-100 antialiased">
   <div class="flex flex-col items-center justify-center min-h-screen py-4 sm:px-6 sm:py-8 mx-auto">

--- a/app/views/layouts/active_admin_logged_out.html.erb
+++ b/app/views/layouts/active_admin_logged_out.html.erb
@@ -4,7 +4,7 @@
   <%= render "active_admin/html_head/title", title: html_head_site_title %>
   <%= render "active_admin/html_head/defaults" %>
 </head>
-<body class="bg-gray-50 dark:bg-gray-900">
+<body class="bg-gray-50 dark:bg-gray-900 text-gray-950 dark:text-gray-100 antialiased">
   <div class="flex flex-col items-center justify-center min-h-screen py-4 sm:px-6 sm:py-8 mx-auto">
     <%= render "active_admin/flash_messages" %>
     <%= yield %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,8 +1,6 @@
 en:
   views:
     pagination:
-      first: "First"
-      last: "Last"
       previous: "Previous"
       next: "Next"
   activerecord:

--- a/features/step_definitions/breadcrumb_steps.rb
+++ b/features/step_definitions/breadcrumb_steps.rb
@@ -10,5 +10,5 @@ Around "@breadcrumb" do |scenario, block|
 end
 
 Then /^I should see a link to "([^"]*)" in the breadcrumb$/ do |text|
-  expect(page).to have_css "[data-test-breadcrumb] > a", text: text
+  expect(page).to have_css "nav[aria-label=breadcrumb] a", text: text
 end

--- a/lib/active_admin/component.rb
+++ b/lib/active_admin/component.rb
@@ -1,12 +1,5 @@
 # frozen_string_literal: true
 module ActiveAdmin
   class Component < Arbre::Component
-    def initialize(*)
-      super
-      add_class default_class_name
-    end
-
-    def default_class_name
-    end
   end
 end

--- a/lib/active_admin/orm/active_record/comments.rb
+++ b/lib/active_admin/orm/active_record/comments.rb
@@ -88,11 +88,13 @@ ActiveAdmin.after_load do |app|
 
       index do
         column I18n.t("active_admin.comments.resource_type"), :resource_type
+        column I18n.t("active_admin.comments.resource"), :resource, class: "min-w-[7rem]"
         column I18n.t("active_admin.comments.author_type"), :author_type
-        column I18n.t("active_admin.comments.resource"), :resource
         column I18n.t("active_admin.comments.author"), :author
-        column I18n.t("active_admin.comments.body"), :body
-        column I18n.t("active_admin.comments.created_at"), :created_at
+        column I18n.t("active_admin.comments.body"), :body, class: "min-w-[16rem]" do |comment|
+          truncate(comment.body, length: 60, separator: " ")
+        end
+        column I18n.t("active_admin.comments.created_at"), :created_at, class: "min-w-[13rem]"
         actions
       end
     end

--- a/lib/active_admin/view_helpers/breadcrumb_helper.rb
+++ b/lib/active_admin/view_helpers/breadcrumb_helper.rb
@@ -5,16 +5,16 @@ module ActiveAdmin
       ID_FORMAT_REGEXP = /\A(\d+|[a-f0-9]{24}|(?:[a-f0-9]{8}-(?:[a-f0-9]{4}-){3}[a-f0-9]{12}))\z/.freeze
 
       # Returns an array of links to use in a breadcrumb
-      def breadcrumb_links(path = request.path)
+      def build_breadcrumb_links(path = request.path, html_options = {})
         config = active_admin_config.breadcrumb
         if config.is_a?(Proc)
           instance_exec(controller, &config)
         elsif config.present?
-          default_breadcrumb_links(path)
+          default_breadcrumb_links(path, html_options)
         end
       end
 
-      def default_breadcrumb_links(path)
+      def default_breadcrumb_links(path, html_options = {})
         # remove leading "/" and split up the URL
         # and remove last since it's used as the page title
         parts = path.split("/").select(&:present?)[0..-2]
@@ -32,7 +32,7 @@ module ActiveAdmin
 
           # Don't create a link if the resource's show action is disabled
           if !config || config.defined_actions.include?(:show)
-            link_to name, "/" + parts[0..index].join("/")
+            link_to name, "/" + parts[0..index].join("/"), html_options
           else
             name
           end

--- a/lib/active_admin/views/components/active_filters_sidebar_content.rb
+++ b/lib/active_admin/views/components/active_filters_sidebar_content.rb
@@ -8,15 +8,12 @@ module ActiveAdmin
       builder_method :active_filters_sidebar_content
 
       def build
+        add_class "active-filters"
         active_filters = ActiveAdmin::Filters::Active.new(active_admin_config, assigns[:search])
         active_scopes = assigns[:search].instance_variable_get(:@scope_args)
 
         scope_block(current_scope)
         filters_list(active_filters, active_scopes)
-      end
-
-      def default_class_name
-        "active-filters"
       end
 
       def scope_block(current_scope)

--- a/lib/active_admin/views/components/attributes_table.rb
+++ b/lib/active_admin/views/components/attributes_table.rb
@@ -11,6 +11,7 @@ module ActiveAdmin
         options = {}
         options[:for] = @collection.first if single_record?
         super(options)
+        add_class "attributes-table"
         @table = table
         build_colgroups
         rows(*attrs)
@@ -41,10 +42,6 @@ module ActiveAdmin
 
       def default_id_for_prefix
         "attributes_table"
-      end
-
-      def default_class_name
-        "attributes-table"
       end
 
       # Build Colgroups

--- a/lib/active_admin/views/components/dropdown_menu.rb
+++ b/lib/active_admin/views/components/dropdown_menu.rb
@@ -34,6 +34,7 @@ module ActiveAdmin
         @menu = build_menu(menu_options)
 
         super(options)
+        add_class "dropdown"
       end
 
       def item(*args, **kwargs, &block)
@@ -44,12 +45,6 @@ module ActiveAdmin
             li link_to(*args, **kwargs)
           end
         end
-      end
-
-      protected
-
-      def default_class_name
-        "dropdown"
       end
 
       private

--- a/lib/active_admin/views/components/index_list.rb
+++ b/lib/active_admin/views/components/index_list.rb
@@ -11,10 +11,6 @@ module ActiveAdmin
 
       include ::ActiveAdmin::Helpers::Collection
 
-      def default_class_name
-        "index-button-group index-list"
-      end
-
       def tag_name
         "div"
       end
@@ -23,6 +19,7 @@ module ActiveAdmin
       #
       # @param [Array] index_classes The class constants that represent index page presenters
       def build(index_classes)
+        add_class "index-button-group index-list"
         unless current_filter_search_empty?
           index_classes.each do |index_class|
             build_index_list(index_class)

--- a/lib/active_admin/views/components/paginated_collection.rb
+++ b/lib/active_admin/views/components/paginated_collection.rb
@@ -48,7 +48,7 @@ module ActiveAdmin
         unless collection.respond_to?(:total_pages)
           raise(StandardError, "Collection is not a paginated scope. Set collection.page(params[:page]).per(10) before calling :paginated_collection.")
         end
-
+        add_class "paginated-collection"
         @contents = div(class: "paginated-collection-contents")
         build_pagination_with_formats(options)
         @built = true
@@ -64,10 +64,6 @@ module ActiveAdmin
       end
 
       protected
-
-      def default_class_name
-        "paginated-collection"
-      end
 
       def build_pagination_with_formats(options)
         div class: "paginated-collection-pagination" do

--- a/lib/active_admin/views/components/scopes.rb
+++ b/lib/active_admin/views/components/scopes.rb
@@ -13,16 +13,13 @@ module ActiveAdmin
       include ActiveAdmin::ScopeChain
       include ::ActiveAdmin::Helpers::Collection
 
-      def default_class_name
-        "scopes"
-      end
-
       def tag_name
         "div"
       end
 
       def build(scopes, options = {})
         super({ role: "toolbar" })
+        add_class "scopes"
         scopes.group_by(&:group).each do |group, group_scopes|
           div class: "index-button-group", role: "group", data: { "group": group_name(group) } do
             group_scopes.each do |scope|

--- a/lib/active_admin/views/components/status_tag.rb
+++ b/lib/active_admin/views/components/status_tag.rb
@@ -50,16 +50,12 @@ module ActiveAdmin
         end
 
         super(content, options)
-
+        add_class "status-tag"
         set_attribute("data-status", convert_status(status)) if status
         add_class(classes) if classes
       end
 
       protected
-
-      def default_class_name
-        "status-tag"
-      end
 
       def convert_to_boolean_status(status)
         case status

--- a/lib/active_admin/views/components/table_for.rb
+++ b/lib/active_admin/views/components/table_for.rb
@@ -20,7 +20,7 @@ module ActiveAdmin
 
         build_table
         super(options)
-        add_class("data-table")
+        add_class "data-table"
         columns(*attrs)
       end
 

--- a/lib/active_admin/views/components/tabs.rb
+++ b/lib/active_admin/views/components/tabs.rb
@@ -12,6 +12,7 @@ module ActiveAdmin
 
       def build(attributes = {}, &block)
         super(attributes)
+        add_class "tabs"
         @menu = nav(class: "tabs-nav", role: "tablist", "data-tabs-toggle": "#tabs-container-#{object_id}")
         @tabs_content = div(class: "tabs-content", id: "tabs-container-#{object_id}")
       end
@@ -27,12 +28,6 @@ module ActiveAdmin
       def build_content_item(title, options, &block)
         options = options.reverse_merge(id: fragmentize(title), class: "hidden", role: "tabpanel", "aria-labelledby": "#{title}-tab")
         div(options, &block)
-      end
-
-      protected
-
-      def default_class_name
-        "tabs"
       end
 
       private

--- a/lib/active_admin/views/index_as_table.rb
+++ b/lib/active_admin/views/index_as_table.rb
@@ -209,6 +209,7 @@ module ActiveAdmin
     #
     class IndexAsTable < ActiveAdmin::Component
       def build(page_presenter, collection)
+        add_class "index-as-table"
         table_options = {
           id: "index_table_#{active_admin_config.resource_name.plural}",
           sortable: true,
@@ -320,21 +321,16 @@ module ActiveAdmin
         class TableActions < ActiveAdmin::Component
           builder_method :table_actions
 
+          def initialize(*)
+            super
+            add_class "data-table-resource-actions"
+          end
+
           def item *args, **kwargs
             text_node link_to(*args, **kwargs)
           end
-
-          def default_class_name
-            "data-table-resource-actions"
-          end
         end
       end # IndexTableFor
-
-      protected
-
-      def default_class_name
-        "index-as-table"
-      end
     end
   end
 end

--- a/lib/generators/active_admin/assets/templates/package.json
+++ b/lib/generators/active_admin/assets/templates/package.json
@@ -2,6 +2,7 @@
   "name": "app",
   "private": "true",
   "dependencies": {
+    "@activeadmin/activeadmin": "^3.1.0",
     "tailwindcss": "^3.3.2"
   },
   "scripts": {

--- a/lib/generators/active_admin/assets/templates/tailwind.config.js
+++ b/lib/generators/active_admin/assets/templates/tailwind.config.js
@@ -14,6 +14,6 @@ module.exports = {
   ],
   darkMode: "class",
   plugins: [
-    require(`${gemPath}/plugin`)
+    require(`@activeadmin/activeadmin/plugin`)
   ]
 }

--- a/plugin.js
+++ b/plugin.js
@@ -311,7 +311,7 @@ module.exports = plugin(
         '@apply w-4 h-4 border-gray-300 focus:ring-2 focus:ring-blue-300 dark:focus:ring-blue-600 dark:focus:bg-blue-600 dark:bg-gray-700 dark:border-gray-600': {}
       },
       [['[type=date]', '[type=email]', '[type=number]', '[type=password]', '[type=tel]', '[type=text]', '[type=time]', '[type=url]', 'select', 'textarea']]: {
-        '@apply bg-gray-50 border border-gray-300 text-gray-900 rounded-lg focus:ring-blue-500 focus:border-blue-500 w-full dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500': {}
+        '@apply bg-gray-50 border border-gray-300 text-gray-900 rounded-md focus:ring-blue-500 focus:border-blue-500 w-full dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500': {}
       },
     });
     addComponents({
@@ -319,7 +319,7 @@ module.exports = plugin(
         '@apply py-2 px-3 text-sm font-medium no-underline text-gray-900 focus:outline-none bg-white rounded-md border border-gray-200 hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700': {}
       },
       '.empty-value': {
-        '@apply text-stone-400/50 text-xs uppercase font-medium': {}
+        '@apply text-gray-400/50 dark:text-gray-700/60 text-xs uppercase font-semibold': {}
       },
       '.link-default :where(a)': {
         '@apply text-blue-600 dark:text-blue-500 underline underline-offset-[.2rem]': {}
@@ -341,22 +341,22 @@ module.exports = plugin(
         '@apply inline-flex items-center justify-center px-3 py-2 text-sm font-medium no-underline text-gray-900 bg-white border border-gray-200 hover:bg-gray-100 focus:z-10 focus:ring-2 focus:ring-blue-700 focus:text-blue-700 first:rounded-s-md last:rounded-e-md dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100 dark:hover:text-gray-200 dark:hover:bg-gray-800 dark:focus:ring-blue-500 dark:focus:text-white': {}
       },
       '.index-button-selected': {
-        '@apply dark:bg-gray-800 bg-gray-100 hover:bg-gray-100': {}
+        '@apply bg-gray-100 hover:bg-gray-100 dark:bg-gray-800 dark:hover:bg-gray-800': {}
       },
       '.scopes-count': {
         '@apply inline-flex items-center justify-center rounded-full bg-indigo-200/80 text-indigo-800 dark:bg-indigo-800 dark:text-indigo-200 px-1.5 py-1 text-xs font-normal ms-2 leading-none': {}
       },
       '.paginated-collection': {
-        '@apply bg-white border border-gray-200 rounded-lg shadow-sm dark:border-gray-700 dark:bg-gray-800 overflow-hidden': {}
+        '@apply border border-gray-200 dark:border-gray-800 rounded-md shadow-sm overflow-hidden': {}
       },
       '.paginated-collection-contents': {
         '@apply overflow-x-auto': {}
       },
       '.paginated-collection-pagination': {
-        '@apply p-2 lg:p-4 flex flex-col-reverse lg:flex-row gap-4 items-center justify-between': {}
+        '@apply p-2 lg:p-3 flex flex-col-reverse lg:flex-row gap-4 items-center justify-between': {}
       },
       '.paginated-collection-footer': {
-        '@apply p-3 flex gap-2 items-center justify-between text-sm border-t border-gray-200 dark:border-gray-700': {}
+        '@apply p-3 flex gap-2 items-center justify-between text-sm border-t border-gray-200 dark:border-gray-800': {}
       },
       '.pagination-per-page': {
         '@apply text-sm py-1 pe-7 w-auto w-min': {}
@@ -368,13 +368,16 @@ module.exports = plugin(
         '@apply w-full text-sm text-left text-gray-800 dark:text-gray-300': {}
       },
       '.data-table :where(thead > tr > th)': {
-        '@apply px-5 py-3 whitespace-nowrap text-xs text-gray-700 uppercase bg-gray-50 border-b dark:bg-gray-800 dark:border-gray-700 dark:text-gray-300': {}
+        '@apply px-3 py-3.5 whitespace-nowrap font-semibold text-xs uppercase border-b text-gray-700 bg-gray-50 dark:bg-gray-950/50 dark:border-gray-800 dark:text-white': {}
+      },
+      '.data-table :where(thead > tr > th > a)': {
+        '@apply text-inherit no-underline': {}
       },
       '.data-table :where(tbody > tr)': {
-        '@apply bg-white border-b dark:bg-gray-900 dark:border-gray-700': {}
+        '@apply border-b dark:border-gray-800': {}
       },
       '.data-table :where(td)': {
-        '@apply px-5 py-3': {}
+        '@apply px-3 py-4': {}
       },
       '.data-table-resource-actions': {
         '@apply flex gap-2': {}
@@ -404,7 +407,7 @@ module.exports = plugin(
         '@apply min-w-[6rem] font-bold text-white bg-blue-600 hover:bg-blue-700 focus:ring-4 focus:outline-none focus:ring-blue-300 rounded-md px-3 py-2 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800 cursor-pointer': {}
       },
       '.filters-form-clear': {
-        '@apply rounded-md bg-white px-3 py-2 font-semibold text-gray-700 hover:bg-gray-100 no-underline dark:bg-white/10 dark:text-white dark:hover:bg-white/20 dark:focus:ring-blue-800': {}
+        '@apply rounded-md px-3 py-2 font-semibold text-gray-700 hover:bg-gray-100 no-underline dark:text-gray-400 dark:hover:bg-inherit dark:hover:text-gray-100 dark:focus:ring-blue-800': {}
       },
       '.active-filters-title': {
         '@apply text-gray-700 dark:text-gray-200 font-bold text-lg mb-4': {}
@@ -428,28 +431,28 @@ module.exports = plugin(
         '@apply block px-2.5 py-2 no-underline text-gray-700 hover:bg-gray-100 hover:text-gray-900 dark:text-white dark:hover:bg-gray-600 dark:hover:text-white': {}
       },
       '.panel': {
-        '@apply mb-6 bg-white border border-gray-200 rounded-lg shadow-sm dark:border-gray-700 dark:bg-gray-800': {}
+        '@apply mb-6 border border-gray-200 rounded-md shadow-sm dark:border-gray-800': {}
       },
       '.panel-title': {
-        '@apply font-bold bg-gray-100 dark:bg-gray-900 rounded-t-lg p-3': {}
+        '@apply font-bold bg-gray-100 dark:bg-gray-900 rounded-t-md p-3': {}
       },
       '.panel-body': {
-        '@apply py-6 px-4': {}
+        '@apply py-5 px-3': {}
       },
       '.attributes-table': {
-        '@apply overflow-hidden mb-6 bg-white border border-gray-200 rounded-lg shadow-sm dark:border-gray-700 dark:bg-gray-800': {}
+        '@apply overflow-hidden mb-6 border border-gray-200 rounded-md shadow-sm dark:border-gray-800': {}
       },
       '.attributes-table > :where(table)': {
         '@apply w-full text-sm text-left text-gray-800 dark:text-gray-300': {}
       },
       '.attributes-table :where(tbody > tr)': {
-        '@apply bg-white border-b dark:bg-gray-800 dark:border-gray-700': {}
+        '@apply border-b dark:border-gray-800': {}
       },
       '.attributes-table :where(tbody > tr > th)': {
-        '@apply w-40 text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400': {}
+        '@apply w-32 sm:w-40 text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-800/60 dark:text-gray-300': {}
       },
       '.attributes-table :where(tbody > tr > th, tbody > tr > td)': {
-        '@apply px-5 py-3': {}
+        '@apply p-3': {}
       },
       '.status-tag': {
         '@apply bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-400 text-sm font-medium px-2.5 py-0.5 rounded': {}

--- a/plugin.js
+++ b/plugin.js
@@ -304,9 +304,6 @@ module.exports = plugin(
       ['[role="tooltip"].invisible > [data-popper-arrow]:before']: {
         visibility: 'hidden',
       },
-      'body': {
-        '@apply bg-white dark:bg-gray-950 dark:text-white antialiased': {}
-      },
       '[type=checkbox]': {
         '@apply w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600': {}
       },

--- a/plugin.js
+++ b/plugin.js
@@ -324,9 +324,6 @@ module.exports = plugin(
       '.empty-value': {
         '@apply text-stone-400/50 text-xs uppercase font-medium': {}
       },
-      '.inner-body-container': {
-        '@apply xl:ms-64': {}
-      },
       '.link-default :where(a)': {
         '@apply text-blue-600 dark:text-blue-500 underline underline-offset-[.2rem]': {}
       },

--- a/plugin.js
+++ b/plugin.js
@@ -455,10 +455,10 @@ module.exports = plugin(
         '@apply p-3': {}
       },
       '.status-tag': {
-        '@apply bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-400 text-sm font-medium px-2.5 py-0.5 rounded': {}
+        '@apply bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-400 inline-flex items-center rounded-full text-sm font-medium px-2.5 py-0.5 whitespace-nowrap': {}
       },
       '.status-tag:where([data-status=yes])': {
-        '@apply bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300 text-sm font-medium px-2.5 py-0.5 rounded': {}
+        '@apply bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300': {}
       },
       '.tabs-nav': {
         '@apply flex flex-wrap mb-2 text-sm font-medium text-center border-b border-gray-200 dark:border-gray-700': {}

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -91,6 +91,7 @@ generate "active_admin:install"
 gsub_file "tailwind.config.js", /^.*const gemPath.*$/, <<~JS
   const gemPath = '../../../';
 JS
+gsub_file "tailwind.config.js", /@activeadmin\/activeadmin/, "${gemPath}"
 
 # Force strong parameters to raise exceptions
 inject_into_file "config/application.rb", after: "class Application < Rails::Application" do

--- a/spec/support/templates_with_data/admin/users.rb
+++ b/spec/support/templates_with_data/admin/users.rb
@@ -14,8 +14,8 @@ ActiveAdmin.register User do
     column :last_name
     column :username
     column :age
-    column :created_at
-    column :updated_at
+    column :created_at, class: "min-w-[13rem]"
+    column :updated_at, class: "min-w-[13rem]"
     actions dropdown: true
   end
 
@@ -41,23 +41,23 @@ ActiveAdmin.register User do
       row :updated_at
     end
 
-    panel "Posts" do
-      paginated_collection(user.posts.includes(:category).order(:updated_at).page(params[:page]).per(10), download_links: false) do
-        table_for(collection) do
-          column :id do |post|
-            link_to post.id, admin_user_post_path(post.author, post)
-          end
-          column :title
-          column :published_date
-          column :category
-          column :created_at
-          column :updated_at
-        end
-      end
+    h3 "Posts", class: "font-bold py-5 text-2xl"
 
-      div class: "mt-4" do
-        link_to "View all posts", admin_user_posts_path(user)
+    paginated_collection(user.posts.includes(:category).order(:updated_at).page(params[:page]).per(10), download_links: false) do
+      table_for(collection) do
+        column :id do |post|
+          link_to post.id, admin_user_post_path(post.author, post)
+        end
+        column :title
+        column :published_date
+        column :category
+        column :created_at
+        column :updated_at
       end
+    end
+
+    div class: "mt-4" do
+      link_to "View all posts", admin_user_posts_path(user)
     end
   end
 end

--- a/spec/unit/component_spec.rb
+++ b/spec/unit/component_spec.rb
@@ -16,18 +16,4 @@ RSpec.describe ActiveAdmin::Component do
   it "should not have a CSS class name by default" do
     expect(component.class_list.empty?).to eq true
   end
-
-  describe "#default_class_name" do
-    let(:component_class) do
-      Class.new(described_class) do
-        def default_class_name
-          "my-component"
-        end
-      end
-    end
-
-    it "should add a default CSS class name if provided" do
-      expect(component.class_list).to include("my-component")
-    end
-  end
 end

--- a/spec/unit/view_helpers/breadcrumbs_spec.rb
+++ b/spec/unit/view_helpers/breadcrumbs_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Breadcrumbs" do
 
   describe "generating a trail from paths" do
     def params; {}; end
-    def link_to(name, url); { name: name, path: url }; end
+    def link_to(name, url, html_options = {}); { name: name, path: url }; end
 
     actions = ActiveAdmin::BaseController::ACTIVE_ADMIN_ACTIONS
 
@@ -25,7 +25,7 @@ RSpec.describe "Breadcrumbs" do
       post_config
     end
 
-    let(:trail) { breadcrumb_links(path) }
+    let(:trail) { build_breadcrumb_links(path) }
 
     context "when request '/admin'" do
       let(:path) { "/admin" }


### PR DESCRIPTION
This moves the main navigation into a dedicated partial with improvements. The html head partials have now been consolidated into a single partial. The title tag is now inlined in the layout files. This revamps the dark mode styles across the board and uses a darker set of colors. The default breadcrumb links now pass `html_options` to `link_to` call so we can apply classes. The default comments resource has been updated so specific columns have a minimum width and the body is now truncated.