### PR TITLE
Ensure form presenter is applied on create/update actions

### DIFF
--- a/app/controllers/active_admin/resource_controller.rb
+++ b/app/controllers/active_admin/resource_controller.rb
@@ -40,7 +40,7 @@ module ActiveAdmin
       case params[:action].to_sym
       when :index
         active_admin_config.get_page_presenter(params[:action], params[:as])
-      when :new, :edit
+      when :new, :edit, :create, :update
         active_admin_config.get_page_presenter(:form)
       end || super
     end

--- a/plugin.js
+++ b/plugin.js
@@ -513,10 +513,10 @@ module.exports = plugin(
         '@apply text-gray-500 mt-2': {}
       },
       '.formtastic :where(.errors)': {
-        '@apply p-4 mb-2 rounded-lg bg-red-50 text-red-800 dark:bg-red-800 dark:text-red-300': {}
+        '@apply p-4 mb-6 rounded-md space-y-2 bg-red-50 text-red-800 dark:bg-red-800 dark:text-red-300': {}
       },
       '.formtastic :where(.errors > li)': {
-        '@apply list-disc ms-4 mb-1': {}
+        '@apply list-disc ms-4': {}
       },
       '.formtastic :where(.inline-errors)': {
         '@apply font-bold mt-2 text-red-600 dark:text-red-300': {}


### PR DESCRIPTION
This fixes a bug when submitting a form that contains validation errors, the form page presenter wasn't being applied so the default was used. I realized during testing that the `f.semantic_errors` display wasn't having any effect when it should have. With this fix, it now does. This is the same fix as we did for the page title on form submission in #8210 specifically this commit https://github.com/activeadmin/activeadmin/pull/8210/commits/783992e2a9679c6a3230edfb98a0acdcc2664083.

This also fixes some styling issues with the form errors list which is what we were testing. If the list only contains a single item then the bottom margin makes the alignment look off. We now use the space-y-* utility to dynamically control the spacing between child elements from the parent.