### PR TITLE
Use consistent text-like inputs selector list for CSS styles

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -312,7 +312,7 @@ module.exports = plugin(
       '[type=radio]': {
         '@apply w-4 h-4 border-gray-300 focus:ring-2 focus:ring-blue-300 dark:focus:ring-blue-600 dark:focus:bg-blue-600 dark:bg-gray-700 dark:border-gray-600': {}
       },
-      [['[type=date]', '[type=email]', '[type=number]', '[type=password]', '[type=tel]', '[type=text]', '[type=time]', '[type=url]', 'select', 'textarea']]: {
+      [['[type=datetime-local]', '[type=month]', '[type=week]', '[type=search]', '[type=date]', '[type=email]', '[type=number]', '[type=password]', '[type=tel]', '[type=text]', '[type=time]', '[type=url]', 'select', 'textarea']]: {
         '@apply bg-gray-50 border border-gray-300 text-gray-900 rounded-md focus:ring-blue-500 focus:border-blue-500 w-full dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500': {}
       },
       'a': {


### PR DESCRIPTION
Previously, inputs with type=datetime-local, type=search, type=week and type=month were missing some tailwind styles.

Before:
![screenshot-20240825-125818](https://github.com/user-attachments/assets/3f7f4614-6201-4374-bf84-1f8cd7ace3a9)

After:
![screenshot-20240825-125752](https://github.com/user-attachments/assets/ed0fbb95-3c3d-4682-8ed3-a4b8503d5ffb)
