### PR TITLE
Use an anchor for tabs component toggle

### DIFF
--- a/lib/active_admin/views/components/tabs.rb
+++ b/lib/active_admin/views/components/tabs.rb
@@ -19,8 +19,8 @@ module ActiveAdmin
 
       def build_menu_item(title, options, &block)
         fragment = options.fetch(:id, fragmentize(title))
-        html_options = options.fetch(:html_options, {}).merge("data-tabs-target": "##{fragment}", role: "tab", "aria-controls": fragment)
-        button html_options do
+        html_options = options.fetch(:html_options, {}).merge("data-tabs-target": "##{fragment}", role: "tab", "aria-controls": fragment, href: "#")
+        a html_options do
           title
         end
       end

--- a/plugin.js
+++ b/plugin.js
@@ -475,8 +475,8 @@ module.exports = plugin(
       '.tabs-nav': {
         '@apply flex flex-wrap mb-2 text-sm font-medium text-center border-b border-gray-200 dark:border-gray-700': {}
       },
-      '.tabs-nav > :where(button)': {
-        '@apply inline-block p-4 border-b-2 border-transparent rounded-t-lg hover:text-gray-600 hover:border-gray-300 dark:hover:text-gray-300': {}
+      '.tabs-nav > :where(a)': {
+        '@apply block p-4 border-b-2 border-transparent rounded-t-md hover:text-gray-600 dark:hover:text-gray-300 no-underline': {}
       },
       '.tabs-content': {
         '@apply p-4 mb-6': {}

--- a/spec/unit/views/components/tabs_spec.rb
+++ b/spec/unit/views/components/tabs_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe ActiveAdmin::Views::Tabs do
       end
 
       it "should have button with specific css class" do
-        expect(subject).to have_button(class: "some_css_class")
+        expect(subject).to have_link(class: "some_css_class")
       end
     end
 
@@ -52,7 +52,7 @@ RSpec.describe ActiveAdmin::Views::Tabs do
       end
 
       it "should create a tab navigation bar based on the symbol" do
-        expect(subject).to have_button("Overview")
+        expect(subject).to have_link("Overview")
       end
 
       it "should create a tab with a span inside of it" do


### PR DESCRIPTION
If using the tabs component within a form, the button styles will conflict. Considering the trade offs, we will replace the button with an anchor for the tab toggle.

I submitted a Flowbite patch in the meantime: https://github.com/themesberg/flowbite/pull/783