### PR TITLE
Bump parser gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,7 +227,7 @@ GEM
       reline (>= 0.4.2)
     iso (0.4.0)
       i18n
-    json (2.7.1)
+    json (2.7.2)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)
@@ -282,7 +282,7 @@ GEM
     parallel (1.24.0)
     parallel_tests (4.6.0)
       parallel
-    parser (3.3.0.5)
+    parser (3.3.1.0)
       ast (~> 2.4.1)
       racc
     psych (5.1.2)
@@ -365,7 +365,7 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.1)
-    rubocop (1.62.1)
+    rubocop (1.63.4)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -376,8 +376,8 @@ GEM
       rubocop-ast (>= 1.31.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.31.2)
-      parser (>= 3.3.0.4)
+    rubocop-ast (1.31.3)
+      parser (>= 3.3.1.0)
     rubocop-capybara (2.20.0)
       rubocop (~> 1.41)
     rubocop-factory_bot (2.25.1)

--- a/gemfiles/rails_61/Gemfile.lock
+++ b/gemfiles/rails_61/Gemfile.lock
@@ -252,7 +252,7 @@ GEM
     parallel (1.24.0)
     parallel_tests (4.6.0)
       parallel
-    parser (3.3.0.5)
+    parser (3.3.1.0)
       ast (~> 2.4.1)
       racc
     public_suffix (5.0.4)

--- a/gemfiles/rails_70/Gemfile.lock
+++ b/gemfiles/rails_70/Gemfile.lock
@@ -258,7 +258,7 @@ GEM
     parallel (1.24.0)
     parallel_tests (4.6.0)
       parallel
-    parser (3.3.0.5)
+    parser (3.3.1.0)
       ast (~> 2.4.1)
       racc
     public_suffix (5.0.4)


### PR DESCRIPTION
To avoid warnings like

```
warning: parser/current is loading parser/ruby33, which recognizes 3.3.0-compliant syntax, but you are running 3.3.1.
```

when running tests with Ruby 3.3.1.

<!--

Thanks for contributing to ActiveAdmin!

You can find the instructions in our contributing guide: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md

Before submitting your PR make sure that:
* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are separated.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all CI checks are passing, but feel free to ask for early feedback if you need guidance.

[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->
