### PR TITLE
Restore inner span tag to form inputs legend (3-0-stable)

### DIFF
--- a/lib/active_admin/views/components/active_admin_form.rb
+++ b/lib/active_admin/views/components/active_admin_form.rb
@@ -127,7 +127,7 @@ module ActiveAdmin
         html_options[:class] ||= "inputs"
         legend = args.shift if args.first.is_a?(::String)
         legend = html_options.delete(:name) if html_options.key?(:name)
-        legend_tag = legend ? helpers.tag.legend(legend, class: "fieldset-title") : ""
+        legend_tag = legend ? helpers.tag.legend(helpers.tag.span(legend), class: "fieldset-title") : ""
         fieldset_attrs = tag_attributes html_options
         @opening_tag = "<fieldset #{fieldset_attrs}>#{legend_tag}<ol>"
         @closing_tag = "</ol></fieldset>"

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -84,12 +84,16 @@ RSpec.describe ActiveAdmin::FormBuilder do
       it "should use the rails helper for rendering attributes" do
         expect(body).to have_css("fieldset[data-test='custom']")
       end
+
+      it "should generate a legend with an inner span containing the name" do
+        expect(body).to have_selector("fieldset legend span", text: "custom_name")
+      end
     end
 
     context "with XSS payload as name" do
       let :body do
         build_form do |f|
-          f.inputs name: '<script>alert(document.domain)</script>' do
+          f.inputs name: "<script>alert(document.domain)</script>" do
             f.input :title
             f.input :body
           end


### PR DESCRIPTION
Fixes the issue described here: https://github.com/activeadmin/activeadmin/issues/8466