### PR TITLE
Update dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,9 @@ group :development, :test do
 
   gem "cssbundling-rails"
   gem "importmap-rails"
+
+  # FIXME: relax this dependency when Ruby 3.1 support will be dropped
+  gem "zeitwerk", "~> 2.6.18"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,7 +202,7 @@ GEM
       rails-i18n
       rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
-    importmap-rails (2.0.1)
+    importmap-rails (2.0.3)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
@@ -341,7 +341,7 @@ GEM
     rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.1)
+    rspec-mocks (3.13.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-rails (7.0.1)
@@ -377,7 +377,7 @@ GEM
       rack (>= 1.1)
       rubocop (>= 1.52.0, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
-    rubocop-rspec (3.0.5)
+    rubocop-rspec (3.1.0)
       rubocop (~> 1.61)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
@@ -463,6 +463,7 @@ DEPENDENCIES
   sprockets-rails
   sqlite3
   webrick
+  zeitwerk (~> 2.6.18)
 
 BUNDLED WITH
-   2.5.20
+   2.5.21

--- a/gemfiles/rails_70/Gemfile
+++ b/gemfiles/rails_70/Gemfile
@@ -16,6 +16,9 @@ group :development, :test do
 
   gem "cssbundling-rails"
   gem "importmap-rails"
+
+  # FIXME: relax this dependency when Ruby 3.1 support will be dropped
+  gem "zeitwerk", "~> 2.6.18"
 end
 
 group :test do

--- a/gemfiles/rails_70/Gemfile.lock
+++ b/gemfiles/rails_70/Gemfile.lock
@@ -193,7 +193,7 @@ GEM
       rails-i18n
       rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
-    importmap-rails (2.0.1)
+    importmap-rails (2.0.3)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
@@ -318,7 +318,7 @@ GEM
     rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.1)
+    rspec-mocks (3.13.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-rails (7.0.1)
@@ -401,6 +401,7 @@ DEPENDENCIES
   sprockets-rails
   sqlite3 (~> 1.7)
   webrick
+  zeitwerk (~> 2.6.18)
 
 BUNDLED WITH
-   2.5.20
+   2.5.21

--- a/gemfiles/rails_71/Gemfile
+++ b/gemfiles/rails_71/Gemfile
@@ -18,6 +18,9 @@ group :development, :test do
 
   gem "cssbundling-rails"
   gem "importmap-rails"
+
+  # FIXME: relax this dependency when Ruby 3.1 support will be dropped
+  gem "zeitwerk", "~> 2.6.18"
 end
 
 group :test do

--- a/gemfiles/rails_71/Gemfile.lock
+++ b/gemfiles/rails_71/Gemfile.lock
@@ -205,7 +205,7 @@ GEM
       rails-i18n
       rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
-    importmap-rails (2.0.1)
+    importmap-rails (2.0.3)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
@@ -343,7 +343,7 @@ GEM
     rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.1)
+    rspec-mocks (3.13.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-rails (7.0.1)
@@ -429,6 +429,7 @@ DEPENDENCIES
   sprockets-rails
   sqlite3
   webrick
+  zeitwerk (~> 2.6.18)
 
 BUNDLED WITH
-   2.5.20
+   2.5.21


### PR DESCRIPTION
Pin zeitwerk to `~> 2.6.18` because 2.7.0 only supports Ruby >= 3.2
