### PR TITLE
Remove deprecation warnings when building with dart sass >= 1.77.7

### DIFF
--- a/app/assets/stylesheets/active_admin/_forms.scss
+++ b/app/assets/stylesheets/active_admin/_forms.scss
@@ -220,9 +220,8 @@ form {
   /* Buttons */
 
   input[type=submit], input[type=button], button {
-    @include dark-button;
     cursor: pointer;
-
+    @include dark-button;
   }
 
   .buttons, .actions {

--- a/app/assets/stylesheets/active_admin/components/_comments.scss
+++ b/app/assets/stylesheets/active_admin/components/_comments.scss
@@ -2,10 +2,10 @@
 .comments {
 
   .active_admin_comment {
-    @include clearfix;
     margin-top: 10px;
     margin-bottom: 20px;
     max-width: 700px;
+    @include clearfix;
 
     .active_admin_comment_meta {
       width: 130px;

--- a/app/assets/stylesheets/active_admin/components/_dropdown_menu.scss
+++ b/app/assets/stylesheets/active_admin/components/_dropdown_menu.scss
@@ -3,9 +3,12 @@
 
   .dropdown_menu_button {
     @include light-button;
-    position: relative;
-    padding-right: 22px !important;
-    cursor: pointer;
+
+    & {
+      position: relative;
+      padding-right: 22px !important;
+      cursor: pointer;
+    }
 
     &:before {
       content: ' ';
@@ -139,11 +142,11 @@
         }
 
         &:last-child {
+          border: none;
           a {
             border-bottom-left-radius: 2px;
             border-bottom-right-radius: 2px;
           }
-          border: none;
         }
       }
     }

--- a/app/assets/stylesheets/active_admin/components/_pagination.scss
+++ b/app/assets/stylesheets/active_admin/components/_pagination.scss
@@ -38,8 +38,11 @@
   margin-left: 4px;
   select {
     @include light-button;
-    @include rounded(0px);
-    padding: 1px 5px;
+
+    & {
+      @include rounded(0px);
+      padding: 1px 5px;
+    }
   }
 }
 

--- a/app/assets/stylesheets/active_admin/components/_table_tools.scss
+++ b/app/assets/stylesheets/active_admin/components/_table_tools.scss
@@ -1,6 +1,6 @@
 .table_tools {
-  @include clearfix;
   margin-bottom: 16px;
+  @include clearfix;
 }
 
 .table_tools .dropdown_menu {
@@ -9,11 +9,14 @@
 
 a.table_tools_button, .table_tools .dropdown_menu_button {
   @include light-button;
-  @include gradient(#FFFFFF, #F0F0F0);
-  @include border-colors(#d9d9d9, #d0d0d0, #c5c5c5);
-  font-size: 0.9em;
-  padding: 4px 14px 4px;
-  margin: 0;
+
+  & {
+    @include gradient(#FFFFFF, #F0F0F0);
+    @include border-colors(#d9d9d9, #d0d0d0, #c5c5c5);
+    font-size: 0.9em;
+    padding: 4px 14px 4px;
+    margin: 0;
+  }
 
   &:not(.disabled) {
     &:hover {

--- a/app/assets/stylesheets/active_admin/components/_tabs.scss
+++ b/app/assets/stylesheets/active_admin/components/_tabs.scss
@@ -28,13 +28,16 @@
 
     a {
       @include light-button;
-      @include gradient(#FFFFFF, #F0F0F0);
-      @include border-colors(#d9d9d9, #d0d0d0, #c5c5c5);
-      text-decoration: none;
-      border-radius: 0;
-      border-width: 1px .5px 1px .5px;
-      margin-right: 0;
-      padding: 4px 14px 4px;
+
+      & {
+        @include gradient(#FFFFFF, #F0F0F0);
+        @include border-colors(#d9d9d9, #d0d0d0, #c5c5c5);
+        text-decoration: none;
+        border-radius: 0;
+        border-width: 1px .5px 1px .5px;
+        margin-right: 0;
+        padding: 4px 14px 4px;
+      }
 
       &:not(.disabled) {
         &:hover {

--- a/app/assets/stylesheets/active_admin/mixins/_buttons.scss
+++ b/app/assets/stylesheets/active_admin/mixins/_buttons.scss
@@ -17,13 +17,13 @@
 }
 
 @mixin default-button {
-  @include basic-button;
   @include gradient(lighten($primary-color, 15%), darken($primary-color, 12%));
   @include text-shadow(#000);
   box-shadow: 0 1px 1px rgba(0,0,0,0.10), 0 1px 0 0px rgba(255,255,255, 0.2) inset;
   border: solid 1px #484e53;
   @include border-colors(#616a71, #484e53, #363b3f);
   color: #efefef;
+  @include basic-button;
 
   &:not(.disabled) {
     &:hover{
@@ -38,13 +38,13 @@
 }
 
 @mixin light-button {
-  @include basic-button;
   @include gradient(#FFFFFF, #E7E7E7);
   box-shadow: 0 1px 1px rgba(0,0,0,0.10), 0 1px 0 0 rgba(255,255,255, 0.8) inset;
   border: solid 1px #c7c7c7;
   @include border-colors(#d3d3d3, #c7c7c7, #c2c2c2);
   @include text-shadow;
   color: $primary-color;
+  @include basic-button;
 
   &:not(.disabled) {
     &:hover {

--- a/app/assets/stylesheets/active_admin/pages/_logged_out.scss
+++ b/app/assets/stylesheets/active_admin/pages/_logged_out.scss
@@ -28,13 +28,13 @@ body.logged_out {
         @include no-shadow;
         background: none;
         padding: 0;
+        margin-bottom: 0;
         li { padding: 10px 0; }
 
         input[type=text], input[type=email], input[type=password] {
           width: 70%;
         }
         &.buttons { margin-left: 20%; }
-        margin-bottom: 0;
       }
     }
 

--- a/app/assets/stylesheets/active_admin/structure/_footer.scss
+++ b/app/assets/stylesheets/active_admin/structure/_footer.scss
@@ -10,10 +10,10 @@
 
 // -------------------------------------- Index Footer (Under Table)
 #index_footer {
-  @include clearfix;
   padding-top: 5px;
   text-align: right;
   font-size: 0.85em;
+  @include clearfix;
 }
 
 .index_content { clear: both; }

--- a/app/assets/stylesheets/active_admin/structure/_title_bar.scss
+++ b/app/assets/stylesheets/active_admin/structure/_title_bar.scss
@@ -1,6 +1,5 @@
 #title_bar {
   @include section-header;
-  @include clearfix;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.37);
   display: table;
   border-bottom-color: #EEE;
@@ -9,6 +8,7 @@
   margin: 0;
   padding: 10px $horizontal-page-margin;
   z-index: 800;
+  @include clearfix;
 
   #titlebar_left, #titlebar_right {
     height: 50px;
@@ -32,8 +32,11 @@
     span.action_item {
       & > a, & > .dropdown_menu > a {
         @include light-button;
-        padding: 12px 17px 10px;
-        margin: 0px;
+
+        & {
+          padding: 12px 17px 10px;
+          margin: 0px;
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #8404

The use of declarations after nested rules is currently deprecated in Sass.

We have a bunch of mixins that have nested rules in their definition: basic-button, dark-button, light-button, clearfix.

To be compatible with dartsass, the solution is to move the inclusion of those mixins to the bottom.

In some scenarios, like dropdown_menu_button (dropdown_menu.scss) the intention is to override default button styles. To keep that behaviour I'm using `& {}` which is the recommended way in dartsass to put rules below a nesting.

Read more about the deprecation here https://sass-lang.com/documentation/breaking-changes/mixed-decls/

Sadly libsass does not implement the deprecation. The only way to test this commit is manually (I don't see the point on building a feature test just to check building against a different sass engine. Specially since v4 doesn't use sass).

Steps to test:
````
bin/rake local bundle add dartsass-rails
bin/rake local rails dartsass:install
cp tmp/development_apps/rails_71/app/assets/stylesheets/active_admin.scss tmp/development_apps/rails_71/app/assets/stylesheets/application.scss
bin/rake local rails dartsass:build
````

I tested this won't break anything by compiling CSS using `sassc-rails` and checking rules order. I also did a manual review of development app

NOTE: I tested against Rails 7.1