### PR TITLE
Use `yarn` consistently everywhere

### DIFF
--- a/.github/workflows/gherkin-lint.yml
+++ b/.github/workflows/gherkin-lint.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: yarn
-      - run: bin/yarn install --frozen-lockfile --immutable
+      - run: yarn install --frozen-lockfile --immutable
         if: steps.changed-files.outputs.any_changed == 'true'
-      - run: bin/yarn gherkin-lint
+      - run: yarn gherkin-lint
         if: steps.changed-files.outputs.any_changed == 'true'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Now install the development dependencies:
 ```sh
 gem install foreman
 bundle install
-bin/yarn install
+yarn install
 ```
 
 Now you should be able to run the entire suite using:

--- a/bin/yarn
+++ b/bin/yarn
@@ -1,9 +1,0 @@
-#!/usr/bin/env ruby
-# frozen_string_literal: true
-begin
-  exec "yarnpkg", *ARGV
-rescue Errno::ENOENT
-  $stderr.puts "Yarn executable was not detected in the system."
-  $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
-  exit 1
-end


### PR DESCRIPTION
Just that, I saw that we normally use just `yarn` so I think we can get rid of the binstub.