### PR TITLE
Update changelog_uri in gemspec metadata to GitHub Releases

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/activeadmin/activeadmin/issues",
-    "changelog_uri" => "https://github.com/activeadmin/activeadmin/blob/master/CHANGELOG.md",
+    "changelog_uri" => "https://github.com/activeadmin/activeadmin/releases",
     "documentation_uri" => "https://activeadmin.info",
     "homepage_uri" => "https://activeadmin.info",
     "mailing_list_uri" => "https://groups.google.com/group/activeadmin",


### PR DESCRIPTION
The gem metadata published to Rubygems points to the CHANGELOG.md file, but this is no longer the official changelog of record. The file says:

> Future changelogs have moved to GitHub Releases

This commit updates the gemspec metadata to point to GitHub Releases so that future releases to Rubygems contain the correct URL.