### PR TITLE
Better implementation of counter-cache-column check

### DIFF
--- a/features/index/filters.feature
+++ b/features/index/filters.feature
@@ -357,3 +357,21 @@ Feature: Index Filtering
     And I press "Filter"
     Then I should see current filter "fancy_filter" equal to "Not Starred" with label "Ransackable Custom Filter"
     And I should see "Hello World"
+
+  Scenario: "counter cache"-like filters
+    Given a user named "Jane Doe" exists
+    And an index configuration of:
+    """
+      ActiveAdmin.register User
+    """
+    When I am on the index page for users
+    Then I should see "Showing 1 of 1"
+    And I should see the following filters:
+     | Sign in count  | number     |
+
+    When I fill in "Sign in count" with "0"
+    And I press "Filter"
+    Then I should see 1 users in the table
+    When I fill in "Sign in count" with "1"
+    And I press "Filter"
+    Then I should see "No Users found"

--- a/features/index/index_as_table.feature
+++ b/features/index/index_as_table.feature
@@ -37,6 +37,15 @@ Feature: Index as Table
     And I should see an id_column link to edit page
     And I should see a link to "Edit"
 
+  Scenario: Viewing the default table with "counter-cache"-like columns
+    Given a user named "Jane Doe" exists
+    And an index configuration of:
+      """
+        ActiveAdmin.register User
+      """
+    When I am on the index page for users
+    Then I should see a sortable table header with "Sign In Count"
+
   Scenario: Customizing the columns with symbols
     Given a post with the title "Hello World" and body "From the body" exists
     And an index configuration of:

--- a/features/show/default_content.feature
+++ b/features/show/default_content.feature
@@ -3,7 +3,7 @@ Feature: Show - Default Content
   Viewing the show page for a resource
 
   Background:
-    Given a unstarred post with the title "Hello World" written by "Jane Doe" exists
+    Given a unstarred post with the title "Hello World" written by "Jane Doe" in category "Stories" exists
 
   Scenario: Viewing the default show page
     Given a show configuration of:
@@ -42,3 +42,20 @@ Feature: Show - Default Content
     And I should see the attribute "Body" with "Empty"
     And I should see the attribute "Created At" with a nicely formatted datetime
     And I should not see the attribute "Author"
+
+  Scenario: Columns with "counter cache"-like names
+    Given a show configuration of:
+      """
+        ActiveAdmin.register User
+      """
+    Then I should see the attribute "First Name" with "Jane"
+    And I should see the attribute "Last Name" with "Doe"
+    And I should see the attribute "Sign In Count" with "0"
+
+  Scenario: Counter cache columns
+    Given a show configuration of:
+      """
+        ActiveAdmin.register Category
+      """
+    Then I should see the attribute "Name" with "Stories"
+    And I should not see the attribute "Posts Count"

--- a/features/step_definitions/configuration_steps.rb
+++ b/features/step_definitions/configuration_steps.rb
@@ -22,6 +22,8 @@ Given /^a(?:n? (index|show))? configuration of:$/ do |action, config_content|
       step "I am on the index page for posts"
     when "Category"
       step "I am on the index page for categories"
+    when "User"
+      step "I am on the index page for users"
     else
       # :nocov:
       raise "#{resource} is not supported"
@@ -32,6 +34,14 @@ Given /^a(?:n? (index|show))? configuration of:$/ do |action, config_content|
     when "Post"
       step "I am logged in"
       step "I am on the index page for posts"
+      step 'I follow "View"'
+    when "User"
+      step "I am logged in"
+      step "I am on the index page for users"
+      step 'I follow "View"'
+    when "Category"
+      step "I am logged in"
+      step "I am on the index page for categories"
       step 'I follow "View"'
     when "Tag"
       step "I am logged in"

--- a/features/step_definitions/filter_steps.rb
+++ b/features/step_definitions/filter_steps.rb
@@ -21,6 +21,10 @@ Then /^I should see a date range filter for "([^"]*)"$/ do |label|
   expect(page).to have_css ".filters-form-field.date_range label", text: label
 end
 
+Then /^I should see a number filter for "([^"]*)"$/ do |label|
+  expect(page).to have_css ".filters-form-field.numeric label", text: label
+end
+
 Then /^I should see the following filters:$/ do |table|
   table.rows_hash.each do |label, type|
     step %{I should see a #{type} filter for "#{label}"}

--- a/lib/active_admin/resource/attributes.rb
+++ b/lib/active_admin/resource/attributes.rb
@@ -37,7 +37,14 @@ module ActiveAdmin
       end
 
       def counter_cache_col?(c)
-        c.name.end_with?("_count")
+        # This helper is called inside a loop. Let's memoize the result.
+        @counter_cache_columns ||= begin
+          resource_class.reflect_on_all_associations(:has_many)
+                        .select(&:has_cached_counter?)
+                        .map(&:counter_cache_column)
+        end
+
+        @counter_cache_columns.include?(c.name)
       end
 
       def filtered_col?(c)

--- a/spec/support/templates/migrations/create_categories.tt
+++ b/spec/support/templates/migrations/create_categories.tt
@@ -3,6 +3,7 @@ class CreateCategories < ActiveRecord::Migration[<%= Rails::VERSION::MAJOR %>.<%
     create_table :categories do |t|
       t.string :name
       t.text :description
+      t.integer :posts_count, default: 0
       t.datetime :created_at
       t.datetime :updated_at
     end

--- a/spec/support/templates/migrations/create_users.tt
+++ b/spec/support/templates/migrations/create_users.tt
@@ -8,6 +8,7 @@ class CreateUsers < ActiveRecord::Migration[<%= Rails::VERSION::MAJOR %>.<%= Rai
       t.integer :age
       t.string :encrypted_password
       t.string :reason_of_sign_in
+      t.integer :sign_in_count, default: 0
       t.datetime :created_at
       t.datetime :updated_at
     end

--- a/spec/support/templates/models/post.rb
+++ b/spec/support/templates/models/post.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class Post < ApplicationRecord
-  belongs_to :category, foreign_key: :custom_category_id, optional: true
+  belongs_to :category, foreign_key: :custom_category_id, optional: true, counter_cache: true
   belongs_to :author, class_name: "User", optional: true
   has_many :taggings
   has_many :tags, through: :taggings

--- a/spec/unit/resource/attributes_spec.rb
+++ b/spec/unit/resource/attributes_spec.rb
@@ -32,6 +32,22 @@ module ActiveAdmin
         expect(subject).to_not include :published_date
         ActiveAdmin.application.filter_attributes = keep
       end
+
+      context "when resource has a counter cache" do
+        subject { ActiveAdmin::Resource.new(namespace, Category).resource_attributes }
+
+        it "should not include counter cache column" do
+          expect(subject.keys).not_to include(:posts_count)
+        end
+      end
+
+      context "when resource has a 'counter cache'-like column" do
+        subject { ActiveAdmin::Resource.new(namespace, User).resource_attributes }
+
+        it "should include that attribute" do
+          expect(subject).to include(sign_in_count: :sign_in_count)
+        end
+      end
     end
 
     describe "#association_columns" do


### PR DESCRIPTION
Reimplementation of https://github.com/activeadmin/activeadmin/pull/7347.
Fixes https://github.com/activeadmin/activeadmin/issues/7346.

Thanks @plashchynski for the work!

Original Issue:
```
I have a model with some column ends with a "_count" substring.
This column doesn't appear on a show page.
It should appear as It is a regular column just like any other.
```