### PR TITLE
Make importmap-rails optional

### DIFF
--- a/lib/active_admin.rb
+++ b/lib/active_admin.rb
@@ -9,6 +9,12 @@ require "formtastic_i18n"
 require "inherited_resources"
 require "arbre"
 
+begin
+  require "importmap-rails"
+rescue LoadError
+  # importmap-rails is optional
+end
+
 module ActiveAdmin
 
   autoload :VERSION, "active_admin/version"
@@ -57,7 +63,6 @@ module ActiveAdmin
     end
 
     def importmap
-      require "importmap-rails"
       @importmap ||= Importmap::Map.new
     end
 

--- a/lib/active_admin/engine.rb
+++ b/lib/active_admin/engine.rb
@@ -15,7 +15,10 @@ module ActiveAdmin
       end
     end
 
-    initializer "active_admin.importmap", before: "importmap" do |app|
+    initializer "active_admin.importmap", after: "importmap" do |app|
+      # Skip if importmap-rails is not installed
+      next unless app.config.respond_to?(:importmap)
+
       ActiveAdmin.importmap.draw(Engine.root.join("config", "importmap.rb"))
       package_path = Engine.root.join("app/javascript")
       if app.config.respond_to?(:assets)


### PR DESCRIPTION
Currently, the engine requires the `importmap-rails` gem during initialization. Is not possible to install the gem without it.

I want to be able to test other alternatives to bundle the javascript. They won't be supported by default, like importmaps-rails.