### PR TITLE
Update @rails/ujs to 7.1.400

### DIFF
--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 pin "flowbite", preload: true # downloaded from https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.2.1/flowbite.min.js
-pin "@rails/ujs", to: "rails_ujs_esm.js", preload: true # downloaded from https://cdn.jsdelivr.net/npm/@rails/ujs@7.1.2/+esm
+pin "@rails/ujs", to: "rails_ujs_esm.js", preload: true # downloaded from https://cdn.jsdelivr.net/npm/@rails/ujs@7.1.400/+esm
 pin "active_admin", to: "active_admin.js", preload: true
 pin_all_from File.expand_path("../app/javascript/active_admin", __dir__), under: "active_admin", preload: true

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@rails/ujs": "7.1.2",
+    "@rails/ujs": "7.1.400",
     "flowbite": "2.3.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -191,10 +191,10 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@rails/ujs@7.1.2":
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-7.1.2.tgz#ea903bcc0224e17156015d995b6f1b83e27d64b2"
-  integrity sha512-c5x02djEKEVVE4qfN4XgElJS4biM0xxtIVpcJ0ZHLK116U19rowTtmD0AJ/RCb3Xaewa4GPIWLlwgeC0dCQqzw==
+"@rails/ujs@7.1.400":
+  version "7.1.400"
+  resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-7.1.400.tgz#b2a76bdccb5197b9e866954536106386c87cfab5"
+  integrity sha512-YwvXm3BR5tn+VCAKYGycLejMRVZE3Ionj5gFjEeGXCZnI0Rpi+7dKpmyu90kdUY7dRUFpHTdu9zZceEzFLl38w==
 
 "@rollup/plugin-alias@^5.1.0":
   version "5.1.0"


### PR DESCRIPTION
It is the same file except for the version number. The new numbering will help with security releases (7.1.4.1 => 7.1.401)

Ref: https://guides.rubyonrails.org/maintenance_policy.html#npm-packages
