### PR TITLE
Some final updates before v4 beta1

### DIFF
--- a/app/controllers/active_admin/resource_controller.rb
+++ b/app/controllers/active_admin/resource_controller.rb
@@ -78,7 +78,7 @@ module ActiveAdmin
         active_admin_config.plural_resource_label
       when :show
         helpers.display_name(resource)
-      when :new, :edit
+      when :new, :edit, :create, :update
         normalized_action = params[:action]
         normalized_action = 'new' if normalized_action == 'create'
         normalized_action = 'edit' if normalized_action == 'update'

--- a/app/javascript/active_admin/features/batch_actions.js
+++ b/app/javascript/active_admin/features/batch_actions.js
@@ -45,7 +45,7 @@ const disableDropdown = function(condition) {
 }
 
 const toggleAllChange = function(event) {
-  const checkboxes = document.querySelectorAll("input[type=checkbox].collection_selection")
+  const checkboxes = document.querySelectorAll(".batch-actions-resource-selection")
   for (const checkbox of checkboxes) {
     checkbox.checked = this.checked
   }
@@ -58,14 +58,14 @@ const toggleAllChange = function(event) {
   disableDropdown(!this.checked)
 }
 
-Rails.delegate(document, "input[type=checkbox].toggle_all", "change", toggleAllChange)
+Rails.delegate(document, ".batch-actions-toggle-all", "change", toggleAllChange)
 
 const toggleCheckboxChange = function(event) {
-  const numChecked = document.querySelectorAll("input[type=checkbox].collection_selection:checked").length;
-  const allChecked = numChecked === document.querySelectorAll("input[type=checkbox].collection_selection").length;
-  const someChecked = (numChecked > 0) && (numChecked < document.querySelectorAll("input[type=checkbox].collection_selection").length);
+  const numChecked = document.querySelectorAll(".batch-actions-resource-selection:checked").length;
+  const allChecked = numChecked === document.querySelectorAll(".batch-actions-resource-selection").length;
+  const someChecked = (numChecked > 0) && (numChecked < document.querySelectorAll(".batch-actions-resource-selection").length);
 
-  const toggleAll = document.querySelector("input[type=checkbox].toggle_all")
+  const toggleAll = document.querySelector(".batch-actions-toggle-all")
   if (toggleAll) {
     toggleAll.checked = allChecked
     toggleAll.indeterminate = someChecked
@@ -74,7 +74,7 @@ const toggleCheckboxChange = function(event) {
   disableDropdown(numChecked === 0)
 }
 
-Rails.delegate(document, "input[type=checkbox].collection_selection", "change", toggleCheckboxChange)
+Rails.delegate(document, ".batch-actions-resource-selection", "change", toggleCheckboxChange)
 
 const tableRowClick = function(event) {
   const type = event.target.type;

--- a/app/views/active_admin/_main_navigation.html.erb
+++ b/app/views/active_admin/_main_navigation.html.erb
@@ -13,12 +13,12 @@
           <ul role="list" class="mt-1 space-y-1 hidden group-data-[open]:block">
             <% children.each do |j| %>
               <li data-item-id="<%= j.id %>">
-                <%= link_to j.label(self), j.url(self), j.html_options.merge(class: "text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white block rounded-md py-1.5 px-2 text-sm #{(current_menu_item?(j) ? "bg-gray-100 dark:bg-white/5 text-gray-900 dark:text-white selected" : "")}") %>
+                <%= link_to j.label(self), j.url(self), j.html_options.merge(class: "text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white block rounded-md py-1.5 px-2 text-sm no-underline #{(current_menu_item?(j) ? "bg-gray-100 dark:bg-white/5 text-gray-900 dark:text-white selected" : "")}") %>
               </li>
             <% end %>
           </ul>
         <% elsif url = item.url(self) %>
-          <%= link_to item.label(self), url, item.html_options.merge(class: "text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white flex items-center w-full rounded-md p-2 gap-x-2 text-sm #{(current_menu_item?(item) ? "bg-gray-100 dark:bg-white/5 text-gray-900 dark:text-white selected" : "")}") %>
+          <%= link_to item.label(self), url, item.html_options.merge(class: "text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white flex items-center w-full rounded-md p-2 gap-x-2 text-sm no-underline #{(current_menu_item?(item) ? "bg-gray-100 dark:bg-white/5 text-gray-900 dark:text-white selected" : "")}") %>
         <% else %>
           <%= item.label(self) %>
         <% end %>

--- a/app/views/active_admin/_page_header.html.erb
+++ b/app/views/active_admin/_page_header.html.erb
@@ -1,6 +1,6 @@
 <div data-test-page-header class="bg-gray-50 border-b p-4 mb-8 flex flex-col gap-4 md:flex-row md:items-center justify-between dark:border-gray-800/50 dark:bg-inherit">
   <div class="flex flex-col gap-3 pt-1">
-    <% breadcrumb_links = build_breadcrumb_links(request.path, class: "text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200") %>
+    <% breadcrumb_links = build_breadcrumb_links(request.path, class: "text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 no-underline") %>
     <% if breadcrumb_links.present? %>
       <nav aria-label="breadcrumb">
         <ol class="flex flex-wrap gap-1 text-sm">

--- a/app/views/active_admin/_site_footer.html.erb
+++ b/app/views/active_admin/_site_footer.html.erb
@@ -1,7 +1,7 @@
 <div class="text-sm text-center mt-16 mx-8 pt-9 pb-12 text-gray-500 border-t dark:border-gray-800">
   <%= I18n.t(
         "active_admin.powered_by",
-        active_admin: link_to("Active Admin", "https://activeadmin.info", class: "hover:text-gray-900 dark:hover:text-gray-400"),
+        active_admin: link_to("Active Admin", "https://activeadmin.info", class: "text-gray-500 dark:text-gray-500 hover:text-gray-900 dark:hover:text-gray-400 no-underline"),
         version: ActiveAdmin::VERSION
       ).html_safe %>
 </div>

--- a/app/views/active_admin/devise/shared/_links.erb
+++ b/app/views/active_admin/devise/shared/_links.erb
@@ -1,4 +1,4 @@
-<div class="mt-6 text-sm link-default">
+<div class="mt-6 text-sm">
 <%- if controller_name != 'sessions' %>
   <% scope = Devise::Mapping.find_scope!(resource_name) %>
   <%= link_to t('active_admin.devise.links.sign_in'), main_app.send(:"new_#{scope}_session_path") %>

--- a/app/views/layouts/active_admin.html.erb
+++ b/app/views/layouts/active_admin.html.erb
@@ -10,7 +10,7 @@
     <%= render "active_admin/main_navigation" %>
     <%= render "active_admin/page_header", title: @page_title || page_title %>
     <%= render "active_admin/flash_messages" %>
-    <div data-test-page-content class="link-default px-2.5 lg:px-5 grid grid-cols-1 gap-4 lg:gap-6 lg:grid-flow-col lg:auto-cols-[minmax(0,250px)]">
+    <div data-test-page-content class="px-2.5 lg:px-5 grid grid-cols-1 gap-4 lg:gap-6 lg:grid-flow-col lg:auto-cols-[minmax(0,250px)]">
       <%= yield %>
       <%= render "active_admin/sidebar" %>
     </div>

--- a/features/index/filters.feature
+++ b/features/index/filters.feature
@@ -21,7 +21,7 @@ Feature: Index Filtering
     When I fill in "Title" with "Hello World 2"
     And I press "Filter"
     And I should see 1 posts in the table
-    And I should see "Hello World 2" within ".index_table"
+    And I should see "Hello World 2" in the table
     And I should see current filter "title_cont" equal to "Hello World 2" with label "Title contains"
 
   Scenario: No XSS in Resources Filters
@@ -46,7 +46,7 @@ Feature: Index Filtering
 
     When I fill in "Title" with "THIS IS NOT AN EXISTING TITLE!!"
     And I press "Filter"
-    Then I should not see ".index_table"
+    Then I should not see ".data-table"
     And I should not see a sortable table header
     And I should not see pagination
     And I should see "No Posts found"
@@ -83,7 +83,7 @@ Feature: Index Filtering
     When I fill in "Title" with "Hello World 2"
     And I press "Filter"
     Then I should see 1 posts in the table
-    And I should see "Hello World 2" within ".index_table"
+    And I should see "Hello World 2" in the table
 
   Scenario: Checkboxes - Filtering posts written by anyone
     Given 1 post exists
@@ -96,7 +96,7 @@ Feature: Index Filtering
     """
     When I press "Filter"
     Then I should see 2 posts in the table
-    And I should see "Hello World" within ".index_table"
+    And I should see "Hello World" in the table
     And the "Jane Doe" checkbox should not be checked
 
   Scenario: Checkboxes - Filtering posts written by Jane Doe
@@ -111,7 +111,7 @@ Feature: Index Filtering
     When I check "Jane Doe"
     And I press "Filter"
     Then I should see 1 posts in the table
-    And I should see "Hello World" within ".index_table"
+    And I should see "Hello World" in the table
     And the "Jane Doe" checkbox should be checked
     And I should see current filter "author_id_in" equal to "Jane Doe"
 
@@ -134,8 +134,8 @@ Feature: Index Filtering
     When I select "Jane Doe" from "Authors"
     And I press "Filter"
     Then I should see 1 categories in the table
-    And I should see "Non-Fiction" within ".index_table"
-    And I should not see "Mystery" within ".index_table"
+    And I should see "Non-Fiction" in the table
+    And I should not see "Mystery" in the table
     And I should see current filter "posts_author_id_eq" equal to "Jane Doe"
 
   @javascript
@@ -171,8 +171,8 @@ Feature: Index Filtering
     """
     When I press "Filter"
     Then I should see 2 posts in the table
-    And I should see "Mystery" within ".index_table"
-    And I should see "Non-Fiction" within ".index_table"
+    And I should see "Mystery" in the table
+    And I should see "Non-Fiction" in the table
     And the "Jane Doe" checkbox should not be checked
     And I should not see "Active Search"
 
@@ -189,7 +189,7 @@ Feature: Index Filtering
     When I check "Jane Doe"
     And I press "Filter"
     Then I should see 1 categories in the table
-    And I should see "Non-Fiction" within ".index_table"
+    And I should see "Non-Fiction" in the table
     And the "Jane Doe" checkbox should be checked
 
   Scenario: Filtering posts without default scope

--- a/features/index/index_blank_slate.feature
+++ b/features/index/index_blank_slate.feature
@@ -15,7 +15,7 @@ Feature: Index Blank Slate
     Then I should not see a sortable table header
     And I should see "There are no Posts yet."
     And I should see "Create one"
-    And I should not see ".index_table"
+    And I should not see ".data-table"
     And I should not see pagination
     When I follow "Create one"
     Then I should be on the new post page

--- a/features/registering_pages.feature
+++ b/features/registering_pages.feature
@@ -178,7 +178,7 @@ Feature: Registering Pages
       content do
         collection = Kaminari.paginate_array(User.all).page(params.fetch(:page, 1))
 
-        table_for(collection, class: "index_table") do
+        table_for(collection) do
           column :first_name
           column :last_name
         end
@@ -215,7 +215,7 @@ Feature: Registering Pages
      ActiveAdmin.register Post
      ActiveAdmin.register_page "Last Posts" do
        content do
-         table_for Post.last(2), sortable: true, class: "index_table" do
+         table_for Post.last(2), sortable: true do
            column :id
            column :title
            column :author

--- a/features/step_definitions/batch_action_steps.rb
+++ b/features/step_definitions/batch_action_steps.rb
@@ -13,7 +13,7 @@ Then /^the (\d+)(?:st|nd|rd|th) batch action should be "([^"]*)"$/ do |index, ti
 end
 
 When /^I check the (\d+)(?:st|nd|rd|th) record$/ do |index|
-  page.all("table.index_table input[type=checkbox]")[index.to_i].set true
+  page.all(".batch-actions-resource-selection")[index.to_i].set true
 end
 
 Then /^I should see that the batch action button is disabled$/ do

--- a/features/step_definitions/table_steps.rb
+++ b/features/step_definitions/table_steps.rb
@@ -1,7 +1,14 @@
 # frozen_string_literal: true
 Then /^I should see (\d+) ([\w]*) in the table$/ do |count, resource_type|
-  expect(page).to \
-    have_css("table.index_table tr > td:first-child", count: count.to_i)
+  expect(page).to have_css(".data-table tr > td:first-child", count: count.to_i)
+end
+
+Then("I should see {string} in the table") do |string|
+  expect(page).to have_css(".data-table tr > td", text: string)
+end
+
+Then("I should not see {string} in the table") do |string|
+  expect(page).to_not have_css(".data-table tr > td", text: string)
 end
 
 Then /^I should see an id_column link to edit page$/ do

--- a/lib/active_admin/batch_actions/views/selection_cells.rb
+++ b/lib/active_admin/batch_actions/views/selection_cells.rb
@@ -10,7 +10,7 @@ module ActiveAdmin
 
       def build(label_text = "")
         label do
-          input type: "checkbox", id: "collection_selection_toggle_all", name: "collection_selection_toggle_all", class: "toggle_all"
+          input type: "checkbox", id: "collection_selection_toggle_all", name: "collection_selection_toggle_all", class: "batch-actions-toggle-all"
           text_node label_text if label_text.present?
         end
       end
@@ -21,7 +21,7 @@ module ActiveAdmin
       builder_method :resource_selection_cell
 
       def build(resource)
-        input type: "checkbox", id: "batch_action_item_#{resource.id}", value: resource.id, class: "collection_selection", name: "collection_selection[]"
+        input type: "checkbox", id: "batch_action_item_#{resource.id}", value: resource.id, class: "batch-actions-resource-selection", name: "collection_selection[]"
       end
     end
 

--- a/lib/active_admin/views/index_as_table.rb
+++ b/lib/active_admin/views/index_as_table.rb
@@ -213,7 +213,6 @@ module ActiveAdmin
         table_options = {
           id: "index_table_#{active_admin_config.resource_name.plural}",
           sortable: true,
-          class: "index_table",
           i18n: active_admin_config.resource_class,
           paginator: page_presenter[:paginator] != false,
           row_class: page_presenter[:row_class]

--- a/plugin.js
+++ b/plugin.js
@@ -316,13 +316,13 @@ module.exports = plugin(
       [['[type=date]', '[type=email]', '[type=number]', '[type=password]', '[type=tel]', '[type=text]', '[type=time]', '[type=url]', 'select', 'textarea']]: {
         '@apply bg-gray-50 border border-gray-300 text-gray-900 rounded-md focus:ring-blue-500 focus:border-blue-500 w-full dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500': {}
       },
+      'a': {
+        '@apply text-blue-600 underline underline-offset-[.2rem]': {}
+      },
     });
     addComponents({
       '.action-item-button': {
         '@apply py-2 px-3 text-sm font-medium no-underline text-gray-900 focus:outline-none bg-white rounded-md border border-gray-200 hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700': {}
-      },
-      '.link-default :where(a)': {
-        '@apply text-blue-600 dark:text-blue-500 underline underline-offset-[.2rem]': {}
       },
       '.index-data-table-toolbar': {
         '@apply flex flex-col lg:flex-row gap-4 mb-4': {}

--- a/plugin.js
+++ b/plugin.js
@@ -482,6 +482,9 @@ module.exports = plugin(
         '@apply p-4 mb-6': {}
       },
       // Forms
+      '.formtastic': {
+        '@apply text-sm': {}
+      },
       '.formtastic :where(.fieldset-title, .has-many-fields-title)': {
         '@apply block w-full mb-3 border-b font-bold text-lg': {}
       },
@@ -507,7 +510,7 @@ module.exports = plugin(
         '@apply sr-only': {}
       },
       '.formtastic :where(.inline-hints)': {
-        '@apply text-gray-500 text-sm mt-2': {}
+        '@apply text-gray-500 mt-2': {}
       },
       '.formtastic :where(.errors)': {
         '@apply p-4 mb-2 rounded-lg bg-red-50 text-red-800 dark:bg-red-800 dark:text-red-300': {}

--- a/spec/support/templates/models/category.rb
+++ b/spec/support/templates/models/category.rb
@@ -3,4 +3,5 @@ class Category < ApplicationRecord
   has_many :posts, foreign_key: :custom_category_id
   has_many :authors, through: :posts
   accepts_nested_attributes_for :posts
+  validates :name, presence: true
 end

--- a/spec/support/templates_with_data/admin/components/custom_index.rb
+++ b/spec/support/templates_with_data/admin/components/custom_index.rb
@@ -4,7 +4,8 @@ module ActiveAdmin
     class CustomIndex < ActiveAdmin::Component
 
       def build(page_presenter, collection)
-        add_class "index"
+        add_class("custom-index")
+        set_attribute("data-index-as", "custom")
         if active_admin_config.batch_actions.any?
           div class: "p-3" do
             resource_selection_toggle_panel

--- a/spec/support/templates_with_data/admin/posts.rb
+++ b/spec/support/templates_with_data/admin/posts.rb
@@ -60,18 +60,6 @@ ActiveAdmin.register Post do
     column :updated_at, class: "min-w-[200px]"
   end
 
-  sidebar :author, only: :show do
-    attributes_table_for resource.author do
-      row :id do |author|
-        link_to author.id, admin_user_path(author)
-      end
-      row :first_name
-      row :last_name
-      row :username
-      row :age
-    end
-  end
-
   member_action :toggle_starred, method: :put do
     resource.update(starred: !resource.starred)
     redirect_to resource_path, notice: "Post updated."

--- a/spec/unit/resource_controller/data_access_spec.rb
+++ b/spec/unit/resource_controller/data_access_spec.rb
@@ -236,7 +236,7 @@ RSpec.describe ActiveAdmin::ResourceController::DataAccess do
       end
     end
 
-    let!(:category) { Category.create! }
+    let!(:category) { Category.create!(name: "Category") }
 
     let(:params) do
       ActionController::Parameters.new(user: { type: "User::VIP", posts_attributes: [custom_category_id: category.id] })


### PR DESCRIPTION
These are some final updates before our first beta release of v4. This fixes the default anchor style by just setting it as a base style and defining no-underline and default text colors where it was missing. I think this will be best to keep a default link style which I think will be expected and not set it by default with a class which had some conflicts with dark mode styles. This keeps the specificity low.