### PR TITLE
Bug Fix: Rails 7.1 Query Contraints multiple foreign keys

### DIFF
--- a/lib/active_admin/resource/attributes.rb
+++ b/lib/active_admin/resource/attributes.rb
@@ -21,7 +21,7 @@ module ActiveAdmin
         @foreign_methods ||= resource_class.reflect_on_all_associations.
           select { |r| r.macro == :belongs_to }.
           reject { |r| r.chain.length > 2 && !r.options[:polymorphic] }.
-          index_by { |r| r.foreign_key.to_sym }
+          index_by { |r| (r.foreign_key.is_a?( Array ) ? r.foreign_key.join( '-' ) : r.foreign_key).to_sym }
       end
 
       def reject_col?(c)

--- a/lib/active_admin/resource/attributes.rb
+++ b/lib/active_admin/resource/attributes.rb
@@ -21,7 +21,7 @@ module ActiveAdmin
         @foreign_methods ||= resource_class.reflect_on_all_associations.
           select { |r| r.macro == :belongs_to }.
           reject { |r| r.chain.length > 2 && !r.options[:polymorphic] }.
-          index_by { |r| (r.foreign_key.is_a?( Array ) ? r.foreign_key.join( '-' ) : r.foreign_key).to_sym }
+          index_by { |r| (r.foreign_key.is_a?(Array) ? r.foreign_key.join('-') : r.foreign_key).to_sym }
       end
 
       def reject_col?(c)


### PR DESCRIPTION
This fixes another Rails 7.1 issue when `query_constraints` are specified. In this case, `foreign_key` returns said query constraints.

See the method implementation here:

```ruby

def foreign_key(infer_from_inverse_of: true)
  @foreign_key ||= if options[:query_constraints]
    options[:query_constraints].map { |fk| fk.to_s.freeze }.freeze
  elsif options[:foreign_key]
    options[:foreign_key].to_s
  else
    derived_fk = derive_foreign_key(infer_from_inverse_of: infer_from_inverse_of)

    if active_record.has_query_constraints?
      derived_fk = derive_fk_query_constraints(derived_fk)
    end

    derived_fk
  end
end
```

This addresses the issue by checking if `foreign_key` is an array and joining it's elements into a string.