### PR TITLE
Allow batch actions without a confirmation dialog

### DIFF
--- a/app/javascript/active_admin/features/batch_actions.js
+++ b/app/javascript/active_admin/features/batch_actions.js
@@ -1,11 +1,20 @@
 import Rails from '@rails/ujs';
 
+const submitForm = function() {
+  let form = document.getElementById("collection_selection")
+  if (form) {
+    form.submit()
+  }
+}
+
 const batchActionClick = function(event) {
   event.preventDefault()
   let batchAction = document.getElementById("batch_action")
   if (batchAction) {
     batchAction.value = this.dataset.action
   }
+
+  if (!event.target.dataset.confirm) { submitForm() }
 }
 
 const batchActionConfirmComplete = function(event) {
@@ -15,10 +24,7 @@ const batchActionConfirmComplete = function(event) {
     if (batchAction) {
       batchAction.value = this.dataset.action
     }
-    let form = document.getElementById("collection_selection")
-    if (form) {
-      form.submit()
-    }
+    submitForm()
   }
 }
 

--- a/features/index/batch_actions.feature
+++ b/features/index/batch_actions.feature
@@ -217,3 +217,23 @@ Feature: Batch Actions
 
     When I press "Submit"
     Then I should see a flash with "Successfully flagged 10 posts"
+
+  @javascript
+  Scenario: Use batch action without confirmation
+    Given 10 posts exist
+    And an index configuration of:
+      """
+      ActiveAdmin.register Post do
+        batch_action :mark_not_starred do |ids|
+          Post.where(id: ids).update_all(starred: false)
+          redirect_to collection_path, notice: "#{ids.count} posts marked as not starred"
+        end
+      end
+      """
+    When I check the 1st record
+    And I check the 3rd record
+    And I press "Batch Actions"
+    Then I should see the batch action :mark_not_starred "Mark Not Starred"
+    When I click "Mark Not Starred"
+    Then I should see a flash with "2 posts marked as not starred"
+    And I should see 10 posts in the table


### PR DESCRIPTION
We have batch actions that don't need to be confirmed, and they should work too. Currently, the click event simply fills the hidden field and doesn't submit the form itself.

This change checks if the batch action has a confirm data-attribute, and if not, it simply submits the form.
