### PR TITLE
3.x: Fix strftime month directive

### DIFF
--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -5,7 +5,7 @@ create_file "app/assets/stylesheets/some-random-css.css"
 create_file "app/assets/javascripts/some-random-js.js"
 create_file "app/assets/images/a/favicon.ico"
 
-initial_timestamp = Time.now.strftime("%Y%M%d%H%M%S").to_i
+initial_timestamp = Time.now.strftime("%Y%m%d%H%M%S").to_i
 
 template File.expand_path("templates/migrations/create_posts.tt", __dir__), "db/migrate/#{initial_timestamp}_create_posts.rb"
 


### PR DESCRIPTION
`%M` is minute of the hour, and Rails 7.2 is guarding against invalid timestamps before executing migrations by default

This commit uses the correct zero-padded month directive `%m`

Fix #8368

Ref: https://ruby-doc.org/stdlib-3.1.0/libdoc/date/rdoc/DateTime.html#method-i-strftime

---

Backport of #8369