### PR TITLE
Bug Fix: Rails 7.1 Composite Primary Key Display Name Fallback

### DIFF
--- a/app/helpers/active_admin/display_helper.rb
+++ b/app/helpers/active_admin/display_helper.rb
@@ -5,7 +5,12 @@ module ActiveAdmin
       klass = self.class
       name = if klass.respond_to?(:model_name)
                if klass.respond_to?(:primary_key)
-                 "#{klass.model_name.human} ##{send(klass.primary_key)}"
+                 primary_key = if klass.primary_key.is_a? Array
+                                 "(#{klass.primary_key.map { |key| "#{key}: #{send(key)}" }.join(" / ")})"
+                               else
+                                 send(klass.primary_key)
+                               end
+                 "#{klass.model_name.human} ##{primary_key}"
                else
                  klass.model_name.human
                end


### PR DESCRIPTION
This PR is a rewrite of #8425 applied to the `main` branch.

---

The changes fixe an issue in Rails 7.1 where because Composite Primary Keys are supported, `primary_key` can return an array.

In this case we iterate the array and produce an output of the form:

```
Model #(key1: value1 / key2: value 2)
```
