### PR TITLE
Use ActiveRecord::Base .with_connection rather than .connection

### DIFF
--- a/lib/active_admin/resource.rb
+++ b/lib/active_admin/resource.rb
@@ -120,7 +120,9 @@ module ActiveAdmin
     end
 
     def resource_quoted_column_name(column)
-      resource_class.connection.quote_column_name(column)
+      resource_class.with_connection do |connection|
+        connection.quote_column_name(column)
+      end
     end
 
     # Clears all the member actions this resource knows about

--- a/lib/active_admin/resource.rb
+++ b/lib/active_admin/resource.rb
@@ -120,8 +120,14 @@ module ActiveAdmin
     end
 
     def resource_quoted_column_name(column)
-      resource_class.with_connection do |connection|
-        connection.quote_column_name(column)
+      if resource_class.respond_to?(:with_connection)
+        # Rails >= 7.2
+        resource_class.with_connection do |connection|
+          connection.quote_column_name(column)
+        end
+      else
+        # Rails < 7.2
+        resource_class.connection.quote_column_name(column)
       end
     end
 

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -100,6 +100,7 @@ end
 if Rails.gem_version >= Gem::Version.new("7.2")
   # Disable permanent connection checkout.
   # ActiveRecord::Base.connection was soft-deprecated in Rails 7.2. Let's make sure we are not using it.
+  # NOTE: Specs will ignore this setting, unless they opt out of transactional fixtures via `uses_transaction`.
   inject_into_file "config/application.rb", after: "class Application < Rails::Application" do
     "\n    config.active_record.permanent_connection_checkout = :disallowed\n"
   end

--- a/spec/unit/order_clause_spec.rb
+++ b/spec/unit/order_clause_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe ActiveAdmin::OrderClause do
       expect(subject.to_sql).to eq '"posts"."id" asc'
     end
 
-    # Prevents automatically wrapping each specified test in a transaction,
-    # to allow application logic transactions to be tested in a top-level.
+    # Prevents automatically wrapping this test in a transaction. Check that we use the proper method to get a connection from the pool to quote the clause.
+    # We don't want to run the test using a leased connection https://github.com/rails/rails/blob/v7.2.1/activerecord/lib/active_record/test_fixtures.rb#L161
     uses_transaction "#to_sql prepends table name"
   end
 

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -42,11 +42,8 @@ module ActiveAdmin
         expect(config.resource_quoted_column_name('first_name')).to eq '"first_name"'
       end
 
-      # Prevents automatically wrapping each specified test in a transaction,
-      # to allow application logic transactions to be tested in a top-level.
-      #
-      # Let's make sure we don't wrap the example in a fixture transaction. We don't want to run the
-      # test using a leased connection https://github.com/rails/rails/blob/v7.2.1/activerecord/lib/active_record/test_fixtures.rb#L161
+      # Prevents automatically wrapping this test in a transaction. Check that we use the proper method to get a connection from the pool.
+      # We don't want to run the test using a leased connection https://github.com/rails/rails/blob/v7.2.1/activerecord/lib/active_record/test_fixtures.rb#L161
       uses_transaction "should return quote argument"
     end
 


### PR DESCRIPTION
Per comment [here][1], calling `ActiveRecord::Base.connection` is soft-deprecated, so this change uses `with_connection`, instead.

[1]: https://github.com/rails/rails/blob/v7.2.1/activerecord/lib/active_record/connection_handling.rb#L259