### PR TITLE
Drop Ruby 3.0 compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,10 +28,6 @@ jobs:
           - rails_72
           - rails_71
           - rails_70
-        include:
-          - ruby: '3.0'
-            os: ubuntu-latest
-            rails: rails_71
     steps:
       - uses: actions/checkout@v4
       - name: Configure bundler (default)

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ require:
 
 AllCops:
   DisabledByDefault: true
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
   TargetRailsVersion: 7.0
 
   Exclude:
@@ -331,6 +331,7 @@ Style/FrozenStringLiteralComment:
 
 Style/HashSyntax:
   Enabled: true
+  EnforcedShorthandSyntax: never
 
 Style/ParallelAssignment:
   Enabled: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,7 +212,7 @@ GEM
       railties (>= 6.0)
       responders (>= 2)
     io-console (0.7.2)
-    irb (1.14.0)
+    irb (1.14.1)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     iso (0.4.0)
@@ -337,7 +337,7 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.3.7)
+    rexml (3.3.8)
     rspec-core (3.13.1)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.3)
@@ -400,10 +400,10 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
-    sqlite3 (2.0.4-aarch64-linux-gnu)
-    sqlite3 (2.0.4-arm64-darwin)
-    sqlite3 (2.0.4-x86_64-darwin)
-    sqlite3 (2.0.4-x86_64-linux-gnu)
+    sqlite3 (2.1.0-aarch64-linux-gnu)
+    sqlite3 (2.1.0-arm64-darwin)
+    sqlite3 (2.1.0-x86_64-darwin)
+    sqlite3 (2.1.0-x86_64-linux-gnu)
     stringio (3.1.1)
     sys-uname (1.3.0)
       ffi (~> 1.1)
@@ -470,4 +470,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.19
+   2.5.20

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
     "wiki_uri" => "https://github.com/activeadmin/activeadmin/wiki"
   }
 
-  s.required_ruby_version = ">= 3.0"
+  s.required_ruby_version = ">= 3.1"
 
   s.add_dependency "arbre", "~> 2.0"
   s.add_dependency "csv"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -244,7 +244,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.3.7)
+    rexml (3.3.8)
     rouge (3.30.0)
     rubyzip (2.3.2)
     safe_yaml (1.0.5)
@@ -275,4 +275,4 @@ DEPENDENCIES
   github-pages
 
 BUNDLED WITH
-   2.5.19
+   2.5.20

--- a/gemfiles/rails_70/Gemfile.lock
+++ b/gemfiles/rails_70/Gemfile.lock
@@ -312,7 +312,7 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.3.7)
+    rexml (3.3.8)
     rspec-core (3.13.1)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.3)
@@ -403,4 +403,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.5.19
+   2.5.20

--- a/gemfiles/rails_71/Gemfile.lock
+++ b/gemfiles/rails_71/Gemfile.lock
@@ -215,7 +215,7 @@ GEM
       railties (>= 6.0)
       responders (>= 2)
     io-console (0.7.2)
-    irb (1.14.0)
+    irb (1.14.1)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     iso (0.4.0)
@@ -337,7 +337,7 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.3.7)
+    rexml (3.3.8)
     rspec-core (3.13.1)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.3)
@@ -372,10 +372,10 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
-    sqlite3 (2.0.4)
+    sqlite3 (2.1.0)
       mini_portile2 (~> 2.8.0)
-    sqlite3 (2.0.4-arm64-darwin)
-    sqlite3 (2.0.4-x86_64-linux-gnu)
+    sqlite3 (2.1.0-arm64-darwin)
+    sqlite3 (2.1.0-x86_64-linux-gnu)
     stringio (3.1.1)
     sys-uname (1.3.0)
       ffi (~> 1.1)
@@ -431,4 +431,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.5.19
+   2.5.20

--- a/tasks/test_application.rb
+++ b/tasks/test_application.rb
@@ -32,23 +32,22 @@ module ActiveAdmin
       FileUtils.mkdir_p base_dir
       args = %W(
         -m spec/support/#{template}.rb
+        --skip-action-cable
         --skip-action-mailbox
         --skip-action-text
         --skip-active-storage
-        --skip-action-cable
         --skip-bootsnap
+        --skip-brakeman
+        --skip-ci
         --skip-decrypted-diffs
         --skip-dev-gems
         --skip-docker
         --skip-git
         --skip-hotwire
         --skip-jbuilder
-        --skip-listen
-        --skip-spring
-        --skip-turbolinks
-        --skip-test
+        --skip-rubocop
         --skip-system-test
-        --skip-webpack-install
+        --skip-test
         --javascript=importmap
       )
 


### PR DESCRIPTION
Also improve test app generator flags:
- Add `brakeman`, `ci`, and `rubocop` skips
- Remove `listen`, `spring`, `turbolinks`, and `webpack-install` skips,
  dropped in Rails 7.0
- Sort remaining skips