### PR TITLE
Move theme setup script into a partial

### DIFF
--- a/app/views/active_admin/_html_head.html.erb
+++ b/app/views/active_admin/_html_head.html.erb
@@ -2,12 +2,6 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <%= csrf_meta_tags %>
 <%= csp_meta_tag %>
-<% # On page load or when changing themes, best to add inline in `head` to avoid FOUC %>
-<%= javascript_tag nonce: true do %>
-  if (localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
-    document.documentElement.classList.add('dark')
-  } else {
-    document.documentElement.classList.remove('dark')
-  }
-<% end %>
+
+<%= render 'active_admin/shared/theme_setup' %>
 <%= javascript_importmap_tags "active_admin", importmap: ActiveAdmin.importmap %>

--- a/app/views/active_admin/shared/_theme_setup.erb
+++ b/app/views/active_admin/shared/_theme_setup.erb
@@ -1,0 +1,8 @@
+<% # On page load or when changing themes, best to add inline in `head` to avoid FOUC %>
+<%= javascript_tag nonce: true do %>
+  if (localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+    document.documentElement.classList.add('dark')
+  } else {
+    document.documentElement.classList.remove('dark')
+  }
+<% end %>


### PR DESCRIPTION
Keep the logic to intialize the them "private".

Users don't need to know the JS we use when they install views.

Simplify the update process for users if we ever make any change to
that.
