### PR TITLE
Use Tailwind's darkMode selector strategy

### DIFF
--- a/lib/generators/active_admin/assets/templates/tailwind.config.js
+++ b/lib/generators/active_admin/assets/templates/tailwind.config.js
@@ -11,7 +11,7 @@ module.exports = {
     './app/views/admin/**/*.{arb,erb,html,rb}',
     './app/javascript/**/*.js'
   ],
-  darkMode: "class",
+  darkMode: "selector",
   plugins: [
     require(`@activeadmin/activeadmin/plugin`)
   ]


### PR DESCRIPTION
Since #8186 we've been using TailwindCSS v3.4.0 which had a behavioral change with dark mode, in v3.4.1 this was resolved through https://github.com/tailwindlabs/tailwindcss/pull/12717 with a new dark mode "selector" strategy so we should be using that instead going forward. The documentation update in https://github.com/tailwindlabs/tailwindcss.com/pull/1781 includes some additional context. The "class" strategy remains supported, just the ideal one is this new one.