### PR TITLE
Include additional files in gem release

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -14,9 +14,9 @@ Gem::Specification.new do |s|
     "application patterns to make it simple for developers to implement " \
     "beautiful and elegant interfaces with very little effort."
 
-  s.files = Dir["LICENSE", "{app,config/locales,lib,vendor}/**/{.*,*}"].reject { |f| File.directory?(f) }
+  s.files = Dir["LICENSE", "plugin.js", "{app,config,lib,vendor}/**/{.*,*}"].reject { |f| File.directory?(f) }
 
-  s.extra_rdoc_files = %w[CHANGELOG.md CODE_OF_CONDUCT.md CONTRIBUTING.md README.md]
+  s.extra_rdoc_files = %w[CHANGELOG.md CODE_OF_CONDUCT.md CONTRIBUTING.md README.md UPGRADING.md]
 
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/activeadmin/activeadmin/issues",


### PR DESCRIPTION
At first, we were tackling a sprockets error which we resolved in beta2 but it became evident that more files were missing that should have been included.

We could have the tailwind content config point to the plugin.js from the npm package but since we have set to use it from the gem, best to just include it. It's how we expected it to work. We also need to include the config directory for our importmap config.

Those were the only required changes but I figured we should have the UPGRADING guide added as well.