### PR TITLE
3.2 stable: update gherkin lint actions

### DIFF
--- a/.github/workflows/gherkin-lint.yml
+++ b/.github/workflows/gherkin-lint.yml
@@ -18,8 +18,8 @@ jobs:
     name: Run gherkin-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'


### PR DESCRIPTION
Prevent a deprecation message related to Node 16 actions
