### PR TITLE
Use defaults from importmap-rails v2

### DIFF
--- a/app/views/active_admin/_html_head.html.erb
+++ b/app/views/active_admin/_html_head.html.erb
@@ -10,4 +10,4 @@
     document.documentElement.classList.remove('dark')
   }
 <% end %>
-<%= javascript_importmap_tags "active_admin", importmap: ActiveAdmin.importmap %>
+<%= javascript_importmap_tags "active_admin", importmap: ActiveAdmin.importmap, shim: false %>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-pin "flowbite" # downloaded from https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.2.1/flowbite.min.js
-pin "@rails/ujs", to: "https://ga.jspm.io/npm:@rails/ujs@7.1.2/app/assets/javascripts/rails-ujs.esm.js"
+pin "flowbite", preload: true # downloaded from https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.2.1/flowbite.min.js
+pin "@rails/ujs", to: "https://ga.jspm.io/npm:@rails/ujs@7.1.2/app/assets/javascripts/rails-ujs.esm.js", preload: true
 pin "active_admin", to: "active_admin.js", preload: true
-pin_all_from File.expand_path("../app/javascript/active_admin", __dir__), under: "active_admin"
+pin_all_from File.expand_path("../app/javascript/active_admin", __dir__), under: "active_admin", preload: true


### PR DESCRIPTION
I was wondering why not to preload and remove shim by now since support is good all around for importmaps. Various defaults were changed and the shim was removed for a importmaps-rails v2 release. Other than the shim flag, the rest remain but use different defaults so let's use the new defaults now with v1 until v2 is released.