### PR TITLE
Make lockfile platforms easier to maintain

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -489,4 +489,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.9
+   2.5.11

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -447,10 +447,8 @@ GEM
 
 PLATFORMS
   aarch64-linux
-  arm64-darwin-21
-  arm64-darwin-22
-  x86_64-darwin-22
-  x86_64-darwin-23
+  arm64-darwin
+  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -269,4 +269,4 @@ DEPENDENCIES
   github-pages
 
 BUNDLED WITH
-   2.5.9
+   2.5.11

--- a/gemfiles/rails_61/Gemfile.lock
+++ b/gemfiles/rails_61/Gemfile.lock
@@ -405,4 +405,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.5.9
+   2.5.11

--- a/gemfiles/rails_61/Gemfile.lock
+++ b/gemfiles/rails_61/Gemfile.lock
@@ -371,8 +371,7 @@ GEM
     zeitwerk (2.6.13)
 
 PLATFORMS
-  arm64-darwin-21
-  arm64-darwin-22
+  arm64-darwin
   ruby
   x86_64-linux
 

--- a/gemfiles/rails_70/Gemfile.lock
+++ b/gemfiles/rails_70/Gemfile.lock
@@ -377,8 +377,7 @@ GEM
     zeitwerk (2.6.13)
 
 PLATFORMS
-  arm64-darwin-21
-  arm64-darwin-22
+  arm64-darwin
   ruby
   x86_64-linux
 

--- a/gemfiles/rails_70/Gemfile.lock
+++ b/gemfiles/rails_70/Gemfile.lock
@@ -409,4 +409,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.5.9
+   2.5.11


### PR DESCRIPTION
This should work equally well and has less churn when maintainers upgrade their OS or switch platforms.