### PR TITLE
Recommend using target="_blank" instead of target="blank" (incorrect)

### DIFF
--- a/docs/1-general-configuration.md
+++ b/docs/1-general-configuration.md
@@ -206,7 +206,7 @@ ActiveAdmin.setup do |config|
   config.namespace :admin do |admin|
     admin.build_menu :utility_navigation do |menu|
       menu.add label: "ActiveAdmin.info", url: "https://www.activeadmin.info",
-                                          html_options: { target: :blank }
+                                          html_options: { target: "_blank" }
       admin.add_current_user_to_menu  menu
       admin.add_logout_button_to_menu menu
     end

--- a/docs/2-resource-customization.md
+++ b/docs/2-resource-customization.md
@@ -300,7 +300,7 @@ config.namespace :admin do |admin|
     menu.add label: "Sites" do |sites|
       sites.add label: "Google",
                 url: "https://google.com",
-                html_options: { target: :blank }
+                html_options: { target: "_blank" }
 
       sites.add label: "Facebook",
                 url: "https://facebook.com"

--- a/lib/generators/active_admin/install/templates/active_admin.rb.erb
+++ b/lib/generators/active_admin/install/templates/active_admin.rb.erb
@@ -203,7 +203,7 @@ ActiveAdmin.setup do |config|
   #
   #   config.namespace :admin do |admin|
   #     admin.build_menu :default do |menu|
-  #       menu.add label: "My Great Website", url: "https://mygreatwebsite.example.com", html_options: { target: :blank }
+  #       menu.add label: "My Great Website", url: "https://mygreatwebsite.example.com", html_options: { target: "_blank" }
   #     end
   #   end
 

--- a/spec/unit/menu_item_spec.rb
+++ b/spec/unit/menu_item_spec.rb
@@ -26,8 +26,8 @@ module ActiveAdmin
     end
 
     it "should accept an options hash for link_to" do
-      item = MenuItem.new html_options: { target: :blank }
-      expect(item.html_options).to include(target: :blank)
+      item = MenuItem.new html_options: { target: "_blank" }
+      expect(item.html_options).to include(target: "_blank")
     end
 
     context "with no items" do


### PR DESCRIPTION
Hello,

This is just a small change to some documentation. I noticed that there were some incorrect usages of `target: :blank`, which has also found it's way into some StackOverflow and ChatGPT answers.

You can find more information about this here: https://stackoverflow.com/questions/35703005/what-is-the-difference-between-target-blank-and-target-blank

> blank targets an existing frame or window called "blank". A new window is created only if "blank" doesn't already exist.
> _blank is a reserved name which targets a new, unnamed window.

So I just thought it might be worth opening a PR to show users the correct way to do it. Thanks!