### PR TITLE
Add `use_static_assets` feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@
 /vendor/bundle
 /rails_70
 /dist
+/lib/active_admin/static_assets/assets
 docs/.vitepress/cache
 docs/.vitepress/dist

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ group :development, :test do
 
   gem "cssbundling-rails"
   gem "importmap-rails"
+  gem "tailwindcss-rails", "~> 2.6"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -412,6 +412,14 @@ GEM
     strscan (3.1.0)
     sys-uname (1.3.0)
       ffi (~> 1.1)
+    tailwindcss-rails (2.6.1-aarch64-linux)
+      railties (>= 7.0.0)
+    tailwindcss-rails (2.6.1-arm64-darwin)
+      railties (>= 7.0.0)
+    tailwindcss-rails (2.6.1-x86_64-darwin)
+      railties (>= 7.0.0)
+    tailwindcss-rails (2.6.1-x86_64-linux)
+      railties (>= 7.0.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.3.1)
@@ -470,6 +478,7 @@ DEPENDENCIES
   simplecov-cobertura
   sprockets-rails
   sqlite3 (~> 1.7)
+  tailwindcss-rails (~> 2.6)
   webrick
   yard
 

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,7 @@ require "bundler/gem_tasks"
 import "tasks/local.rake"
 import "tasks/test.rake"
 import "tasks/dependencies.rake"
+import "tasks/static_assets.rake"
 
 gemfile = ENV["BUNDLE_GEMFILE"]
 
@@ -19,3 +20,6 @@ task :console do
   ARGV.clear
   IRB.start
 end
+
+# ensure fresh assets are included when packaging the gem
+task build: :static_assets

--- a/app/controllers/active_admin/base_controller.rb
+++ b/app/controllers/active_admin/base_controller.rb
@@ -10,6 +10,7 @@ module ActiveAdmin
     helper AutoLinkHelper
     helper DisplayHelper
     helper IndexHelper
+    helper StaticAssetsHelper
 
     layout "active_admin"
 

--- a/app/helpers/active_admin/static_assets_helper.rb
+++ b/app/helpers/active_admin/static_assets_helper.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module ActiveAdmin
+  module StaticAssetsHelper
+    def static_stylesheet_link_tag(name)
+      tag.link(rel: :stylesheet, href: "#{static_assets_path}/css/#{name}.css")
+    end
+
+    def static_javascript_importmap_tags(...)
+      Resolver.new(request, self, static_assets_path).javascript_importmap_tags(...)
+    end
+
+    def static_assets_path
+      ActiveAdmin.application.static_assets_path
+    end
+
+    # resolves importmaps to static paths
+    Resolver = Struct.new(:request, :default, :root) do
+      include ActionView::Helpers::TagHelper
+      include Importmap::ImportmapTagsHelper if defined?(Importmap::ImportmapTagsHelper)
+
+      def path_to_asset(path, ...)
+        # Don't try to use static assets for custom additions to importmap
+        unless path.match?(%r{\A(?:active_admin|flowbite|rails_ujs_esm)[/.]})
+          return default.asset_path(path, ...)
+        end
+
+        "#{root}/js/#{path}"
+      end
+    end
+  end
+end

--- a/app/views/active_admin/_html_head.html.erb
+++ b/app/views/active_admin/_html_head.html.erb
@@ -1,4 +1,9 @@
-<%= stylesheet_link_tag "active_admin" %>
+<%- if active_admin_application.use_static_assets %>
+  <%= static_stylesheet_link_tag "active_admin" %>
+<%- else %>
+  <%= stylesheet_link_tag "active_admin" %>
+<%- end %>
+
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <%= csrf_meta_tags %>
 <%= csp_meta_tag %>
@@ -10,4 +15,9 @@
     document.documentElement.classList.remove('dark')
   }
 <% end %>
-<%= javascript_importmap_tags "active_admin", importmap: ActiveAdmin.importmap %>
+
+<%- if active_admin_application.use_static_assets %>
+  <%= static_javascript_importmap_tags "active_admin", importmap: ActiveAdmin.importmap %>
+<%- else %>
+  <%= javascript_importmap_tags "active_admin", importmap: ActiveAdmin.importmap %>
+<%- end %>

--- a/bin/tailwindcss
+++ b/bin/tailwindcss
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+
+require "rubygems"
+require "bundler/setup"
+
+load Gem.bin_path("tailwindcss-rails", "tailwindcss")

--- a/lib/active_admin.rb
+++ b/lib/active_admin.rb
@@ -46,6 +46,7 @@ module ActiveAdmin
   autoload :Scope, "active_admin/scope"
   autoload :ScopeChain, "active_admin/helpers/scope_chain"
   autoload :SidebarSection, "active_admin/sidebar_section"
+  autoload :StaticAssetsMiddleware, "active_admin/static_assets_middleware"
   autoload :TableBuilder, "active_admin/table_builder"
   autoload :ViewHelpers, "active_admin/view_helpers"
   autoload :Views, "active_admin/views"

--- a/lib/active_admin/application_settings.rb
+++ b/lib/active_admin/application_settings.rb
@@ -39,5 +39,12 @@ module ActiveAdmin
 
     # Remove sensitive attributes from being displayed, made editable, or exported by default
     register :filter_attributes, [:encrypted_password, :password, :password_confirmation]
+
+    # Use pre-compiled, static assets included in the gem
+    register :use_static_assets, false # TODO: or default to true?
+
+    # Static assets are served from this path. It includes the VERSION to
+    # invalidate browser caches on gem updates.
+    register :static_assets_path, "/active_admin_static_assets/#{VERSION}"
   end
 end

--- a/lib/active_admin/devise.rb
+++ b/lib/active_admin/devise.rb
@@ -30,6 +30,7 @@ module ActiveAdmin
         layout "active_admin_logged_out"
         helper ::ActiveAdmin::LayoutHelper
         helper ::ActiveAdmin::FormHelper
+        helper ::ActiveAdmin::StaticAssetsHelper
       end
 
       # Redirect to the default namespace on logout

--- a/lib/active_admin/engine.rb
+++ b/lib/active_admin/engine.rb
@@ -41,5 +41,17 @@ module ActiveAdmin
     initializer "active_admin.deprecator" do |app|
       app.deprecators[:activeadmin] = ActiveAdmin.deprecator if app.respond_to?(:deprecators)
     end
+
+    initializer "active_admin.static_assets" do |app|
+      next unless ActiveAdmin.application.use_static_assets
+
+      customizations = Dir[app.root.join('app/assets/{builds,stylesheets}/active_admin.*')]
+      customizations.any? and warn ""\
+        "ActiveAdmin's use_static_assets setting is not compatible with "\
+        "providing core activeadmin assets yourself. You can turn off the "\
+        "setting or remove your custom files: #{customizations}"
+
+      app.middleware.insert 0, ActiveAdmin::StaticAssetsMiddleware
+    end
   end
 end

--- a/lib/active_admin/static_assets_middleware.rb
+++ b/lib/active_admin/static_assets_middleware.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module ActiveAdmin
+  # Catches active admin asset requests and serves them from the gem.
+  class StaticAssetsMiddleware
+    def initialize(app, *)
+      @app = app
+      @regexp = %r{^#{ActiveAdmin.application.static_assets_path}(.*)}
+    end
+
+    def call(env)
+      if asset_path = env[Rack::PATH_INFO][@regexp, 1]
+        static_path = File.join(__dir__, 'static_assets', 'assets', "#{asset_path}.gz")
+        send_data(static_path)
+      else
+        @app.call(env)
+      end
+    end
+
+    # This could be made more efficient with sendfile,
+    # perhaps after checking main_app.config.action_dispatch.x_sendfile_header
+    def send_data(path)
+      data = File.read(path)
+      headers = {
+        'cache-control' => 'public, max-age=86400',
+        'content-encoding' => 'gzip',
+        'content-length' => data.bytesize.to_s,
+        'content-type' => path['.css'] ? 'text/css' : 'text/javascript',
+      }
+      [200, headers, [data]]
+    end
+  end
+end

--- a/lib/generators/active_admin/install/templates/active_admin.rb.erb
+++ b/lib/generators/active_admin/install/templates/active_admin.rb.erb
@@ -25,6 +25,16 @@ ActiveAdmin.setup do |config|
   #     File.join(Rails.root, 'app', 'cashier')
   #   ]
 
+  # == Static assets
+  #
+  # This setting makes Active Admin use included static copies of all
+  # required assets, so that no precompilation and no asset gems are needed,
+  # except of importmap-rails.
+  # Please note that this will prevent you from customizing the tailwind setup
+  # or using tailwind classes that are not already used by Active Admin itself.
+  #
+  # config.use_static_assets = true
+
   # == Default Namespace
   #
   # Set the default namespace each administration resource

--- a/tasks/static_assets.rake
+++ b/tasks/static_assets.rake
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+
+desc 'Create static copies of all assets'
+task static_assets: %w[static_assets:css static_assets:js]
+
+namespace :static_assets do
+  dest_dir = "#{__dir__}/../lib/active_admin/static_assets/assets"
+
+  desc 'Create static copies of stylesheets'
+  task :css do
+    dest = "#{dest_dir}/css/active_admin.css"
+
+    tailwind_command = [
+      "#{__dir__}/../bin/tailwindcss",
+      '-i', "#{__dir__}/../lib/generators/active_admin/assets/templates/active_admin.css",
+      '-o', "#{dest}",
+      '-c', "#{__dir__}/static_assets.tailwind.config.js",
+    ]
+
+    system(*tailwind_command, exception: true)
+    system('gzip', '-f', dest, exception: true)
+  end
+
+  desc 'Create static copies of javascripts'
+  task :js do
+    files = Dir["#{__dir__}/../{app,vendor}/javascript/**/*.js"]
+    files.any? || raise('No javascript files found')
+
+    files.each do |file|
+      relative_path = file.split(%r{(?:app|vendor)/javascript/}).last
+      dest = "#{dest_dir}/js/#{relative_path}"
+      FileUtils.mkdir_p(File.dirname(dest))
+
+      FileUtils.cp(file, dest)
+      system('gzip', '-f', dest, exception: true)
+    end
+  end
+end

--- a/tasks/static_assets.tailwind.config.js
+++ b/tasks/static_assets.tailwind.config.js
@@ -1,0 +1,18 @@
+// TODO: I'm not sure why in lib/generators/active_admin/assets/templates/tailwind.config.js,
+// `plugins` uses the plugin package, though `contents` uses the plugin.js from the gem.
+// If that's by coincidence, and `plugins` can use the one from the gem,
+// then we can use the template and don't need this file at all.
+const execSync = require('child_process').execSync
+const activeAdminPath = execSync('bundle show activeadmin', { encoding: 'utf-8' }).trim()
+
+module.exports = {
+  content: [
+    `${activeAdminPath}/vendor/javascript/flowbite.js`,
+    `${activeAdminPath}/plugin.js`,
+    `${activeAdminPath}/app/views/**/*.{arb,erb,html,rb}`,
+  ],
+  darkMode: "selector",
+  plugins: [
+    `${activeAdminPath}/plugin.js`
+  ]
+}


### PR DESCRIPTION
Related to #8246.

This increases the gem size from 173 to 203 KB (as a side note, it might be worth investigating why it is already so big).

Set `use_static_assets` to true to test. I tested it with sprockets, propshaft, and the default pipeline. Of course this would need some automated tests as well. It could also use a mention in the documentation (UPGRADING.md? web docs?), and possibly a generator flag.
