### PR TITLE
Support async_count for scopes

### DIFF
--- a/lib/active_admin/async_count.rb
+++ b/lib/active_admin/async_count.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module ActiveAdmin
+  class AsyncCount
+    def initialize(collection)
+      @collection = collection.except(:select, :order)
+      @promise = @collection.async_count
+    end
+
+    def count
+      value = @promise.value
+      # value.value due to Rails bug https://github.com/rails/rails/issues/50776
+      value.respond_to?(:value) ? value.value : value
+    end
+
+    delegate :except, :group_values, :length, :limit_value, to: :@collection
+  end
+end

--- a/lib/active_admin/async_count.rb
+++ b/lib/active_admin/async_count.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 module ActiveAdmin
   class AsyncCount
     def initialize(collection)

--- a/lib/active_admin/async_count.rb
+++ b/lib/active_admin/async_count.rb
@@ -12,6 +12,8 @@ module ActiveAdmin
       value.respond_to?(:value) ? value.value : value
     end
 
+    alias size count
+
     delegate :except, :group_values, :length, :limit_value, to: :@collection
   end
 end

--- a/lib/active_admin/async_count.rb
+++ b/lib/active_admin/async_count.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 module ActiveAdmin
   class AsyncCount
+    class NotSupportedError < RuntimeError; end
+
     def initialize(collection)
+      raise NotSupportedError, "#{collection.inspect} does not support :async_count" unless collection.respond_to?(:async_count)
+
       @collection = collection.except(:select, :order)
       @promise = @collection.async_count
     end

--- a/lib/active_admin/scope.rb
+++ b/lib/active_admin/scope.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require "active_admin/async_count"
+
 module ActiveAdmin
   class Scope
 

--- a/lib/active_admin/scope.rb
+++ b/lib/active_admin/scope.rb
@@ -14,6 +14,12 @@ module ActiveAdmin
     #   Scope.new('Published', :public)
     #   # => Scope with name 'Published' and scope method :public
     #
+    #   Scope.new(:published, show_count: :async)
+    #   # => Scope with name 'Published' that queries its count asynchronously
+    #
+    #   Scope.new(:published, show_count: false)
+    #   # => Scope with name 'Published' that does not display a count
+    #
     #   Scope.new 'Published', :public, if: proc { current_admin_user.can? :manage, resource_class } do |articles|
     #     articles.where published: true
     #   end
@@ -59,6 +65,10 @@ module ActiveAdmin
       when Symbol then @localizer ? @localizer.t(@name, scope: "scopes") : @name.to_s.titleize
       else @name
       end
+    end
+
+    def async_count?
+      @show_count == :async
     end
 
   end

--- a/lib/active_admin/scope.rb
+++ b/lib/active_admin/scope.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
-require "active_admin/async_count"
-
 module ActiveAdmin
   class Scope
 

--- a/lib/active_admin/views/components/scopes.rb
+++ b/lib/active_admin/views/components/scopes.rb
@@ -58,9 +58,9 @@ module ActiveAdmin
 
       # Return the count for the scope passed in.
       def get_scope_count(scope)
-        chained = scope_chain(scope, collection_before_scope)
+        chained = @async_counts[scope] || scope_chain(scope, collection_before_scope)
 
-        collection_size(@async_counts[scope] || chained)
+        collection_size(chained)
       end
 
       def group_name(group)

--- a/lib/active_admin/views/components/scopes.rb
+++ b/lib/active_admin/views/components/scopes.rb
@@ -73,14 +73,10 @@ module ActiveAdmin
         call_method_or_exec_proc(scope.display_if_block)
       end
 
-      def async_counts?
-        collection_before_scope.respond_to?(:async_count)
-      end
-
       def prepare_async_counts(scopes, options)
-        @async_counts = if options[:scope_count] && async_counts?
+        @async_counts = if options[:scope_count]
                           scopes
-                            .select(&:show_count)
+                            .select(&:async_count?)
                             .select { |scope| display_scope?(scope) }
                             .index_with { |scope| AsyncCount.new(scope_chain(scope, collection_before_scope)) }
                         else

--- a/lib/active_admin/views/components/scopes.rb
+++ b/lib/active_admin/views/components/scopes.rb
@@ -21,7 +21,7 @@ module ActiveAdmin
         scopes.group_by(&:group).each do |group, group_scopes|
           div class: "index-button-group", role: "group", data: { "group": group_name(group) } do
             group_scopes
-              .select(&method(:display_scope?))
+              .select { |scope| display_scope?(scope) }
               .each { |scope| build_scope(scope, options) }
 
             nil
@@ -81,7 +81,7 @@ module ActiveAdmin
         @async_counts = if options[:scope_count] && async_counts?
                           scopes
                             .select(&:show_count)
-                            .select(&method(:display_scope?))
+                            .select { |scope| display_scope?(scope) }
                             .index_with { |scope| AsyncCount.new(scope_chain(scope, collection_before_scope)) }
                         else
                           {}

--- a/lib/active_admin/views/components/scopes.rb
+++ b/lib/active_admin/views/components/scopes.rb
@@ -20,9 +20,9 @@ module ActiveAdmin
 
         scopes.group_by(&:group).each do |group, group_scopes|
           div class: "index-button-group", role: "group", data: { "group": group_name(group) } do
-            group_scopes
-              .select { |scope| display_scope?(scope) }
-              .each { |scope| build_scope(scope, options) }
+            group_scopes.each do |scope|
+              build_scope(scope, options) if display_scope?(scope)
+            end
 
             nil
           end

--- a/lib/active_admin/views/components/scopes.rb
+++ b/lib/active_admin/views/components/scopes.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "active_admin/async_count"
 require "active_admin/view_helpers/method_or_proc_helper"
 
 module ActiveAdmin

--- a/spec/unit/async_count_spec.rb
+++ b/spec/unit/async_count_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe ActiveAdmin::AsyncCount do
       promise = instance_double(ActiveRecord::Promise, value: Post.count)
       promise_wrapper = instance_double(ActiveRecord::Promise, value: promise)
       collection = class_double(Post, async_count: promise_wrapper)
-      allow(collection).to receive(:except).and_return(collection)
+      expect(collection).to receive(:except).and_return(collection)
 
       expect(described_class.new(collection).count).to eq(Post.count)
     end

--- a/spec/unit/async_count_spec.rb
+++ b/spec/unit/async_count_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe ActiveAdmin::AsyncCount, if: Post.respond_to?(:async_count) do
+  include ActiveAdmin::IndexHelper
+
+  def seed_posts
+    [1, 2].map do |i|
+      Post.create!(title: "Test #{i}", author_id: i * 100)
+    end
+  end
+
+  it "can be passed to the collection_size helper" do
+    seed_posts
+
+    expect(collection_size(described_class.new(Post.all))).to eq(Post.count)
+    expect(collection_size(described_class.new(Post.group(:author_id)))).to eq(Post.distinct.pluck(:author_id).size)
+  end
+
+  describe "#initialize" do
+    it "initiates an async_count query" do
+      collection = Post.all
+      expect(collection).to receive(:async_count)
+      described_class.new(collection)
+    end
+  end
+
+  describe "#count" do
+    before { seed_posts }
+
+    it "returns the result of a count query" do
+      async_count = described_class.new(Post.all)
+      expect(async_count.count).to eq(Post.count)
+    end
+
+    it "returns the Hash of counts for a grouped query" do
+      async_count = described_class.new(Post.group(:author_id))
+      expect(async_count.count).to eq(100 => 1, 200 => 1)
+    end
+
+    # See https://github.com/rails/rails/issues/50776
+    it "works around a Rails 7.1.3 bug with wrapped promises" do
+      promise = instance_double(ActiveRecord::Promise, value: Post.count)
+      promise_wrapper = instance_double(ActiveRecord::Promise, value: promise)
+      collection = class_double(Post, async_count: promise_wrapper)
+      allow(collection).to receive(:except).and_return(collection)
+
+      expect(described_class.new(collection).count).to eq(Post.count)
+    end
+  end
+
+  describe "delegation" do
+    let(:collection) { Post.all }
+
+    %i[
+      except
+      group_values
+      length
+      limit_value
+    ].each do |method|
+      it "delegates #{method}" do
+        allow(collection).to receive(method).and_call_original
+
+        async_count = described_class.new(collection)
+        async_count.public_send(method)
+
+        expect(collection).to have_received(method).at_least(:once)
+      end
+    end
+  end
+end

--- a/spec/unit/scope_spec.rb
+++ b/spec/unit/scope_spec.rb
@@ -199,9 +199,31 @@ RSpec.describe ActiveAdmin::Scope do
       expect(scope.show_count).to eq false
     end
 
+    it "should allow setting of show_count to query counts asynchronously" do
+      scope = ActiveAdmin::Scope.new(:default, nil, show_count: :async)
+      expect(scope.show_count).to eq :async
+    end
+
     it "should set show_count to true if not passed in" do
       scope = ActiveAdmin::Scope.new(:default)
       expect(scope.show_count).to eq true
+    end
+  end
+
+  describe "#async_count?" do
+    it "should return true when show_count is :async" do
+      scope = ActiveAdmin::Scope.new(:default, nil, show_count: :async)
+      expect(scope.async_count?).to eq true
+    end
+
+    it "should return false show_count is not passed in" do
+      scope = ActiveAdmin::Scope.new(:default)
+      expect(scope.async_count?).to eq false
+    end
+
+    it "should return false when show_count is false" do
+      scope = ActiveAdmin::Scope.new(:default, nil, show_count: false)
+      expect(scope.async_count?).to eq false
     end
   end
 

--- a/spec/unit/views/components/scopes_spec.rb
+++ b/spec/unit/views/components/scopes_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe ActiveAdmin::Views::Scopes do
+  describe "the scopes list" do
+    let(:collection) { Post.all }
+    let(:active_admin_config) { ActiveAdmin.register(Post) }
+
+    let(:assigns) do
+      {
+        active_admin_config: active_admin_config,
+        collection_before_scope: collection
+      }
+    end
+
+    let(:helpers) do
+      helpers = mock_action_view
+
+      allow(helpers.request)
+        .to receive(:path_parameters)
+        .and_return(controller: "admin/posts", action: "index")
+
+      helpers
+    end
+
+    let(:configured_scopes) do
+      [
+        ActiveAdmin::Scope.new(:all),
+        ActiveAdmin::Scope.new(:published) { |posts| posts.where.not(published_date: nil) }
+      ]
+    end
+
+    let(:scope_options) do
+      { scope_count: true }
+    end
+
+    let(:scopes) do
+      scopes_to_render = configured_scopes
+      options = scope_options
+
+      render_arbre_component assigns, helpers do
+        insert_tag(ActiveAdmin::Views::Scopes, scopes_to_render, options)
+      end
+    end
+
+    before do
+      allow(ActiveAdmin::AsyncCount).to receive(:new).and_call_original
+    end
+
+    around do |example|
+      with_resources_during(example) { active_admin_config }
+    end
+
+    it "renders the scopes component" do
+      html = Capybara.string(scopes.to_s)
+      expect(html).to have_selector("div.scopes")
+
+      configured_scopes.each do |scope|
+        expect(html).to have_selector("a[href='/admin/posts?scope=#{scope.id}']")
+      end
+    end
+
+    it "uses AsyncCounts when available", if: Post.respond_to?(:async_count) do
+      scopes
+
+      expect(ActiveAdmin::AsyncCount).to have_received(:new).with(Post.all)
+      expect(ActiveAdmin::AsyncCount).to have_received(:new).with(Post.where.not(published_date: nil))
+    end
+
+    it "avoids AsyncCounts when unavailable", unless: Post.respond_to?(:async_count) do
+      scopes
+
+      expect(ActiveAdmin::AsyncCount).not_to have_received(:new)
+    end
+
+    context "when an individual scope is configured to hide its count" do
+      let(:configured_scopes) do
+        [
+          ActiveAdmin::Scope.new(:all, nil, show_count: false)
+        ]
+      end
+
+      it "avoids AsyncCounts" do
+        scopes
+
+        expect(ActiveAdmin::AsyncCount).not_to have_received(:new)
+      end
+    end
+
+    context "when a scope is not to be displayed" do
+      let(:configured_scopes) do
+        [
+          ActiveAdmin::Scope.new(:all, nil, if: -> { false })
+        ]
+      end
+
+      it "avoids AsyncCounts" do
+        scopes
+
+        expect(ActiveAdmin::AsyncCount).not_to have_received(:new)
+      end
+    end
+
+    context "when :show_count is configured as false" do
+      let(:scope_options) do
+        { scope_count: false }
+      end
+
+      it "avoids AsyncCounts" do
+        scopes
+
+        expect(ActiveAdmin::AsyncCount).not_to have_received(:new)
+      end
+    end
+  end
+end

--- a/spec/unit/views/components/scopes_spec.rb
+++ b/spec/unit/views/components/scopes_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe ActiveAdmin::Views::Scopes do
       end
 
       it "raises an error when ActiveRecord async_count is unavailable", unless: Post.respond_to?(:async_count) do
-        expect { scopes }.to raise_error(NoMethodError, %r{async_count})
+        expect { scopes }.to raise_error(ActiveAdmin::AsyncCount::NotSupportedError, %r{does not support :async_count})
       end
 
       context "when async_count is available in Rails", if: Post.respond_to?(:async_count) do

--- a/spec/unit/views/components/scopes_spec.rb
+++ b/spec/unit/views/components/scopes_spec.rb
@@ -53,10 +53,10 @@ RSpec.describe ActiveAdmin::Views::Scopes do
 
     it "renders the scopes component" do
       html = Capybara.string(scopes.to_s)
-      expect(html).to have_selector("div.scopes")
+      expect(html).to have_css("div.scopes")
 
       configured_scopes.each do |scope|
-        expect(html).to have_selector("a[href='/admin/posts?scope=#{scope.id}']")
+        expect(html).to have_css("a[href='/admin/posts?scope=#{scope.id}']")
       end
     end
 


### PR DESCRIPTION
# Background

In ActiveAdmin applications, a surprising performance bottleneck can be the `COUNT` queries that run to provide counts for each scope made available on an resource's index page. In many cases, performance issues can be addressed by adding missing indices and/or otherwise speeding up the underlying query.

There is another performance boost that could be low-hanging fruit, however. The `COUNT` queries for scopes currently run sequentially.  In Rails 7.1, the framework provides the `async_count` method that allows queries to be run in parallel. For index pages with many scopes (and many COUNTs) running queries in parallel could offer a significant time savings.

This PR will use `async_count` to query the collection size of scopes in versions of Rails where `async_count` is available. Rails apps not running on Rails 7.1 will continue to rely on sequential queries.

# Approach

This PR introduces an `ActiveAdmin::AsyncCount` class that quacks enough like an ActiveRecord Relation to play nicely with the `collection_size` helper.  The `ActiveAdmin::Views::Scopes` class eagerly initializes `AsyncCount`s for each scope that is configured like
```ruby
scope(:my_scope, show_count: :async)
```
which kicks off async queries.  As a result, rendering the scopes component should only be as slow as its slowest `COUNT`.

## Closed Questions

* Should the async query behavior be more opt-in? ✅ (it was made more opt-in in the latest commits)
  * ~Should individual scopes have an `async_count: true` option?~ (I choose `show_count: :async` to leverage the existing `show_count` attribute)
  * ~Should the index options support a `scope_count: :async` option?~ (It seems easy enough to configure many scopes to use `async_count` using the `with_options` Rails/ActiveSupport helper.  Example:
```ruby
with_options(show_count: :async) do
  scope(:one)
  scope(:two)
end
```
  * ~Should consumers be able to configure their own `ScopeCounter` class globally and/or per index?~ Not necessary

# Credits

@tuffylock @aturar