### PR TITLE
Be able to customize Tag resource form

### DIFF
--- a/features/edit_page.feature
+++ b/features/edit_page.feature
@@ -6,8 +6,11 @@ Feature: Edit Page
     Given a category named "Music" exists
     And a user named "John Doe" exists
     And a post with the title "Hello World" written by "John Doe" exists
+    And a tag named "Bugs" exists
     And I am logged in
-    And a configuration of:
+
+  Scenario: Default form with no config
+    Given a configuration of:
     """
       ActiveAdmin.register Post do
         permit_params :custom_category_id, :author_id, :title,
@@ -15,9 +18,7 @@ Feature: Edit Page
       end
     """
     When I am on the index page for posts
-
-  Scenario: Default form with no config
-    Given I follow "Edit"
+    And I follow "Edit"
     Then the "Title" field should contain "Hello World"
     And the "Body" field should contain ""
     And the "Category" field should contain ""
@@ -47,6 +48,7 @@ Feature: Edit Page
         end
       end
     """
+    When I am on the index page for posts
     And I follow "Edit"
     Then I should see a fieldset titled "Your Post"
     And I should see a fieldset titled "Publishing"
@@ -76,6 +78,7 @@ Feature: Edit Page
         end
       end
     """
+    When I am on the index page for posts
     And I follow "New"
     Then I follow "Posts"
     And I follow "Edit"
@@ -107,6 +110,7 @@ Feature: Edit Page
         form partial: "form"
       end
     """
+    When I am on the index page for posts
     And I follow "Edit"
     Then the "Title" field should contain "Hello World"
     And the "Body" field should contain ""
@@ -115,3 +119,20 @@ Feature: Edit Page
     Then I should see "Post was successfully updated."
     And I should see the attribute "Title" with "Hello World from update"
     And I should see the attribute "Author" with "John Doe"
+
+  Scenario: Generating a custom form for Tag resource
+    Given a configuration of:
+    """
+      ActiveAdmin.register Tag do
+        form do |f|
+          f.inputs "Details" do
+            f.input :name
+          end
+          f.actions
+        end
+      end
+    """
+    When I am on the index page for tags
+    And I follow "Edit"
+    Then I should see a fieldset titled "Details"
+    And the "Name" field should contain "Bugs"

--- a/features/step_definitions/factory_steps.rb
+++ b/features/step_definitions/factory_steps.rb
@@ -28,6 +28,10 @@ Given /^a store named "([^"]*)" exists$/ do |name|
   Store.create! name: name
 end
 
+Given /^a tag named "([^"]*)" exists$/ do |name|
+  Tag.create! name: name
+end
+
 Given /^I create a new post with the title "([^"]*)"$/ do |title|
   first(:link, "Posts").click
   click_on "New Post"

--- a/lib/active_admin/views/components/active_admin_form.rb
+++ b/lib/active_admin/views/components/active_admin_form.rb
@@ -131,7 +131,7 @@ module ActiveAdmin
         html_options[:class] ||= "inputs"
         legend = args.shift if args.first.is_a?(::String)
         legend = html_options.delete(:name) if html_options.key?(:name)
-        legend_tag = legend ? tag.legend(legend, class: "fieldset-title") : ""
+        legend_tag = legend ? helpers.tag.legend(legend, class: "fieldset-title") : ""
         fieldset_attrs = tag_attributes html_options
         @opening_tag = "<fieldset #{fieldset_attrs}>#{legend_tag}<ol>"
         @closing_tag = "</ol></fieldset>"
@@ -144,9 +144,9 @@ module ActiveAdmin
         if Rails::VERSION::MAJOR <= 6
           # Reimplement tag.attributes to backport support for Rails 6.1.
           # TODO: this can be removed when support for Rails 6.x is dropped
-          tag.tag_options(html_options.to_h).to_s.strip.html_safe
+          helpers.tag.tag_options(html_options.to_h).to_s.strip.html_safe
         else
-          tag.attributes html_options
+          helpers.tag.attributes html_options
         end
       end
     end


### PR DESCRIPTION
https://github.com/activeadmin/activeadmin/pull/8439 improved form attributes rendering but introduced an issue if host app has an admin for Tag resource.

The following code (generated by our template app) raise errors

```ruby
# admin/tags.rb
ActiveAdmin.register Tag do
  form do |f|
    f.inputs "Details" do
      f.input :name
    end
    f.actions
  end
end
```

The problem is that `tag` (`tag.attributes`) evaluates to the resource and not the `TagHelper`.

The default form works because it's rendered in a different scope (view context?).

The problem surfaced during backport development: https://github.com/activeadmin/activeadmin/pull/8446.

Let's prefix the call with `helpers`.

<!--

Thanks for contributing to ActiveAdmin!

You can find the instructions in our contributing guide: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md

Before submitting your PR make sure that:
* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are separated.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all CI checks are passing, but feel free to ask for early feedback if you need guidance.

[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->
