### PR TITLE
Unify specifying label in attributes_table component

### DIFF
--- a/lib/active_admin/views/components/attributes_table.rb
+++ b/lib/active_admin/views/components/attributes_table.rb
@@ -23,6 +23,7 @@ module ActiveAdmin
 
       def row(*args, &block)
         title = args[0]
+        data = args[1] || args[0]
         options = args.extract_options!
         options["data-row"] = title.to_s.parameterize(separator: "_") if title.present?
 
@@ -32,7 +33,7 @@ module ActiveAdmin
           end
           @collection.each do |record|
             td do
-              content_for(record, block || title)
+              content_for(record, block || data)
             end
           end
         end

--- a/spec/unit/views/components/attributes_table_spec.rb
+++ b/spec/unit/views/components/attributes_table_spec.rb
@@ -47,6 +47,15 @@ RSpec.describe ActiveAdmin::Views::AttributesTable do
           end
         end
       },
+      "when you create each row with a string and symbol" => proc {
+        render_arbre_component(assigns) do
+          attributes_table_for post do
+            row "Id", :id
+            row "Title", :title
+            row "Body", :body
+          end
+        end
+      },
       "when you create each row with a custom block that returns nil" => proc {
         render_arbre_component(assigns) do
           attributes_table_for post do


### PR DESCRIPTION
In-repo clone of https://github.com/activeadmin/activeadmin/pull/5661.

-------

Up to now, the only way to specify a label in a row in attributes_table was by using the first argument. The data was then taken from executing a block:
```
attributes_table do
  row 'Renamed' do |r|
    r.username
  end
end
```

This pull request allows for syntax:
```
attributes_table do
  row 'Renamed', :username
end
```

The same syntax is used by index:
```
index do
    column 'Renamed', :username
end
```

Closes #3359, closes #167