### PR TITLE
Fix typo in spec context

### DIFF
--- a/spec/helpers/breadcrumb_helper_spec.rb
+++ b/spec/helpers/breadcrumb_helper_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe ActiveAdmin::BreadcrumbHelper, type: :helper do
       end
     end
 
-    context "when path '/admin/users/1/coments/1'" do
+    context "when path '/admin/users/1/posts/1'" do
       let(:path) { "/admin/users/1/posts/1" }
 
       it "should have 4 items" do
@@ -216,7 +216,7 @@ RSpec.describe ActiveAdmin::BreadcrumbHelper, type: :helper do
       end
     end
 
-    context "when path '/admin/users/1/coments/1/edit'" do
+    context "when path '/admin/users/1/posts/1/edit'" do
       let(:path) { "/admin/users/1/posts/1/edit" }
 
       it "should have 5 items" do


### PR DESCRIPTION
Found with `codespell`

The typo was there before #2601, but according to #2601 the intent is to test `/posts/1` and not `comments` anymore
