### PR TITLE
Move pagination translations to active_admin scope

### DIFF
--- a/app/views/active_admin/kaminari/_next_page.html.erb
+++ b/app/views/active_admin/kaminari/_next_page.html.erb
@@ -8,7 +8,7 @@
 -%>
 <% unless current_page.last? %>
   <%= link_to url, rel: 'next', remote: remote, class: "flex items-center justify-center px-2.5 py-3 h-8 leading-tight text-gray-500 dark:text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-800 dark:hover:text-white rounded no-underline" do %>
-    <span class="sr-only"><%= t('views.pagination.next').html_safe %></span>
+    <span class="sr-only"><%= t('active_admin.pagination.next') %></span>
     <svg class="w-2.5 h-2.5 rtl:rotate-180" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 6 10">
       <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 9 4-4-4-4"/>
     </svg>

--- a/app/views/active_admin/kaminari/_prev_page.html.erb
+++ b/app/views/active_admin/kaminari/_prev_page.html.erb
@@ -8,7 +8,7 @@
 -%>
 <% unless current_page.first? %>
   <%= link_to url, rel: 'prev', remote: remote, class: "flex items-center justify-center px-2.5 py-3 h-8 leading-tight text-gray-500 dark:text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-800 dark:hover:text-white rounded no-underline" do %>
-    <span class="sr-only"><%= t('views.pagination.previous').html_safe %></span>
+    <span class="sr-only"><%= t('active_admin.pagination.previous') %></span>
     <svg class="w-2.5 h-2.5 rtl:rotate-180" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 6 10">
       <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 1 1 5l4 4"/>
     </svg>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,8 +1,4 @@
 en:
-  views:
-    pagination:
-      previous: "Previous"
-      next: "Next"
   activerecord:
     models:
       comment:
@@ -68,6 +64,8 @@ en:
       multiple: "Showing <b>%{from}-%{to}</b> of <b>%{total}</b>"
       multiple_without_total: "Showing <b>%{from}-%{to}</b>"
       per_page: "Per page "
+      previous: "Previous"
+      next: "Next"
       entry:
         one: "entry"
         other: "entries"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,8 +1,4 @@
 fr:
-  views:
-    pagination:
-      previous: "Précédent"
-      next: "Suivant"
   activerecord:
     models:
       comment:
@@ -65,6 +61,8 @@ fr:
       multiple: "Affichage de <b>%{from}-%{to}</b> sur <b>%{total}</b>"
       multiple_without_total: "Affichage de <b>%{from}-%{to}</b>"
       per_page: "Par page "
+      previous: "Précédent"
+      next: "Suivant"
       entry:
         one: "entrée"
         other: "entrées"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,8 +1,4 @@
 nl:
-  views:
-    pagination:
-      previous: "Vorige"
-      next: "Volgende"
   active_admin:
     dashboard: Dashboard
     view: "Bekijk"
@@ -52,6 +48,8 @@ nl:
       multiple: "Toont <b>%{from}-%{to}</b> van <b>%{total}</b>"
       multiple_without_total: "Toont <b>%{from}-%{to}</b>"
       per_page: "Per pagina: "
+      previous: "Vorige"
+      next: "Volgende"
       entry:
         one: "entry"
         other: "entries"


### PR DESCRIPTION
Active Admin uses the Kaminari gem for pagination, which may also be used by the host application. Moving the translations from `views.pagination` to `active_admin.pagination` prevents potential conflicts.

Fix #8215
