### PR TITLE
Include partials in NPM package for Tailwind config

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/active_admin.js",
   "type": "module",
   "files": [
+    "app/views/**/*.{arb,erb}",
     "dist/**/*.js",
     "plugin.js",
     "vendor/javascript/*.js"


### PR DESCRIPTION
The current tailwind configuration depends on the presence of the ruby gem. This is not flexible for all build systems and processes. By publishing all the files referenced in the tailwind config to npm, we can remove this dependency so that a yarn or npm build can run independently.
