### PR TITLE
Fix batch action with partial and no confirm doesn't submit the form on click

### DIFF
--- a/app/javascript/active_admin/features/batch_actions.js
+++ b/app/javascript/active_admin/features/batch_actions.js
@@ -14,7 +14,7 @@ const batchActionClick = function(event) {
     batchAction.value = this.dataset.action
   }
 
-  if (!event.target.dataset.confirm) { submitForm() }
+  if (!event.target.dataset.confirm && !event.target.dataset.modalTarget) { submitForm() }
 }
 
 const batchActionConfirmComplete = function(event) {

--- a/features/index/batch_actions.feature
+++ b/features/index/batch_actions.feature
@@ -204,6 +204,8 @@ Feature: Batch Actions
         batch_action :set_starred, partial: "starred_batch_action_form", link_html_options: { "data-modal-target": "starred-batch-action-modal", "data-modal-show": "starred-batch-action-modal" } do |ids, inputs|
           if inputs["starred"].present?
             redirect_to collection_path, notice: "Successfully flagged 10 posts"
+          else
+            redirect_to collection_path, notice: "Didn't flag any posts"
           end
         end
       end


### PR DESCRIPTION
<!--

Thanks for contributing to ActiveAdmin!

You can find the instructions in our contributing guide: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md

Before submitting your PR make sure that:
* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are separated.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all CI checks are passing, but feel free to ask for early feedback if you need guidance.

[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->

A batch action rendered with a partial is automatically being submitted when the batch action is clicked as a result of https://github.com/activeadmin/activeadmin/pull/8389. The form is being submitted automatically if there is no `confirm` dataset attribute.

The batch action feature test was incorrectly passing because it was not re-rendering the page unless `inputs["starred"]` was present.

Fixes #8440