### PR TITLE
Cleanup tailwind template

### DIFF
--- a/lib/generators/active_admin/assets/templates/tailwind.config.js
+++ b/lib/generators/active_admin/assets/templates/tailwind.config.js
@@ -4,7 +4,7 @@ const activeAdminPath = execSync('bundle show activeadmin', { encoding: 'utf-8' 
 module.exports = {
   content: [
     `${activeAdminPath}/vendor/javascript/flowbite.js`,
-    `${activeAdminPath}/app/views/**/*.{arb,erb,html,rb}`,
+    `${activeAdminPath}/app/views/**/*.{arb,erb}`,
     './app/admin/**/*.{arb,erb,html,rb}',
     './app/views/active_admin/**/*.{arb,erb,html,rb}',
     './app/views/admin/**/*.{arb,erb,html,rb}',

--- a/lib/generators/active_admin/assets/templates/tailwind.config.js
+++ b/lib/generators/active_admin/assets/templates/tailwind.config.js
@@ -4,7 +4,6 @@ const activeAdminPath = execSync('bundle show activeadmin', { encoding: 'utf-8' 
 module.exports = {
   content: [
     `${activeAdminPath}/vendor/javascript/flowbite.js`,
-    `${activeAdminPath}/plugin.js`,
     `${activeAdminPath}/app/views/**/*.{arb,erb,html,rb}`,
     './app/admin/**/*.{arb,erb,html,rb}',
     './app/views/active_admin/**/*.{arb,erb,html,rb}',


### PR DESCRIPTION
Small tweaks tailwind template.

I believe there is no need to scan our plugin.js. It's not javascript that we use in our pages.

Also, we don't have views ending with html / rb extensions.

I understand if these changes are rejected