### PR TITLE
Add active admin layouts to tailwind config

### DIFF
--- a/lib/generators/active_admin/assets/templates/tailwind.config.js
+++ b/lib/generators/active_admin/assets/templates/tailwind.config.js
@@ -9,6 +9,7 @@ module.exports = {
     './app/admin/**/*.{arb,erb,html,rb}',
     './app/views/active_admin/**/*.{arb,erb,html,rb}',
     './app/views/admin/**/*.{arb,erb,html,rb}',
+    './app/views/layouts/active_admin*.{arb,erb,html,rb}',
     './app/javascript/**/*.js'
   ],
   darkMode: "selector",


### PR DESCRIPTION
The generated tailwind config includes all the partials that are copied to an app but does not include the layouts. This PR adds the layouts.