### PR TITLE
Add tbody_html and row_html options to TableFor and IndexAsTable

### DIFF
--- a/docs/3-index-pages/index-as-table.md
+++ b/docs/3-index-pages/index-as-table.md
@@ -196,13 +196,22 @@ index do
 end
 ```
 
-## Custom row class
+## Custom tbody HTML attributes
 
-In order to add special class to table rows pass the proc object as a `:row_class` option
-of the `index` method.
+In order to add HTML attributes to the tbody use the `:tbody_html` option.
 
 ```ruby
-index row_class: ->elem { 'active' if elem.active? } do
+index tbody_html: { class: "my-class", data: { controller: 'stimulus-controller' } } do
+  # columns
+end
+```
+
+## Custom row HTML attributes
+
+In order to add HTML attributes to table rows, use a proc object in the `:row_html` option.
+
+```ruby
+index row_html: ->elem { { class: ('active' if elem.active?), data: { 'element-id' => elem.id } } } do
   # columns
 end
 ```

--- a/lib/active_admin/views/components/table_for.rb
+++ b/lib/active_admin/views/components/table_for.rb
@@ -16,6 +16,9 @@ module ActiveAdmin
         @resource_class ||= @collection.klass if @collection.respond_to? :klass
 
         @columns = []
+        @tbody_html = options.delete(:tbody_html)
+        @row_html = options.delete(:row_html)
+        # To be deprecated, please use row_html instead.
         @row_class = options.delete(:row_class)
 
         build_table
@@ -91,10 +94,12 @@ module ActiveAdmin
       end
 
       def build_table_body
-        @tbody = tbody do
+        @tbody = tbody **(@tbody_html || {}) do
           # Build enough rows for our collection
           @collection.each do |elem|
-            tr(id: dom_id_for(elem), class: @row_class&.call(elem))
+            html_options = @row_html&.call(elem) || {}
+            html_options.reverse_merge!(class: @row_class&.call(elem))
+            tr(id: dom_id_for(elem), **html_options)
           end
         end
       end

--- a/lib/active_admin/views/index_as_table.rb
+++ b/lib/active_admin/views/index_as_table.rb
@@ -196,17 +196,25 @@ module ActiveAdmin
     # end
     # ```
     #
-    # ## Custom row class
+    # ## Custom tbody HTML attributes
     #
-    # In order to add special class to table rows pass the proc object as a `:row_class` option
-    # of the `index` method.
+    # In order to add HTML attributes to the tbody use the `:tbody_html` option.
     #
     # ```ruby
-    # index row_class: ->elem { 'active' if elem.active? } do
+    # index tbody_html: { class: "my-class", data: { controller: 'stimulus-controller' } } do
     #   # columns
     # end
     # ```
     #
+    # ## Custom row HTML attributes
+    #
+    # In order to add HTML attributes to table rows, use a proc object in the `:row_html` option.
+    #
+    # ```ruby
+    # index row_html: ->elem { { class: ('active' if elem.active?), data: { 'element-id' => elem.id } } } do
+    #   # columns
+    # end
+    # ```
     class IndexAsTable < ActiveAdmin::Component
       def build(page_presenter, collection)
         add_class "index-as-table"
@@ -215,6 +223,9 @@ module ActiveAdmin
           sortable: true,
           i18n: active_admin_config.resource_class,
           paginator: page_presenter[:paginator] != false,
+          tbody_html: page_presenter[:tbody_html],
+          row_html: page_presenter[:row_html],
+          # To be deprecated, please use row_html instead.
           row_class: page_presenter[:row_class]
         }
 

--- a/spec/unit/views/components/table_for_spec.rb
+++ b/spec/unit/views/components/table_for_spec.rb
@@ -294,7 +294,24 @@ RSpec.describe ActiveAdmin::Views::TableFor do
       end
     end
 
-    context "when row_class" do
+    context "with tbody_html option" do
+      let(:table) do
+        render_arbre_component assigns, helpers do
+          table_for(collection, tbody_html: { class: "my-class", data: { size: collection.size } }) do
+            column :starred
+          end
+        end
+      end
+
+      it "should render data-size attribute within tbody tag" do
+        tbody = table.find_by_tag("tbody").first
+        expect(tbody.attributes).to include(
+          class: "my-class",
+          data: { size: 3 })
+      end
+    end
+
+    context "with row_class (soft deprecated)" do
       let(:table) do
         render_arbre_component assigns, helpers do
           table_for(collection, row_class: -> e { "starred" if e.starred }) do
@@ -310,6 +327,34 @@ RSpec.describe ActiveAdmin::Views::TableFor do
         expect(trs.second.class_list.to_s).to eq "starred"
         expect(trs.third.class_list.to_s).to eq ""
         expect(trs.fourth.class_list.to_s).to eq ""
+      end
+    end
+
+    context "with row_html options (takes precedence over deprecated row_class)" do
+      let(:table) do
+        render_arbre_component assigns, helpers do
+          table_for(
+            collection,
+            row_class: -> e { "foo" },
+            row_html: -> e {
+              {
+                class: ("starred" if e.starred),
+                data: { title: e.title },
+              }
+            }
+          ) do
+            column :starred
+          end
+        end
+      end
+
+      it "should render html attributes within collection row" do
+        trs = table.find_by_tag("tr")
+        expect(trs.size).to eq 4
+        expect(trs.first.attributes).to be_empty
+        expect(trs.second.attributes).to include(class: "starred", data: { title: "First Post" })
+        expect(trs.third.attributes).to include(class: nil, data: { title: "Second Post" })
+        expect(trs.fourth.attributes).to include(class: nil, data: { title: "Third Post" })
       end
     end
 


### PR DESCRIPTION
This patch adds a `tbody_html` and `row_html` options to the `TableFor` (and
`IndexAsTable`) classes. These options allow you to pass a hash of HTML options
attributes to the `tbody` and `tr` elements.

This is useful when you want to add features to the table that require data
attributes. For example, adding a sortable row via JavaScript.

You can see how I'm currently using this approach in [this app](https://github.com/acp-admin/acp-admin):
- [monkey patching](https://github.com/acp-admin/acp-admin/blob/master/config/initializers/active_admin.rb#L261-L328) (same approach as this PR)
- [using both options on a `table_for` method](https://github.com/acp-admin/acp-admin/blob/master/app/views/active_admin/deliveries/_baskets.html.arb#L10-L13) for using [Stimulus Sortable component](https://www.stimulus-components.com/docs/stimulus-sortable/).

The existing `row_class` option is kept for backwards compatibility, but the
`row_html` will take precedence if both are provided.