### PR TITLE
Run rubocop against ruby 3.3 by default

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 env:
-  RUBY_VERSION: ${{ vars.RUBOCOP_RUBY_VERSION || '3.2' }}
+  RUBY_VERSION: ${{ vars.RUBOCOP_RUBY_VERSION || '3.3' }}
 
 jobs:
   rubocop:


### PR DESCRIPTION
Now that we test against ruby 3.3 (#8213) it make sense to run Rubocop against Ruby 3.3 by default