### PR TITLE
Suppress ruby 3.3 warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     activeadmin (4.0.0.beta5)
       arbre (~> 2.0)
+      csv
       formtastic (>= 3.1)
       formtastic_i18n (>= 0.4)
       inherited_resources (~> 1.7)
@@ -124,6 +125,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.0)
       railties (>= 6.0.0)
+    csv (3.3.0)
     cucumber (9.2.0)
       builder (~> 3.2)
       cucumber-ci-environment (> 9, < 11)

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 3.0"
 
   s.add_dependency "arbre", "~> 2.0"
+  s.add_dependency "csv"
   s.add_dependency "formtastic", ">= 3.1"
   s.add_dependency "formtastic_i18n", ">= 0.4"
   s.add_dependency "inherited_resources", "~> 1.7"

--- a/gemfiles/rails_61/Gemfile.lock
+++ b/gemfiles/rails_61/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     activeadmin (4.0.0.beta5)
       arbre (~> 2.0)
+      csv
       formtastic (>= 3.1)
       formtastic_i18n (>= 0.4)
       inherited_resources (~> 1.7)
@@ -107,6 +108,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.0)
       railties (>= 6.0.0)
+    csv (3.3.0)
     cucumber (9.2.0)
       builder (~> 3.2)
       cucumber-ci-environment (> 9, < 11)

--- a/gemfiles/rails_70/Gemfile.lock
+++ b/gemfiles/rails_70/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     activeadmin (4.0.0.beta5)
       arbre (~> 2.0)
+      csv
       formtastic (>= 3.1)
       formtastic_i18n (>= 0.4)
       inherited_resources (~> 1.7)
@@ -113,6 +114,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.0)
       railties (>= 6.0.0)
+    csv (3.3.0)
     cucumber (9.2.0)
       builder (~> 3.2)
       cucumber-ci-environment (> 9, < 11)


### PR DESCRIPTION
We updated the Ruby version of our application to 3.3.1 and got the following warning.

```
/myapp/vendor/bundle/gems/zeitwerk-2.6.13/lib/zeitwerk/kernel.rb:34: warning: csv was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec. Also contact author of activeadmin-3.2.0 to add csv into its gemspec.
```

I have added the csv gem to gemspec as per the warning.