### PR TITLE
Ignore I18n-tasks config

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -18,6 +18,7 @@ search:
   # Files or `File.fnmatch` patterns to exclude from search
   exclude:
     - app/assets/images
+    - lib/generators
     - tasks/tmp
 
   # Guess usages such as t("categories.#{category}.title")
@@ -35,3 +36,7 @@ ignore_inconsistent_interpolations:
   - active_admin.pagination.multiple
   - active_admin.pagination.multiple_without_total
   - active_admin.blank_slate.content
+
+ignore_missing:
+  - errors.messages.not_saved # Devise
+  - views.pagination.* # Kaminari


### PR DESCRIPTION
Prevents i18n-tasks from reporting false positive missing locale keys

```
| all | date.formats              | lib/generators/active_admin/install/templates/active_admin.rb.erb:171 |
| all | errors.messages.not_saved | app/views/active_admin/devise/shared/_error_messages.html.erb:4       |
| all | views.pagination.truncate | app/views/active_admin/kaminari/_gap.html.erb:9                       |
```

- Ignore `lib/generators` because they contain an example of date format
- Ignore `errors.messages.not_saved` (Devise)
- Ignore `views.pagination` (Kaminari)
