### PR TITLE
Mention the sass-rails dependency in documentation

### DIFF
--- a/docs/0-installation.md
+++ b/docs/0-installation.md
@@ -9,6 +9,9 @@ Active Admin is a Ruby Gem.
 ```ruby
 gem 'activeadmin'
 
+# If you're not using webpacker, ensure you have:
+# gem 'sass-rails'
+
 # Plus integrations with:
 gem 'devise'
 gem 'cancancan'


### PR DESCRIPTION
If think the dependency on sass-rails was removed because of the newer webpacker option, but in some API apps, you can end up not having the sass compiler at hands, this PR just mention it in the setup documentation

<!--

Thanks for contributing to ActiveAdmin!

You can find the instructions in our contributing guide: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md

Before submitting your PR make sure that:
* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are separated.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all CI checks are passing, but feel free to ask for early feedback if you need guidance.

[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->
