### PR TITLE
Remove i18n-tasks.yml from gem release

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
     "application patterns to make it simple for developers to implement " \
     "beautiful and elegant interfaces with very little effort."
 
-  s.files = Dir["LICENSE", "plugin.js", "{app,config,lib,vendor}/**/{.*,*}"].reject { |f| File.directory?(f) }
+  s.files = Dir["LICENSE", "plugin.js", 'config/importmap.rb', "{app,config/locales,lib,vendor}/**/{.*,*}"].reject { |f| File.directory?(f) }
 
   s.extra_rdoc_files = %w[CHANGELOG.md CODE_OF_CONDUCT.md CONTRIBUTING.md README.md UPGRADING.md]
 


### PR DESCRIPTION
Remove i18n-tasks.yml from gem release.

it got introduced in https://github.com/activeadmin/activeadmin/commit/f3d68213e169fcb9aadfc7eb21b0f4225c1d887d.