### PR TITLE
Sync vendor and package json

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@ require "bundler/gem_tasks"
 
 import "tasks/local.rake"
 import "tasks/test.rake"
+import "tasks/dependencies.rake"
 
 gemfile = ENV["BUNDLE_GEMFILE"]
 

--- a/bin/prep-release
+++ b/bin/prep-release
@@ -29,5 +29,6 @@ end
 bump_version_file(version)
 system "bin/bundle"
 bump_npm_package(version)
+system "yarn install --frozen-lockfile"
 system "bin/rake", "dependencies:vendor"
 system "yarn build"

--- a/bin/prep-release
+++ b/bin/prep-release
@@ -29,4 +29,5 @@ end
 bump_version_file(version)
 system "bin/bundle"
 bump_npm_package(version)
+system "bin/rake", "dependencies:vendor"
 system "yarn build"

--- a/tasks/dependencies.rake
+++ b/tasks/dependencies.rake
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+namespace :dependencies do
+  desc "Copy package.json dependencies into vendor/javascript"
+  task :vendor do
+    # Update dependencies
+    system "yarn install --frozen-lockfile"
+
+    node_modules = File.expand_path("../node_modules", __dir__)
+    vendor = File.expand_path("../vendor/javascript", __dir__)
+
+    # Copy flowbite to vendor
+    FileUtils.cp(
+      File.join(node_modules, 'flowbite', 'dist', 'flowbite.min.js'),
+      File.join(vendor, 'flowbite.js')
+    )
+
+    # Delete sourcemaps refs
+    Dir.glob(File.join(vendor, '**', '*.js')).each do |file|
+      content = File.read(file)
+
+      File.write(file, content.gsub(/\/\/# sourceMappingURL=\S+/, ''))
+    end
+  end
+end

--- a/tasks/dependencies.rake
+++ b/tasks/dependencies.rake
@@ -3,9 +3,6 @@
 namespace :dependencies do
   desc "Copy package.json dependencies into vendor/javascript"
   task :vendor do
-    # Update dependencies
-    system "yarn install --frozen-lockfile"
-
     node_modules = File.expand_path("../node_modules", __dir__)
     vendor = File.expand_path("../vendor/javascript", __dir__)
 
@@ -21,5 +18,7 @@ namespace :dependencies do
 
       File.write(file, content.gsub(/\/\/# sourceMappingURL=\S+/, ''))
     end
+  rescue Errno::ENOENT
+    puts "Error: Missing node_modules. Run `yarn install`."
   end
 end

--- a/tasks/test_application.rb
+++ b/tasks/test_application.rb
@@ -18,7 +18,7 @@ module ActiveAdmin
       end
       Bundler.with_original_env do
         Kernel.system("yarn install") # so tailwindcss/plugin is available for test app
-        Kernel.system("rake dependencies:vendor") # so flowbite is available for test app
+        Kernel.system("rake dependencies:vendor") # ensure flowbite is updated for test app
         Dir.chdir(app_dir) do
           Kernel.system("yarn add @activeadmin/activeadmin")
           Kernel.system('npm pkg set scripts.build:css="tailwindcss -i ./app/assets/stylesheets/active_admin.css -o ./app/assets/builds/active_admin.css --minify -c tailwind-active_admin.config.js"')

--- a/tasks/test_application.rb
+++ b/tasks/test_application.rb
@@ -18,6 +18,7 @@ module ActiveAdmin
       end
       Bundler.with_original_env do
         Kernel.system("yarn install") # so tailwindcss/plugin is available for test app
+        Kernel.system("rake dependencies:vendor") # so flowbite is available for test app
         Dir.chdir(app_dir) do
           Kernel.system("yarn add @activeadmin/activeadmin")
           Kernel.system('npm pkg set scripts.build:css="tailwindcss -i ./app/assets/stylesheets/active_admin.css -o ./app/assets/builds/active_admin.css --minify -c tailwind-active_admin.config.js"')


### PR DESCRIPTION
This PR is a WIP. I'm not gonna be able to continue working on it for a while. I'm leaving as a way to show what I was doing.

My goal is to write something general, independent of the dependencies we have today. 

I found an issue with this approach. npm registry is hierarchical while importmaps is not. Let's take `flowbite` dependency as an example. When you pin it using importmaps it adds `@popperjs/core` to the map.

Flowbite has one file in it's package that includes popperjs in it. It's not picked by default. I guess it will be hard to code a universal way of finding this files, if they exists.

I don't want to end with an importmap of the importmap (a file saying which file to download for each importmap exception).

On idea to explore is use importamp.rb comments to decide what to do with the dependency.


```
# Default import
pin "@rails/ujs", to: "@rails--ujs.js" # @7.1.2

# Custom import 
pin "flowbite", preload: true # downloaded from https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.2.1/flowbite.min.js
```

Default imports can be handled with the code that is right now in the PR.

For custom import we can rebuild the URL using package.json version and download the file. If the file is gone, raising an error force us to rewrite the comment with proper URLs.



The idea is not simple. Maybe we can use another approach, like always generate the importmap from package.json. In that case I'm not sure how to force/check that importmap.rb is in sync with package.json. 
