### PR TITLE
Include vendor JS files in NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "files": [
     "app/javascript/**/*.js",
-    "plugin.js"
+    "plugin.js",
+    "vendor/javascript/*.js"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
While users could install these as NPM dependencies to replace JS from importmap-rails, we only test against our vendor based JS so they should be able to include these if they want. It makes no real difference in the NPM package size so best to keep these consistent between the gem and npm package.