### PR TITLE
Drop Ruby 2.7 support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ require:
 
 AllCops:
   DisabledByDefault: true
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
 
   Exclude:
     - tmp/development_apps/**/*

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
     "wiki_uri" => "https://github.com/activeadmin/activeadmin/wiki"
   }
 
-  s.required_ruby_version = ">= 2.7"
+  s.required_ruby_version = ">= 3.0"
 
   s.add_dependency "arbre", "~> 2.0"
   s.add_dependency "formtastic", ">= 3.1"


### PR DESCRIPTION
Copy changes from https://github.com/activeadmin/activeadmin/pull/8158 and resolve merge conflicts. 

Thanks @alejandroperea  for the contribution!