### PR TITLE
Fix styles for select[multiple] form controls

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -44,7 +44,6 @@ module.exports = plugin(
         "[type='tel']",
         "[type='time']",
         "[type='week']",
-        '[multiple]',
         'textarea',
         'select',
       ]]: {


### PR DESCRIPTION
Hi there!

I had a small problem when using a filter with multiple selection turned on

```ruby
   filter :role_in, as: :select, multiple: true
```

It currently looks like this:

<img width="274" alt="image" src="https://github.com/user-attachments/assets/3a710453-1f46-4288-abb8-5e92ceabfa36">

As you can see, the `<select multiple>` element is getting a white background with white text when in dark mode.

The rule in plugin.js is supposed to kick in and apply some tailwind styles to make things look good in dark mode i.e.
```
      [['[type=date]', '[type=email]', '[type=number]', '[type=password]', '[type=tel]', '[type=text]', '[type=time]', '[type=url]', 'select', 'textarea']]: {
        '@apply bg-gray-50 border border-gray-300 text-gray-900 rounded-md focus:ring-blue-500 focus:border-blue-500 w-full dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500': {}
```

.. but the specificity of the base input styles near the top of plugin.js is getting in the way of applying `dark:bg-gray-700` properly. It's stuck with `background-color: #fff`.

It looks like it is a CSS specificity issue because the rule matches both the `select` and `[multiple]` rules.

This PR removes the `[multiple]` selector on the base input style.. I think it should already be covered by the `select` selector?


Thanks!