### PR TITLE
include can now include modules with private included method

### DIFF
--- a/lib/active_admin/dsl.rb
+++ b/lib/active_admin/dsl.rb
@@ -53,7 +53,7 @@ module ActiveAdmin
     #
     # @return [Nil]
     def include(mod)
-      mod.included(self)
+      mod.send(:included, self)
     end
 
     # Returns the controller for this resource. If you pass a


### PR DESCRIPTION
Using Rails 7, ActionView::Helpers::TagHelper has its method `included` set as `private`.

Trying to make

```
ActiveAdmin.register PaperTrail::Version do

  include ActionView::Helpers::TagHelper

end
```

Resulted in `NoMethodError: private method 'included' called for ActionView::Helpers::TagHelper:Module`

Seems that the method became private, changing the call to `send` overrides this error.

It is important to analyze whether is valid to override the Module's visibility configuration or not.

<!--

Thanks for contributing to ActiveAdmin!

You can find the instructions in our contributing guide: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md

Before submitting your PR make sure that:
* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are separated.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all CI checks are passing, but feel free to ask for early feedback if you need guidance.

[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->
