### PR TITLE
Use attribute_types instead of columns_hash to determine type

### DIFF
--- a/app/helpers/active_admin/display_helper.rb
+++ b/app/helpers/active_admin/display_helper.rb
@@ -108,8 +108,8 @@ module ActiveAdmin
       when TrueClass, FalseClass
         true
       else
-        if resource.class.respond_to? :columns_hash
-          column = resource.class.columns_hash[attr.to_s] and column.type == :boolean
+        if resource.class.respond_to? :attribute_types
+          resource.class.attribute_types[attr.to_s].is_a?(ActiveModel::Type::Boolean)
         end
       end
     end

--- a/spec/helpers/display_helper_spec.rb
+++ b/spec/helpers/display_helper_spec.rb
@@ -223,6 +223,22 @@ RSpec.describe ActiveAdmin::DisplayHelper, type: :helper do
       expect(value.to_s).to eq "<span class=\"status-tag\" data-status=\"yes\">Yes</span>\n"
     end
 
+    context "with non-database boolean attribute" do
+      let(:model_class) do
+        Class.new(Post) do
+          attribute :a_virtual_attribute, :boolean
+        end
+      end
+
+      it "calls status_tag even when attribute is nil" do
+        post = model_class.new a_virtual_attribute: nil
+
+        value = helper.format_attribute post, :a_virtual_attribute
+
+        expect(value.to_s).to eq "<span class=\"status-tag\" data-status=\"unset\">Unknown</span>\n"
+      end
+    end
+
     it "calls status_tag for boolean non-database values" do
       post = Post.new
       post.define_singleton_method(:true_method) do


### PR DESCRIPTION
Previously, virtual attributes of type boolean with value `nil` would not be rendered as status tag. This also improves boolean detection in rare cases when an `attribute` declaration overrides the type detected in the database.

`attribute_types` existed already in Rails 6.1, so it should be safe to use.