### PR TITLE
perform_database_query_matcher should be truthy as long as one query matches

### DIFF
--- a/spec/support/matchers/perform_database_query_matcher.rb
+++ b/spec/support/matchers/perform_database_query_matcher.rb
@@ -7,7 +7,9 @@ RSpec::Matchers.define :perform_database_query do |query|
     @match = nil
 
     callback = lambda do |_name, _started, _finished, _unique_id, payload|
-      @match ||= query_regexp.match?(payload[:sql])
+      if query_regexp.match?(payload[:sql])
+        @match = true
+      end
     end
 
     ActiveSupport::Notifications.subscribed(callback, "sql.active_record", &block)

--- a/spec/support/matchers/perform_database_query_matcher.rb
+++ b/spec/support/matchers/perform_database_query_matcher.rb
@@ -7,7 +7,7 @@ RSpec::Matchers.define :perform_database_query do |query|
     @match = nil
 
     callback = lambda do |_name, _started, _finished, _unique_id, payload|
-      @match = query_regexp.match?(payload[:sql])
+      @match ||= query_regexp.match?(payload[:sql])
     end
 
     ActiveSupport::Notifications.subscribed(callback, "sql.active_record", &block)


### PR DESCRIPTION
Found while working in https://github.com/activeadmin/activeadmin/pull/8470

Before this commit the order or SQL queries matter:

- match, not match

results in a false matching when it should be true

