### PR TITLE
Include vendor directory in gem release

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
     "application patterns to make it simple for developers to implement " \
     "beautiful and elegant interfaces with very little effort."
 
-  s.files = Dir["LICENSE", "{app,config/locales,lib,vendor/assets}/**/{.*,*}"].reject { |f| File.directory?(f) }
+  s.files = Dir["LICENSE", "{app,config/locales,lib,vendor}/**/{.*,*}"].reject { |f| File.directory?(f) }
 
   s.extra_rdoc_files = %w[CHANGELOG.md CODE_OF_CONDUCT.md CONTRIBUTING.md README.md]
 


### PR DESCRIPTION
This fixes the issue in v4.0.0.beta1 not including the vendor directory which we need as we are vendoring the Flowbite library.