### PR TITLE
Add I18n health check

### DIFF
--- a/.github/workflows/i18n-health.yml
+++ b/.github/workflows/i18n-health.yml
@@ -1,0 +1,33 @@
+name: I18n health
+
+on:
+  pull_request:
+
+env:
+  RUBY_VERSION: ${{ vars.RUBOCOP_RUBY_VERSION || '3.3' }}
+
+jobs:
+  i18n_health:
+    name: Run i18n-tasks health
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_ONLY: ${{ vars.RUBOCOP_BUNDLE_ONLY || 'translations' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tj-actions/changed-files@v45
+        id: changed-files
+        with:
+          files: |
+            .github/workflows/i18n-health.yml
+            app
+            config/i18n-tasks.yml
+            config/locales/*.yml
+            lib
+      - uses: ruby/setup-ruby@v1
+        if: steps.changed-files.outputs.any_changed == 'true'
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
+      - name: Run i18n-tasks health
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: bin/i18n-tasks health

--- a/Gemfile
+++ b/Gemfile
@@ -37,8 +37,9 @@ group :test do
   gem "parallel_tests"
   gem "rspec-rails"
   gem "sqlite3", platform: :mri
+end
 
-  # Translations
+group :test, :translations do
   gem "i18n-tasks"
   gem "i18n-spec"
   gem "rails-i18n" # Provides default i18n for many languages

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -34,6 +34,7 @@ ar:
       resource: مصدر
       resource_type: نوع المصدر
       title_content: تعليقات (%{count})
+    create_another: Create another %{model}
     dashboard: لوحة تحكم
     delete: حذف
     delete_confirmation: هل تريد تأكيد الحذف؟
@@ -58,6 +59,8 @@ ar:
         title: تسجيل الدخول
       password:
         title: كلمة المرور
+      password_confirmation:
+        title: Confirm Password
       resend_confirmation_instructions:
         submit: إعادة ارسال تعليمات التأكيد
         title: إعادة ارسال تعليمات التأكيد
@@ -82,12 +85,16 @@ ar:
       buttons:
         clear: تفريغ التصفية
         filter: تصفية
+      predicates:
+        from: From
+        to: To
     has_many_delete: حذف
     has_many_new: إضافة %{model} جديد
     has_many_remove: إزالة
     index_list:
       table: جدول
     logout: تسجيل الخروج
+    move: Move
     new_model: "%{model} جديد"
     next: التالي
     pagination:
@@ -97,12 +104,19 @@ ar:
         other: مدخلات
       multiple: عرض %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> من <b>%{total}</b> بالمجمل
       multiple_without_total: عرض %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      next: Next
       one: عرض <b>1</b> %{model}
       one_page: عرض <b>all %{n}</b> %{model}
+      per_page: 'Per page '
+      previous: Previous
     powered_by: تنفيذ %{active_admin} %{version}
     previous: السابق
+    scopes:
+      all: All
     search_status:
       no_current_filters: بدون
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: المُرشحات
       search_status: حالات البحث
@@ -110,4 +124,24 @@ ar:
       'no': لا
       unset: لا
       'yes': نعم
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: عرض
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Author type
+        body: Body
+        created_at: Created
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Updated
+    models:
+      active_admin/comment:
+        one: Comment
+        other: Comments
+      comment:
+        one: Comment
+        other: Comments

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -13,8 +13,12 @@ ar:
         destroy: حذف
       selection_toggle_explanation: "(تتبيث الخيار)"
       succesfully_destroyed:
+        few: حُذف بنجاح %{count} %{plural_model}
+        many: حُذف بنجاح %{count} %{plural_model}
         one: حُذف بنجاح 1 %{model}
         other: حُذف بنجاح %{count} %{plural_model}
+        two: حُذف بنجاح %{count} %{plural_model}
+        zero: حُذف بنجاح %{count} %{plural_model}
     blank_slate:
       content: لايوجد %{resource_name} بعد.
       link: إنشاء
@@ -100,8 +104,12 @@ ar:
     pagination:
       empty: 'لا يوجد %{model} '
       entry:
+        few: مدخلات
+        many: مدخلات
         one: مدخل
         other: مدخلات
+        two: مدخلات
+        zero: مدخلات
       multiple: عرض %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> من <b>%{total}</b> بالمجمل
       multiple_without_total: عرض %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
       next: Next
@@ -140,8 +148,16 @@ ar:
         updated_at: Updated
     models:
       active_admin/comment:
+        few: Comments
+        many: Comments
         one: Comment
         other: Comments
+        two: Comments
+        zero: Comments
       comment:
+        few: Comments
+        many: Comments
         one: Comment
         other: Comments
+        two: Comments
+        zero: Comments

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -1,112 +1,113 @@
+---
 ar:
   active_admin:
-    dashboard: "لوحة تحكم"
-    view: "عرض"
-    edit: "تعديل"
-    delete: "حذف"
-    delete_confirmation: "هل تريد تأكيد الحذف؟"
-    new_model: "%{model} جديد"
-    edit_model: "تعديل %{model}"
-    delete_model: "حذف %{model}"
-    details: "تفاصيل %{model}"
-    cancel: "إلغاء"
-    empty: "فارغ"
-    previous: "السابق"
-    next: "التالي"
-    download: "تحميل"
-    has_many_new: "إضافة %{model} جديد"
-    has_many_delete: "حذف"
-    has_many_remove: "إزالة"
+    access_denied:
+      message: لم يُصرّح لك بهذا الإجراء.
+    any: أي
+    batch_actions:
+      action_label: اُختير %{title}
+      button_label: إجراءات متعددة
+      default_confirmation: هل أنت متأكّد؟
+      delete_confirmation: هل أنت متأكّد من حذف هذه %{plural_model}؟
+      labels:
+        destroy: حذف
+      selection_toggle_explanation: "(تتبيث الخيار)"
+      succesfully_destroyed:
+        one: حُذف بنجاح 1 %{model}
+        other: حُذف بنجاح %{count} %{plural_model}
+    blank_slate:
+      content: لايوجد %{resource_name} بعد.
+      link: إنشاء
+    cancel: إلغاء
+    comments:
+      add: إضافة تعليق
+      author: مؤلّف
+      author_missing: مجهول
+      author_type: نوع الؤلّف
+      body: هيكل
+      created_at: أُنشئ
+      delete: حذف تعليق
+      delete_confirmation: هل أنت متأكّد من حذف هذه التعليقات؟
+      errors:
+        empty_text: لم يُحفظ التعليق، النص فارغ.
+      no_comments_yet: لا يوجد تعليقات بعد.
+      resource: مصدر
+      resource_type: نوع المصدر
+      title_content: تعليقات (%{count})
+    dashboard: لوحة تحكم
+    delete: حذف
+    delete_confirmation: هل تريد تأكيد الحذف؟
+    delete_model: حذف %{model}
+    details: تفاصيل %{model}
+    devise:
+      change_password:
+        submit: تغير كلمة المرور خاصتي
+        title: تغير كلمة المرور خاصتك
+      email:
+        title: البريد الإلكترونيّ
+      links:
+        forgot_your_password: هل نسيت كلمة المرور؟
+        resend_confirmation_instructions: إعادة إرسال تعليمات تأكيد الحساب
+        resend_unlock_instructions: إعادة إرسال تعليمات تنشيط الحساب
+        sign_in: تسجيل الدخول
+        sign_in_with_omniauth_provider: تسجيل الدخول بـ %{provider}
+        sign_up: التسجيل
+      login:
+        remember_me: تذكرني
+        submit: تسجيل الدخول
+        title: تسجيل الدخول
+      password:
+        title: كلمة المرور
+      resend_confirmation_instructions:
+        submit: إعادة ارسال تعليمات التأكيد
+        title: إعادة ارسال تعليمات التأكيد
+      reset_password:
+        submit: استرجاع كلمة المرور
+        title: هل نسيت كلمة المرور؟
+      sign_up:
+        submit: تسجيل
+        title: تسجيل
+      subdomain:
+        title: مجال فرعي
+      unlock:
+        submit: إعادة إرسال تعليمات فك الحظر
+        title: إعادة إرسال تعليمات فك الحظر
+      username:
+        title: اسم المستخدم
+    download: تحميل
+    edit: تعديل
+    edit_model: تعديل %{model}
+    empty: فارغ
     filters:
       buttons:
-        filter: "تصفية"
-        clear: "تفريغ التصفية"
-    search_status:
-      no_current_filters: "بدون"
-    status_tag:
-      "yes": "نعم"
-      "no": "لا"
-      "unset": "لا"
-    logout: "تسجيل الخروج"
-    powered_by: "تنفيذ %{active_admin} %{version}"
-    sidebars:
-      filters: "المُرشحات"
-      search_status: "حالات البحث"
-    pagination:
-      empty: "لا يوجد %{model} "
-      one: "عرض <b>1</b> %{model}"
-      one_page: "عرض <b>all %{n}</b> %{model}"
-      multiple: "عرض %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> من <b>%{total}</b> بالمجمل"
-      multiple_without_total: "عرض %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      entry:
-        one: "مدخل"
-        other: "مدخلات"
-    any: "أي"
-    blank_slate:
-      content: "لايوجد %{resource_name} بعد."
-      link: "إنشاء"
-    batch_actions:
-      button_label: "إجراءات متعددة"
-      default_confirmation: "هل أنت متأكّد؟"
-      delete_confirmation: "هل أنت متأكّد من حذف هذه %{plural_model}؟"
-      succesfully_destroyed:
-        one: "حُذف بنجاح 1 %{model}"
-        other: "حُذف بنجاح %{count} %{plural_model}"
-      selection_toggle_explanation: "(تتبيث الخيار)"
-      action_label: "اُختير %{title}"
-      labels:
-        destroy: "حذف"
-    comments:
-      resource_type: "نوع المصدر"
-      author_type: "نوع الؤلّف"
-      body: "هيكل"
-      author: "مؤلّف"
-      add: "إضافة تعليق"
-      resource: "مصدر"
-      no_comments_yet: "لا يوجد تعليقات بعد."
-      author_missing: "مجهول"
-      title_content: "تعليقات (%{count})"
-      errors:
-        empty_text: "لم يُحفظ التعليق، النص فارغ."
-      created_at: "أُنشئ"
-      delete: "حذف تعليق"
-      delete_confirmation: "هل أنت متأكّد من حذف هذه التعليقات؟"
-    devise:
-      username:
-        title: "اسم المستخدم"
-      email:
-        title: "البريد الإلكترونيّ"
-      subdomain:
-        title: "مجال فرعي"
-      password:
-        title: "كلمة المرور"
-      sign_up:
-        title: "تسجيل"
-        submit: "تسجيل"
-      login:
-        title: "تسجيل الدخول"
-        remember_me: "تذكرني"
-        submit: "تسجيل الدخول"
-      reset_password:
-        title: "هل نسيت كلمة المرور؟"
-        submit: "استرجاع كلمة المرور"
-      change_password:
-        title: "تغير كلمة المرور خاصتك"
-        submit: "تغير كلمة المرور خاصتي"
-      unlock:
-        title: "إعادة إرسال تعليمات فك الحظر"
-        submit: "إعادة إرسال تعليمات فك الحظر"
-      resend_confirmation_instructions:
-        title: "إعادة ارسال تعليمات التأكيد"
-        submit: "إعادة ارسال تعليمات التأكيد"
-      links:
-        sign_up: "التسجيل"
-        sign_in: "تسجيل الدخول"
-        forgot_your_password: "هل نسيت كلمة المرور؟"
-        sign_in_with_omniauth_provider: "تسجيل الدخول بـ %{provider}"
-        resend_unlock_instructions: "إعادة إرسال تعليمات تنشيط الحساب"
-        resend_confirmation_instructions: "إعادة إرسال تعليمات تأكيد الحساب"
-    access_denied:
-      message: "لم يُصرّح لك بهذا الإجراء."
+        clear: تفريغ التصفية
+        filter: تصفية
+    has_many_delete: حذف
+    has_many_new: إضافة %{model} جديد
+    has_many_remove: إزالة
     index_list:
-      table: "جدول"
+      table: جدول
+    logout: تسجيل الخروج
+    new_model: "%{model} جديد"
+    next: التالي
+    pagination:
+      empty: 'لا يوجد %{model} '
+      entry:
+        one: مدخل
+        other: مدخلات
+      multiple: عرض %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> من <b>%{total}</b> بالمجمل
+      multiple_without_total: عرض %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      one: عرض <b>1</b> %{model}
+      one_page: عرض <b>all %{n}</b> %{model}
+    powered_by: تنفيذ %{active_admin} %{version}
+    previous: السابق
+    search_status:
+      no_current_filters: بدون
+    sidebars:
+      filters: المُرشحات
+      search_status: حالات البحث
+    status_tag:
+      'no': لا
+      unset: لا
+      'yes': نعم
+    view: عرض

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -36,6 +36,7 @@ az:
       resource: Resurs
       resource_type: Resursun tipi
       title_content: Şərhlər (%{count})
+    create_another: Create another %{model}
     dashboard: İdarəetmə paneli
     delete: Sil
     delete_confirmation: Siz bunu silmək istədiyinizdən əminsiniz?
@@ -60,6 +61,8 @@ az:
         title: Giriş
       password:
         title: Şifrə
+      password_confirmation:
+        title: Confirm Password
       resend_confirmation_instructions:
         submit: Aktivləşdirmə ismarışını yenidən göndərmək
         title: Aktivləşdirmə ismarışını yenidən göndərmək
@@ -84,12 +87,16 @@ az:
       buttons:
         clear: Təmizlə
         filter: Filtrlə
+      predicates:
+        from: From
+        to: To
     has_many_delete: Sil
     has_many_new: "%{model} əlavə et"
     has_many_remove: Yığışdır
     index_list:
       table: Cədvəl
     logout: Çıxış
+    move: Move
     new_model: "%{model} yarat"
     next: İrəli
     pagination:
@@ -101,16 +108,44 @@ az:
         other: yazı
       multiple: 'Nəticə: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> <b>%{total}</b>'
       multiple_without_total: 'Nəticə: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>'
+      next: Next
       one: 'Nəticə: <b>1</b> %{model}'
       one_page: 'Nəticə: <b>%{n}</b> %{model}'
+      per_page: 'Per page '
+      previous: Previous
     powered_by: Работает на %{active_admin} %{version}
     previous: Geri
+    scopes:
+      all: All
     search_status:
       no_current_filters: Heç biri
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: Filterlə
       search_status: Axtarışın statusu
     status_tag:
       'no': Xeyr
+      unset: Unknown
       'yes': Bəli
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: Aç
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Author type
+        body: Body
+        created_at: Created
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Updated
+    models:
+      active_admin/comment:
+        one: Comment
+        other: Comments
+      comment:
+        one: Comment
+        other: Comments

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -1,115 +1,116 @@
+---
 az:
   active_admin:
-    dashboard: "İdarəetmə paneli"
-    view: "Aç"
-    edit: "Dəyiş"
-    delete: "Sil"
-    delete_confirmation: "Siz bunu silmək istədiyinizdən əminsiniz?"
-    new_model: "%{model} yarat"
-    edit_model: "%{model} dəyiş"
-    delete_model: "%{model} sil"
-    details: "%{model} haqqında"
-    cancel: "İmtina"
-    empty: "Boş"
-    previous: "Geri"
-    next: "İrəli"
-    download: "Yüklənmə:"
-    has_many_new: "%{model} əlavə et"
-    has_many_delete: "Sil"
-    has_many_remove: "Yığışdır"
-    filters:
-      buttons:
-        filter: "Filtrlə"
-        clear: "Təmizlə"
-    search_status:
-      no_current_filters: "Heç biri"
-    status_tag:
-      "yes": "Bəli"
-      "no": "Xeyr"
-    logout: "Çıxış"
-    powered_by: "Работает на %{active_admin} %{version}"
-    sidebars:
-      filters: "Filterlə"
-      search_status: "Axtarışın statusu"
-    pagination:
-      empty: "%{model} tapılmadı"
-      one: "Nəticə: <b>1</b> %{model}"
-      one_page: "Nəticə: <b>%{n}</b> %{model}"
-      multiple: "Nəticə: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> <b>%{total}</b>"
-      multiple_without_total: "Nəticə: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      entry:
-        one: "yazı"
-        few: "yazı"
-        many: "yazı"
-        other: "yazı"
-    any: "İstənilən"
+    access_denied:
+      message: Bunu etmək üçün daxil olmalısınız.
+    any: İstənilən
+    batch_actions:
+      action_label: "%{title} seçilmiş"
+      button_label: Qrup əməliyyatları
+      default_confirmation: Siz bunu etməyinizə əminsiniz?
+      delete_confirmation: Siz %{plural_model} silməyə əminsiniz?
+      labels:
+        destroy: Sil
+      selection_toggle_explanation: "(Hamısını seç / Seçilmişləri sıfırla)"
+      succesfully_destroyed:
+        few: 'Uğurla silindi: %{count} %{plural_model}'
+        many: 'Uğurla silindi: %{count} %{plural_model}'
+        one: 'Uğurla silindi: 1 %{model}'
+        other: 'Uğurla silindi: %{count} %{plural_model}'
     blank_slate:
       content: "%{resource_name} hələ yoxdur."
-      link: "Yarat"
-    batch_actions:
-      button_label: "Qrup əməliyyatları"
-      default_confirmation: "Siz bunu etməyinizə əminsiniz?"
-      delete_confirmation: "Siz %{plural_model} silməyə əminsiniz?"
-      succesfully_destroyed:
-        one: "Uğurla silindi: 1 %{model}"
-        few: "Uğurla silindi: %{count} %{plural_model}"
-        many: "Uğurla silindi: %{count} %{plural_model}"
-        other: "Uğurla silindi: %{count} %{plural_model}"
-      selection_toggle_explanation: "(Hamısını seç / Seçilmişləri sıfırla)"
-      action_label: "%{title} seçilmiş"
-      labels:
-        destroy: "Sil"
+      link: Yarat
+    cancel: İmtina
     comments:
-      created_at: "Yaranma tarixi"
-      resource_type: "Resursun tipi"
-      author_type: "Müəllifin tipi"
-      body: "Mətn"
-      author: "Müəllif"
-      add: "Şərh əlavə et"
-      delete: "Şərhi sil"
-      delete_confirmation: "Siz bu şərhi silmək istədiyinizdən əminsiniz?"
-      resource: "Resurs"
-      no_comments_yet: "Hələ şərhlər yoxdur."
-      author_missing: "Naməlum"
-      title_content: "Şərhlər (%{count})"
+      add: Şərh əlavə et
+      author: Müəllif
+      author_missing: Naməlum
+      author_type: Müəllifin tipi
+      body: Mətn
+      created_at: Yaranma tarixi
+      delete: Şərhi sil
+      delete_confirmation: Siz bu şərhi silmək istədiyinizdən əminsiniz?
       errors:
-        empty_text: "Şərh yadda saxlanılmadı, mətn boş ola bilməz."
+        empty_text: Şərh yadda saxlanılmadı, mətn boş ola bilməz.
+      no_comments_yet: Hələ şərhlər yoxdur.
+      resource: Resurs
+      resource_type: Resursun tipi
+      title_content: Şərhlər (%{count})
+    dashboard: İdarəetmə paneli
+    delete: Sil
+    delete_confirmation: Siz bunu silmək istədiyinizdən əminsiniz?
+    delete_model: "%{model} sil"
+    details: "%{model} haqqında"
     devise:
-      username:
-        title: "İstifadəçi adı"
-      email:
-        title: "E-poçt"
-      subdomain:
-        title: "Subdomen"
-      password:
-        title: "Şifrə"
-      sign_up:
-        title: "Qeydiyyat"
-        submit: "Qeydiyyatdan keç"
-      login:
-        title: "Giriş"
-        remember_me: "Məni yadda saxla"
-        submit: "Daxil ol"
-      reset_password:
-        title: "Şifrəni unutmusunuz?"
-        submit: "Şifrəni sıfırla"
       change_password:
-        title: "Şifrənin dəyişdirilməsi"
-        submit: "Şifrəni dəyiş"
-      unlock:
-        title: "Blokdan çıxarma üzrə təlimatı yenidən göndərmək"
-        submit: "Blokdan çıxarma üzrə təlimatı yenidən göndərmək"
-      resend_confirmation_instructions:
-        title: "Aktivləşdirmə ismarışını yenidən göndərmək"
-        submit: "Aktivləşdirmə ismarışını yenidən göndərmək"
+        submit: Şifrəni dəyiş
+        title: Şifrənin dəyişdirilməsi
+      email:
+        title: E-poçt
       links:
-        sign_up: "Qeydiyyat"
-        sign_in: "Giriş"
-        forgot_your_password: "Şifrəni unutmusunuz?"
+        forgot_your_password: Şifrəni unutmusunuz?
+        resend_confirmation_instructions: Aktivləşdirmə ismarışını yenidən göndərilməsi
+        resend_unlock_instructions: Blokdan çıxarma üzrə təlimatı yenidən göndərilməsi
+        sign_in: Giriş
         sign_in_with_omniauth_provider: "%{provider} vasitəsilə daxil ol"
-        resend_unlock_instructions: "Blokdan çıxarma üzrə təlimatı yenidən göndərilməsi"
-        resend_confirmation_instructions: "Aktivləşdirmə ismarışını yenidən göndərilməsi"
-    access_denied:
-      message: "Bunu etmək üçün daxil olmalısınız."
+        sign_up: Qeydiyyat
+      login:
+        remember_me: Məni yadda saxla
+        submit: Daxil ol
+        title: Giriş
+      password:
+        title: Şifrə
+      resend_confirmation_instructions:
+        submit: Aktivləşdirmə ismarışını yenidən göndərmək
+        title: Aktivləşdirmə ismarışını yenidən göndərmək
+      reset_password:
+        submit: Şifrəni sıfırla
+        title: Şifrəni unutmusunuz?
+      sign_up:
+        submit: Qeydiyyatdan keç
+        title: Qeydiyyat
+      subdomain:
+        title: Subdomen
+      unlock:
+        submit: Blokdan çıxarma üzrə təlimatı yenidən göndərmək
+        title: Blokdan çıxarma üzrə təlimatı yenidən göndərmək
+      username:
+        title: İstifadəçi adı
+    download: 'Yüklənmə:'
+    edit: Dəyiş
+    edit_model: "%{model} dəyiş"
+    empty: Boş
+    filters:
+      buttons:
+        clear: Təmizlə
+        filter: Filtrlə
+    has_many_delete: Sil
+    has_many_new: "%{model} əlavə et"
+    has_many_remove: Yığışdır
     index_list:
-      table: "Cədvəl"
+      table: Cədvəl
+    logout: Çıxış
+    new_model: "%{model} yarat"
+    next: İrəli
+    pagination:
+      empty: "%{model} tapılmadı"
+      entry:
+        few: yazı
+        many: yazı
+        one: yazı
+        other: yazı
+      multiple: 'Nəticə: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> <b>%{total}</b>'
+      multiple_without_total: 'Nəticə: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>'
+      one: 'Nəticə: <b>1</b> %{model}'
+      one_page: 'Nəticə: <b>%{n}</b> %{model}'
+    powered_by: Работает на %{active_admin} %{version}
+    previous: Geri
+    search_status:
+      no_current_filters: Heç biri
+    sidebars:
+      filters: Filterlə
+      search_status: Axtarışın statusu
+    status_tag:
+      'no': Xeyr
+      'yes': Bəli
+    view: Aç

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -1,103 +1,104 @@
+---
 bg:
   active_admin:
+    access_denied:
+      message: Нямате права да извършите това действие.
+    any: Без значение
+    batch_actions:
+      action_label: "%{title} избран"
+      button_label: Масови действия
+      default_confirmation: Наистина ли искате да направите това?
+      delete_confirmation: Сигурни ли сте, че искате да изтриете тези %{plural_model}?
+      labels:
+        destroy: Изтриване
+      selection_toggle_explanation: "(Инвертиране на маркирането)"
+      succesfully_destroyed:
+        one: Успешно изтриване на 1 %{model}
+        other: Успешно изтриване на %{count} %{plural_model}
+    blank_slate:
+      content: Все още няма добавени %{resource_name}.
+      link: Създаване
+    cancel: Отказ
+    comments:
+      add: Добавяне на коментар
+      author: Автор
+      author_missing: Анонимен
+      author_type: Тип автор
+      body: Текст
+      errors:
+        empty_text: Коментарът с празен текст не беше запазен.
+      no_comments_yet: Все още няма коментари.
+      resource: Ресурс
+      resource_type: Тип ресурс
+      title_content: Коментари (%{count})
     dashboard: Табло
-    view: "Преглед"
-    edit: "Редакция"
-    delete: "Изтриване"
-    delete_confirmation: "Сигурни ли сте, че искате да изтриете това?"
-    new_model: "Създаване на %{model}"
-    edit_model: "Редакция на %{model}"
-    delete_model: "Изтриване на %{model}"
+    delete: Изтриване
+    delete_confirmation: Сигурни ли сте, че искате да изтриете това?
+    delete_model: Изтриване на %{model}
     details: "%{model} детайли"
-    cancel: "Отказ"
-    empty: "Празно"
-    previous: "Предишно"
-    next: "Следващо"
-    download: "Изтегляне:"
-    has_many_new: "Добавяне на %{model}"
-    has_many_delete: "Изтриване"
-    has_many_remove: "Премахване"
+    devise:
+      change_password:
+        submit: Промяна на паролата
+        title: Промяна на паролата
+      email:
+        title: Поща
+      links:
+        forgot_your_password: Забравена парола?
+        sign_in: Вход
+        sign_in_with_omniauth_provider: Влез с %{provider}
+      login:
+        remember_me: Запомни ме
+        submit: Вход
+        title: Вход
+      password:
+        title: Парола
+      resend_confirmation_instructions:
+        submit: Изпрати отново инструкциите за потвърждаване
+        title: Изпрати отново инструкциите за потвърждаване
+      reset_password:
+        submit: Изпращане на нова парола
+        title: Забравена парола?
+      sign_up:
+        submit: Регистрация
+        title: Регистрация
+      subdomain:
+        title: Поддомейн
+      unlock:
+        submit: Изпрати отново инструкциите за отключване
+        title: Изпрати отново инструкциите за отключване
+      username:
+        title: Потребителско име
+    download: 'Изтегляне:'
+    edit: Редакция
+    edit_model: Редакция на %{model}
+    empty: Празно
     filters:
       buttons:
-        filter: "Филтриране"
-        clear: "Изчистване"
-    status_tag:
-      "yes": "Да"
-      "no": "не"
-      "unset": "не"
-    logout: "Изход"
-    powered_by: "Задвижва се от %{active_admin} %{version}"
-    sidebars:
-      filters: "Филтри"
-    pagination:
-      empty: "Не са намерени %{model}"
-      one: "Показване на <b>1</b> %{model}"
-      one_page: "Показване на <b>всички %{n}</b> %{model}"
-      multiple: "Показване %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> от общо <b>%{total}</b>"
-      multiple_without_total: "Показване %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      entry:
-        one: "запис"
-        other: "записи"
-    any: "Без значение"
-    blank_slate:
-      content: "Все още няма добавени %{resource_name}."
-      link: "Създаване"
-    batch_actions:
-      button_label: "Масови действия"
-      default_confirmation: "Наистина ли искате да направите това?"
-      delete_confirmation: "Сигурни ли сте, че искате да изтриете тези %{plural_model}?"
-      succesfully_destroyed:
-        one: "Успешно изтриване на 1 %{model}"
-        other: "Успешно изтриване на %{count} %{plural_model}"
-      selection_toggle_explanation: "(Инвертиране на маркирането)"
-      action_label: "%{title} избран"
-      labels:
-        destroy: "Изтриване"
-    comments:
-      resource_type: "Тип ресурс"
-      author_type: "Тип автор"
-      body: "Текст"
-      author: "Автор"
-      add: "Добавяне на коментар"
-      resource: "Ресурс"
-      no_comments_yet: "Все още няма коментари."
-      author_missing: "Анонимен"
-      title_content: "Коментари (%{count})"
-      errors:
-        empty_text: "Коментарът с празен текст не беше запазен."
-    devise:
-      username:
-        title: "Потребителско име"
-      email:
-        title: "Поща"
-      subdomain:
-        title: "Поддомейн"
-      password:
-        title: "Парола"
-      sign_up:
-        title: "Регистрация"
-        submit: "Регистрация"
-      login:
-        title: "Вход"
-        remember_me: "Запомни ме"
-        submit: "Вход"
-      reset_password:
-        title: "Забравена парола?"
-        submit: "Изпращане на нова парола"
-      change_password:
-        title: "Промяна на паролата"
-        submit: "Промяна на паролата"
-      unlock:
-        title: "Изпрати отново инструкциите за отключване"
-        submit: "Изпрати отново инструкциите за отключване"
-      resend_confirmation_instructions:
-        title: "Изпрати отново инструкциите за потвърждаване"
-        submit: "Изпрати отново инструкциите за потвърждаване"
-      links:
-        sign_in: "Вход"
-        forgot_your_password: "Забравена парола?"
-        sign_in_with_omniauth_provider: "Влез с %{provider}"
-    access_denied:
-      message: "Нямате права да извършите това действие."
+        clear: Изчистване
+        filter: Филтриране
+    has_many_delete: Изтриване
+    has_many_new: Добавяне на %{model}
+    has_many_remove: Премахване
     index_list:
-      table: "Таблица"
+      table: Таблица
+    logout: Изход
+    new_model: Създаване на %{model}
+    next: Следващо
+    pagination:
+      empty: Не са намерени %{model}
+      entry:
+        one: запис
+        other: записи
+      multiple: Показване %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> от общо <b>%{total}</b>
+      multiple_without_total: Показване %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      one: Показване на <b>1</b> %{model}
+      one_page: Показване на <b>всички %{n}</b> %{model}
+    powered_by: Задвижва се от %{active_admin} %{version}
+    previous: Предишно
+    sidebars:
+      filters: Филтри
+    status_tag:
+      'no': не
+      unset: не
+      'yes': Да
+    view: Преглед

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -25,12 +25,16 @@ bg:
       author_missing: Анонимен
       author_type: Тип автор
       body: Текст
+      created_at: Created
+      delete: Delete Comment
+      delete_confirmation: Are you sure you want to delete this comment?
       errors:
         empty_text: Коментарът с празен текст не беше запазен.
       no_comments_yet: Все още няма коментари.
       resource: Ресурс
       resource_type: Тип ресурс
       title_content: Коментари (%{count})
+    create_another: Create another %{model}
     dashboard: Табло
     delete: Изтриване
     delete_confirmation: Сигурни ли сте, че искате да изтриете това?
@@ -44,14 +48,19 @@ bg:
         title: Поща
       links:
         forgot_your_password: Забравена парола?
+        resend_confirmation_instructions: Resend confirmation instructions
+        resend_unlock_instructions: Resend unlock instructions
         sign_in: Вход
         sign_in_with_omniauth_provider: Влез с %{provider}
+        sign_up: Sign up
       login:
         remember_me: Запомни ме
         submit: Вход
         title: Вход
       password:
         title: Парола
+      password_confirmation:
+        title: Confirm Password
       resend_confirmation_instructions:
         submit: Изпрати отново инструкциите за потвърждаване
         title: Изпрати отново инструкциите за потвърждаване
@@ -76,12 +85,16 @@ bg:
       buttons:
         clear: Изчистване
         filter: Филтриране
+      predicates:
+        from: From
+        to: To
     has_many_delete: Изтриване
     has_many_new: Добавяне на %{model}
     has_many_remove: Премахване
     index_list:
       table: Таблица
     logout: Изход
+    move: Move
     new_model: Създаване на %{model}
     next: Следващо
     pagination:
@@ -91,14 +104,44 @@ bg:
         other: записи
       multiple: Показване %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> от общо <b>%{total}</b>
       multiple_without_total: Показване %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      next: Next
       one: Показване на <b>1</b> %{model}
       one_page: Показване на <b>всички %{n}</b> %{model}
+      per_page: 'Per page '
+      previous: Previous
     powered_by: Задвижва се от %{active_admin} %{version}
     previous: Предишно
+    scopes:
+      all: All
+    search_status:
+      no_current_filters: No filters applied
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: Филтри
+      search_status: Search Status
     status_tag:
       'no': не
       unset: не
       'yes': Да
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: Преглед
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Author type
+        body: Body
+        created_at: Created
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Updated
+    models:
+      active_admin/comment:
+        one: Comment
+        other: Comments
+      comment:
+        one: Comment
+        other: Comments

--- a/config/locales/bs.yml
+++ b/config/locales/bs.yml
@@ -27,12 +27,16 @@ bs:
       author_missing: Anoniman
       author_type: Tip autora
       body: Sadržaj
+      created_at: Created
+      delete: Delete Comment
+      delete_confirmation: Are you sure you want to delete this comment?
       errors:
         empty_text: Komentar nije spremljen, sadržaj je prazan.
       no_comments_yet: Još nema komentara.
       resource: Objekt
       resource_type: Tip objekta
       title_content: Komentari (%{count})
+    create_another: Create another %{model}
     dashboard: Upravljačka ploča
     delete: Obriši
     delete_confirmation: Jeste li sigurni da želite ovo obrisati?
@@ -46,14 +50,19 @@ bs:
         title: Email
       links:
         forgot_your_password: Zaboravljena lozinka?
+        resend_confirmation_instructions: Resend confirmation instructions
+        resend_unlock_instructions: Resend unlock instructions
         sign_in: Prijavi se
         sign_in_with_omniauth_provider: Prijavite se za %{provider}
+        sign_up: Sign up
       login:
         remember_me: Zapamti me
         submit: Prijavi se
         title: Prijava
       password:
         title: Lozinka
+      password_confirmation:
+        title: Confirm Password
       resend_confirmation_instructions:
         submit: Pošalji
         title: Ponovno slanje uputstva za potvrdu
@@ -78,12 +87,16 @@ bs:
       buttons:
         clear: Ukloni filtere
         filter: Filtriraj
+      predicates:
+        from: From
+        to: To
     has_many_delete: Obriši
     has_many_new: Dodaj novi %{model}
     has_many_remove: Ukloniti
     index_list:
       table: Tabela
     logout: Odjavi se
+    move: Move
     new_model: Novi %{model}
     next: Sljedeći
     pagination:
@@ -95,14 +108,44 @@ bs:
         other: zapisa
       multiple: Prikazani %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> od ukupno <b>%{total}</b>
       multiple_without_total: Prikazani %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      next: Next
       one: Prikazan <b>1</b> %{model}
       one_page: Prikazano <b>svih %{n}</b> %{model}
+      per_page: 'Per page '
+      previous: Previous
     powered_by: Powered by %{active_admin} %{version}
     previous: Prethodni
+    scopes:
+      all: All
+    search_status:
+      no_current_filters: No filters applied
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: Filtriranje
+      search_status: Search Status
     status_tag:
       'no': Nema
       unset: Nema
       'yes': Da
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: Pregledaj
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Author type
+        body: Body
+        created_at: Created
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Updated
+    models:
+      active_admin/comment:
+        one: Comment
+        other: Comments
+      comment:
+        one: Comment
+        other: Comments

--- a/config/locales/bs.yml
+++ b/config/locales/bs.yml
@@ -1,107 +1,108 @@
+---
 bs:
   active_admin:
-    dashboard: "Upravljačka ploča"
-    view: "Pregledaj"
-    edit: "Uredi"
-    delete: "Obriši"
-    delete_confirmation: "Jeste li sigurni da želite ovo obrisati?"
-    new_model: "Novi %{model}"
-    edit_model: "Uredi %{model}"
-    delete_model: "Obriši %{model}"
+    access_denied:
+      message: Nemaš dopuštenja.
+    any: Bilo koji
+    batch_actions:
+      action_label: "%{title} označene"
+      button_label: Grupne akcije
+      default_confirmation: Jeste li sigurni da želite to učiniti?
+      delete_confirmation: Jeste li sigurni da želite obrisati %{plural_model}?
+      labels:
+        destroy: Obriši
+      selection_toggle_explanation: "(Izmijeni odabir)"
+      succesfully_destroyed:
+        few: Uspješno su obrisana %{count} %{plural_model}
+        many: Uspješno je obrisano %{count} %{plural_model}
+        one: Uspješno je obrisan 1 %{model}
+        other: Uspješno je obrisano %{count} %{plural_model}
+    blank_slate:
+      content: Još uvijek ne postoji niti jedan zapis tipa %{resource_name}.
+      link: Izradi jedan
+    cancel: Odustani
+    comments:
+      add: Dodaj komentar
+      author: Autor
+      author_missing: Anoniman
+      author_type: Tip autora
+      body: Sadržaj
+      errors:
+        empty_text: Komentar nije spremljen, sadržaj je prazan.
+      no_comments_yet: Još nema komentara.
+      resource: Objekt
+      resource_type: Tip objekta
+      title_content: Komentari (%{count})
+    dashboard: Upravljačka ploča
+    delete: Obriši
+    delete_confirmation: Jeste li sigurni da želite ovo obrisati?
+    delete_model: Obriši %{model}
     details: "%{model} detalji"
-    cancel: "Odustani"
-    empty: "Prazno"
-    previous: "Prethodni"
-    next: "Sljedeći"
-    download: "Spremi na računalo:"
-    has_many_new: "Dodaj novi %{model}"
-    has_many_delete: "Obriši"
-    has_many_remove: "Ukloniti"
+    devise:
+      change_password:
+        submit: Izmijeni lozinku
+        title: Izmjena lozinke
+      email:
+        title: Email
+      links:
+        forgot_your_password: Zaboravljena lozinka?
+        sign_in: Prijavi se
+        sign_in_with_omniauth_provider: Prijavite se za %{provider}
+      login:
+        remember_me: Zapamti me
+        submit: Prijavi se
+        title: Prijava
+      password:
+        title: Lozinka
+      resend_confirmation_instructions:
+        submit: Pošalji
+        title: Ponovno slanje uputstva za potvrdu
+      reset_password:
+        submit: Resetuj lozinku
+        title: Zaboravljena lozinka?
+      sign_up:
+        submit: Registruj
+        title: Registracija
+      subdomain:
+        title: Poddomena
+      unlock:
+        submit: Pošalji
+        title: Ponovno slanje uputstva za otključavanje
+      username:
+        title: Korisničko ime
+    download: 'Spremi na računalo:'
+    edit: Uredi
+    edit_model: Uredi %{model}
+    empty: Prazno
     filters:
       buttons:
-        filter: "Filtriraj"
-        clear: "Ukloni filtere"
-    status_tag:
-      "yes": "Da"
-      "no": "Nema"
-      "unset": "Nema"
-    logout: "Odjavi se"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filtriranje"
-    pagination:
-      empty: "Nije pronađen niti jedan %{model}."
-      one: "Prikazan <b>1</b> %{model}"
-      one_page: "Prikazano <b>svih %{n}</b> %{model}"
-      multiple: "Prikazani %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> od ukupno <b>%{total}</b>"
-      multiple_without_total: "Prikazani %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      entry:
-        one: "zapis"
-        few: "zapisa"
-        many: "zapisa"
-        other: "zapisa"
-    any: "Bilo koji"
-    blank_slate:
-      content: "Još uvijek ne postoji niti jedan zapis tipa %{resource_name}."
-      link: "Izradi jedan"
-    batch_actions:
-      button_label: "Grupne akcije"
-      default_confirmation: "Jeste li sigurni da želite to učiniti?"
-      delete_confirmation: "Jeste li sigurni da želite obrisati %{plural_model}?"
-      succesfully_destroyed:
-        one: "Uspješno je obrisan 1 %{model}"
-        few: "Uspješno su obrisana %{count} %{plural_model}"
-        many: "Uspješno je obrisano %{count} %{plural_model}"
-        other: "Uspješno je obrisano %{count} %{plural_model}"
-      selection_toggle_explanation: "(Izmijeni odabir)"
-      action_label: "%{title} označene"
-      labels:
-        destroy: "Obriši"
-    comments:
-      resource_type: "Tip objekta"
-      author_type: "Tip autora"
-      body: "Sadržaj"
-      author: "Autor"
-      add: "Dodaj komentar"
-      resource: "Objekt"
-      no_comments_yet: "Još nema komentara."
-      author_missing: "Anoniman"
-      title_content: "Komentari (%{count})"
-      errors:
-        empty_text: "Komentar nije spremljen, sadržaj je prazan."
-    devise:
-      username:
-        title: "Korisničko ime"
-      email:
-        title: "Email"
-      subdomain:
-        title: "Poddomena"
-      password:
-        title: "Lozinka"
-      sign_up:
-        title: "Registracija"
-        submit: "Registruj"
-      login:
-        title: "Prijava"
-        remember_me: "Zapamti me"
-        submit: "Prijavi se"
-      reset_password:
-        title: "Zaboravljena lozinka?"
-        submit: "Resetuj lozinku"
-      change_password:
-        title: "Izmjena lozinke"
-        submit: "Izmijeni lozinku"
-      unlock:
-        title: "Ponovno slanje uputstva za otključavanje"
-        submit: "Pošalji"
-      resend_confirmation_instructions:
-        title: "Ponovno slanje uputstva za potvrdu"
-        submit: "Pošalji"
-      links:
-        sign_in: "Prijavi se"
-        forgot_your_password: "Zaboravljena lozinka?"
-        sign_in_with_omniauth_provider: "Prijavite se za %{provider}"
-    access_denied:
-      message: "Nemaš dopuštenja."
+        clear: Ukloni filtere
+        filter: Filtriraj
+    has_many_delete: Obriši
+    has_many_new: Dodaj novi %{model}
+    has_many_remove: Ukloniti
     index_list:
-      table: "Tabela"
+      table: Tabela
+    logout: Odjavi se
+    new_model: Novi %{model}
+    next: Sljedeći
+    pagination:
+      empty: Nije pronađen niti jedan %{model}.
+      entry:
+        few: zapisa
+        many: zapisa
+        one: zapis
+        other: zapisa
+      multiple: Prikazani %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> od ukupno <b>%{total}</b>
+      multiple_without_total: Prikazani %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      one: Prikazan <b>1</b> %{model}
+      one_page: Prikazano <b>svih %{n}</b> %{model}
+    powered_by: Powered by %{active_admin} %{version}
+    previous: Prethodni
+    sidebars:
+      filters: Filtriranje
+    status_tag:
+      'no': Nema
+      unset: Nema
+      'yes': Da
+    view: Pregledaj

--- a/config/locales/bs.yml
+++ b/config/locales/bs.yml
@@ -144,8 +144,10 @@ bs:
         updated_at: Updated
     models:
       active_admin/comment:
+        few: Comments
         one: Comment
         other: Comments
       comment:
+        few: Comments
         one: Comment
         other: Comments

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -124,6 +124,10 @@ ca:
       'no': 'No'
       unset: Desconegut
       'yes': Sí
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: Mostra
   activerecord:
     attributes:

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1,142 +1,143 @@
+---
 ca:
-  activerecord:
-    models:
-      comment:
-        one: "Comentari"
-        other: "Comentaris"
-      active_admin/comment:
-        one: "Comentari"
-        other: "Comentaris"
-    attributes:
-      active_admin/comment:
-        author_type: "Tipus d'autor"
-        body: "Missatge"
-        created_at: "Creat el"
-        namespace: "Espai de noms"
-        resource_type: "Tipus de recurs"
-        updated_at: "Actualitzat el"
   active_admin:
-    dashboard: "Tauler d'activitat"
-    view: "Mostra"
-    edit: "Edita"
-    delete: "Elimina"
-    delete_confirmation: "Segur que voleu eliminar-ho?"
-    create_another: "Crear un altre %{model}"
-    new_model: "Crear %{model}"
-    edit_model: "Editar %{model}"
-    delete_model: "Eliminar %{model}"
-    details: "Detalls de %{model}"
-    cancel: "Cancel·lar"
-    empty: "Buit"
-    previous: "Anterior"
-    next: "Següent"
-    download: "Descarregar:"
-    has_many_new: "Afegir un altre %{model}"
-    has_many_delete: "Eliminar"
-    has_many_remove: "Treure"
-    move: "Moure"
+    access_denied:
+      message: No esteu autoritzats a realitzar aquesta acció
+    any: Qualsevol
+    batch_actions:
+      action_label: "%{title} seleccionat"
+      button_label: Accions per lots
+      default_confirmation: Segur que voleu fer-ho?
+      delete_confirmation: Segurs que voleu eliminar aquests %{plural_model}?
+      labels:
+        destroy: Esborrar
+      selection_toggle_explanation: "(Invertir la selecció)"
+      succesfully_destroyed:
+        one: 1 %{model} eliminat
+        other: "%{count} %{plural_model} eliminats"
+    blank_slate:
+      content: Encara no hi ha cap %{resource_name}.
+      link: Crea'n un/a
+    cancel: Cancel·lar
+    comments:
+      add: Afegeix comentari
+      author: Autor
+      author_missing: Anònim
+      author_type: Tipus d'author
+      body: Missatge
+      created_at: Creat el
+      delete: Elimina comentari
+      delete_confirmation: Esteu segurs que voleu eliminar aquest comentari?
+      errors:
+        empty_text: El comentari no s'ha desat, no hi havia text.
+      no_comments_yet: Sense comentaris
+      resource: Recurs
+      resource_type: Tipus de recurs
+      title_content: Tots els comentaris (%{count})
+    create_another: Crear un altre %{model}
+    dashboard: Tauler d'activitat
+    delete: Elimina
+    delete_confirmation: Segur que voleu eliminar-ho?
+    delete_model: Eliminar %{model}
+    details: Detalls de %{model}
+    devise:
+      change_password:
+        submit: Canvia'm la contrasenya
+        title: Canvieu la contrasenya
+      email:
+        title: Email
+      links:
+        forgot_your_password: Heu perdut la contrasenya?
+        resend_confirmation_instructions: Reenviar les instruccions de confirmació
+        resend_unlock_instructions: Reenviar les instruccions de desbloqueig
+        sign_in: Sign in
+        sign_in_with_omniauth_provider: Identificació via %{provider}
+        sign_up: Sign up
+      login:
+        remember_me: Recorda'm
+        submit: Identifiqueu-vos
+        title: Identifiqueu-vos
+      password:
+        title: Contrasenya
+      password_confirmation:
+        title: Confirmeu la contrasenya
+      resend_confirmation_instructions:
+        submit: Reenviar instruccions de confirmació
+        title: Reenviar instruccions de confirmació
+      reset_password:
+        submit: Restablir la contrasenya
+        title: Heu oblidat la contrasenya?
+      sign_up:
+        submit: Doneu-vos d'alta
+        title: Doneu-vos d'alta
+      subdomain:
+        title: Subdomini
+      unlock:
+        submit: Reenvia instruccions per a desbloquejar
+        title: Reenvia instruccions per a desbloquejar
+      username:
+        title: Usuari
+    download: 'Descarregar:'
+    edit: Edita
+    edit_model: Editar %{model}
+    empty: Buit
     filters:
       buttons:
-        filter: "Filtra"
-        clear: "Elimina els filtres"
+        clear: Elimina els filtres
+        filter: Filtra
       predicates:
-        from: "Des de"
-        to: "Fins"
-    scopes:
-      all: "Tots"
-    search_status:
-      title: "Cerca activa"
-      title_with_scope: "Cerca activa per %{name}"
-      no_current_filters: "Sense filtres actius"
-    status_tag:
-      "yes": "Sí"
-      "no": "No"
-      "unset": "Desconegut"
-    logout: "Tanca la sessió"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filtres"
-      search_status: "Estat de la cerca"
-    pagination:
-      empty: "No s'ha trobat cap %{model}"
-      one: "S'està mostrant <b>1</b> de <b>1</b>"
-      one_page: "S'estan mostrant <b>tots %{n}</b>"
-      multiple: "Se n'estan mostrant <b>%{from}-%{to}</b> d'un total de <b>%{total}</b>"
-      multiple_without_total: "Se n'estan mostrant <b>%{from}-%{to}</b>"
-      per_page: "Per pàgina"
-      previous: "Anterior"
-      next: "Següent"
-      entry:
-        one: "entrada"
-        other: "entrades"
-    any: "Qualsevol"
-    blank_slate:
-      content: "Encara no hi ha cap %{resource_name}."
-      link: "Crea'n un/a"
-    batch_actions:
-      button_label: "Accions per lots"
-      default_confirmation: "Segur que voleu fer-ho?"
-      delete_confirmation: "Segurs que voleu eliminar aquests %{plural_model}?"
-      succesfully_destroyed:
-        one: "1 %{model} eliminat"
-        other: "%{count} %{plural_model} eliminats"
-      selection_toggle_explanation: "(Invertir la selecció)"
-      action_label: "%{title} seleccionat"
-      labels:
-        destroy: "Esborrar"
-    comments:
-      created_at: "Creat el"
-      resource_type: "Tipus de recurs"
-      author_type: "Tipus d'author"
-      body: "Missatge"
-      author: "Autor"
-      add: "Afegeix comentari"
-      delete: "Elimina comentari"
-      delete_confirmation: "Esteu segurs que voleu eliminar aquest comentari?"
-      resource: "Recurs"
-      no_comments_yet: "Sense comentaris"
-      author_missing: "Anònim"
-      title_content: "Tots els comentaris (%{count})"
-      errors:
-        empty_text: "El comentari no s'ha desat, no hi havia text."
-    devise:
-      username:
-        title: "Usuari"
-      email:
-        title: "Email"
-      subdomain:
-        title: "Subdomini"
-      password:
-        title: "Contrasenya"
-      password_confirmation:
-        title: "Confirmeu la contrasenya"
-      sign_up:
-        title: "Doneu-vos d'alta"
-        submit: "Doneu-vos d'alta"
-      login:
-        title: "Identifiqueu-vos"
-        remember_me: "Recorda'm"
-        submit: "Identifiqueu-vos"
-      reset_password:
-        title: "Heu oblidat la contrasenya?"
-        submit: "Restablir la contrasenya"
-      change_password:
-        title: "Canvieu la contrasenya"
-        submit: "Canvia'm la contrasenya"
-      unlock:
-        title: "Reenvia instruccions per a desbloquejar"
-        submit: "Reenvia instruccions per a desbloquejar"
-      resend_confirmation_instructions:
-        title: "Reenviar instruccions de confirmació"
-        submit: "Reenviar instruccions de confirmació"
-      links:
-        sign_up: "Sign up"
-        sign_in: "Sign in"
-        forgot_your_password: "Heu perdut la contrasenya?"
-        sign_in_with_omniauth_provider: "Identificació via %{provider}"
-        resend_unlock_instructions: "Reenviar les instruccions de desbloqueig"
-        resend_confirmation_instructions: "Reenviar les instruccions de confirmació"
-    access_denied:
-      message: "No esteu autoritzats a realitzar aquesta acció"
+        from: Des de
+        to: Fins
+    has_many_delete: Eliminar
+    has_many_new: Afegir un altre %{model}
+    has_many_remove: Treure
     index_list:
-      table: "Taula"
+      table: Taula
+    logout: Tanca la sessió
+    move: Moure
+    new_model: Crear %{model}
+    next: Següent
+    pagination:
+      empty: No s'ha trobat cap %{model}
+      entry:
+        one: entrada
+        other: entrades
+      multiple: Se n'estan mostrant <b>%{from}-%{to}</b> d'un total de <b>%{total}</b>
+      multiple_without_total: Se n'estan mostrant <b>%{from}-%{to}</b>
+      next: Següent
+      one: S'està mostrant <b>1</b> de <b>1</b>
+      one_page: S'estan mostrant <b>tots %{n}</b>
+      per_page: Per pàgina
+      previous: Anterior
+    powered_by: Powered by %{active_admin} %{version}
+    previous: Anterior
+    scopes:
+      all: Tots
+    search_status:
+      no_current_filters: Sense filtres actius
+      title: Cerca activa
+      title_with_scope: Cerca activa per %{name}
+    sidebars:
+      filters: Filtres
+      search_status: Estat de la cerca
+    status_tag:
+      'no': 'No'
+      unset: Desconegut
+      'yes': Sí
+    view: Mostra
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Tipus d'autor
+        body: Missatge
+        created_at: Creat el
+        namespace: Espai de noms
+        resource_type: Tipus de recurs
+        updated_at: Actualitzat el
+    models:
+      active_admin/comment:
+        one: Comentari
+        other: Comentaris
+      comment:
+        one: Comentari
+        other: Comentaris

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -1,93 +1,94 @@
+---
 cs:
   active_admin:
+    access_denied:
+      message: Nemáte oprávnění k provedení této akce.
+    any: Kterákoliv
+    batch_actions:
+      action_label: "%{title}"
+      button_label: Hromadné akce
+      default_confirmation: Jste si jisti, že chcete provést?
+      delete_confirmation: Jste si jisti, že chcete smazat tyto %{plural_model}?
+      labels:
+        destroy: Vymazat
+      selection_toggle_explanation: "(Změnit výběr)"
+      succesfully_destroyed:
+        few: Úspěšně smazány %{count} %{plural_model}
+        one: Úspěšně smazán %{model}
+        other: Úspěšně smazáno %{count} %{plural_model}
+        zero: Nebyl smazán žádný %{model}
+    blank_slate:
+      content: Zatím zde není žádný obsah.
+      link: Vytvořit
+    cancel: Zrušit
+    comments:
+      add: Přidat komentář
+      author: Autor
+      author_missing: Anonymní
+      author_type: Typ autora
+      body: Tělo
+      errors:
+        empty_text: Komentář nebyl uložen, je prázdný.
+      no_comments_yet: Žádný komentář
+      resource: Zdroj
+      resource_type: Typ zdroje
+      title_content: Komentáře administrátorů (%{count})
     dashboard: Úvod
-    view: "Zobrazit"
-    edit: "Upravit"
-    delete: "Smazat"
-    delete_confirmation: "Jste si jistí, že chcete tuto položku smazat?"
-    new_model: "Vytvořit"
-    edit_model: "Upravit"
-    delete_model: "Smazat"
-    details: "Detaily"
-    cancel: "Zrušit"
-    empty: "Prázdné"
-    previous: "Předchozí"
-    next: "Následující"
-    download: "Stáhnout:"
-    has_many_new: "Přidat nový"
-    has_many_delete: "Smazat"
-    has_many_remove: "Odstranit"
+    delete: Smazat
+    delete_confirmation: Jste si jistí, že chcete tuto položku smazat?
+    delete_model: Smazat
+    details: Detaily
+    devise:
+      change_password:
+        submit: Změnit své heslo
+        title: Změnit heslo
+      links:
+        forgot_your_password: Zapomněli jste heslo?
+        sign_in: Přihlásit se
+        sign_in_with_omniauth_provider: Přihlásit se přes %{provider}
+        sign_up: Registrovat se
+      login:
+        remember_me: Zapamatovat si mě
+        submit: Přihlásit
+        title: Přihlášení
+      reset_password:
+        submit: Obnovit heslo
+        title: Zapomněli jste heslo?
+      unlock:
+        submit: Zaslat instrukce k odemčení účtu
+        title: Zaslání instrukcí k odemčení účtu
+    download: 'Stáhnout:'
+    edit: Upravit
+    edit_model: Upravit
+    empty: Prázdné
     filters:
       buttons:
-        filter: "Filtrovat"
-        clear: "Vyčistit filtry"
-    status_tag:
-      "yes": "Ano"
-      "no": "Ne"
-      "unset": "Ne"
-    logout: "Odhlásit"
-    powered_by: "%{active_admin} %{version}"
-    sidebars:
-      filters: "Filtry"
+        clear: Vyčistit filtry
+        filter: Filtrovat
+    has_many_delete: Smazat
+    has_many_new: Přidat nový
+    has_many_remove: Odstranit
+    index_list:
+      table: Tabulka
+    logout: Odhlásit
+    new_model: Vytvořit
+    next: Následující
     pagination:
-      empty: "Nenalezen."
-      one: "Zobrazena  <b>1</b> položka"
-      one_page: "Počet zobrazených položek %{n}"
+      empty: Nenalezen.
+      entry:
+        few: položky
+        one: položka
+        other: položky
       multiple: "<b>%{from}&nbsp;-&nbsp;%{to}</b> z <b>%{total}</b>"
       multiple_without_total: "<b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      entry:
-        one: "položka"
-        few: "položky"
-        other: "položky"
-    any: "Kterákoliv"
-    blank_slate:
-      content: "Zatím zde není žádný obsah."
-      link: "Vytvořit"
-    batch_actions:
-      button_label: "Hromadné akce"
-      default_confirmation: "Jste si jisti, že chcete provést?"
-      delete_confirmation: "Jste si jisti, že chcete smazat tyto %{plural_model}?"
-      succesfully_destroyed:
-        zero: "Nebyl smazán žádný %{model}"
-        one: "Úspěšně smazán %{model}"
-        few: "Úspěšně smazány %{count} %{plural_model}"
-        other: "Úspěšně smazáno %{count} %{plural_model}"
-      selection_toggle_explanation: "(Změnit výběr)"
-      action_label: "%{title}"
-      labels:
-        destroy: "Vymazat"
-    comments:
-      resource_type: "Typ zdroje"
-      author_type: "Typ autora"
-      body: "Tělo"
-      author: "Autor"
-      add: "Přidat komentář"
-      resource: "Zdroj"
-      no_comments_yet: "Žádný komentář"
-      author_missing: "Anonymní"
-      title_content: "Komentáře administrátorů (%{count})"
-      errors:
-        empty_text: "Komentář nebyl uložen, je prázdný."
-    devise:
-      login:
-        title: "Přihlášení"
-        remember_me: "Zapamatovat si mě"
-        submit: "Přihlásit"
-      reset_password:
-        title: "Zapomněli jste heslo?"
-        submit: "Obnovit heslo"
-      change_password:
-        title: "Změnit heslo"
-        submit: "Změnit své heslo"
-      unlock:
-        title: "Zaslání instrukcí k odemčení účtu"
-        submit: "Zaslat instrukce k odemčení účtu"
-      links:
-        sign_in: "Přihlásit se"
-        sign_up: "Registrovat se"
-        forgot_your_password: "Zapomněli jste heslo?"
-        sign_in_with_omniauth_provider: "Přihlásit se přes %{provider}"
-    access_denied:
-      message: "Nemáte oprávnění k provedení této akce."
-    index_list:
-      table: "Tabulka"
+      one: Zobrazena  <b>1</b> položka
+      one_page: Počet zobrazených položek %{n}
+    powered_by: "%{active_admin} %{version}"
+    previous: Předchozí
+    sidebars:
+      filters: Filtry
+    status_tag:
+      'no': Ne
+      unset: Ne
+      'yes': Ano
+    view: Zobrazit

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -27,12 +27,16 @@ cs:
       author_missing: Anonymní
       author_type: Typ autora
       body: Tělo
+      created_at: Created
+      delete: Delete Comment
+      delete_confirmation: Are you sure you want to delete this comment?
       errors:
         empty_text: Komentář nebyl uložen, je prázdný.
       no_comments_yet: Žádný komentář
       resource: Zdroj
       resource_type: Typ zdroje
       title_content: Komentáře administrátorů (%{count})
+    create_another: Create another %{model}
     dashboard: Úvod
     delete: Smazat
     delete_confirmation: Jste si jistí, že chcete tuto položku smazat?
@@ -42,8 +46,12 @@ cs:
       change_password:
         submit: Změnit své heslo
         title: Změnit heslo
+      email:
+        title: Email
       links:
         forgot_your_password: Zapomněli jste heslo?
+        resend_confirmation_instructions: Resend confirmation instructions
+        resend_unlock_instructions: Resend unlock instructions
         sign_in: Přihlásit se
         sign_in_with_omniauth_provider: Přihlásit se přes %{provider}
         sign_up: Registrovat se
@@ -51,12 +59,26 @@ cs:
         remember_me: Zapamatovat si mě
         submit: Přihlásit
         title: Přihlášení
+      password:
+        title: Password
+      password_confirmation:
+        title: Confirm Password
+      resend_confirmation_instructions:
+        submit: Resend confirmation instructions
+        title: Resend confirmation instructions
       reset_password:
         submit: Obnovit heslo
         title: Zapomněli jste heslo?
+      sign_up:
+        submit: Sign up
+        title: Sign up
+      subdomain:
+        title: Subdomain
       unlock:
         submit: Zaslat instrukce k odemčení účtu
         title: Zaslání instrukcí k odemčení účtu
+      username:
+        title: Username
     download: 'Stáhnout:'
     edit: Upravit
     edit_model: Upravit
@@ -65,12 +87,16 @@ cs:
       buttons:
         clear: Vyčistit filtry
         filter: Filtrovat
+      predicates:
+        from: From
+        to: To
     has_many_delete: Smazat
     has_many_new: Přidat nový
     has_many_remove: Odstranit
     index_list:
       table: Tabulka
     logout: Odhlásit
+    move: Move
     new_model: Vytvořit
     next: Následující
     pagination:
@@ -81,14 +107,44 @@ cs:
         other: položky
       multiple: "<b>%{from}&nbsp;-&nbsp;%{to}</b> z <b>%{total}</b>"
       multiple_without_total: "<b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      next: Next
       one: Zobrazena  <b>1</b> položka
       one_page: Počet zobrazených položek %{n}
+      per_page: 'Per page '
+      previous: Previous
     powered_by: "%{active_admin} %{version}"
     previous: Předchozí
+    scopes:
+      all: All
+    search_status:
+      no_current_filters: No filters applied
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: Filtry
+      search_status: Search Status
     status_tag:
       'no': Ne
       unset: Ne
       'yes': Ano
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: Zobrazit
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Author type
+        body: Body
+        created_at: Created
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Updated
+    models:
+      active_admin/comment:
+        one: Comment
+        other: Comments
+      comment:
+        one: Comment
+        other: Comments

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -143,8 +143,10 @@ cs:
         updated_at: Updated
     models:
       active_admin/comment:
+        few: Comments
         one: Comment
         other: Comments
       comment:
+        few: Comments
         one: Comment
         other: Comments

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -1,114 +1,115 @@
+---
 da:
   active_admin:
-    dashboard: "Kontrolpanel"
-    view: "Vis"
-    edit: "Rediger"
-    delete: "Slet"
-    delete_confirmation: "Er du sikker på, at du ønsker at slette?"
-    create_another: "Opret endnu en %{model}"
-    new_model: "Ny(t) %{model}"
-    edit_model: "Rediger %{model}"
-    delete_model: "Slet %{model}"
+    access_denied:
+      message: Du har ikke rettigheder til at udføre denne handling.
+    any: Alle
+    batch_actions:
+      action_label: "%{title} Valgte"
+      button_label: Batch Handlinger
+      default_confirmation: Er du sikker på du vil gøre dette?
+      delete_confirmation: Er du sikker på du vil slette disse %{plural_model}?
+      labels:
+        destroy: Slet
+      selection_toggle_explanation: "(Skift valg)"
+      succesfully_destroyed:
+        one: Vellykket ødelagt 1 %{model}
+        other: Vellykket ødelagt %{count} %{plural_model}
+    blank_slate:
+      content: Der er ingen %{resource_name} endnu.
+      link: Opret
+    cancel: Fortryd
+    comments:
+      add: Tilføj Kommentar
+      author: Forfatter
+      author_missing: Anonym
+      author_type: Forfatter type
+      body: Krop
+      created_at: Oprettet
+      delete: Slet kommentar
+      delete_confirmation: Er du sikker på du vil slette disse kommentarer?
+      errors:
+        empty_text: Kommentar blev ikke gemt, tekst var tom.
+      no_comments_yet: Ingen kommentarer endnu.
+      resource: Resource
+      resource_type: Resource type
+      title_content: Kommentarer (%{count})
+    create_another: Opret endnu en %{model}
+    dashboard: Kontrolpanel
+    delete: Slet
+    delete_confirmation: Er du sikker på, at du ønsker at slette?
+    delete_model: Slet %{model}
     details: "%{model} detaljer"
-    cancel: "Fortryd"
-    empty: "Tom"
-    previous: "Forrige"
-    next: "Næste"
-    download: "Download:"
-    has_many_new: "Tilføj ny(t) %{model}"
-    has_many_delete: "Slet"
-    has_many_remove: "Fjern"
+    devise:
+      change_password:
+        submit: Skift min adgangskode
+        title: Skift din adgangskode
+      email:
+        title: Email
+      links:
+        forgot_your_password: Glemt din adgangskode?
+        resend_confirmation_instructions: Send oplåsningsinstruktioner igen
+        resend_unlock_instructions: Send oplåsningsinstruktioner igen
+        sign_in: Log ind
+        sign_in_with_omniauth_provider: Log ind med %{provider}
+        sign_up: Opret bruger
+      login:
+        remember_me: Husk mig
+        submit: Login
+        title: Login
+      password:
+        title: Kodeord
+      resend_confirmation_instructions:
+        submit: Send bekræftigelsesinstruktioner igen
+        title: Send bekræftigelsesinstruktioner igen
+      reset_password:
+        submit: Nulstille min adgangskode
+        title: Glemt din adgangskode?
+      sign_up:
+        submit: Opret bruger
+        title: Opret bruger
+      subdomain:
+        title: Underdomæne
+      unlock:
+        submit: Send oplåsningsinstruktioner igen
+        title: Send oplåsningsinstruktioner igen
+      username:
+        title: Brugernavn
+    download: 'Download:'
+    edit: Rediger
+    edit_model: Rediger %{model}
+    empty: Tom
     filters:
       buttons:
-        filter: "Filtrer"
-        clear: "Ryd filtre"
-    search_status:
-      no_current_filters: "Ingen"
-    status_tag:
-      "yes": "Ja"
-      "no": "Nej"
-      "unset": "Nej"
-    logout: "Log ud"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filtre"
-      search_status: "Søgestatus"
-    pagination:
-      empty: "Ingen %{model} fundet"
-      one: "Viser <b>1</b> %{model}"
-      one_page: "Viser <b>alle %{n}</b> %{model}"
-      multiple: "Viser %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> af <b>%{total}</b> i alt"
-      multiple_without_total: "Viser %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      per_page: "Per side: "
-      entry:
-        one: "post"
-        other: "poster"
-    any: "Alle"
-    blank_slate:
-      content: "Der er ingen %{resource_name} endnu."
-      link: "Opret"
-    batch_actions:
-      button_label: "Batch Handlinger"
-      default_confirmation: "Er du sikker på du vil gøre dette?"
-      delete_confirmation: "Er du sikker på du vil slette disse %{plural_model}?"
-      succesfully_destroyed:
-        one: "Vellykket ødelagt 1 %{model}"
-        other: "Vellykket ødelagt %{count} %{plural_model}"
-      selection_toggle_explanation: "(Skift valg)"
-      action_label: "%{title} Valgte"
-      labels:
-        destroy: "Slet"
-    comments:
-      created_at: "Oprettet"
-      resource_type: "Resource type"
-      author_type: "Forfatter type"
-      body: "Krop"
-      author: "Forfatter"
-      add: "Tilføj Kommentar"
-      delete: "Slet kommentar"
-      delete_confirmation: "Er du sikker på du vil slette disse kommentarer?"
-      resource: "Resource"
-      no_comments_yet: "Ingen kommentarer endnu."
-      author_missing: "Anonym"
-      title_content: "Kommentarer (%{count})"
-      errors:
-        empty_text: "Kommentar blev ikke gemt, tekst var tom."
-    devise:
-      username:
-        title: "Brugernavn"
-      email:
-        title: "Email"
-      subdomain:
-        title: "Underdomæne"
-      password:
-        title: "Kodeord"
-      sign_up:
-        title: "Opret bruger"
-        submit: "Opret bruger"
-      login:
-        title: "Login"
-        remember_me: "Husk mig"
-        submit: "Login"
-      reset_password:
-        title: "Glemt din adgangskode?"
-        submit: "Nulstille min adgangskode"
-      change_password:
-        title: "Skift din adgangskode"
-        submit: "Skift min adgangskode"
-      unlock:
-        title: "Send oplåsningsinstruktioner igen"
-        submit: "Send oplåsningsinstruktioner igen"
-      resend_confirmation_instructions:
-        title: "Send bekræftigelsesinstruktioner igen"
-        submit: "Send bekræftigelsesinstruktioner igen"
-      links:
-        sign_up: "Opret bruger"
-        sign_in: "Log ind"
-        forgot_your_password: "Glemt din adgangskode?"
-        sign_in_with_omniauth_provider: "Log ind med %{provider}"
-        resend_unlock_instructions: "Send oplåsningsinstruktioner igen"
-        resend_confirmation_instructions: "Send oplåsningsinstruktioner igen"
-    access_denied:
-      message: "Du har ikke rettigheder til at udføre denne handling."
+        clear: Ryd filtre
+        filter: Filtrer
+    has_many_delete: Slet
+    has_many_new: Tilføj ny(t) %{model}
+    has_many_remove: Fjern
     index_list:
-      table: "Tabel"
+      table: Tabel
+    logout: Log ud
+    new_model: Ny(t) %{model}
+    next: Næste
+    pagination:
+      empty: Ingen %{model} fundet
+      entry:
+        one: post
+        other: poster
+      multiple: Viser %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> af <b>%{total}</b> i alt
+      multiple_without_total: Viser %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      one: Viser <b>1</b> %{model}
+      one_page: Viser <b>alle %{n}</b> %{model}
+      per_page: 'Per side: '
+    powered_by: Powered by %{active_admin} %{version}
+    previous: Forrige
+    search_status:
+      no_current_filters: Ingen
+    sidebars:
+      filters: Filtre
+      search_status: Søgestatus
+    status_tag:
+      'no': Nej
+      unset: Nej
+      'yes': Ja
+    view: Vis

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -59,6 +59,8 @@ da:
         title: Login
       password:
         title: Kodeord
+      password_confirmation:
+        title: Confirm Password
       resend_confirmation_instructions:
         submit: Send bekræftigelsesinstruktioner igen
         title: Send bekræftigelsesinstruktioner igen
@@ -83,12 +85,16 @@ da:
       buttons:
         clear: Ryd filtre
         filter: Filtrer
+      predicates:
+        from: From
+        to: To
     has_many_delete: Slet
     has_many_new: Tilføj ny(t) %{model}
     has_many_remove: Fjern
     index_list:
       table: Tabel
     logout: Log ud
+    move: Move
     new_model: Ny(t) %{model}
     next: Næste
     pagination:
@@ -98,13 +104,19 @@ da:
         other: poster
       multiple: Viser %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> af <b>%{total}</b> i alt
       multiple_without_total: Viser %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      next: Next
       one: Viser <b>1</b> %{model}
       one_page: Viser <b>alle %{n}</b> %{model}
       per_page: 'Per side: '
+      previous: Previous
     powered_by: Powered by %{active_admin} %{version}
     previous: Forrige
+    scopes:
+      all: All
     search_status:
       no_current_filters: Ingen
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: Filtre
       search_status: Søgestatus
@@ -112,4 +124,24 @@ da:
       'no': Nej
       unset: Nej
       'yes': Ja
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: Vis
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Author type
+        body: Body
+        created_at: Created
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Updated
+    models:
+      active_admin/comment:
+        one: Comment
+        other: Comments
+      comment:
+        one: Comment
+        other: Comments

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -124,6 +124,10 @@ de:
       'no': Nein
       unset: Nein
       'yes': Ja
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: Anzeigen
   activerecord:
     attributes:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,142 +1,143 @@
+---
 de:
-  activerecord:
-    models:
-      comment:
-        one: "Kommentar"
-        other: "Kommentare"
-      active_admin/comment:
-        one: "Kommentar"
-        other: "Kommentare"
-    attributes:
-      active_admin/comment:
-        author_type: "Autortyp"
-        body: "Inhalt"
-        created_at: "Erstellt"
-        namespace: "Namensraum"
-        resource_type: "Ressourcentyp"
-        updated_at: "Aktualisiert"
   active_admin:
-    dashboard: "Übersicht"
-    view: "Anzeigen"
-    edit: "Bearbeiten"
-    delete: "Löschen"
-    delete_confirmation: "Wollen Sie dieses Element wirklich löschen?"
-    create_another: "Mehr %{model} erstellen"
-    new_model: "%{model} erstellen"
-    edit_model: "%{model} bearbeiten"
+    access_denied:
+      message: Sie haben nicht die Berechtigung um diese Aktion auszuführen.
+    any: Alle
+    batch_actions:
+      action_label: Ausgewählte %{title}
+      button_label: Stapelverarbeitung
+      default_confirmation: Sind Sie sicher?
+      delete_confirmation: Sind Sie sicher dass Sie diese %{plural_model} löschen wollen?
+      labels:
+        destroy: löschen
+      selection_toggle_explanation: "(Auswahl umschalten)"
+      succesfully_destroyed:
+        one: Erfolgreich 1 %{model} gelöscht
+        other: Erfolgreich %{count} %{plural_model} gelöscht
+    blank_slate:
+      content: Es gibt noch keine %{resource_name}.
+      link: Erstellen
+    cancel: Abbrechen
+    comments:
+      add: Kommentar hinzufügen
+      author: Autor
+      author_missing: Unbekannt
+      author_type: Autor-Typ
+      body: Inhalt
+      created_at: Erstellt
+      delete: Löschen
+      delete_confirmation: Sind Sie sicher dass Sie diesen Kommentar löschen wollen?
+      errors:
+        empty_text: Der Kommentar wurde nicht gespeichert, da der Text fehlt.
+      no_comments_yet: Es gibt noch keine Kommentare.
+      resource: Res­sour­ce
+      resource_type: Res­sour­cen-Typ
+      title_content: Kommentare (%{count})
+    create_another: Mehr %{model} erstellen
+    dashboard: Übersicht
+    delete: Löschen
+    delete_confirmation: Wollen Sie dieses Element wirklich löschen?
     delete_model: "%{model} löschen"
     details: "%{model} Details"
-    cancel: "Abbrechen"
-    empty: "Leer"
-    previous: "Zurück"
-    next: "Weiter"
-    download: "Herunterladen:"
-    has_many_new: "%{model} hinzufügen"
-    has_many_delete: "Löschen"
-    has_many_remove: "Entfernen"
-    move: "Verschieben"
+    devise:
+      change_password:
+        submit: Mein Passwort ändern
+        title: Ändern Sie Ihr Passwort
+      email:
+        title: E-Mail-Adresse
+      links:
+        forgot_your_password: Passwort vergessen?
+        resend_confirmation_instructions: Bestätigungsanweisung erneut senden
+        resend_unlock_instructions: Entsperrungsanweisung erneut senden
+        sign_in: Anmeldung
+        sign_in_with_omniauth_provider: Anmeldung mit %{provider}
+        sign_up: Registrieren
+      login:
+        remember_me: Angemeldet bleiben
+        submit: Login
+        title: Login
+      password:
+        title: Passwort
+      password_confirmation:
+        title: Passwort Bestätigung
+      resend_confirmation_instructions:
+        submit: Anleitung zur Bestätigung noch mal schicken
+        title: Anleitung zur Bestätigung noch mal schicken
+      reset_password:
+        submit: Mein Passwort zurücksetzen
+        title: Passwort vergessen?
+      sign_up:
+        submit: Registrieren
+        title: Registrieren
+      subdomain:
+        title: Subdomain
+      unlock:
+        submit: Entsperrungsanweisung erneut senden
+        title: Entsperrungsanweisung erneut senden
+      username:
+        title: Benutzername
+    download: 'Herunterladen:'
+    edit: Bearbeiten
+    edit_model: "%{model} bearbeiten"
+    empty: Leer
     filters:
       buttons:
-        filter: "Filtern"
-        clear: "Filter entfernen"
+        clear: Filter entfernen
+        filter: Filtern
       predicates:
-        from: "Von"
-        to: "Bis"
-    scopes:
-      all: "Alle"
-    search_status:
-      title: "Aktive Filter"
-      title_with_scope: "Aktive Filter in %{name}"
-      no_current_filters: "Keine"
-    status_tag:
-      "yes": "Ja"
-      "no": "Nein"
-      "unset": "Nein"
-    logout: "Abmelden"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filter"
-      search_status: "Aktive Filter"
+        from: Von
+        to: Bis
+    has_many_delete: Löschen
+    has_many_new: "%{model} hinzufügen"
+    has_many_remove: Entfernen
+    index_list:
+      table: Tabelle
+    logout: Abmelden
+    move: Verschieben
+    new_model: "%{model} erstellen"
+    next: Weiter
     pagination:
-      empty: "Keine %{model} gefunden"
-      one: "<b>1</b> %{model}"
-      one_page: "<b>Alle %{n}</b> %{model}"
+      empty: Keine %{model} gefunden
+      entry:
+        one: Eintrag
+        other: Einträge
       multiple: "%{model} <b>%{from}&nbsp;–&nbsp;%{to}</b> von <b>%{total}</b>"
       multiple_without_total: "%{model} <b>%{from}&nbsp;–&nbsp;%{to}</b>"
-      per_page: "Pro Seite: "
-      previous: "Vorherige"
-      next: "Nächste"
-      entry:
-        one: "Eintrag"
-        other: "Einträge"
-    any: "Alle"
-    blank_slate:
-      content: "Es gibt noch keine %{resource_name}."
-      link: "Erstellen"
-    batch_actions:
-      button_label: "Stapelverarbeitung"
-      default_confirmation: "Sind Sie sicher?"
-      delete_confirmation: "Sind Sie sicher dass Sie diese %{plural_model} löschen wollen?"
-      succesfully_destroyed:
-        one: "Erfolgreich 1 %{model} gelöscht"
-        other: "Erfolgreich %{count} %{plural_model} gelöscht"
-      selection_toggle_explanation: "(Auswahl umschalten)"
-      action_label: "Ausgewählte %{title}"
-      labels:
-        destroy: "löschen"
-    comments:
-      created_at: "Erstellt"
-      resource_type: "Res­sour­cen-Typ"
-      author_type: "Autor-Typ"
-      body: "Inhalt"
-      author: "Autor"
-      add: "Kommentar hinzufügen"
-      delete: "Löschen"
-      delete_confirmation: "Sind Sie sicher dass Sie diesen Kommentar löschen wollen?"
-      resource: "Res­sour­ce"
-      no_comments_yet: "Es gibt noch keine Kommentare."
-      author_missing: "Unbekannt"
-      title_content: "Kommentare (%{count})"
-      errors:
-        empty_text: "Der Kommentar wurde nicht gespeichert, da der Text fehlt."
-    devise:
-      username:
-        title: "Benutzername"
-      email:
-        title: "E-Mail-Adresse"
-      subdomain:
-        title: "Subdomain"
-      password:
-        title: "Passwort"
-      password_confirmation:
-        title: "Passwort Bestätigung"
-      sign_up:
-        title: "Registrieren"
-        submit: "Registrieren"
-      login:
-        title: "Login"
-        remember_me: "Angemeldet bleiben"
-        submit: "Login"
-      reset_password:
-        title: "Passwort vergessen?"
-        submit: "Mein Passwort zurücksetzen"
-      change_password:
-        title: "Ändern Sie Ihr Passwort"
-        submit: "Mein Passwort ändern"
-      unlock:
-        title: "Entsperrungsanweisung erneut senden"
-        submit: "Entsperrungsanweisung erneut senden"
-      resend_confirmation_instructions:
-        title: "Anleitung zur Bestätigung noch mal schicken"
-        submit: "Anleitung zur Bestätigung noch mal schicken"
-      links:
-        sign_up: "Registrieren"
-        sign_in: "Anmeldung"
-        forgot_your_password: "Passwort vergessen?"
-        sign_in_with_omniauth_provider: "Anmeldung mit %{provider}"
-        resend_unlock_instructions: "Entsperrungsanweisung erneut senden"
-        resend_confirmation_instructions: "Bestätigungsanweisung erneut senden"
-    access_denied:
-      message: "Sie haben nicht die Berechtigung um diese Aktion auszuführen."
-    index_list:
-      table: "Tabelle"
+      next: Nächste
+      one: "<b>1</b> %{model}"
+      one_page: "<b>Alle %{n}</b> %{model}"
+      per_page: 'Pro Seite: '
+      previous: Vorherige
+    powered_by: Powered by %{active_admin} %{version}
+    previous: Zurück
+    scopes:
+      all: Alle
+    search_status:
+      no_current_filters: Keine
+      title: Aktive Filter
+      title_with_scope: Aktive Filter in %{name}
+    sidebars:
+      filters: Filter
+      search_status: Aktive Filter
+    status_tag:
+      'no': Nein
+      unset: Nein
+      'yes': Ja
+    view: Anzeigen
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Autortyp
+        body: Inhalt
+        created_at: Erstellt
+        namespace: Namensraum
+        resource_type: Ressourcentyp
+        updated_at: Aktualisiert
+    models:
+      active_admin/comment:
+        one: Kommentar
+        other: Kommentare
+      comment:
+        one: Kommentar
+        other: Kommentare

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -25,12 +25,16 @@ el:
       author_missing: Ανώνυμος
       author_type: Τύπος Συγγραφέα
       body: Κείμενο
+      created_at: Created
+      delete: Delete Comment
+      delete_confirmation: Are you sure you want to delete this comment?
       errors:
         empty_text: Το σχόλιο δε σώθηκε, το κείμενο ήταν κενό.
       no_comments_yet: Δεν υπάρχει κανένα σχόλιο.
       resource: Εγγραφή
       resource_type: Τύπος Εγγραφής
       title_content: Σχόλια (%{count})
+    create_another: Create another %{model}
     dashboard: Σελίδα διαχείρισης
     delete: Διαγραφή
     delete_confirmation: Είστε σίγουρος πως θέλετε να το διαγράψετε;
@@ -55,6 +59,8 @@ el:
         title: Σύνδεση
       password:
         title: Κωδικός
+      password_confirmation:
+        title: Confirm Password
       resend_confirmation_instructions:
         submit: Αποστολή οδηγιών επιβεβαίωσης
         title: Αποστολή οδηγιών επιβεβαίωσης
@@ -79,12 +85,16 @@ el:
       buttons:
         clear: Καθαρισμός Φίλτρων
         filter: Φίλτρα
+      predicates:
+        from: From
+        to: To
     has_many_delete: Διαγραφή
     has_many_new: Προσθήκη Νέου %{model}
     has_many_remove: Αφαίρεση
     index_list:
       table: Πίνακας
     logout: Αποσύνδεση
+    move: Move
     new_model: Δημιουργία %{model}
     next: Επόμενη
     pagination:
@@ -94,14 +104,44 @@ el:
         other: εγγραφές
       multiple: Εμφανίζονται %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> από <b>%{total}</b> συνολικά
       multiple_without_total: Εμφανίζονται %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      next: Next
       one: Εμφάνιζεται <b>1</b> %{model}
       one_page: Εμφανίζονται <b>όλες οι %{n}</b> εγγραφές %{model}
+      per_page: 'Per page '
+      previous: Previous
     powered_by: Powered by %{active_admin} %{version}
     previous: Προηγούμενη
+    scopes:
+      all: All
+    search_status:
+      no_current_filters: No filters applied
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: Φίλτρα
+      search_status: Search Status
     status_tag:
       'no': Όχι
       unset: Όχι
       'yes': Ναι
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: Προβολή
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Author type
+        body: Body
+        created_at: Created
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Updated
+    models:
+      active_admin/comment:
+        one: Comment
+        other: Comments
+      comment:
+        one: Comment
+        other: Comments

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -1,106 +1,107 @@
+---
 el:
   active_admin:
-    dashboard: "Σελίδα διαχείρισης"
-    view: "Προβολή"
-    edit: "Επεξεργασία"
-    delete: "Διαγραφή"
-    delete_confirmation: "Είστε σίγουρος πως θέλετε να το διαγράψετε;"
-    new_model: "Δημιουργία %{model}"
-    edit_model: "Επεξεργασία %{model}"
-    delete_model: "Διαγραφή %{model}"
-    details: "Λεπτομέρειες %{model}"
-    cancel: "Ακύρωση"
-    empty: "Άδειο"
-    previous: "Προηγούμενη"
-    next: "Επόμενη"
-    download: "Κατέβασμα:"
-    has_many_new: "Προσθήκη Νέου %{model}"
-    has_many_delete: "Διαγραφή"
-    has_many_remove: "Αφαίρεση"
+    access_denied:
+      message: Δεν έχετε πρόσβαση για αυτή την ενέργεια.
+    any: Όλες οι εγγραφές
+    batch_actions:
+      action_label: "%{title} επιλεγμένων"
+      button_label: Μαζικές Ενέργειες
+      default_confirmation: Είστε σίγουρος πως θέλετε να το κάνετε αυτό;
+      delete_confirmation: Είστε σίγουρος πως θέλετε να διαγράψετε αυτά τα %{plural_model}?
+      labels:
+        destroy: Διαγραφή
+      selection_toggle_explanation: "(Αντιστροφή επιλογών)"
+      succesfully_destroyed:
+        one: Διαγράφηκε επιτυχώς 1 %{model}
+        other: Διαγράφηκαν επιτυχώς %{count} %{plural_model}
+    blank_slate:
+      content: Δεν υπάρχουν %{resource_name} ακόμα.
+      link: Δημιουργήστε μία εγγραφή
+    cancel: Ακύρωση
+    comments:
+      add: Προσθήκη Σχολίου
+      author: Συγγραφέας
+      author_missing: Ανώνυμος
+      author_type: Τύπος Συγγραφέα
+      body: Κείμενο
+      errors:
+        empty_text: Το σχόλιο δε σώθηκε, το κείμενο ήταν κενό.
+      no_comments_yet: Δεν υπάρχει κανένα σχόλιο.
+      resource: Εγγραφή
+      resource_type: Τύπος Εγγραφής
+      title_content: Σχόλια (%{count})
+    dashboard: Σελίδα διαχείρισης
+    delete: Διαγραφή
+    delete_confirmation: Είστε σίγουρος πως θέλετε να το διαγράψετε;
+    delete_model: Διαγραφή %{model}
+    details: Λεπτομέρειες %{model}
+    devise:
+      change_password:
+        submit: Αλλαγή του κωδικού
+        title: Αλλάξτε τον κωδικό σας
+      email:
+        title: Email
+      links:
+        forgot_your_password: Ξεχάσατε τον κωδικό σας;
+        resend_confirmation_instructions: Αποστολή οδηγιών επιβεβαίωσης
+        resend_unlock_instructions: Αποστολή οδηγιών ξεκλειδώματος
+        sign_in: Σύνδεση
+        sign_in_with_omniauth_provider: Σύνδεση με %{provider}
+        sign_up: Εγγραφή
+      login:
+        remember_me: Να με θυμάσαι
+        submit: Σύνδεση
+        title: Σύνδεση
+      password:
+        title: Κωδικός
+      resend_confirmation_instructions:
+        submit: Αποστολή οδηγιών επιβεβαίωσης
+        title: Αποστολή οδηγιών επιβεβαίωσης
+      reset_password:
+        submit: Επαναφορά κωδικού
+        title: Ξεχάσατε τον κωδικό σας;
+      sign_up:
+        submit: Εγγραφή
+        title: Εγγραφή
+      subdomain:
+        title: Subdomain
+      unlock:
+        submit: Αποστολή οδηγιών ξεκλειδώματος
+        title: Αποστολή οδηγιών ξεκλειδώματος
+      username:
+        title: Όνομα χρήστη
+    download: 'Κατέβασμα:'
+    edit: Επεξεργασία
+    edit_model: Επεξεργασία %{model}
+    empty: Άδειο
     filters:
       buttons:
-        filter: "Φίλτρα"
-        clear: "Καθαρισμός Φίλτρων"
-    status_tag:
-      "yes": "Ναι"
-      "no": "Όχι"
-      "unset": "Όχι"
-    logout: "Αποσύνδεση"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Φίλτρα"
-    pagination:
-      empty: "Δε βρέθηκαν %{model}"
-      one: "Εμφάνιζεται <b>1</b> %{model}"
-      one_page: "Εμφανίζονται <b>όλες οι %{n}</b> εγγραφές %{model}"
-      multiple: "Εμφανίζονται %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> από <b>%{total}</b> συνολικά"
-      multiple_without_total: "Εμφανίζονται %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      entry:
-        one: "εγγραφή"
-        other: "εγγραφές"
-    any: "Όλες οι εγγραφές"
-    blank_slate:
-      content: "Δεν υπάρχουν %{resource_name} ακόμα."
-      link: "Δημιουργήστε μία εγγραφή"
-    batch_actions:
-      button_label: "Μαζικές Ενέργειες"
-      default_confirmation: "Είστε σίγουρος πως θέλετε να το κάνετε αυτό;"
-      delete_confirmation: "Είστε σίγουρος πως θέλετε να διαγράψετε αυτά τα %{plural_model}?"
-      succesfully_destroyed:
-        one: "Διαγράφηκε επιτυχώς 1 %{model}"
-        other: "Διαγράφηκαν επιτυχώς %{count} %{plural_model}"
-      selection_toggle_explanation: "(Αντιστροφή επιλογών)"
-      action_label: "%{title} επιλεγμένων"
-      labels:
-        destroy: "Διαγραφή"
-    comments:
-      resource_type: "Τύπος Εγγραφής"
-      author_type: "Τύπος Συγγραφέα"
-      body: "Κείμενο"
-      author: "Συγγραφέας"
-      add: "Προσθήκη Σχολίου"
-      resource: "Εγγραφή"
-      no_comments_yet: "Δεν υπάρχει κανένα σχόλιο."
-      author_missing: "Ανώνυμος"
-      title_content: "Σχόλια (%{count})"
-      errors:
-        empty_text: "Το σχόλιο δε σώθηκε, το κείμενο ήταν κενό."
-    devise:
-      username:
-        title: "Όνομα χρήστη"
-      email:
-        title: "Email"
-      subdomain:
-        title: "Subdomain"
-      password:
-        title: "Κωδικός"
-      sign_up:
-        title: "Εγγραφή"
-        submit: "Εγγραφή"
-      login:
-        title: "Σύνδεση"
-        remember_me: "Να με θυμάσαι"
-        submit: "Σύνδεση"
-      reset_password:
-        title: "Ξεχάσατε τον κωδικό σας;"
-        submit: "Επαναφορά κωδικού"
-      change_password:
-        title: "Αλλάξτε τον κωδικό σας"
-        submit: "Αλλαγή του κωδικού"
-      unlock:
-        title: "Αποστολή οδηγιών ξεκλειδώματος"
-        submit: "Αποστολή οδηγιών ξεκλειδώματος"
-      resend_confirmation_instructions:
-        title: "Αποστολή οδηγιών επιβεβαίωσης"
-        submit: "Αποστολή οδηγιών επιβεβαίωσης"
-      links:
-        sign_in: "Σύνδεση"
-        sign_up: "Εγγραφή"
-        forgot_your_password: "Ξεχάσατε τον κωδικό σας;"
-        sign_in_with_omniauth_provider: "Σύνδεση με %{provider}"
-        resend_unlock_instructions: "Αποστολή οδηγιών ξεκλειδώματος"
-        resend_confirmation_instructions: "Αποστολή οδηγιών επιβεβαίωσης"
-    access_denied:
-      message: "Δεν έχετε πρόσβαση για αυτή την ενέργεια."
+        clear: Καθαρισμός Φίλτρων
+        filter: Φίλτρα
+    has_many_delete: Διαγραφή
+    has_many_new: Προσθήκη Νέου %{model}
+    has_many_remove: Αφαίρεση
     index_list:
-      table: "Πίνακας"
+      table: Πίνακας
+    logout: Αποσύνδεση
+    new_model: Δημιουργία %{model}
+    next: Επόμενη
+    pagination:
+      empty: Δε βρέθηκαν %{model}
+      entry:
+        one: εγγραφή
+        other: εγγραφές
+      multiple: Εμφανίζονται %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> από <b>%{total}</b> συνολικά
+      multiple_without_total: Εμφανίζονται %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      one: Εμφάνιζεται <b>1</b> %{model}
+      one_page: Εμφανίζονται <b>όλες οι %{n}</b> εγγραφές %{model}
+    powered_by: Powered by %{active_admin} %{version}
+    previous: Προηγούμενη
+    sidebars:
+      filters: Φίλτρα
+    status_tag:
+      'no': Όχι
+      unset: Όχι
+      'yes': Ναι
+    view: Προβολή

--- a/config/locales/en-CA.yml
+++ b/config/locales/en-CA.yml
@@ -1,116 +1,117 @@
-"en-CA":
+---
+en-CA:
   active_admin:
+    access_denied:
+      message: You are not authorized to perform this action.
+    any: Any
+    batch_actions:
+      action_label: "%{title} Selected"
+      button_label: Batch Actions
+      default_confirmation: Are you sure you want to do this?
+      delete_confirmation: Are you sure you want to delete these %{plural_model}?
+      labels:
+        destroy: Delete
+      selection_toggle_explanation: "(Toggle Selection)"
+      succesfully_destroyed:
+        one: Successfully deleted 1 %{model}
+        other: Successfully deleted %{count} %{plural_model}
+    blank_slate:
+      content: There are no %{resource_name} yet.
+      link: Create one
+    cancel: Cancel
+    comments:
+      add: Add Comment
+      author: Author
+      author_missing: Anonymous
+      author_type: Author Type
+      body: Body
+      created_at: Created
+      delete: Delete Comment
+      delete_confirmation: Are you sure you want to delete these comments?
+      errors:
+        empty_text: Comment wasn't saved, text was empty.
+      no_comments_yet: No comments yet.
+      resource: Resource
+      resource_type: Resource Type
+      title_content: Comments (%{count})
+    create_another: Create another %{model}
     dashboard: Dashboard
-    view: "View"
-    edit: "Edit"
-    delete: "Delete"
-    delete_confirmation: "Are you sure you want to delete this?"
-    create_another: "Create another %{model}"
-    new_model: "New %{model}"
-    edit_model: "Edit %{model}"
-    delete_model: "Delete %{model}"
+    delete: Delete
+    delete_confirmation: Are you sure you want to delete this?
+    delete_model: Delete %{model}
     details: "%{model} Details"
-    cancel: "Cancel"
-    empty: "Empty"
-    previous: "Previous"
-    next: "Next"
-    download: "Download:"
-    has_many_new: "Add New %{model}"
-    has_many_delete: "Delete"
-    has_many_remove: "Remove"
+    devise:
+      change_password:
+        submit: Change my password
+        title: Change your password
+      email:
+        title: Email
+      links:
+        forgot_your_password: Forgot your password?
+        resend_confirmation_instructions: Resend confirmation instructions
+        resend_unlock_instructions: Resend unlock instructions
+        sign_in: Sign in
+        sign_in_with_omniauth_provider: Sign in with %{provider}
+        sign_up: Sign up
+      login:
+        remember_me: Remember me
+        submit: Login
+        title: Login
+      password:
+        title: Password
+      password_confirmation:
+        title: Confirm Password
+      resend_confirmation_instructions:
+        submit: Resend confirmation instructions
+        title: Resend confirmation instructions
+      reset_password:
+        submit: Reset My Password
+        title: Forgot your password?
+      sign_up:
+        submit: Sign up
+        title: Sign up
+      subdomain:
+        title: Subdomain
+      unlock:
+        submit: Resend unlock instructions
+        title: Resend unlock instructions
+      username:
+        title: Username
+    download: 'Download:'
+    edit: Edit
+    edit_model: Edit %{model}
+    empty: Empty
     filters:
       buttons:
-        filter: "Filter"
-        clear: "Clear Filters"
-    search_status:
-      no_current_filters: "None"
-    status_tag:
-      "yes": "Yes"
-      "no": "No"
-      "unset": "No"
-    logout: "Logout"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filters"
-      search_status: "Search Status"
-    pagination:
-      empty: "No %{model} found"
-      one: "Displaying <b>1</b> %{model}"
-      one_page: "Displaying <b>all %{n}</b> %{model}"
-      multiple: "Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> of <b>%{total}</b> in total"
-      multiple_without_total: "Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      per_page: "Per page: "
-      entry:
-        one: "entry"
-        other: "entries"
-    any: "Any"
-    blank_slate:
-      content: "There are no %{resource_name} yet."
-      link: "Create one"
-    batch_actions:
-      button_label: "Batch Actions"
-      default_confirmation: "Are you sure you want to do this?"
-      delete_confirmation: "Are you sure you want to delete these %{plural_model}?"
-      succesfully_destroyed:
-        one: "Successfully deleted 1 %{model}"
-        other: "Successfully deleted %{count} %{plural_model}"
-      selection_toggle_explanation: "(Toggle Selection)"
-      action_label: "%{title} Selected"
-      labels:
-        destroy: "Delete"
-    comments:
-      created_at: "Created"
-      resource_type: "Resource Type"
-      author_type: "Author Type"
-      body: "Body"
-      author: "Author"
-      add: "Add Comment"
-      delete: "Delete Comment"
-      delete_confirmation: "Are you sure you want to delete these comments?"
-      resource: "Resource"
-      no_comments_yet: "No comments yet."
-      author_missing: "Anonymous"
-      title_content: "Comments (%{count})"
-      errors:
-        empty_text: "Comment wasn't saved, text was empty."
-    devise:
-      username:
-        title: "Username"
-      email:
-        title: "Email"
-      subdomain:
-        title: "Subdomain"
-      password:
-        title: "Password"
-      password_confirmation:
-        title: "Confirm Password"
-      sign_up:
-        title: "Sign up"
-        submit: "Sign up"
-      login:
-        title: "Login"
-        remember_me: "Remember me"
-        submit: "Login"
-      reset_password:
-        title: "Forgot your password?"
-        submit: "Reset My Password"
-      change_password:
-        title: "Change your password"
-        submit: "Change my password"
-      unlock:
-        title: "Resend unlock instructions"
-        submit: "Resend unlock instructions"
-      resend_confirmation_instructions:
-        title: "Resend confirmation instructions"
-        submit: "Resend confirmation instructions"
-      links:
-        sign_up: "Sign up"
-        sign_in: "Sign in"
-        forgot_your_password: "Forgot your password?"
-        sign_in_with_omniauth_provider: "Sign in with %{provider}"
-        resend_unlock_instructions: "Resend unlock instructions"
-        resend_confirmation_instructions: "Resend confirmation instructions"
-    access_denied:
-      message: "You are not authorized to perform this action."
+        clear: Clear Filters
+        filter: Filter
+    has_many_delete: Delete
+    has_many_new: Add New %{model}
+    has_many_remove: Remove
     index_list:
-      table: "Table"
+      table: Table
+    logout: Logout
+    new_model: New %{model}
+    next: Next
+    pagination:
+      empty: No %{model} found
+      entry:
+        one: entry
+        other: entries
+      multiple: Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> of <b>%{total}</b> in total
+      multiple_without_total: Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      one: Displaying <b>1</b> %{model}
+      one_page: Displaying <b>all %{n}</b> %{model}
+      per_page: 'Per page: '
+    powered_by: Powered by %{active_admin} %{version}
+    previous: Previous
+    search_status:
+      no_current_filters: None
+    sidebars:
+      filters: Filters
+      search_status: Search Status
+    status_tag:
+      'no': 'No'
+      unset: 'No'
+      'yes': 'Yes'
+    view: View

--- a/config/locales/en-CA.yml
+++ b/config/locales/en-CA.yml
@@ -85,12 +85,16 @@ en-CA:
       buttons:
         clear: Clear Filters
         filter: Filter
+      predicates:
+        from: From
+        to: To
     has_many_delete: Delete
     has_many_new: Add New %{model}
     has_many_remove: Remove
     index_list:
       table: Table
     logout: Logout
+    move: Move
     new_model: New %{model}
     next: Next
     pagination:
@@ -100,13 +104,19 @@ en-CA:
         other: entries
       multiple: Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> of <b>%{total}</b> in total
       multiple_without_total: Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      next: Next
       one: Displaying <b>1</b> %{model}
       one_page: Displaying <b>all %{n}</b> %{model}
       per_page: 'Per page: '
+      previous: Previous
     powered_by: Powered by %{active_admin} %{version}
     previous: Previous
+    scopes:
+      all: All
     search_status:
       no_current_filters: None
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: Filters
       search_status: Search Status
@@ -114,4 +124,24 @@ en-CA:
       'no': 'No'
       unset: 'No'
       'yes': 'Yes'
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: View
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Author type
+        body: Body
+        created_at: Created
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Updated
+    models:
+      active_admin/comment:
+        one: Comment
+        other: Comments
+      comment:
+        one: Comment
+        other: Comments

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -85,12 +85,16 @@ en-GB:
       buttons:
         clear: Clear Filters
         filter: Filter
+      predicates:
+        from: From
+        to: To
     has_many_delete: Delete
     has_many_new: Add New %{model}
     has_many_remove: Remove
     index_list:
       table: Table
     logout: Logout
+    move: Move
     new_model: New %{model}
     next: Next
     pagination:
@@ -100,13 +104,19 @@ en-GB:
         other: entries
       multiple: Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> of <b>%{total}</b> in total
       multiple_without_total: Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      next: Next
       one: Displaying <b>1</b> %{model}
       one_page: Displaying <b>all %{n}</b> %{model}
       per_page: 'Per page: '
+      previous: Previous
     powered_by: Powered by %{active_admin} %{version}
     previous: Previous
+    scopes:
+      all: All
     search_status:
       no_current_filters: None
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: Filters
       search_status: Search Status
@@ -114,4 +124,24 @@ en-GB:
       'no': 'No'
       unset: 'No'
       'yes': 'Yes'
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: View
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Author type
+        body: Body
+        created_at: Created
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Updated
+    models:
+      active_admin/comment:
+        one: Comment
+        other: Comments
+      comment:
+        one: Comment
+        other: Comments

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -1,116 +1,117 @@
-"en-GB":
+---
+en-GB:
   active_admin:
+    access_denied:
+      message: You are not authorised to perform this action.
+    any: Any
+    batch_actions:
+      action_label: "%{title} Selected"
+      button_label: Batch Actions
+      default_confirmation: Are you sure you want to do this?
+      delete_confirmation: Are you sure you want to delete these %{plural_model}?
+      labels:
+        destroy: Delete
+      selection_toggle_explanation: "(Toggle Selection)"
+      succesfully_destroyed:
+        one: Successfully deleted 1 %{model}
+        other: Successfully deleted %{count} %{plural_model}
+    blank_slate:
+      content: There are no %{resource_name} yet.
+      link: Create one
+    cancel: Cancel
+    comments:
+      add: Add Comment
+      author: Author
+      author_missing: Anonymous
+      author_type: Author Type
+      body: Body
+      created_at: Created
+      delete: Delete Comment
+      delete_confirmation: Are you sure you want to delete these comments?
+      errors:
+        empty_text: Comment wasn't saved, text was empty.
+      no_comments_yet: No comments yet.
+      resource: Resource
+      resource_type: Resource Type
+      title_content: Comments (%{count})
+    create_another: Create another %{model}
     dashboard: Dashboard
-    view: "View"
-    edit: "Edit"
-    delete: "Delete"
-    delete_confirmation: "Are you sure you want to delete this?"
-    create_another: "Create another %{model}"
-    new_model: "New %{model}"
-    edit_model: "Edit %{model}"
-    delete_model: "Delete %{model}"
+    delete: Delete
+    delete_confirmation: Are you sure you want to delete this?
+    delete_model: Delete %{model}
     details: "%{model} Details"
-    cancel: "Cancel"
-    empty: "Empty"
-    previous: "Previous"
-    next: "Next"
-    download: "Download:"
-    has_many_new: "Add New %{model}"
-    has_many_delete: "Delete"
-    has_many_remove: "Remove"
+    devise:
+      change_password:
+        submit: Change my password
+        title: Change your password
+      email:
+        title: Email
+      links:
+        forgot_your_password: Forgot your password?
+        resend_confirmation_instructions: Resend confirmation instructions
+        resend_unlock_instructions: Resend unlock instructions
+        sign_in: Sign in
+        sign_in_with_omniauth_provider: Sign in with %{provider}
+        sign_up: Sign up
+      login:
+        remember_me: Remember me
+        submit: Login
+        title: Login
+      password:
+        title: Password
+      password_confirmation:
+        title: Confirm Password
+      resend_confirmation_instructions:
+        submit: Resend confirmation instructions
+        title: Resend confirmation instructions
+      reset_password:
+        submit: Reset My Password
+        title: Forgot your password?
+      sign_up:
+        submit: Sign up
+        title: Sign up
+      subdomain:
+        title: Subdomain
+      unlock:
+        submit: Resend unlock instructions
+        title: Resend unlock instructions
+      username:
+        title: Username
+    download: 'Download:'
+    edit: Edit
+    edit_model: Edit %{model}
+    empty: Empty
     filters:
       buttons:
-        filter: "Filter"
-        clear: "Clear Filters"
-    search_status:
-      no_current_filters: "None"
-    status_tag:
-      "yes": "Yes"
-      "no": "No"
-      "unset": "No"
-    logout: "Logout"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filters"
-      search_status: "Search Status"
-    pagination:
-      empty: "No %{model} found"
-      one: "Displaying <b>1</b> %{model}"
-      one_page: "Displaying <b>all %{n}</b> %{model}"
-      multiple: "Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> of <b>%{total}</b> in total"
-      multiple_without_total: "Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      per_page: "Per page: "
-      entry:
-        one: "entry"
-        other: "entries"
-    any: "Any"
-    blank_slate:
-      content: "There are no %{resource_name} yet."
-      link: "Create one"
-    batch_actions:
-      button_label: "Batch Actions"
-      default_confirmation: "Are you sure you want to do this?"
-      delete_confirmation: "Are you sure you want to delete these %{plural_model}?"
-      succesfully_destroyed:
-        one: "Successfully deleted 1 %{model}"
-        other: "Successfully deleted %{count} %{plural_model}"
-      selection_toggle_explanation: "(Toggle Selection)"
-      action_label: "%{title} Selected"
-      labels:
-        destroy: "Delete"
-    comments:
-      created_at: "Created"
-      resource_type: "Resource Type"
-      author_type: "Author Type"
-      body: "Body"
-      author: "Author"
-      add: "Add Comment"
-      delete: "Delete Comment"
-      delete_confirmation: "Are you sure you want to delete these comments?"
-      resource: "Resource"
-      no_comments_yet: "No comments yet."
-      author_missing: "Anonymous"
-      title_content: "Comments (%{count})"
-      errors:
-        empty_text: "Comment wasn't saved, text was empty."
-    devise:
-      username:
-        title: "Username"
-      email:
-        title: "Email"
-      subdomain:
-        title: "Subdomain"
-      password:
-        title: "Password"
-      password_confirmation:
-        title: "Confirm Password"
-      sign_up:
-        title: "Sign up"
-        submit: "Sign up"
-      login:
-        title: "Login"
-        remember_me: "Remember me"
-        submit: "Login"
-      reset_password:
-        title: "Forgot your password?"
-        submit: "Reset My Password"
-      change_password:
-        title: "Change your password"
-        submit: "Change my password"
-      unlock:
-        title: "Resend unlock instructions"
-        submit: "Resend unlock instructions"
-      resend_confirmation_instructions:
-        title: "Resend confirmation instructions"
-        submit: "Resend confirmation instructions"
-      links:
-        sign_up: "Sign up"
-        sign_in: "Sign in"
-        forgot_your_password: "Forgot your password?"
-        sign_in_with_omniauth_provider: "Sign in with %{provider}"
-        resend_unlock_instructions: "Resend unlock instructions"
-        resend_confirmation_instructions: "Resend confirmation instructions"
-    access_denied:
-      message: "You are not authorised to perform this action."
+        clear: Clear Filters
+        filter: Filter
+    has_many_delete: Delete
+    has_many_new: Add New %{model}
+    has_many_remove: Remove
     index_list:
-      table: "Table"
+      table: Table
+    logout: Logout
+    new_model: New %{model}
+    next: Next
+    pagination:
+      empty: No %{model} found
+      entry:
+        one: entry
+        other: entries
+      multiple: Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> of <b>%{total}</b> in total
+      multiple_without_total: Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      one: Displaying <b>1</b> %{model}
+      one_page: Displaying <b>all %{n}</b> %{model}
+      per_page: 'Per page: '
+    powered_by: Powered by %{active_admin} %{version}
+    previous: Previous
+    search_status:
+      no_current_filters: None
+    sidebars:
+      filters: Filters
+      search_status: Search Status
+    status_tag:
+      'no': 'No'
+      unset: 'No'
+      'yes': 'Yes'
+    view: View

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,146 +1,147 @@
+---
 en:
-  activerecord:
-    models:
-      comment:
-        one: "Comment"
-        other: "Comments"
-      active_admin/comment:
-        one: "Comment"
-        other: "Comments"
-    attributes:
-      active_admin/comment:
-        author_type: "Author type"
-        body: "Body"
-        created_at: "Created"
-        namespace: "Namespace"
-        resource_type: "Resource type"
-        updated_at: "Updated"
   active_admin:
-    dashboard: "Dashboard"
-    view: "View"
-    edit: "Edit"
-    delete: "Delete"
-    delete_confirmation: "Are you sure you want to delete this?"
-    create_another: "Create another %{model}"
-    new_model: "New %{model}"
-    edit_model: "Edit %{model}"
-    delete_model: "Delete %{model}"
+    access_denied:
+      message: You are not authorized to perform this action.
+    any: Any
+    batch_actions:
+      action_label: "%{title} Selected"
+      button_label: Batch Actions
+      default_confirmation: Are you sure you want to do this?
+      delete_confirmation: Are you sure you want to delete these %{plural_model}?
+      labels:
+        destroy: Delete
+      selection_toggle_explanation: "(Toggle Selection)"
+      succesfully_destroyed:
+        one: Successfully deleted 1 %{model}
+        other: Successfully deleted %{count} %{plural_model}
+    blank_slate:
+      content: There are no %{resource_name} yet.
+      link: Create one
+    cancel: Cancel
+    comments:
+      add: Add Comment
+      author: Author
+      author_missing: Anonymous
+      author_type: Author Type
+      body: Body
+      created_at: Created
+      delete: Delete Comment
+      delete_confirmation: Are you sure you want to delete this comment?
+      errors:
+        empty_text: Comment wasn't saved, text was empty.
+      no_comments_yet: No comments yet.
+      resource: Resource
+      resource_type: Resource Type
+      title_content: All Comments (%{count})
+    create_another: Create another %{model}
+    dashboard: Dashboard
+    delete: Delete
+    delete_confirmation: Are you sure you want to delete this?
+    delete_model: Delete %{model}
     details: "%{model} Details"
-    cancel: "Cancel"
-    empty: "Empty"
-    previous: "Previous"
-    next: "Next"
-    download: "Download:"
-    has_many_new: "Add New %{model}"
-    has_many_delete: "Delete"
-    has_many_remove: "Remove"
-    move: "Move"
+    devise:
+      change_password:
+        submit: Change my password
+        title: Change your password
+      email:
+        title: Email
+      links:
+        forgot_your_password: Forgot your password?
+        resend_confirmation_instructions: Resend confirmation instructions
+        resend_unlock_instructions: Resend unlock instructions
+        sign_in: Sign in
+        sign_in_with_omniauth_provider: Sign in with %{provider}
+        sign_up: Sign up
+      login:
+        remember_me: Remember me
+        submit: Sign In
+        title: Sign In
+      password:
+        title: Password
+      password_confirmation:
+        title: Confirm Password
+      resend_confirmation_instructions:
+        submit: Resend confirmation instructions
+        title: Resend confirmation instructions
+      reset_password:
+        submit: Reset My Password
+        title: Forgot your password?
+      sign_up:
+        submit: Sign up
+        title: Sign up
+      subdomain:
+        title: Subdomain
+      unlock:
+        submit: Resend unlock instructions
+        title: Resend unlock instructions
+      username:
+        title: Username
+    download: 'Download:'
+    edit: Edit
+    edit_model: Edit %{model}
+    empty: Empty
     filters:
       buttons:
-        filter: "Filter"
-        clear: "Clear Filters"
+        clear: Clear Filters
+        filter: Filter
       predicates:
-        from: "From"
-        to: "To"
+        from: From
+        to: To
+    has_many_delete: Delete
+    has_many_new: Add New %{model}
+    has_many_remove: Remove
+    index_list:
+      table: Table
+    logout: Sign out
+    move: Move
+    new_model: New %{model}
+    next: Next
+    pagination:
+      empty: No %{model} found
+      entry:
+        one: entry
+        other: entries
+      multiple: Showing <b>%{from}-%{to}</b> of <b>%{total}</b>
+      multiple_without_total: Showing <b>%{from}-%{to}</b>
+      next: Next
+      one: Showing <b>1</b> of <b>1</b>
+      one_page: Showing <b>all %{n}</b>
+      per_page: 'Per page '
+      previous: Previous
+    powered_by: Powered by %{active_admin} %{version}
+    previous: Previous
     scopes:
-      all: "All"
+      all: All
     search_status:
-      title: "Active Search"
-      title_with_scope: "Active Search for %{name}"
-      no_current_filters: "No filters applied"
+      no_current_filters: No filters applied
+      title: Active Search
+      title_with_scope: Active Search for %{name}
+    sidebars:
+      filters: Filters
+      search_status: Search Status
     status_tag:
-      "yes": "Yes"
-      "no": "No"
-      "unset": "Unknown"
+      'no': 'No'
+      unset: Unknown
+      'yes': 'Yes'
     toggle_dark_mode: Toggle dark mode
     toggle_main_navigation_menu: Toggle main navigation menu
     toggle_section: Toggle section
     toggle_user_menu: Toggle user menu
-    logout: "Sign out"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filters"
-      search_status: "Search Status"
-    pagination:
-      empty: "No %{model} found"
-      one: "Showing <b>1</b> of <b>1</b>"
-      one_page: "Showing <b>all %{n}</b>"
-      multiple: "Showing <b>%{from}-%{to}</b> of <b>%{total}</b>"
-      multiple_without_total: "Showing <b>%{from}-%{to}</b>"
-      per_page: "Per page "
-      previous: "Previous"
-      next: "Next"
-      entry:
-        one: "entry"
-        other: "entries"
-    any: "Any"
-    blank_slate:
-      content: "There are no %{resource_name} yet."
-      link: "Create one"
-    batch_actions:
-      button_label: "Batch Actions"
-      default_confirmation: "Are you sure you want to do this?"
-      delete_confirmation: "Are you sure you want to delete these %{plural_model}?"
-      succesfully_destroyed:
-        one: "Successfully deleted 1 %{model}"
-        other: "Successfully deleted %{count} %{plural_model}"
-      selection_toggle_explanation: "(Toggle Selection)"
-      action_label: "%{title} Selected"
-      labels:
-        destroy: "Delete"
-    comments:
-      created_at: "Created"
-      resource_type: "Resource Type"
-      author_type: "Author Type"
-      body: "Body"
-      author: "Author"
-      add: "Add Comment"
-      delete: "Delete Comment"
-      delete_confirmation: "Are you sure you want to delete this comment?"
-      resource: "Resource"
-      no_comments_yet: "No comments yet."
-      author_missing: "Anonymous"
-      title_content: "All Comments (%{count})"
-      errors:
-        empty_text: "Comment wasn't saved, text was empty."
-    devise:
-      username:
-        title: "Username"
-      email:
-        title: "Email"
-      subdomain:
-        title: "Subdomain"
-      password:
-        title: "Password"
-      password_confirmation:
-        title: "Confirm Password"
-      sign_up:
-        title: "Sign up"
-        submit: "Sign up"
-      login:
-        title: "Sign In"
-        remember_me: "Remember me"
-        submit: "Sign In"
-      reset_password:
-        title: "Forgot your password?"
-        submit: "Reset My Password"
-      change_password:
-        title: "Change your password"
-        submit: "Change my password"
-      unlock:
-        title: "Resend unlock instructions"
-        submit: "Resend unlock instructions"
-      resend_confirmation_instructions:
-        title: "Resend confirmation instructions"
-        submit: "Resend confirmation instructions"
-      links:
-        sign_up: "Sign up"
-        sign_in: "Sign in"
-        forgot_your_password: "Forgot your password?"
-        sign_in_with_omniauth_provider: "Sign in with %{provider}"
-        resend_unlock_instructions: "Resend unlock instructions"
-        resend_confirmation_instructions: "Resend confirmation instructions"
-    access_denied:
-      message: "You are not authorized to perform this action."
-    index_list:
-      table: "Table"
+    view: View
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Author type
+        body: Body
+        created_at: Created
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Updated
+    models:
+      active_admin/comment:
+        one: Comment
+        other: Comments
+      comment:
+        one: Comment
+        other: Comments

--- a/config/locales/eo.yml
+++ b/config/locales/eo.yml
@@ -1,120 +1,121 @@
+---
 eo:
   active_admin:
+    access_denied:
+      message: Vi ne rajtas fari tiun agon.
+    any: Ĉiuj
+    batch_actions:
+      action_label: "%{title} elektita"
+      button_label: Amasagoj
+      default_confirmation: Ĉu vi certas, ke vi volas fari tion?
+      delete_confirmation: Ĉu vi certas, ke vi volas forigi tiujn %{plural_model}?
+      labels:
+        destroy: Forigi
+      selection_toggle_explanation: "(Baskuligi elekton)"
+      succesfully_destroyed:
+        one: 1 %{model} sukcese forigita
+        other: "%{count} %{plural_model} sukcese forigitaj"
+    blank_slate:
+      content: Ankoraŭ ne estas %{resource_name}.
+      link: Krei novan
+    cancel: Nuligi
+    comments:
+      add: Aldoni komenton
+      author: Aŭtoro
+      author_missing: Anonimulo
+      author_type: Aŭtorotipo
+      body: Enhavo
+      created_at: Kreita
+      delete: Forigi komenton
+      delete_confirmation: Ĉu vi certas, ke vi volas forigi tiun komenton?
+      errors:
+        empty_text: La komento ne estis konservita, la teksto estis malplena.
+      no_comments_yet: Ankoraŭ neniu komento.
+      resource: Resurso
+      resource_type: Resursotipo
+      title_content: Komentoj (%{count})
+    create_another: Krei alian %{model}
     dashboard: Panelo
-    view: "Vidi"
-    edit: "Redakti"
-    delete: "Forigi"
-    delete_confirmation: "Ĉu vi certas, ke vi volas forigi tion?"
-    create_another: "Krei alian %{model}"
-    new_model: "Nova %{model}"
-    edit_model: "Redakti %{model}"
-    delete_model: "Forigi %{model}"
-    details: "Detaloj de %{model}"
-    cancel: "Nuligi"
-    empty: "Malplena"
-    previous: "Antaŭa"
-    next: "Sekva"
-    download: "Elŝuti:"
-    has_many_new: "Aldoni novan %{model}"
-    has_many_delete: "Forigi"
-    has_many_remove: "Forigi"
-    move: "Movi"
+    delete: Forigi
+    delete_confirmation: Ĉu vi certas, ke vi volas forigi tion?
+    delete_model: Forigi %{model}
+    details: Detaloj de %{model}
+    devise:
+      change_password:
+        submit: Ŝanĝi mian pasvorton
+        title: Ŝanĝi vian pasvorton
+      email:
+        title: Retpoŝtadreso
+      links:
+        forgot_your_password: Ĉu vi forgesis vian pasvorton?
+        resend_confirmation_instructions: Resendi klarigojn por konfirmi
+        resend_unlock_instructions: Resendi klarigojn por malŝlosi
+        sign_in: Ensaluti
+        sign_in_with_omniauth_provider: Ensaluti per %{provider}
+        sign_up: Registriĝi
+      login:
+        remember_me: Memori min
+        submit: Ensaluti
+        title: Ensaluti
+      password:
+        title: Pasvorto
+      password_confirmation:
+        title: Konfirmi pasvorton
+      resend_confirmation_instructions:
+        submit: Resendi klarigojn por konfirmi
+        title: Resendi klarigojn por konfirmi
+      reset_password:
+        submit: Restarigi mian pasvorton
+        title: Ĉu vi forgesis vian pasvorton?
+      sign_up:
+        submit: Registriĝi
+        title: Registriĝi
+      subdomain:
+        title: Subdomajno
+      unlock:
+        submit: Resendi klarigojn por malŝlosi
+        title: Resendi klarigojn por malŝlosi
+      username:
+        title: Uzantnomo
+    download: 'Elŝuti:'
+    edit: Redakti
+    edit_model: Redakti %{model}
+    empty: Malplena
     filters:
       buttons:
-        filter: "Filtri"
-        clear: "Viŝi filtrilojn"
+        clear: Viŝi filtrilojn
+        filter: Filtri
       predicates:
-        from: "De"
-        to: "Al"
-    search_status:
-      no_current_filters: "Neniu"
-    status_tag:
-      "yes": "Jes"
-      "no": "Ne"
-      "unset": "Ne"
-    logout: "Elsaluti"
-    powered_by: "Povigita de %{active_admin} %{version}"
-    sidebars:
-      filters: "Filtriloj"
-      search_status: "Serĉstato"
-    pagination:
-      empty: "Neniu %{model} trovita"
-      one: "Montras <b>1</b> %{model}"
-      one_page: "Montras <b>ĉiujn %{n}</b> %{model}"
-      multiple: "Montras %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> de <b>%{total}</b> entute"
-      multiple_without_total: "Montras %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      per_page: "Paĝe: "
-      entry:
-        one: "ero"
-        other: "eroj"
-    any: "Ĉiuj"
-    blank_slate:
-      content: "Ankoraŭ ne estas %{resource_name}."
-      link: "Krei novan"
-    batch_actions:
-      button_label: "Amasagoj"
-      default_confirmation: "Ĉu vi certas, ke vi volas fari tion?"
-      delete_confirmation: "Ĉu vi certas, ke vi volas forigi tiujn %{plural_model}?"
-      succesfully_destroyed:
-        one: "1 %{model} sukcese forigita"
-        other: "%{count} %{plural_model} sukcese forigitaj"
-      selection_toggle_explanation: "(Baskuligi elekton)"
-      action_label: "%{title} elektita"
-      labels:
-        destroy: "Forigi"
-    comments:
-      created_at: "Kreita"
-      resource_type: "Resursotipo"
-      author_type: "Aŭtorotipo"
-      body: "Enhavo"
-      author: "Aŭtoro"
-      add: "Aldoni komenton"
-      delete: "Forigi komenton"
-      delete_confirmation: "Ĉu vi certas, ke vi volas forigi tiun komenton?"
-      resource: "Resurso"
-      no_comments_yet: "Ankoraŭ neniu komento."
-      author_missing: "Anonimulo"
-      title_content: "Komentoj (%{count})"
-      errors:
-        empty_text: "La komento ne estis konservita, la teksto estis malplena."
-    devise:
-      username:
-        title: "Uzantnomo"
-      email:
-        title: "Retpoŝtadreso"
-      subdomain:
-        title: "Subdomajno"
-      password:
-        title: "Pasvorto"
-      password_confirmation:
-        title: "Konfirmi pasvorton"
-      sign_up:
-        title: "Registriĝi"
-        submit: "Registriĝi"
-      login:
-        title: "Ensaluti"
-        remember_me: "Memori min"
-        submit: "Ensaluti"
-      reset_password:
-        title: "Ĉu vi forgesis vian pasvorton?"
-        submit: "Restarigi mian pasvorton"
-      change_password:
-        title: "Ŝanĝi vian pasvorton"
-        submit: "Ŝanĝi mian pasvorton"
-      unlock:
-        title: "Resendi klarigojn por malŝlosi"
-        submit: "Resendi klarigojn por malŝlosi"
-      resend_confirmation_instructions:
-        title: "Resendi klarigojn por konfirmi"
-        submit: "Resendi klarigojn por konfirmi"
-      links:
-        sign_up: "Registriĝi"
-        sign_in: "Ensaluti"
-        forgot_your_password: "Ĉu vi forgesis vian pasvorton?"
-        sign_in_with_omniauth_provider: "Ensaluti per %{provider}"
-        resend_unlock_instructions: "Resendi klarigojn por malŝlosi"
-        resend_confirmation_instructions: "Resendi klarigojn por konfirmi"
-    access_denied:
-      message: "Vi ne rajtas fari tiun agon."
+        from: De
+        to: Al
+    has_many_delete: Forigi
+    has_many_new: Aldoni novan %{model}
+    has_many_remove: Forigi
     index_list:
-      table: "Tabelo"
+      table: Tabelo
+    logout: Elsaluti
+    move: Movi
+    new_model: Nova %{model}
+    next: Sekva
+    pagination:
+      empty: Neniu %{model} trovita
+      entry:
+        one: ero
+        other: eroj
+      multiple: Montras %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> de <b>%{total}</b> entute
+      multiple_without_total: Montras %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      one: Montras <b>1</b> %{model}
+      one_page: Montras <b>ĉiujn %{n}</b> %{model}
+      per_page: 'Paĝe: '
+    powered_by: Povigita de %{active_admin} %{version}
+    previous: Antaŭa
+    search_status:
+      no_current_filters: Neniu
+    sidebars:
+      filters: Filtriloj
+      search_status: Serĉstato
+    status_tag:
+      'no': Ne
+      unset: Ne
+      'yes': Jes
+    view: Vidi

--- a/config/locales/eo.yml
+++ b/config/locales/eo.yml
@@ -104,13 +104,19 @@ eo:
         other: eroj
       multiple: Montras %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> de <b>%{total}</b> entute
       multiple_without_total: Montras %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      next: Next
       one: Montras <b>1</b> %{model}
       one_page: Montras <b>ĉiujn %{n}</b> %{model}
       per_page: 'Paĝe: '
+      previous: Previous
     powered_by: Povigita de %{active_admin} %{version}
     previous: Antaŭa
+    scopes:
+      all: All
     search_status:
       no_current_filters: Neniu
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: Filtriloj
       search_status: Serĉstato
@@ -118,4 +124,24 @@ eo:
       'no': Ne
       unset: Ne
       'yes': Jes
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: Vidi
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Author type
+        body: Body
+        created_at: Created
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Updated
+    models:
+      active_admin/comment:
+        one: Comment
+        other: Comments
+      comment:
+        one: Comment
+        other: Comments

--- a/config/locales/es-MX.yml
+++ b/config/locales/es-MX.yml
@@ -1,6 +1,8 @@
 ---
 es-MX:
   active_admin:
+    access_denied:
+      message: You are not authorized to perform this action.
     any: Cualquiera
     batch_actions:
       action_label: "%{title} seleccionados"
@@ -20,12 +22,19 @@ es-MX:
     comments:
       add: Comentar
       author: Autor
+      author_missing: Anonymous
+      author_type: Author Type
       body: Cuerpo
+      created_at: Created
+      delete: Delete Comment
+      delete_confirmation: Are you sure you want to delete this comment?
       errors:
         empty_text: El comentario no fue guardado, el texto estaba vacío.
       no_comments_yet: Aún sin comentarios.
       resource: Recurso
+      resource_type: Resource Type
       title_content: Comentarios (%{count})
+    create_another: Create another %{model}
     dashboard: Inicio
     delete: Eliminar
     delete_confirmation: "¿Está seguro de que quiere eliminar esto?"
@@ -35,8 +44,12 @@ es-MX:
       change_password:
         submit: Cambiar mi contraseña
         title: Cambie su contraseña
+      email:
+        title: Email
       links:
         forgot_your_password: "¿Olvidó su contraseña?"
+        resend_confirmation_instructions: Resend confirmation instructions
+        resend_unlock_instructions: Resend unlock instructions
         sign_in: Iniciar Sesión
         sign_in_with_omniauth_provider: Conéctate con %{provider}
         sign_up: Registrarse
@@ -44,9 +57,26 @@ es-MX:
         remember_me: Recordarme
         submit: Iniciar Sesión
         title: Iniciar Sesión
+      password:
+        title: Password
+      password_confirmation:
+        title: Confirm Password
+      resend_confirmation_instructions:
+        submit: Resend confirmation instructions
+        title: Resend confirmation instructions
       reset_password:
         submit: Restablecer mi contraseña
         title: "¿Olvidó su contraseña?"
+      sign_up:
+        submit: Sign up
+        title: Sign up
+      subdomain:
+        title: Subdomain
+      unlock:
+        submit: Resend unlock instructions
+        title: Resend unlock instructions
+      username:
+        title: Username
     download: 'Descargar:'
     edit: Editar
     edit_model: Editar %{model}
@@ -55,12 +85,16 @@ es-MX:
       buttons:
         clear: Quitar Filtros
         filter: Filtrar
+      predicates:
+        from: From
+        to: To
     has_many_delete: Eliminar
     has_many_new: Añadir %{model}
     has_many_remove: Quitar
     index_list:
       table: Tabla
     logout: Salir
+    move: Move
     new_model: Añadir %{model}
     next: Siguiente
     pagination:
@@ -69,14 +103,45 @@ es-MX:
         one:
         other:
       multiple: Mostrando %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> de un total de <b>%{total}</b>
+      multiple_without_total: Showing <b>%{from}-%{to}</b>
+      next: Next
       one: Mostrando <b>1</b> %{model}
       one_page: Mostrando <b>un total de %{n}</b> %{model}
+      per_page: 'Per page '
+      previous: Previous
     powered_by: Powered by %{active_admin} %{version}
     previous: Anterior
+    scopes:
+      all: All
+    search_status:
+      no_current_filters: No filters applied
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: Filtros
+      search_status: Search Status
     status_tag:
       'no': 'No'
       unset: 'No'
       'yes': Sí
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: Ver
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Author type
+        body: Body
+        created_at: Created
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Updated
+    models:
+      active_admin/comment:
+        one: Comment
+        other: Comments
+      comment:
+        one: Comment
+        other: Comments

--- a/config/locales/es-MX.yml
+++ b/config/locales/es-MX.yml
@@ -1,81 +1,82 @@
+---
 es-MX:
   active_admin:
+    any: Cualquiera
+    batch_actions:
+      action_label: "%{title} seleccionados"
+      button_label: Acciones en masa
+      default_confirmation: "¿Seguro que quieres hacer esto?"
+      delete_confirmation: 'Eliminar %{plural_model}: ¿Está seguro?'
+      labels:
+        destroy: Borrar
+      selection_toggle_explanation: "(Cambiar selección)"
+      succesfully_destroyed:
+        one: Se ha destruido 1 %{model} con éxito
+        other: Se han destruido %{count} %{plural_model} con éxito
+    blank_slate:
+      content: No hay %{resource_name} aún.
+      link: Añadir
+    cancel: Cancelar
+    comments:
+      add: Comentar
+      author: Autor
+      body: Cuerpo
+      errors:
+        empty_text: El comentario no fue guardado, el texto estaba vacío.
+      no_comments_yet: Aún sin comentarios.
+      resource: Recurso
+      title_content: Comentarios (%{count})
     dashboard: Inicio
-    view: "Ver"
-    edit: "Editar"
-    delete: "Eliminar"
+    delete: Eliminar
     delete_confirmation: "¿Está seguro de que quiere eliminar esto?"
-    new_model: "Añadir %{model}"
-    edit_model: "Editar %{model}"
-    delete_model: "Eliminar %{model}"
-    details: "Detalles de %{model}"
-    cancel: "Cancelar"
-    empty: "Vacío"
-    previous: "Anterior"
-    next: "Siguiente"
-    download: "Descargar:"
-    has_many_new: "Añadir %{model}"
-    has_many_delete: "Eliminar"
-    has_many_remove: "Quitar"
+    delete_model: Eliminar %{model}
+    details: Detalles de %{model}
+    devise:
+      change_password:
+        submit: Cambiar mi contraseña
+        title: Cambie su contraseña
+      links:
+        forgot_your_password: "¿Olvidó su contraseña?"
+        sign_in: Iniciar Sesión
+        sign_in_with_omniauth_provider: Conéctate con %{provider}
+        sign_up: Registrarse
+      login:
+        remember_me: Recordarme
+        submit: Iniciar Sesión
+        title: Iniciar Sesión
+      reset_password:
+        submit: Restablecer mi contraseña
+        title: "¿Olvidó su contraseña?"
+    download: 'Descargar:'
+    edit: Editar
+    edit_model: Editar %{model}
+    empty: Vacío
     filters:
       buttons:
-        filter: "Filtrar"
-        clear: "Quitar Filtros"
-    status_tag:
-      "yes": "Sí"
-      "no": "No"
-      "unset": "No"
-    logout: "Salir"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filtros"
+        clear: Quitar Filtros
+        filter: Filtrar
+    has_many_delete: Eliminar
+    has_many_new: Añadir %{model}
+    has_many_remove: Quitar
+    index_list:
+      table: Tabla
+    logout: Salir
+    new_model: Añadir %{model}
+    next: Siguiente
     pagination:
-      empty: "No se han encontrado %{model}"
-      one: "Mostrando <b>1</b> %{model}"
-      one_page: "Mostrando <b>un total de %{n}</b> %{model}"
-      multiple: "Mostrando %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> de un total de <b>%{total}</b>"
+      empty: No se han encontrado %{model}
       entry:
         one:
         other:
-    blank_slate:
-      content: "No hay %{resource_name} aún."
-      link: "Añadir"
-    any: "Cualquiera"
-    batch_actions:
-      button_label: "Acciones en masa"
-      default_confirmation: "¿Seguro que quieres hacer esto?"
-      delete_confirmation: "Eliminar %{plural_model}: ¿Está seguro?"
-      succesfully_destroyed:
-        one: "Se ha destruido 1 %{model} con éxito"
-        other: "Se han destruido %{count} %{plural_model} con éxito"
-      selection_toggle_explanation: "(Cambiar selección)"
-      action_label: "%{title} seleccionados"
-      labels:
-        destroy: "Borrar"
-    comments:
-      body: "Cuerpo"
-      author: "Autor"
-      add: "Comentar"
-      resource: "Recurso"
-      no_comments_yet: "Aún sin comentarios."
-      title_content: "Comentarios (%{count})"
-      errors:
-        empty_text: "El comentario no fue guardado, el texto estaba vacío."
-    devise:
-      login:
-        title: "Iniciar Sesión"
-        remember_me: "Recordarme"
-        submit: "Iniciar Sesión"
-      reset_password:
-        title: "¿Olvidó su contraseña?"
-        submit: "Restablecer mi contraseña"
-      change_password:
-        title: "Cambie su contraseña"
-        submit: "Cambiar mi contraseña"
-      links:
-        sign_in: "Iniciar Sesión"
-        sign_up: "Registrarse"
-        forgot_your_password: "¿Olvidó su contraseña?"
-        sign_in_with_omniauth_provider: "Conéctate con %{provider}"
-    index_list:
-      table: "Tabla"
+      multiple: Mostrando %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> de un total de <b>%{total}</b>
+      one: Mostrando <b>1</b> %{model}
+      one_page: Mostrando <b>un total de %{n}</b> %{model}
+    powered_by: Powered by %{active_admin} %{version}
+    previous: Anterior
+    sidebars:
+      filters: Filtros
+    status_tag:
+      'no': 'No'
+      unset: 'No'
+      'yes': Sí
+    view: Ver

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,144 +1,145 @@
+---
 es:
-  activerecord:
-    models:
-      comment:
-        one: "Comentario"
-        other: "Comentarios"
-      active_admin/comment:
-        one: "Comentario"
-        other: "Comentarios"
-    attributes:
-      active_admin/comment:
-        namespace: "Espacio de nombres"
-        body: "Cuerpo"
-        resource_type: "Tipo de recurso"
-        author_type: "Tipo de autor"
-        created_at: "Fecha de creación"
-        updated_at: "Fecha de actualización"
   active_admin:
-    dashboard: "Inicio"
-    view: "Ver"
-    edit: "Editar"
-    delete: "Eliminar"
+    access_denied:
+      message: No está autorizado/a a realizar esta acción.
+    any: Cualquiera
+    batch_actions:
+      action_label: "%{title} seleccionados"
+      button_label: Acciones en masa
+      default_confirmation: "¿Seguro que quieres hacer esto?"
+      delete_confirmation: Se eliminarán %{plural_model}. ¿Desea continuar?
+      labels:
+        destroy: Borrar
+      selection_toggle_explanation: "(Cambiar selección)"
+      succesfully_destroyed:
+        one: Se ha destruido 1 %{model} con éxito
+        other: Se han destruido %{count} %{plural_model} con éxito
+    blank_slate:
+      content: No hay %{resource_name} aún.
+      link: Añadir
+    cancel: Cancelar
+    comments:
+      add: Comentar
+      author: Autor
+      author_missing: Anónimo
+      author_type: Tipo de autor
+      body: Cuerpo
+      created_at: Fecha de creación
+      delete: Borrar Comentario
+      delete_confirmation: "¿Confirma que desea borrar este comentario?"
+      errors:
+        empty_text: El comentario no fue guardado, el texto estaba vacío.
+      no_comments_yet: No hay comentarios aún.
+      resource: Recurso
+      resource_type: Tipo de recurso
+      title_content: Comentarios (%{count})
+    create_another: Crear otro %{model}
+    dashboard: Inicio
+    delete: Eliminar
     delete_confirmation: "¿Confirma que desea borrar este elemento?"
-    create_another: "Crear otro %{model}"
-    new_model: "Añadir %{model}"
-    edit_model: "Editar %{model}"
-    delete_model: "Eliminar %{model}"
-    details: "Detalles de %{model}"
-    cancel: "Cancelar"
-    empty: "Vacío"
-    previous: "Anterior"
-    next: "Siguiente"
-    download: "Descargar:"
-    has_many_new: "Añadir %{model}"
-    has_many_delete: "Eliminar"
-    has_many_remove: "Quitar"
-    move: "Mover"
-    toggle_dark_mode: "Alternar modo oscuro"
-    toggle_main_navigation_menu: "Alternar el menú de navegación principal"
-    toggle_user_menu: "Alternar menú de usuario"
-    toggle_section: "Alternar sección"
+    delete_model: Eliminar %{model}
+    details: Detalles de %{model}
+    devise:
+      change_password:
+        submit: Cambiar mi contraseña
+        title: Cambie su contraseña
+      email:
+        title: Email
+      links:
+        forgot_your_password: "¿Olvidó su contraseña?"
+        resend_confirmation_instructions: Reenviar instrucciones de confirmación
+        resend_unlock_instructions: Reenviar instrucciones de desbloqueo
+        sign_in: Iniciar Sesión
+        sign_in_with_omniauth_provider: Conéctate con %{provider}
+        sign_up: Registrarse
+      login:
+        remember_me: Recordarme
+        submit: Iniciar Sesión
+        title: Iniciar Sesión
+      password:
+        title: Contraseña
+      password_confirmation:
+        title: Confirmar Contraseña
+      resend_confirmation_instructions:
+        submit: Reenviar instrucciones de confirmación
+        title: Reenviar instrucciones de confirmación
+      reset_password:
+        submit: Restablecer mi contraseña
+        title: "¿Olvidó su contraseña?"
+      sign_up:
+        submit: Registrarse
+        title: Registrarse
+      subdomain:
+        title: Subdominio
+      unlock:
+        submit: Reenviar instrucciones de desbloqueo
+        title: Reenviar instrucciones de desbloqueo
+      username:
+        title: Nombre de usuario
+    download: 'Descargar:'
+    edit: Editar
+    edit_model: Editar %{model}
+    empty: Vacío
     filters:
       buttons:
-        filter: "Filtrar"
-        clear: "Quitar Filtros"
+        clear: Quitar Filtros
+        filter: Filtrar
       predicates:
-        from: "Desde"
-        to: "Hasta"
-    scopes:
-      all: "Todos"
-    search_status:
-      no_current_filters: "Ninguno"
-    status_tag:
-      "yes": "Sí"
-      "no": "No"
-      "unset": "No"
-    logout: "Salir"
-    powered_by: "Funciona con %{active_admin} %{version}"
-    sidebars:
-      filters: "Filtros"
-      search_status: "Estado de la búsqueda"
-    pagination:
-      empty: "No se han encontrado %{model}"
-      one: "Mostrando <b>1</b> %{model}"
-      one_page: "Mostrando <b>un total de %{n}</b> %{model}"
-      multiple: "Mostrando %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> de un total de <b>%{total}</b>"
-      multiple_without_total: "Mostrando %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      per_page: "Por página: "
-      previous: "Anterior"
-      next: "Siguiente"
-      entry:
-        one: "registro"
-        other: "registros"
-    any: "Cualquiera"
-    blank_slate:
-      content: "No hay %{resource_name} aún."
-      link: "Añadir"
-    batch_actions:
-      button_label: "Acciones en masa"
-      default_confirmation: "¿Seguro que quieres hacer esto?"
-      delete_confirmation: "Se eliminarán %{plural_model}. ¿Desea continuar?"
-      succesfully_destroyed:
-        one: "Se ha destruido 1 %{model} con éxito"
-        other: "Se han destruido %{count} %{plural_model} con éxito"
-      selection_toggle_explanation: "(Cambiar selección)"
-      action_label: "%{title} seleccionados"
-      labels:
-        destroy: "Borrar"
-    comments:
-      created_at: "Fecha de creación"
-      resource_type: "Tipo de recurso"
-      author_type: "Tipo de autor"
-      body: "Cuerpo"
-      author: "Autor"
-      add: "Comentar"
-      delete: "Borrar Comentario"
-      delete_confirmation: "¿Confirma que desea borrar este comentario?"
-      resource: "Recurso"
-      no_comments_yet: "No hay comentarios aún."
-      author_missing: "Anónimo"
-      title_content: "Comentarios (%{count})"
-      errors:
-        empty_text: "El comentario no fue guardado, el texto estaba vacío."
-    devise:
-      username:
-        title: "Nombre de usuario"
-      email:
-        title: "Email"
-      subdomain:
-        title: "Subdominio"
-      password:
-        title: "Contraseña"
-      password_confirmation:
-        title: "Confirmar Contraseña"
-      sign_up:
-        title: "Registrarse"
-        submit: "Registrarse"
-      login:
-        title: "Iniciar Sesión"
-        remember_me: "Recordarme"
-        submit: "Iniciar Sesión"
-      reset_password:
-        title: "¿Olvidó su contraseña?"
-        submit: "Restablecer mi contraseña"
-      change_password:
-        title: "Cambie su contraseña"
-        submit: "Cambiar mi contraseña"
-      unlock:
-        title: "Reenviar instrucciones de desbloqueo"
-        submit: "Reenviar instrucciones de desbloqueo"
-      resend_confirmation_instructions:
-        title: "Reenviar instrucciones de confirmación"
-        submit: "Reenviar instrucciones de confirmación"
-      links:
-        sign_up: "Registrarse"
-        sign_in: "Iniciar Sesión"
-        forgot_your_password: "¿Olvidó su contraseña?"
-        sign_in_with_omniauth_provider: "Conéctate con %{provider}"
-        resend_unlock_instructions: "Reenviar instrucciones de desbloqueo"
-        resend_confirmation_instructions: "Reenviar instrucciones de confirmación"
-    access_denied:
-      message: "No está autorizado/a a realizar esta acción."
+        from: Desde
+        to: Hasta
+    has_many_delete: Eliminar
+    has_many_new: Añadir %{model}
+    has_many_remove: Quitar
     index_list:
-      table: "Tabla"
+      table: Tabla
+    logout: Salir
+    move: Mover
+    new_model: Añadir %{model}
+    next: Siguiente
+    pagination:
+      empty: No se han encontrado %{model}
+      entry:
+        one: registro
+        other: registros
+      multiple: Mostrando %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> de un total de <b>%{total}</b>
+      multiple_without_total: Mostrando %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      next: Siguiente
+      one: Mostrando <b>1</b> %{model}
+      one_page: Mostrando <b>un total de %{n}</b> %{model}
+      per_page: 'Por página: '
+      previous: Anterior
+    powered_by: Funciona con %{active_admin} %{version}
+    previous: Anterior
+    scopes:
+      all: Todos
+    search_status:
+      no_current_filters: Ninguno
+    sidebars:
+      filters: Filtros
+      search_status: Estado de la búsqueda
+    status_tag:
+      'no': 'No'
+      unset: 'No'
+      'yes': Sí
+    toggle_dark_mode: Alternar modo oscuro
+    toggle_main_navigation_menu: Alternar el menú de navegación principal
+    toggle_section: Alternar sección
+    toggle_user_menu: Alternar menú de usuario
+    view: Ver
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Tipo de autor
+        body: Cuerpo
+        created_at: Fecha de creación
+        namespace: Espacio de nombres
+        resource_type: Tipo de recurso
+        updated_at: Fecha de actualización
+    models:
+      active_admin/comment:
+        one: Comentario
+        other: Comentarios
+      comment:
+        one: Comentario
+        other: Comentarios

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -115,6 +115,8 @@ es:
       all: Todos
     search_status:
       no_current_filters: Ninguno
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: Filtros
       search_status: Estado de la búsqueda

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -1,103 +1,104 @@
+---
 fa:
   active_admin:
-    dashboard: "داشبرد"
-    view: "نمایش"
-    edit: "ویرایش"
-    delete: "حذف"
-    delete_confirmation: "آیا برای حذف این آیتم اطمینان دارید؟"
-    new_model: "%{model} جدید"
-    edit_model: "ویرایش %{model}"
-    delete_model: "حذف %{model}"
-    details: "جزئیات %{model}"
-    cancel: "لغو"
-    empty: "خالی"
-    previous: "قبلی"
-    next: "بعدی"
-    download: "دریافت:"
-    has_many_new: "اضافه کردن %{model} جدید"
-    has_many_delete: "حذف"
-    has_many_remove: "حذف"
+    access_denied:
+      message: شما دسترسی لازم برای انجام این عملیات را ندارید.
+    any: هرکدام
+    batch_actions:
+      action_label: "%{title} انتخاب شده است"
+      button_label: عملیات‌های دسته‌ای
+      default_confirmation: آیا برای اجرای این عملیات اطمینان دارید؟
+      delete_confirmation: آیا برای حذف همه رکوردهای %{plural_model} اطمینان دارید؟
+      labels:
+        destroy: حذف
+      selection_toggle_explanation: "(انتخاب‌ها برعکس شوند)"
+      succesfully_destroyed:
+        one: 1 %{model} با موفقیت حذف شد
+        other: "%{count} %{plural_model} با موفقت حذف شدند."
+    blank_slate:
+      content: هنوز هیچ رکوردی از %{resource_name} درج نشده.
+      link: درج اولین رکورد
+    cancel: لغو
+    comments:
+      add: افزودن کامنت
+      author: ایجاد کننده
+      author_missing: بی‌نام
+      author_type: نوع ایجاد کننده
+      body: بدنه
+      errors:
+        empty_text: کامنت درج نشد، متن کامنت خالی بود.
+      no_comments_yet: هنوز هیچ کامنتی نوشته نشده.
+      resource: رکورد
+      resource_type: نوع رکورد
+      title_content: کامنت‌ها (%{count})
+    dashboard: داشبرد
+    delete: حذف
+    delete_confirmation: آیا برای حذف این آیتم اطمینان دارید؟
+    delete_model: حذف %{model}
+    details: جزئیات %{model}
+    devise:
+      change_password:
+        submit: تغییر کلمه عبور
+        title: تغییر کلمه عبور
+      email:
+        title: ایمیل
+      links:
+        forgot_your_password: کلمه عبور را فراموش کرده‌اید؟
+        sign_in: ورود
+        sign_in_with_omniauth_provider: ورود با حساب %{provider}
+      login:
+        remember_me: مرا به خاطر بسپار
+        submit: ورود
+        title: ورود
+      password:
+        title: کلمه‌عبور
+      resend_confirmation_instructions:
+        submit: ارسال مجدد تاییدیه ایمیل
+        title: ارسال مجدد تاییدیه ایمیل
+      reset_password:
+        submit: دریافت کلمه عبور جدید
+        title: کلمه عبور را فراموش کرده‌اید؟
+      sign_up:
+        submit: ثبت‌نام
+        title: ثبت‌نام
+      subdomain:
+        title: Subdomain
+      unlock:
+        submit: ارسال مجدد دستورالعمل بازگشایی حساب کاربری
+        title: ارسال مجدد دستورالعمل بازگشایی حساب کاربری
+      username:
+        title: نام کاربری
+    download: 'دریافت:'
+    edit: ویرایش
+    edit_model: ویرایش %{model}
+    empty: خالی
     filters:
       buttons:
-        filter: "فیلتر"
-        clear: "پاک کردن فیلتر"
-    status_tag:
-      "yes": "بله"
-      "no": "بدون"
-      "unset": "بدون"
-    logout: "خروج"
-    powered_by: "قدرت گرفته از %{active_admin} %{version}"
-    sidebars:
-      filters: "فیلتر‌ها"
-    pagination:
-      empty: "هیچ رکورد %{model} یافت نشد"
-      one: "نمایش <b>1</b> %{model}"
-      one_page: "نمایش <b>همه %{n}</b> %{model}"
-      multiple: "نمایش %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> از کل <b>%{total}</b> رکورد"
-      multiple_without_total: "نمایش %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      entry:
-        one: "آیتم"
-        other: "آیتم‌ها"
-    any: "هرکدام"
-    blank_slate:
-      content: "هنوز هیچ رکوردی از %{resource_name} درج نشده."
-      link: "درج اولین رکورد"
-    batch_actions:
-      button_label: "عملیات‌های دسته‌ای"
-      default_confirmation: "آیا برای اجرای این عملیات اطمینان دارید؟"
-      delete_confirmation: "آیا برای حذف همه رکوردهای %{plural_model} اطمینان دارید؟"
-      succesfully_destroyed:
-        one: "1 %{model} با موفقیت حذف شد"
-        other: "%{count} %{plural_model} با موفقت حذف شدند."
-      selection_toggle_explanation: "(انتخاب‌ها برعکس شوند)"
-      action_label: "%{title} انتخاب شده است"
-      labels:
-        destroy: "حذف"
-    comments:
-      resource_type: "نوع رکورد"
-      author_type: "نوع ایجاد کننده"
-      body: "بدنه"
-      author: "ایجاد کننده"
-      add: "افزودن کامنت"
-      resource: "رکورد"
-      no_comments_yet: "هنوز هیچ کامنتی نوشته نشده."
-      author_missing: "بی‌نام"
-      title_content: "کامنت‌ها (%{count})"
-      errors:
-        empty_text: "کامنت درج نشد، متن کامنت خالی بود."
-    devise:
-      username:
-        title: "نام کاربری"
-      email:
-        title: "ایمیل"
-      subdomain:
-        title: "Subdomain"
-      password:
-        title: "کلمه‌عبور"
-      sign_up:
-        title: "ثبت‌نام"
-        submit: "ثبت‌نام"
-      login:
-        title: "ورود"
-        remember_me: "مرا به خاطر بسپار"
-        submit: "ورود"
-      reset_password:
-        title: "کلمه عبور را فراموش کرده‌اید؟"
-        submit: "دریافت کلمه عبور جدید"
-      change_password:
-        title: "تغییر کلمه عبور"
-        submit: "تغییر کلمه عبور"
-      unlock:
-        title: "ارسال مجدد دستورالعمل بازگشایی حساب کاربری"
-        submit: "ارسال مجدد دستورالعمل بازگشایی حساب کاربری"
-      resend_confirmation_instructions:
-        title: "ارسال مجدد تاییدیه ایمیل"
-        submit: "ارسال مجدد تاییدیه ایمیل"
-      links:
-        sign_in: "ورود"
-        forgot_your_password: "کلمه عبور را فراموش کرده‌اید؟"
-        sign_in_with_omniauth_provider: "ورود با حساب %{provider}"
-    access_denied:
-      message: "شما دسترسی لازم برای انجام این عملیات را ندارید."
+        clear: پاک کردن فیلتر
+        filter: فیلتر
+    has_many_delete: حذف
+    has_many_new: اضافه کردن %{model} جدید
+    has_many_remove: حذف
     index_list:
-      table: "جدول"
+      table: جدول
+    logout: خروج
+    new_model: "%{model} جدید"
+    next: بعدی
+    pagination:
+      empty: هیچ رکورد %{model} یافت نشد
+      entry:
+        one: آیتم
+        other: آیتم‌ها
+      multiple: نمایش %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> از کل <b>%{total}</b> رکورد
+      multiple_without_total: نمایش %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      one: نمایش <b>1</b> %{model}
+      one_page: نمایش <b>همه %{n}</b> %{model}
+    powered_by: قدرت گرفته از %{active_admin} %{version}
+    previous: قبلی
+    sidebars:
+      filters: فیلتر‌ها
+    status_tag:
+      'no': بدون
+      unset: بدون
+      'yes': بله
+    view: نمایش

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -25,12 +25,16 @@ fa:
       author_missing: بی‌نام
       author_type: نوع ایجاد کننده
       body: بدنه
+      created_at: Created
+      delete: Delete Comment
+      delete_confirmation: Are you sure you want to delete this comment?
       errors:
         empty_text: کامنت درج نشد، متن کامنت خالی بود.
       no_comments_yet: هنوز هیچ کامنتی نوشته نشده.
       resource: رکورد
       resource_type: نوع رکورد
       title_content: کامنت‌ها (%{count})
+    create_another: Create another %{model}
     dashboard: داشبرد
     delete: حذف
     delete_confirmation: آیا برای حذف این آیتم اطمینان دارید؟
@@ -44,14 +48,19 @@ fa:
         title: ایمیل
       links:
         forgot_your_password: کلمه عبور را فراموش کرده‌اید؟
+        resend_confirmation_instructions: Resend confirmation instructions
+        resend_unlock_instructions: Resend unlock instructions
         sign_in: ورود
         sign_in_with_omniauth_provider: ورود با حساب %{provider}
+        sign_up: Sign up
       login:
         remember_me: مرا به خاطر بسپار
         submit: ورود
         title: ورود
       password:
         title: کلمه‌عبور
+      password_confirmation:
+        title: Confirm Password
       resend_confirmation_instructions:
         submit: ارسال مجدد تاییدیه ایمیل
         title: ارسال مجدد تاییدیه ایمیل
@@ -76,12 +85,16 @@ fa:
       buttons:
         clear: پاک کردن فیلتر
         filter: فیلتر
+      predicates:
+        from: From
+        to: To
     has_many_delete: حذف
     has_many_new: اضافه کردن %{model} جدید
     has_many_remove: حذف
     index_list:
       table: جدول
     logout: خروج
+    move: Move
     new_model: "%{model} جدید"
     next: بعدی
     pagination:
@@ -91,14 +104,44 @@ fa:
         other: آیتم‌ها
       multiple: نمایش %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> از کل <b>%{total}</b> رکورد
       multiple_without_total: نمایش %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      next: Next
       one: نمایش <b>1</b> %{model}
       one_page: نمایش <b>همه %{n}</b> %{model}
+      per_page: 'Per page '
+      previous: Previous
     powered_by: قدرت گرفته از %{active_admin} %{version}
     previous: قبلی
+    scopes:
+      all: All
+    search_status:
+      no_current_filters: No filters applied
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: فیلتر‌ها
+      search_status: Search Status
     status_tag:
       'no': بدون
       unset: بدون
       'yes': بله
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: نمایش
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Author type
+        body: Body
+        created_at: Created
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Updated
+    models:
+      active_admin/comment:
+        one: Comment
+        other: Comments
+      comment:
+        one: Comment
+        other: Comments

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -22,14 +22,19 @@ fi:
     comments:
       add: Lisää kommentti
       author: Luoja
+      author_missing: Anonymous
       author_type: Luoja-tyyppi
       body: Runko
+      created_at: Created
+      delete: Delete Comment
+      delete_confirmation: Are you sure you want to delete this comment?
       errors:
         empty_text: Kommenttia ei pystytty tallentamaan, et kirjoittanut kommenttitekstiä.
       no_comments_yet: Ei kommentteja.
       resource: Resurssi
       resource_type: Resurssityyppi
       title_content: Kommentteja (%{count})
+    create_another: Create another %{model}
     dashboard: Etusivu
     delete: Poista
     delete_confirmation: Oletko varma, että haluat poistaa tämän?
@@ -43,17 +48,28 @@ fi:
         title: Sähköposti
       links:
         forgot_your_password: Unohtunut salasana?
+        resend_confirmation_instructions: Resend confirmation instructions
+        resend_unlock_instructions: Resend unlock instructions
         sign_in: Kirjaudu sisään
         sign_in_with_omniauth_provider: Kirjaudu sisään %{provider}:ia käyttäen
+        sign_up: Sign up
       login:
         remember_me: Muista minut
         submit: Kirjaudu sisään
         title: Sisäänkirjautuminen
       password:
         title: Salasana
+      password_confirmation:
+        title: Confirm Password
+      resend_confirmation_instructions:
+        submit: Resend confirmation instructions
+        title: Resend confirmation instructions
       reset_password:
         submit: Resetoi salasana
         title: Unohtunut salasana?
+      sign_up:
+        submit: Sign up
+        title: Sign up
       subdomain:
         title: Subdomain
       unlock:
@@ -69,12 +85,16 @@ fi:
       buttons:
         clear: Tyhjennä valinnat
         filter: Hae
+      predicates:
+        from: From
+        to: To
     has_many_delete: Poista
     has_many_new: Lisää uusi %{model}
     has_many_remove: Poista
     index_list:
       table: Taulukko
     logout: Kirjaudu ulos
+    move: Move
     new_model: Uusi %{model}
     next: Seuraava
     pagination:
@@ -84,14 +104,44 @@ fi:
         other: syötteet
       multiple: Näytetään %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> (yhteensä <b>%{total}</b>)
       multiple_without_total: Näytetään %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      next: Next
       one: Näytetään <b>1</b> %{model}
       one_page: Näytetään <b>kaikki %{n}</b> %{model}:it
+      per_page: 'Per page '
+      previous: Previous
     powered_by: Käyttää %{active_admin} %{version}:ia
     previous: Edellinen
+    scopes:
+      all: All
+    search_status:
+      no_current_filters: No filters applied
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: Haku
+      search_status: Search Status
     status_tag:
       'no': Ei
       unset: Ei
       'yes': Kyllä
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: Katso
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Author type
+        body: Body
+        created_at: Created
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Updated
+    models:
+      active_admin/comment:
+        one: Comment
+        other: Comments
+      comment:
+        one: Comment
+        other: Comments

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -1,96 +1,97 @@
+---
 fi:
   active_admin:
+    access_denied:
+      message: Sinulla ei ole oikeuksia suorittaa yrittämääsi toimintoa.
+    any: mikä vain
+    batch_actions:
+      action_label: "%{title} Valittu"
+      button_label: Toimet
+      default_confirmation: Oletko varma, että haluat tehdä tämän?
+      delete_confirmation: Oletko varma, että haluat poistaa nämä %{plural_model}:t?
+      labels:
+        destroy: Poista
+      selection_toggle_explanation: "(Vaihda valintaa)"
+      succesfully_destroyed:
+        one: 1 %{model} poistettu
+        other: "%{count} %{plural_model}:a poistettu"
+    blank_slate:
+      content: Järjestelmässä ei ole yhtään %{resource_name}:ia vielä.
+      link: Luo ensimmäinen
+    cancel: Peruuta
+    comments:
+      add: Lisää kommentti
+      author: Luoja
+      author_type: Luoja-tyyppi
+      body: Runko
+      errors:
+        empty_text: Kommenttia ei pystytty tallentamaan, et kirjoittanut kommenttitekstiä.
+      no_comments_yet: Ei kommentteja.
+      resource: Resurssi
+      resource_type: Resurssityyppi
+      title_content: Kommentteja (%{count})
     dashboard: Etusivu
-    view: "Katso"
-    edit: "Muokkaa"
-    delete: "Poista"
-    delete_confirmation: "Oletko varma, että haluat poistaa tämän?"
-    new_model: "Uusi %{model}"
-    edit_model: "Muokkaa %{model}"
-    delete_model: "Poista %{model}"
+    delete: Poista
+    delete_confirmation: Oletko varma, että haluat poistaa tämän?
+    delete_model: Poista %{model}
     details: "%{model} Tiedot"
-    cancel: "Peruuta"
-    empty: "Tyhjä"
-    previous: "Edellinen"
-    next: "Seuraava"
-    download: "Lataa:"
-    has_many_new: "Lisää uusi %{model}"
-    has_many_delete: "Poista"
-    has_many_remove: "Poista"
+    devise:
+      change_password:
+        submit: Vaihda salasana
+        title: Vaihda salasana
+      email:
+        title: Sähköposti
+      links:
+        forgot_your_password: Unohtunut salasana?
+        sign_in: Kirjaudu sisään
+        sign_in_with_omniauth_provider: Kirjaudu sisään %{provider}:ia käyttäen
+      login:
+        remember_me: Muista minut
+        submit: Kirjaudu sisään
+        title: Sisäänkirjautuminen
+      password:
+        title: Salasana
+      reset_password:
+        submit: Resetoi salasana
+        title: Unohtunut salasana?
+      subdomain:
+        title: Subdomain
+      unlock:
+        submit: Lähetä ohjeet lukituksen poistoon
+        title: Lähetä ohjeet lukituksen poistoon
+      username:
+        title: Käyttäjänimi
+    download: 'Lataa:'
+    edit: Muokkaa
+    edit_model: Muokkaa %{model}
+    empty: Tyhjä
     filters:
       buttons:
-        filter: "Hae"
-        clear: "Tyhjennä valinnat"
-    status_tag:
-      "yes": "Kyllä"
-      "no": "Ei"
-      "unset": "Ei"
-    logout: "Kirjaudu ulos"
-    powered_by: "Käyttää %{active_admin} %{version}:ia"
-    sidebars:
-      filters: "Haku"
+        clear: Tyhjennä valinnat
+        filter: Hae
+    has_many_delete: Poista
+    has_many_new: Lisää uusi %{model}
+    has_many_remove: Poista
+    index_list:
+      table: Taulukko
+    logout: Kirjaudu ulos
+    new_model: Uusi %{model}
+    next: Seuraava
     pagination:
       empty: "%{model}:ia ei löytynyt"
-      one: "Näytetään <b>1</b> %{model}"
-      one_page: "Näytetään <b>kaikki %{n}</b> %{model}:it"
-      multiple: "Näytetään %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> (yhteensä <b>%{total}</b>)"
-      multiple_without_total: "Näytetään %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
       entry:
-        one: "syöte"
-        other: "syötteet"
-    any: "mikä vain"
-    blank_slate:
-      content: "Järjestelmässä ei ole yhtään %{resource_name}:ia vielä."
-      link: "Luo ensimmäinen"
-    batch_actions:
-      button_label: "Toimet"
-      default_confirmation: "Oletko varma, että haluat tehdä tämän?"
-      delete_confirmation: "Oletko varma, että haluat poistaa nämä %{plural_model}:t?"
-      succesfully_destroyed:
-        one: "1 %{model} poistettu"
-        other: "%{count} %{plural_model}:a poistettu"
-      selection_toggle_explanation: "(Vaihda valintaa)"
-      action_label: "%{title} Valittu"
-      labels:
-        destroy: "Poista"
-    comments:
-      resource_type: "Resurssityyppi"
-      author_type: "Luoja-tyyppi"
-      body: "Runko"
-      author: "Luoja"
-      add: "Lisää kommentti"
-      resource: "Resurssi"
-      no_comments_yet: "Ei kommentteja."
-      title_content: "Kommentteja (%{count})"
-      errors:
-        empty_text: "Kommenttia ei pystytty tallentamaan, et kirjoittanut kommenttitekstiä."
-    devise:
-      username:
-        title: "Käyttäjänimi"
-      email:
-        title: "Sähköposti"
-      subdomain:
-        title: "Subdomain"
-      password:
-        title: "Salasana"
-      login:
-        title: "Sisäänkirjautuminen"
-        remember_me: "Muista minut"
-        submit: "Kirjaudu sisään"
-      reset_password:
-        title: "Unohtunut salasana?"
-        submit: "Resetoi salasana"
-      change_password:
-        title: "Vaihda salasana"
-        submit: "Vaihda salasana"
-      unlock:
-        title: "Lähetä ohjeet lukituksen poistoon"
-        submit: "Lähetä ohjeet lukituksen poistoon"
-      links:
-        sign_in: "Kirjaudu sisään"
-        forgot_your_password: "Unohtunut salasana?"
-        sign_in_with_omniauth_provider: "Kirjaudu sisään %{provider}:ia käyttäen"
-    access_denied:
-      message: "Sinulla ei ole oikeuksia suorittaa yrittämääsi toimintoa."
-    index_list:
-      table: "Taulukko"
+        one: syöte
+        other: syötteet
+      multiple: Näytetään %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> (yhteensä <b>%{total}</b>)
+      multiple_without_total: Näytetään %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      one: Näytetään <b>1</b> %{model}
+      one_page: Näytetään <b>kaikki %{n}</b> %{model}:it
+    powered_by: Käyttää %{active_admin} %{version}:ia
+    previous: Edellinen
+    sidebars:
+      filters: Haku
+    status_tag:
+      'no': Ei
+      unset: Ei
+      'yes': Kyllä
+    view: Katso

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,137 +1,138 @@
+---
 fr:
-  activerecord:
-    models:
-      comment:
-        one: "Commentaire"
-        other: "Commentaires"
-      active_admin/comment:
-        one: "Commentaire"
-        other: "Commentaires"
-    attributes:
-      active_admin/comment:
-        author_type: "Type d'auteur"
-        body: "Corps"
-        created_at: "Créé le"
-        namespace: "Espace de nom"
-        resource_type: "Type de ressource"
-        updated_at: "Mis à jour le"
   active_admin:
-    dashboard: "Tableau de bord"
-    view: "Voir"
-    edit: "Modifier"
-    delete: "Supprimer"
-    delete_confirmation: "Voulez-vous vraiment supprimer ceci ?"
-    create_another: "Créer autre %{model}"
-    new_model: "Créer %{model}"
-    edit_model: "Modifier %{model}"
-    delete_model: "Supprimer %{model}"
-    details: "Détails de %{model}"
-    cancel: "Annuler"
-    empty: "Vide"
-    previous: "Précédent"
-    next: "Suivant"
-    download: "Télécharger :"
-    has_many_new: "Ajouter un(e) %{model}"
-    has_many_delete: "Supprimer"
-    has_many_remove: "Enlever"
+    access_denied:
+      message: Vous n'êtes pas autorisé à exécuter cette action
+    any: N'importe lequel
+    batch_actions:
+      action_label: "%{title} les éléments sélectionnés"
+      button_label: Actions groupées
+      default_confirmation: Voulez-vous vraiment faire cela ?
+      delete_confirmation: Voulez-vous vraiment supprimer ces %{plural_model} ?
+      labels:
+        destroy: Supprimer
+      selection_toggle_explanation: "(Inverser la sélection)"
+      succesfully_destroyed:
+        one: 1 %{model} supprimé(e)
+        other: "%{count} %{plural_model} supprimé(e)s"
+    blank_slate:
+      content: Il n'y a pas encore de %{resource_name}.
+      link: Créez en un
+    cancel: Annuler
+    comments:
+      add: Ajouter un commentaire
+      author: Auteur
+      author_missing: Anonyme
+      author_type: Profil de l'auteur
+      body: Corps
+      created_at: Créé le
+      delete: Supprimer ce commentaire
+      delete_confirmation: Voulez-vous vraiment supprimer ce commentaire ?
+      errors:
+        empty_text: Le commentaire n'a pas été enregistré puisque le texte était vide.
+      no_comments_yet: Aucun commentaire actuellement
+      resource: Ressource
+      resource_type: Type de ressource
+      title_content: Tous les commentaires (%{count})
+    create_another: Créer autre %{model}
+    dashboard: Tableau de bord
+    delete: Supprimer
+    delete_confirmation: Voulez-vous vraiment supprimer ceci ?
+    delete_model: Supprimer %{model}
+    details: Détails de %{model}
+    devise:
+      change_password:
+        submit: Changer mon mot de passe
+        title: Changez votre mot de passe
+      email:
+        title: Email
+      links:
+        forgot_your_password: Vous avez oublié votre mot de passe ?
+        resend_confirmation_instructions: Renvoyer les instructions de confirmation
+        resend_unlock_instructions: Renvoyer les informations de déverrouillage
+        sign_in: Connectez-vous
+        sign_in_with_omniauth_provider: Connectez-vous avec %{provider}
+        sign_up: Inscrivez-vous
+      login:
+        remember_me: Garder ma session ouverte
+        submit: Se connecter
+        title: Connexion
+      password:
+        title: Mot de passe
+      resend_confirmation_instructions:
+        submit: Renvoyer les instructions de confirmation
+        title: Renvoyer les instructions de confirmation
+      reset_password:
+        submit: Réinitialiser mon mot de passe
+        title: Vous avez oublié votre mot de passe ?
+      sign_up:
+        submit: S'inscrire
+        title: S'inscrire
+      subdomain:
+        title: Sous-domaine
+      unlock:
+        submit: Renvoyer les informations de déverrouillage
+        title: Renvoyer les informations de déverrouillage
+      username:
+        title: Nom d'utilisateur
+    download: 'Télécharger :'
+    edit: Modifier
+    edit_model: Modifier %{model}
+    empty: Vide
     filters:
       buttons:
-        filter: "Filtrer"
-        clear: "Supprimer les filtres"
+        clear: Supprimer les filtres
+        filter: Filtrer
       predicates:
-        from: "De"
-        to: "À"
-    search_status:
-      title: "Recherche active"
-      title_with_scope: "Recherche active pour %{name}"
-      no_current_filters: "Aucun filtre appliqué"
-    status_tag:
-      "yes": "Oui"
-      "no": "Non"
-      "unset": "Inconnu"
-    logout: "Déconnexion"
-    powered_by: "Propulsé par %{active_admin} %{version}"
-    sidebars:
-      filters: "Filtres"
-      search_status: "Statut de la recherche"
-    pagination:
-      empty: "Aucun(e) %{model} trouvé(e)"
-      one: "Affichage de <b>1</b> sur <b>1</b>"
-      one_page: "Affichage de <b>tous les %{n}</b>"
-      multiple: "Affichage de <b>%{from}-%{to}</b> sur <b>%{total}</b>"
-      multiple_without_total: "Affichage de <b>%{from}-%{to}</b>"
-      per_page: "Par page "
-      previous: "Précédent"
-      next: "Suivant"
-      entry:
-        one: "entrée"
-        other: "entrées"
-    any: "N'importe lequel"
-    blank_slate:
-      content: "Il n'y a pas encore de %{resource_name}."
-      link: "Créez en un"
-    batch_actions:
-      button_label: "Actions groupées"
-      default_confirmation: "Voulez-vous vraiment faire cela ?"
-      delete_confirmation: "Voulez-vous vraiment supprimer ces %{plural_model} ?"
-      succesfully_destroyed:
-        one: "1 %{model} supprimé(e)"
-        other: "%{count} %{plural_model} supprimé(e)s"
-      selection_toggle_explanation: "(Inverser la sélection)"
-      action_label: "%{title} les éléments sélectionnés"
-      labels:
-        destroy: "Supprimer"
-    comments:
-      created_at: "Créé le"
-      resource_type: "Type de ressource"
-      author_type: "Profil de l'auteur"
-      body: "Corps"
-      author: "Auteur"
-      add: "Ajouter un commentaire"
-      delete: "Supprimer ce commentaire"
-      delete_confirmation: "Voulez-vous vraiment supprimer ce commentaire ?"
-      resource: "Ressource"
-      no_comments_yet: "Aucun commentaire actuellement"
-      author_missing: "Anonyme"
-      title_content: "Tous les commentaires (%{count})"
-      errors:
-        empty_text: "Le commentaire n'a pas été enregistré puisque le texte était vide."
-    devise:
-      username:
-        title: "Nom d'utilisateur"
-      email:
-        title: "Email"
-      subdomain:
-        title: "Sous-domaine"
-      password:
-        title: "Mot de passe"
-      sign_up:
-        title: "S'inscrire"
-        submit: "S'inscrire"
-      login:
-        title: "Connexion"
-        remember_me: "Garder ma session ouverte"
-        submit: "Se connecter"
-      reset_password:
-        title: "Vous avez oublié votre mot de passe ?"
-        submit: "Réinitialiser mon mot de passe"
-      change_password:
-        title: "Changez votre mot de passe"
-        submit: "Changer mon mot de passe"
-      unlock:
-        title: "Renvoyer les informations de déverrouillage"
-        submit: "Renvoyer les informations de déverrouillage"
-      resend_confirmation_instructions:
-        title: "Renvoyer les instructions de confirmation"
-        submit: "Renvoyer les instructions de confirmation"
-      links:
-        sign_up: "Inscrivez-vous"
-        sign_in: "Connectez-vous"
-        forgot_your_password: "Vous avez oublié votre mot de passe ?"
-        sign_in_with_omniauth_provider: "Connectez-vous avec %{provider}"
-        resend_unlock_instructions: "Renvoyer les informations de déverrouillage"
-        resend_confirmation_instructions: "Renvoyer les instructions de confirmation"
-    access_denied:
-      message: "Vous n'êtes pas autorisé à exécuter cette action"
+        from: De
+        to: À
+    has_many_delete: Supprimer
+    has_many_new: Ajouter un(e) %{model}
+    has_many_remove: Enlever
     index_list:
-      table: "Tableau"
+      table: Tableau
+    logout: Déconnexion
+    new_model: Créer %{model}
+    next: Suivant
+    pagination:
+      empty: Aucun(e) %{model} trouvé(e)
+      entry:
+        one: entrée
+        other: entrées
+      multiple: Affichage de <b>%{from}-%{to}</b> sur <b>%{total}</b>
+      multiple_without_total: Affichage de <b>%{from}-%{to}</b>
+      next: Suivant
+      one: Affichage de <b>1</b> sur <b>1</b>
+      one_page: Affichage de <b>tous les %{n}</b>
+      per_page: 'Par page '
+      previous: Précédent
+    powered_by: Propulsé par %{active_admin} %{version}
+    previous: Précédent
+    search_status:
+      no_current_filters: Aucun filtre appliqué
+      title: Recherche active
+      title_with_scope: Recherche active pour %{name}
+    sidebars:
+      filters: Filtres
+      search_status: Statut de la recherche
+    status_tag:
+      'no': Non
+      unset: Inconnu
+      'yes': Oui
+    view: Voir
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Type d'auteur
+        body: Corps
+        created_at: Créé le
+        namespace: Espace de nom
+        resource_type: Type de ressource
+        updated_at: Mis à jour le
+    models:
+      active_admin/comment:
+        one: Commentaire
+        other: Commentaires
+      comment:
+        one: Commentaire
+        other: Commentaires

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -59,6 +59,8 @@ fr:
         title: Connexion
       password:
         title: Mot de passe
+      password_confirmation:
+        title: Confirm Password
       resend_confirmation_instructions:
         submit: Renvoyer les instructions de confirmation
         title: Renvoyer les instructions de confirmation
@@ -92,6 +94,7 @@ fr:
     index_list:
       table: Tableau
     logout: Déconnexion
+    move: Move
     new_model: Créer %{model}
     next: Suivant
     pagination:
@@ -108,6 +111,8 @@ fr:
       previous: Précédent
     powered_by: Propulsé par %{active_admin} %{version}
     previous: Précédent
+    scopes:
+      all: All
     search_status:
       no_current_filters: Aucun filtre appliqué
       title: Recherche active
@@ -119,6 +124,10 @@ fr:
       'no': Non
       unset: Inconnu
       'yes': Oui
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: Voir
   activerecord:
     attributes:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -85,12 +85,16 @@ he:
       buttons:
         clear: איפוס שדות
         filter: סינון
+      predicates:
+        from: From
+        to: To
     has_many_delete: מחיקה
     has_many_new: הוספת %{model} חדש
     has_many_remove: להסיר
     index_list:
       table: טבלה
     logout: התנתקות
+    move: Move
     new_model: "%{model} חדש"
     next: הבא
     pagination:
@@ -100,13 +104,19 @@ he:
         other: רשומות
       multiple: מציג %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> מתוך <b>%{total}</b> בסך הכל
       multiple_without_total: מציג %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      next: Next
       one: מציג <b>1</b> %{model}
       one_page: הצגת <b>כל %{n}</b> %{model}
       per_page: 'בדף: '
+      previous: Previous
     powered_by: ממונע בעזרת %{active_admin} %{version}
     previous: הקודם
+    scopes:
+      all: All
     search_status:
       no_current_filters: ללא
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: סינון
       search_status: מצב החיפוש
@@ -114,4 +124,24 @@ he:
       'no': לא
       unset: לא
       'yes': כן
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: צפייה
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Author type
+        body: Body
+        created_at: Created
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Updated
+    models:
+      active_admin/comment:
+        one: Comment
+        other: Comments
+      comment:
+        one: Comment
+        other: Comments

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1,116 +1,117 @@
+---
 he:
   active_admin:
+    access_denied:
+      message: אינך רשאי לבצע פעולה זו.
+    any: Any
+    batch_actions:
+      action_label: "%{title} נבחר"
+      button_label: פעולות מרובות
+      default_confirmation: אתה בטוח שאתה רוצה לעשות את זה?
+      delete_confirmation: האם הנך בטוח שאתה רוצה למרוח את %{plural_model}?
+      labels:
+        destroy: מחק
+      selection_toggle_explanation: "(שינוי בחירה)"
+      succesfully_destroyed:
+        one: 1 %{model} נמחק בהצלחה
+        other: "%{count} %{plural_model} נמחק בהצלחה"
+    blank_slate:
+      content: כרגע אין עוד אף %{resource_name}.
+      link: צור אחד
+    cancel: ביטול
+    comments:
+      add: הוסף תגובה
+      author: נוצר ע"י
+      author_missing: אנונימי
+      author_type: סוג מחבר
+      body: תוכן
+      created_at: נוצר
+      delete: מחק תגובה
+      delete_confirmation: האם אתה בטוח שברצונך למחוק תגובה זאת?
+      errors:
+        empty_text: התגובה לא נשמרה, שדה התוכן ריק.
+      no_comments_yet: אין עדיין תגובות.
+      resource: רשומה
+      resource_type: סוג רישום
+      title_content: תגובות (%{count})
+    create_another: צור עוד %{model}
     dashboard: פנל ניהול
-    view: "צפייה"
-    edit: "עריכה"
-    delete: "מחיקה"
-    delete_confirmation: "האם אתה בטוח שאתה רוצה למחוק את זה?"
-    create_another: "צור עוד %{model}"
-    new_model: "%{model} חדש"
-    edit_model: "ערוך %{model}"
-    delete_model: "מחיקת %{model}"
-    details: "פרטים על %{model}"
-    cancel: "ביטול"
-    empty: "ריק"
-    previous: "הקודם"
-    next: "הבא"
-    download: "הורד:"
-    has_many_new: "הוספת %{model} חדש"
-    has_many_delete: "מחיקה"
-    has_many_remove: "להסיר"
+    delete: מחיקה
+    delete_confirmation: האם אתה בטוח שאתה רוצה למחוק את זה?
+    delete_model: מחיקת %{model}
+    details: פרטים על %{model}
+    devise:
+      change_password:
+        submit: שנה את הסיסמא שלי
+        title: שנה את הסיסמא שלך
+      email:
+        title: כתובת דוא״ל
+      links:
+        forgot_your_password: שכחת את הסיסמא שלך?
+        resend_confirmation_instructions: שלח שוב הוראות אישור
+        resend_unlock_instructions: שלח שוב הוראות שיחרור
+        sign_in: כניסה
+        sign_in_with_omniauth_provider: "%{provider} היכנס עם"
+        sign_up: הרשמה
+      login:
+        remember_me: זכור אותי
+        submit: הכנס
+        title: כניסה
+      password:
+        title: סיסמא
+      password_confirmation:
+        title: אישור סיסמא
+      resend_confirmation_instructions:
+        submit: שלח שוב הוראות אישור
+        title: שלח שוב הוראות אישור
+      reset_password:
+        submit: אפס את הסיסמא שלי
+        title: שכחת סיסמא?
+      sign_up:
+        submit: הרשמה
+        title: הרשמה
+      subdomain:
+        title: תת-דומיין
+      unlock:
+        submit: שלח שוב הוראות שיחרור
+        title: שלח שוב הוראות שיחרור
+      username:
+        title: שם משתמש
+    download: 'הורד:'
+    edit: עריכה
+    edit_model: ערוך %{model}
+    empty: ריק
     filters:
       buttons:
-        filter: "סינון"
-        clear: "איפוס שדות"
-    search_status:
-      no_current_filters: "ללא"
-    status_tag:
-      "yes": "כן"
-      "no": "לא"
-      "unset": "לא"
-    logout: "התנתקות"
-    powered_by: "ממונע בעזרת %{active_admin} %{version}"
-    sidebars:
-      filters: "סינון"
-      search_status: "מצב החיפוש"
-    pagination:
-      empty: "אין %{model} בנמצא"
-      one: "מציג <b>1</b> %{model}"
-      one_page: "הצגת <b>כל %{n}</b> %{model}"
-      multiple: "מציג %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> מתוך <b>%{total}</b> בסך הכל"
-      multiple_without_total: "מציג %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      per_page: "בדף: "
-      entry:
-        one: "רשומה בודדה"
-        other: "רשומות"
-    any: "Any"
-    blank_slate:
-      content: "כרגע אין עוד אף %{resource_name}."
-      link: "צור אחד"
-    batch_actions:
-      button_label: "פעולות מרובות"
-      default_confirmation: "אתה בטוח שאתה רוצה לעשות את זה?"
-      delete_confirmation: "האם הנך בטוח שאתה רוצה למרוח את %{plural_model}?"
-      succesfully_destroyed:
-        one: "1 %{model} נמחק בהצלחה"
-        other: "%{count} %{plural_model} נמחק בהצלחה"
-      selection_toggle_explanation: "(שינוי בחירה)"
-      action_label: "%{title} נבחר"
-      labels:
-        destroy: "מחק"
-    comments:
-      created_at: "נוצר"
-      resource_type: "סוג רישום"
-      author_type: "סוג מחבר"
-      body: "תוכן"
-      author: 'נוצר ע"י'
-      add: "הוסף תגובה"
-      delete: "מחק תגובה"
-      delete_confirmation: "האם אתה בטוח שברצונך למחוק תגובה זאת?"
-      resource: "רשומה"
-      no_comments_yet: "אין עדיין תגובות."
-      author_missing: "אנונימי"
-      title_content: "תגובות (%{count})"
-      errors:
-        empty_text: "התגובה לא נשמרה, שדה התוכן ריק."
-    devise:
-      username:
-        title: "שם משתמש"
-      email:
-        title: "כתובת דוא״ל"
-      subdomain:
-        title: "תת-דומיין"
-      password:
-        title: "סיסמא"
-      password_confirmation:
-        title: "אישור סיסמא"
-      sign_up:
-        title: "הרשמה"
-        submit: "הרשמה"
-      login:
-        title: "כניסה"
-        remember_me: "זכור אותי"
-        submit: "הכנס"
-      reset_password:
-        title: "שכחת סיסמא?"
-        submit: "אפס את הסיסמא שלי"
-      change_password:
-        title: "שנה את הסיסמא שלך"
-        submit: "שנה את הסיסמא שלי"
-      unlock:
-        title: "שלח שוב הוראות שיחרור"
-        submit: "שלח שוב הוראות שיחרור"
-      resend_confirmation_instructions:
-        title: "שלח שוב הוראות אישור"
-        submit: "שלח שוב הוראות אישור"
-      links:
-        sign_up: "הרשמה"
-        sign_in: "כניסה"
-        forgot_your_password: "שכחת את הסיסמא שלך?"
-        sign_in_with_omniauth_provider: "%{provider} היכנס עם"
-        resend_unlock_instructions: "שלח שוב הוראות שיחרור"
-        resend_confirmation_instructions: "שלח שוב הוראות אישור"
-    access_denied:
-      message: "אינך רשאי לבצע פעולה זו."
+        clear: איפוס שדות
+        filter: סינון
+    has_many_delete: מחיקה
+    has_many_new: הוספת %{model} חדש
+    has_many_remove: להסיר
     index_list:
-      table: "טבלה"
+      table: טבלה
+    logout: התנתקות
+    new_model: "%{model} חדש"
+    next: הבא
+    pagination:
+      empty: אין %{model} בנמצא
+      entry:
+        one: רשומה בודדה
+        other: רשומות
+      multiple: מציג %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> מתוך <b>%{total}</b> בסך הכל
+      multiple_without_total: מציג %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      one: מציג <b>1</b> %{model}
+      one_page: הצגת <b>כל %{n}</b> %{model}
+      per_page: 'בדף: '
+    powered_by: ממונע בעזרת %{active_admin} %{version}
+    previous: הקודם
+    search_status:
+      no_current_filters: ללא
+    sidebars:
+      filters: סינון
+      search_status: מצב החיפוש
+    status_tag:
+      'no': לא
+      unset: לא
+      'yes': כן
+    view: צפייה

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -1,107 +1,108 @@
+---
 hr:
   active_admin:
-    dashboard: "Upravljačka ploča"
-    view: "Pregledaj"
-    edit: "Uredi"
-    delete: "Obriši"
-    delete_confirmation: "Jeste li sigurni da želite ovo obrisati?"
-    new_model: "Novi %{model}"
-    edit_model: "Uredi %{model}"
-    delete_model: "Obriši %{model}"
+    access_denied:
+      message: Nemaš dopuštenja.
+    any: Bilo koji
+    batch_actions:
+      action_label: "%{title} označene"
+      button_label: Grupne akcije
+      default_confirmation: Jeste li sigurni da želite to učiniti?
+      delete_confirmation: Jeste li sigurni da želite obrisati %{plural_model}?
+      labels:
+        destroy: Obriši
+      selection_toggle_explanation: "(Izmijeni odabir)"
+      succesfully_destroyed:
+        few: Uspješno su obrisana %{count} %{plural_model}
+        many: Uspješno je obrisano %{count} %{plural_model}
+        one: Uspješno je obrisan 1 %{model}
+        other: Uspješno je obrisano %{count} %{plural_model}
+    blank_slate:
+      content: Još uvijek ne postoji niti jedan zapis tipa %{resource_name}.
+      link: Izradi jedan
+    cancel: Odustani
+    comments:
+      add: Dodaj komentar
+      author: Autor
+      author_missing: Anoniman
+      author_type: Tip autora
+      body: Sadržaj
+      errors:
+        empty_text: Komentar nije spremljen, sadržaj je prazan.
+      no_comments_yet: Još nema komentara.
+      resource: Objekt
+      resource_type: Tip objekta
+      title_content: Komentari (%{count})
+    dashboard: Upravljačka ploča
+    delete: Obriši
+    delete_confirmation: Jeste li sigurni da želite ovo obrisati?
+    delete_model: Obriši %{model}
     details: "%{model} detalji"
-    cancel: "Odustani"
-    empty: "Prazno"
-    previous: "Prijašnji"
-    next: "Sljedeći"
-    download: "Spremi na računalo:"
-    has_many_new: "Dodaj novi %{model}"
-    has_many_delete: "Obriši"
-    has_many_remove: "Ukloniti"
+    devise:
+      change_password:
+        submit: Izmijeni lozinku
+        title: Izmjena lozinke
+      email:
+        title: Email
+      links:
+        forgot_your_password: Zaboravljena lozinka?
+        sign_in: Prijavi se
+        sign_in_with_omniauth_provider: Prijavite se za %{provider}
+      login:
+        remember_me: Zapamti me
+        submit: Prijavi se
+        title: Prijava
+      password:
+        title: Lozinka
+      resend_confirmation_instructions:
+        submit: Pošalji
+        title: Ponovno slanje uputstva za potvrdu
+      reset_password:
+        submit: Resetiraj lozinku
+        title: Zaboravljena lozinka?
+      sign_up:
+        submit: Registruj
+        title: Registracija
+      subdomain:
+        title: Poddomena
+      unlock:
+        submit: Pošalji
+        title: Ponovno slanje uputstva za otključavanje
+      username:
+        title: Korisničko ime
+    download: 'Spremi na računalo:'
+    edit: Uredi
+    edit_model: Uredi %{model}
+    empty: Prazno
     filters:
       buttons:
-        filter: "Filtriraj"
-        clear: "Očisti filtere"
-    status_tag:
-      "yes": "Da"
-      "no": "Nema"
-      "unset": "Nema"
-    logout: "Odjavi se"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filtriranje"
-    pagination:
-      empty: "Nije pronađen niti jedan %{model}."
-      one: "Prikazan <b>1</b> %{model}"
-      one_page: "Prikazano <b>svih %{n}</b> %{model}"
-      multiple: "Prikazani %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> od ukupno <b>%{total}</b>"
-      multiple_without_total: "Prikazani %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      entry:
-        one: "zapis"
-        few: "zapisa"
-        many: "zapisa"
-        other: "zapisa"
-    any: "Bilo koji"
-    blank_slate:
-      content: "Još uvijek ne postoji niti jedan zapis tipa %{resource_name}."
-      link: "Izradi jedan"
-    batch_actions:
-      button_label: "Grupne akcije"
-      default_confirmation: "Jeste li sigurni da želite to učiniti?"
-      delete_confirmation: "Jeste li sigurni da želite obrisati %{plural_model}?"
-      succesfully_destroyed:
-        one: "Uspješno je obrisan 1 %{model}"
-        few: "Uspješno su obrisana %{count} %{plural_model}"
-        many: "Uspješno je obrisano %{count} %{plural_model}"
-        other: "Uspješno je obrisano %{count} %{plural_model}"
-      selection_toggle_explanation: "(Izmijeni odabir)"
-      action_label: "%{title} označene"
-      labels:
-        destroy: "Obriši"
-    comments:
-      resource_type: "Tip objekta"
-      author_type: "Tip autora"
-      body: "Sadržaj"
-      author: "Autor"
-      add: "Dodaj komentar"
-      resource: "Objekt"
-      no_comments_yet: "Još nema komentara."
-      author_missing: "Anoniman"
-      title_content: "Komentari (%{count})"
-      errors:
-        empty_text: "Komentar nije spremljen, sadržaj je prazan."
-    devise:
-      username:
-        title: "Korisničko ime"
-      email:
-        title: "Email"
-      subdomain:
-        title: "Poddomena"
-      password:
-        title: "Lozinka"
-      sign_up:
-        title: "Registracija"
-        submit: "Registruj"
-      login:
-        title: "Prijava"
-        remember_me: "Zapamti me"
-        submit: "Prijavi se"
-      reset_password:
-        title: "Zaboravljena lozinka?"
-        submit: "Resetiraj lozinku"
-      change_password:
-        title: "Izmjena lozinke"
-        submit: "Izmijeni lozinku"
-      unlock:
-        title: "Ponovno slanje uputstva za otključavanje"
-        submit: "Pošalji"
-      resend_confirmation_instructions:
-        title: "Ponovno slanje uputstva za potvrdu"
-        submit: "Pošalji"
-      links:
-        sign_in: "Prijavi se"
-        forgot_your_password: "Zaboravljena lozinka?"
-        sign_in_with_omniauth_provider: "Prijavite se za %{provider}"
-    access_denied:
-      message: "Nemaš dopuštenja."
+        clear: Očisti filtere
+        filter: Filtriraj
+    has_many_delete: Obriši
+    has_many_new: Dodaj novi %{model}
+    has_many_remove: Ukloniti
     index_list:
-      table: "Tabela"
+      table: Tabela
+    logout: Odjavi se
+    new_model: Novi %{model}
+    next: Sljedeći
+    pagination:
+      empty: Nije pronađen niti jedan %{model}.
+      entry:
+        few: zapisa
+        many: zapisa
+        one: zapis
+        other: zapisa
+      multiple: Prikazani %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> od ukupno <b>%{total}</b>
+      multiple_without_total: Prikazani %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      one: Prikazan <b>1</b> %{model}
+      one_page: Prikazano <b>svih %{n}</b> %{model}
+    powered_by: Powered by %{active_admin} %{version}
+    previous: Prijašnji
+    sidebars:
+      filters: Filtriranje
+    status_tag:
+      'no': Nema
+      unset: Nema
+      'yes': Da
+    view: Pregledaj

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -27,12 +27,16 @@ hr:
       author_missing: Anoniman
       author_type: Tip autora
       body: Sadržaj
+      created_at: Created
+      delete: Delete Comment
+      delete_confirmation: Are you sure you want to delete this comment?
       errors:
         empty_text: Komentar nije spremljen, sadržaj je prazan.
       no_comments_yet: Još nema komentara.
       resource: Objekt
       resource_type: Tip objekta
       title_content: Komentari (%{count})
+    create_another: Create another %{model}
     dashboard: Upravljačka ploča
     delete: Obriši
     delete_confirmation: Jeste li sigurni da želite ovo obrisati?
@@ -46,14 +50,19 @@ hr:
         title: Email
       links:
         forgot_your_password: Zaboravljena lozinka?
+        resend_confirmation_instructions: Resend confirmation instructions
+        resend_unlock_instructions: Resend unlock instructions
         sign_in: Prijavi se
         sign_in_with_omniauth_provider: Prijavite se za %{provider}
+        sign_up: Sign up
       login:
         remember_me: Zapamti me
         submit: Prijavi se
         title: Prijava
       password:
         title: Lozinka
+      password_confirmation:
+        title: Confirm Password
       resend_confirmation_instructions:
         submit: Pošalji
         title: Ponovno slanje uputstva za potvrdu
@@ -78,12 +87,16 @@ hr:
       buttons:
         clear: Očisti filtere
         filter: Filtriraj
+      predicates:
+        from: From
+        to: To
     has_many_delete: Obriši
     has_many_new: Dodaj novi %{model}
     has_many_remove: Ukloniti
     index_list:
       table: Tabela
     logout: Odjavi se
+    move: Move
     new_model: Novi %{model}
     next: Sljedeći
     pagination:
@@ -95,14 +108,44 @@ hr:
         other: zapisa
       multiple: Prikazani %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> od ukupno <b>%{total}</b>
       multiple_without_total: Prikazani %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      next: Next
       one: Prikazan <b>1</b> %{model}
       one_page: Prikazano <b>svih %{n}</b> %{model}
+      per_page: 'Per page '
+      previous: Previous
     powered_by: Powered by %{active_admin} %{version}
     previous: Prijašnji
+    scopes:
+      all: All
+    search_status:
+      no_current_filters: No filters applied
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: Filtriranje
+      search_status: Search Status
     status_tag:
       'no': Nema
       unset: Nema
       'yes': Da
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: Pregledaj
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Author type
+        body: Body
+        created_at: Created
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Updated
+    models:
+      active_admin/comment:
+        one: Comment
+        other: Comments
+      comment:
+        one: Comment
+        other: Comments

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -144,8 +144,10 @@ hr:
         updated_at: Updated
     models:
       active_admin/comment:
+        few: Comments
         one: Comment
         other: Comments
       comment:
+        few: Comments
         one: Comment
         other: Comments

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -1,6 +1,8 @@
 ---
 hu:
   active_admin:
+    access_denied:
+      message: You are not authorized to perform this action.
     any: Összes
     batch_actions:
       action_label: "%{title} kiválasztva"
@@ -20,12 +22,19 @@ hu:
     comments:
       add: Új hozzászólás
       author: Szerző
+      author_missing: Anonymous
+      author_type: Author Type
       body: Törzs
+      created_at: Created
+      delete: Delete Comment
+      delete_confirmation: Are you sure you want to delete this comment?
       errors:
         empty_text: A hozzászólás nem lett mentve, a törzs nem lehet üres.
       no_comments_yet: Nincsenek hozzászólások.
       resource: Erőforrás
+      resource_type: Resource Type
       title_content: "%{count} hozzászólás"
+    create_another: Create another %{model}
     dashboard: Vezérlőpult
     delete: Törlés
     delete_confirmation: Biztosan törli ezt az elemet?
@@ -35,23 +44,39 @@ hu:
       change_password:
         submit: Jelszó módosítása
         title: A jelszó módosítása
+      email:
+        title: Email
       links:
         forgot_your_password: Elfelejtette a jelszavát?
+        resend_confirmation_instructions: Resend confirmation instructions
+        resend_unlock_instructions: Resend unlock instructions
         sign_in: Bejelentkezés
         sign_in_with_omniauth_provider: Jelentkezzen be a %{provider}
+        sign_up: Sign up
       login:
         remember_me: Emlékezz rám
         submit: Belépés
         title: Bejelentkezés
+      password:
+        title: Password
+      password_confirmation:
+        title: Confirm Password
       resend_confirmation_instructions:
         submit: Megerősítő levél újraküldése
         title: Megerősítő levél újraküldése
       reset_password:
         submit: Jelszó visszaállítása
         title: Elfelejtette a jelszavát?
+      sign_up:
+        submit: Sign up
+        title: Sign up
+      subdomain:
+        title: Subdomain
       unlock:
         submit: Újraküldés unlock utasítások
         title: Újraküldés unlock utasítások
+      username:
+        title: Username
     download: 'Letöltés:'
     edit: Szerkesztés
     edit_model: "%{model} módosítása"
@@ -66,7 +91,10 @@ hu:
     has_many_delete: Törlés
     has_many_new: Új %{model} hozzáadása
     has_many_remove: Eltávolít
+    index_list:
+      table: Table
     logout: Kilépés
+    move: Move
     new_model: Új %{model}
     next: Következő
     pagination:
@@ -76,14 +104,44 @@ hu:
         other: elem
       multiple: "%{model} listájának megjelenítése, <b>%{from}&nbsp;-&nbsp;%{to}</b>/<b>%{total}</b> "
       multiple_without_total: "%{model} listájának megjelenítése, <b>%{from}&nbsp;-&nbsp;%{to}</b> "
+      next: Next
       one: "<b>Egy</b> %{model} megjelenítése"
       one_page: "<b>Az összes (%{n} db)</b> %{model} megjelenítése"
+      per_page: 'Per page '
+      previous: Previous
     powered_by: Powered by %{active_admin} %{version}
     previous: Előző
+    scopes:
+      all: All
+    search_status:
+      no_current_filters: No filters applied
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: Szűrők
+      search_status: Search Status
     status_tag:
       'no': Nem
       unset: Nem
       'yes': Igen
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: Megtekintés
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Author type
+        body: Body
+        created_at: Created
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Updated
+    models:
+      active_admin/comment:
+        one: Comment
+        other: Comments
+      comment:
+        one: Comment
+        other: Comments

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -1,88 +1,89 @@
+---
 hu:
   active_admin:
+    any: Összes
+    batch_actions:
+      action_label: "%{title} kiválasztva"
+      button_label: Tömeges műveletek
+      default_confirmation: Biztos vagy benne, hogy a ön akar-hoz csinál ez?
+      delete_confirmation: Biztosan törli ezeket a %{plural_model}?
+      labels:
+        destroy: Törlés
+      selection_toggle_explanation: "(Kijelölés megfordítása)"
+      succesfully_destroyed:
+        one: 1 %{model} sikeresen törölve
+        other: "%{count} %{plural_model} sikeresen törölve"
+    blank_slate:
+      content: Még nincs létrehozva %{resource_name}.
+      link: Létrehozás most
+    cancel: Mégsem
+    comments:
+      add: Új hozzászólás
+      author: Szerző
+      body: Törzs
+      errors:
+        empty_text: A hozzászólás nem lett mentve, a törzs nem lehet üres.
+      no_comments_yet: Nincsenek hozzászólások.
+      resource: Erőforrás
+      title_content: "%{count} hozzászólás"
     dashboard: Vezérlőpult
-    view: "Megtekintés"
-    edit: "Szerkesztés"
-    delete: "Törlés"
-    delete_confirmation: "Biztosan törli ezt az elemet?"
-    new_model: "Új %{model}"
-    edit_model: "%{model} módosítása"
+    delete: Törlés
+    delete_confirmation: Biztosan törli ezt az elemet?
     delete_model: "%{model} törlése"
     details: "%{model} részletei"
-    cancel: "Mégsem"
-    empty: "Üres"
-    previous: "Előző"
-    next: "Következő"
-    download: "Letöltés:"
-    has_many_new: "Új %{model} hozzáadása"
-    has_many_delete: "Törlés"
-    has_many_remove: "Eltávolít"
+    devise:
+      change_password:
+        submit: Jelszó módosítása
+        title: A jelszó módosítása
+      links:
+        forgot_your_password: Elfelejtette a jelszavát?
+        sign_in: Bejelentkezés
+        sign_in_with_omniauth_provider: Jelentkezzen be a %{provider}
+      login:
+        remember_me: Emlékezz rám
+        submit: Belépés
+        title: Bejelentkezés
+      resend_confirmation_instructions:
+        submit: Megerősítő levél újraküldése
+        title: Megerősítő levél újraküldése
+      reset_password:
+        submit: Jelszó visszaállítása
+        title: Elfelejtette a jelszavát?
+      unlock:
+        submit: Újraküldés unlock utasítások
+        title: Újraküldés unlock utasítások
+    download: 'Letöltés:'
+    edit: Szerkesztés
+    edit_model: "%{model} módosítása"
+    empty: Üres
     filters:
       buttons:
-        filter: "Szűrés"
-        clear: "Feltételek törlése"
+        clear: Feltételek törlése
+        filter: Szűrés
       predicates:
         from: "-tól"
         to: "-ig"
-    status_tag:
-      "yes": "Igen"
-      "no": "Nem"
-      "unset": "Nem"
-    logout: "Kilépés"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Szűrők"
+    has_many_delete: Törlés
+    has_many_new: Új %{model} hozzáadása
+    has_many_remove: Eltávolít
+    logout: Kilépés
+    new_model: Új %{model}
+    next: Következő
     pagination:
-      empty: "Nincs több %{model}"
-      one: "<b>Egy</b> %{model} megjelenítése"
-      one_page: "<b>Az összes (%{n} db)</b> %{model} megjelenítése"
+      empty: Nincs több %{model}
+      entry:
+        one: elem
+        other: elem
       multiple: "%{model} listájának megjelenítése, <b>%{from}&nbsp;-&nbsp;%{to}</b>/<b>%{total}</b> "
       multiple_without_total: "%{model} listájának megjelenítése, <b>%{from}&nbsp;-&nbsp;%{to}</b> "
-      entry:
-        one: "elem"
-        other: "elem"
-    any: "Összes"
-    blank_slate:
-      content: "Még nincs létrehozva %{resource_name}."
-      link: "Létrehozás most"
-    batch_actions:
-      button_label: "Tömeges műveletek"
-      default_confirmation: "Biztos vagy benne, hogy a ön akar-hoz csinál ez?"
-      delete_confirmation: "Biztosan törli ezeket a %{plural_model}?"
-      succesfully_destroyed:
-        one: "1 %{model} sikeresen törölve"
-        other: "%{count} %{plural_model} sikeresen törölve"
-      selection_toggle_explanation: "(Kijelölés megfordítása)"
-      action_label: "%{title} kiválasztva"
-      labels:
-        destroy: "Törlés"
-    comments:
-      body: "Törzs"
-      author: "Szerző"
-      add: "Új hozzászólás"
-      resource: "Erőforrás"
-      no_comments_yet: "Nincsenek hozzászólások."
-      title_content: "%{count} hozzászólás"
-      errors:
-        empty_text: "A hozzászólás nem lett mentve, a törzs nem lehet üres."
-    devise:
-      login:
-        title: "Bejelentkezés"
-        remember_me: "Emlékezz rám"
-        submit: "Belépés"
-      reset_password:
-        title: "Elfelejtette a jelszavát?"
-        submit: "Jelszó visszaállítása"
-      change_password:
-        title: "A jelszó módosítása"
-        submit: "Jelszó módosítása"
-      unlock:
-        title: "Újraküldés unlock utasítások"
-        submit: "Újraküldés unlock utasítások"
-      resend_confirmation_instructions:
-        title: "Megerősítő levél újraküldése"
-        submit: "Megerősítő levél újraküldése"
-      links:
-        sign_in: "Bejelentkezés"
-        forgot_your_password: "Elfelejtette a jelszavát?"
-        sign_in_with_omniauth_provider: "Jelentkezzen be a %{provider}"
+      one: "<b>Egy</b> %{model} megjelenítése"
+      one_page: "<b>Az összes (%{n} db)</b> %{model} megjelenítése"
+    powered_by: Powered by %{active_admin} %{version}
+    previous: Előző
+    sidebars:
+      filters: Szűrők
+    status_tag:
+      'no': Nem
+      unset: Nem
+      'yes': Igen
+    view: Megtekintés

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -1,112 +1,113 @@
+---
 id:
   active_admin:
-    dashboard: Dashboard
-    view: "Lihat"
-    edit: "Ubah"
-    delete: "Hapus"
-    delete_confirmation: "Apakah anda yakin ingin menghapus data ini?"
-    new_model: "Tambah %{model} baru"
-    edit_model: "Ubah %{model}"
-    delete_model: "Hapus %{model}"
-    details: "Detail %{model}"
-    cancel: "Batal"
-    empty: "Kosong"
-    previous: "Sebelumnya"
-    next: "Berikutnya"
-    download: "Unduh:"
-    has_many_new: "Tambah %{model} baru"
-    has_many_delete: "Hapus"
-    has_many_remove: "Hapus"
-    filters:
-      buttons:
-        filter: "Filter"
-        clear: "Hapus Filters"
-    search_status:
-      no_current_filters: "Tidak ada"
-    status_tag:
-      "yes": "Ya"
-      "no": "Tidak"
-      "unset": "Tidak"
-    logout: "Keluar"
-    powered_by: "Dibuat dengan %{active_admin} %{version}"
-    sidebars:
-      filters: "Filter"
-      search_status: "Status Pencarian"
-    pagination:
-      empty: "Tidak ada %{model} yang bisa ditemukan"
-      one: "Menampilkan <b>1</b> %{model}"
-      one_page: "Menampilkan <b>semua %{n}</b> %{model}"
-      multiple: "Menampilkan <b>%{from}&nbsp;-&nbsp;%{to}</b> dari <b>%{total}</b> keseluruhan %{model}"
-      multiple_without_total: "Menampilkan <b>%{from}&nbsp;-&nbsp;%{to} %{model}</b>"
-      entry:
-        one: "data"
-        other: "data"
-    any: "Apapun"
+    access_denied:
+      message: Anda tidak diperkenankan melakukan aksi tersebut.
+    any: Apapun
+    batch_actions:
+      action_label: "%{title} terpilih"
+      button_label: Tindakan Serentak
+      default_confirmation: Apakah anda yakin akan melakukan ini?
+      delete_confirmation: Apakah anda yakin akan menghapus %{plural_model}?
+      labels:
+        destroy: Hapus
+      selection_toggle_explanation: "(Tampilkan Pilihan)"
+      succesfully_destroyed:
+        one: Berhasil menghapus %{model}
+        other: Berhasil menghapus %{count} %{plural_model}
     blank_slate:
       content: "%{resource_name} masih belum ada sama sekali."
-      link: "Tambah data"
-    batch_actions:
-      button_label: "Tindakan Serentak"
-      default_confirmation: "Apakah anda yakin akan melakukan ini?"
-      delete_confirmation: "Apakah anda yakin akan menghapus %{plural_model}?"
-      succesfully_destroyed:
-        one: "Berhasil menghapus %{model}"
-        other: "Berhasil menghapus %{count} %{plural_model}"
-      selection_toggle_explanation: "(Tampilkan Pilihan)"
-      action_label: "%{title} terpilih"
-      labels:
-        destroy: "Hapus"
+      link: Tambah data
+    cancel: Batal
     comments:
-      created_at: "Dibuat"
-      resource_type: "Jenis Resource"
-      author_type: "Tipe Penulis"
-      body: "Isi"
-      author: "Penulis"
-      add: "Tambah Komentar"
-      delete: "Hapus Komentar"
-      delete_confirmation: "Apakah anda yakin akan menghapus komentar tersebut?"
-      resource: "Resource"
-      no_comments_yet: "Belum ada komentar sama sekali."
-      author_missing: "Anonim"
-      title_content: "Komentar (%{count})"
+      add: Tambah Komentar
+      author: Penulis
+      author_missing: Anonim
+      author_type: Tipe Penulis
+      body: Isi
+      created_at: Dibuat
+      delete: Hapus Komentar
+      delete_confirmation: Apakah anda yakin akan menghapus komentar tersebut?
       errors:
-        empty_text: "Komentar tak bisa disimpan, text tidak boleh dikosongi."
+        empty_text: Komentar tak bisa disimpan, text tidak boleh dikosongi.
+      no_comments_yet: Belum ada komentar sama sekali.
+      resource: Resource
+      resource_type: Jenis Resource
+      title_content: Komentar (%{count})
+    dashboard: Dashboard
+    delete: Hapus
+    delete_confirmation: Apakah anda yakin ingin menghapus data ini?
+    delete_model: Hapus %{model}
+    details: Detail %{model}
     devise:
-      username:
-        title: "Username"
-      email:
-        title: "Email"
-      subdomain:
-        title: "Subdomain"
-      password:
-        title: "Password"
-      sign_up:
-        title: " - Daftar"
-        submit: "Daftar"
-      login:
-        title: " - Masuk"
-        remember_me: "Ingat saya"
-        submit: "Masuk"
-      reset_password:
-        title: " - Form Atur Ulang Password"
-        submit: "Atur ulang password"
       change_password:
+        submit: Kirimkan instruksi pengaturan ulang password
         title: " - Atur Ulang Password"
-        submit: "Kirimkan instruksi pengaturan ulang password"
-      unlock:
-        title: " - Kirim Instruksi Pengaktifan Kembali Akun"
-        submit: "Kirimkan instruksi pengaktifan kembali akun"
-      resend_confirmation_instructions:
-        title: " - Kirim Lagi Instruksi Konfirmasi Akun"
-        submit: "Kirimkan lagi instruksi konfirmasi akun"
+      email:
+        title: Email
       links:
-        sign_up: "Daftar"
-        sign_in: "Masuk"
-        forgot_your_password: "Lupa password?"
-        sign_in_with_omniauth_provider: "Daftar melalui %{provider}"
-        resend_unlock_instructions: "Kirim instruksi pengaktifan kembali akun"
-        resend_confirmation_instructions: "Kirim lagi instruksi konfirmasi akun"
-    access_denied:
-      message: "Anda tidak diperkenankan melakukan aksi tersebut."
+        forgot_your_password: Lupa password?
+        resend_confirmation_instructions: Kirim lagi instruksi konfirmasi akun
+        resend_unlock_instructions: Kirim instruksi pengaktifan kembali akun
+        sign_in: Masuk
+        sign_in_with_omniauth_provider: Daftar melalui %{provider}
+        sign_up: Daftar
+      login:
+        remember_me: Ingat saya
+        submit: Masuk
+        title: " - Masuk"
+      password:
+        title: Password
+      resend_confirmation_instructions:
+        submit: Kirimkan lagi instruksi konfirmasi akun
+        title: " - Kirim Lagi Instruksi Konfirmasi Akun"
+      reset_password:
+        submit: Atur ulang password
+        title: " - Form Atur Ulang Password"
+      sign_up:
+        submit: Daftar
+        title: " - Daftar"
+      subdomain:
+        title: Subdomain
+      unlock:
+        submit: Kirimkan instruksi pengaktifan kembali akun
+        title: " - Kirim Instruksi Pengaktifan Kembali Akun"
+      username:
+        title: Username
+    download: 'Unduh:'
+    edit: Ubah
+    edit_model: Ubah %{model}
+    empty: Kosong
+    filters:
+      buttons:
+        clear: Hapus Filters
+        filter: Filter
+    has_many_delete: Hapus
+    has_many_new: Tambah %{model} baru
+    has_many_remove: Hapus
     index_list:
-      table: "Tabel"
+      table: Tabel
+    logout: Keluar
+    new_model: Tambah %{model} baru
+    next: Berikutnya
+    pagination:
+      empty: Tidak ada %{model} yang bisa ditemukan
+      entry:
+        one: data
+        other: data
+      multiple: Menampilkan <b>%{from}&nbsp;-&nbsp;%{to}</b> dari <b>%{total}</b> keseluruhan %{model}
+      multiple_without_total: Menampilkan <b>%{from}&nbsp;-&nbsp;%{to} %{model}</b>
+      one: Menampilkan <b>1</b> %{model}
+      one_page: Menampilkan <b>semua %{n}</b> %{model}
+    powered_by: Dibuat dengan %{active_admin} %{version}
+    previous: Sebelumnya
+    search_status:
+      no_current_filters: Tidak ada
+    sidebars:
+      filters: Filter
+      search_status: Status Pencarian
+    status_tag:
+      'no': Tidak
+      unset: Tidak
+      'yes': Ya
+    view: Lihat

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -34,6 +34,7 @@ id:
       resource: Resource
       resource_type: Jenis Resource
       title_content: Komentar (%{count})
+    create_another: Create another %{model}
     dashboard: Dashboard
     delete: Hapus
     delete_confirmation: Apakah anda yakin ingin menghapus data ini?
@@ -58,6 +59,8 @@ id:
         title: " - Masuk"
       password:
         title: Password
+      password_confirmation:
+        title: Confirm Password
       resend_confirmation_instructions:
         submit: Kirimkan lagi instruksi konfirmasi akun
         title: " - Kirim Lagi Instruksi Konfirmasi Akun"
@@ -82,12 +85,16 @@ id:
       buttons:
         clear: Hapus Filters
         filter: Filter
+      predicates:
+        from: From
+        to: To
     has_many_delete: Hapus
     has_many_new: Tambah %{model} baru
     has_many_remove: Hapus
     index_list:
       table: Tabel
     logout: Keluar
+    move: Move
     new_model: Tambah %{model} baru
     next: Berikutnya
     pagination:
@@ -97,12 +104,19 @@ id:
         other: data
       multiple: Menampilkan <b>%{from}&nbsp;-&nbsp;%{to}</b> dari <b>%{total}</b> keseluruhan %{model}
       multiple_without_total: Menampilkan <b>%{from}&nbsp;-&nbsp;%{to} %{model}</b>
+      next: Next
       one: Menampilkan <b>1</b> %{model}
       one_page: Menampilkan <b>semua %{n}</b> %{model}
+      per_page: 'Per page '
+      previous: Previous
     powered_by: Dibuat dengan %{active_admin} %{version}
     previous: Sebelumnya
+    scopes:
+      all: All
     search_status:
       no_current_filters: Tidak ada
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: Filter
       search_status: Status Pencarian
@@ -110,4 +124,24 @@ id:
       'no': Tidak
       unset: Tidak
       'yes': Ya
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: Lihat
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Author type
+        body: Body
+        created_at: Created
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Updated
+    models:
+      active_admin/comment:
+        one: Comment
+        other: Comments
+      comment:
+        one: Comment
+        other: Comments

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,146 +1,147 @@
+---
 it:
-  activerecord:
-    models:
-      comment:
-        one: "Commento"
-        other: "Commenti"
-      active_admin/comment:
-        one: "Commento"
-        other: "Commenti"
-    attributes:
-      active_admin/comment:
-        author_type: "Tipo di Autore"
-        body: "Corpo"
-        created_at: "Creato il"
-        namespace: "Namespace"
-        resource_type: "Tipo di risorsa"
-        updated_at: "Aggiornato il"
   active_admin:
+    access_denied:
+      message: Non hai le autorizzazioni necessarie per eseguire questa azione.
+    any: Qualsiasi
+    batch_actions:
+      action_label: "%{title} Selezionati"
+      button_label: Azioni multiple
+      default_confirmation: Sei sicuro di che voler proseguire?
+      delete_confirmation: Sei sicuro di volere cancellare %{plural_model}?
+      labels:
+        destroy: Elimina
+      selection_toggle_explanation: "(cambia selezione)"
+      succesfully_destroyed:
+        one: Eliminato con successo 1 %{model}
+        other: Eliminati con successo %{count} %{plural_model}
+    blank_slate:
+      content: Non sono presenti %{resource_name}
+      link: Crea nuovo/a
+    cancel: Annulla
+    comments:
+      add: Aggiungi Commento
+      author: Autore
+      author_missing: Anonimo
+      author_type: Tipo di Autore
+      body: Corpo
+      created_at: Creato il
+      delete: Cancella Commento
+      delete_confirmation: Sei sicuro di voler cancellare questo commento?
+      errors:
+        empty_text: Il commento non può essere salvato, il testo è vuoto.
+      no_comments_yet: Nessun commento.
+      resource: Risorsa
+      resource_type: Tipo di risorsa
+      title_content: Commenti (%{count})
+    create_another: Crea un altro %{model}
     dashboard: Dashboard
-    view: "Mostra"
-    edit: "Modifica"
-    delete: "Rimuovi"
-    delete_confirmation: "Sei sicuro di volerlo rimuovere?"
-    create_another: "Crea un altro %{model}"
-    new_model: "Aggiungi %{model}"
-    edit_model: "Modifica %{model}"
-    delete_model: "Rimuovi %{model}"
-    details: "Dettagli %{model}"
-    cancel: "Annulla"
-    empty: "Vuoto"
-    previous: "Precedente"
-    next: "Prossimo"
-    download: "Scarica:"
-    has_many_new: "Aggiungi nuovo/a %{model}"
-    has_many_delete: "Rimuovi"
-    has_many_remove: "Rimuovi"
-    move: "Sposta"
+    delete: Rimuovi
+    delete_confirmation: Sei sicuro di volerlo rimuovere?
+    delete_model: Rimuovi %{model}
+    details: Dettagli %{model}
+    devise:
+      change_password:
+        submit: Cambia la mia password
+        title: Cambia la tua password
+      email:
+        title: Email
+      links:
+        forgot_your_password: Dimenticato la password?
+        resend_confirmation_instructions: Invia di nuovo le istruzioni per la conferma
+        resend_unlock_instructions: Invia di nuovo le istruzioni per lo sblocco
+        sign_in: Entra
+        sign_in_with_omniauth_provider: Collegati a %{provider}
+        sign_up: Iscriviti
+      login:
+        remember_me: Ricordami
+        submit: Entra
+        title: Entra
+      password:
+        title: Password
+      password_confirmation:
+        title: Conferma password
+      resend_confirmation_instructions:
+        submit: Invia di nuovo le istruzioni per la conferma
+        title: Invia di nuovo le istruzioni per la conferma
+      reset_password:
+        submit: Reimposta la tua password
+        title: Dimenticato la password?
+      sign_up:
+        submit: Iscriviti
+        title: Iscriviti
+      subdomain:
+        title: Sottodominio
+      unlock:
+        submit: Invia di nuovo le istruzioni per sbloccare
+        title: Invia di nuovo le istruzioni per sbloccare
+      username:
+        title: Nome Utente
+    download: 'Scarica:'
+    edit: Modifica
+    edit_model: Modifica %{model}
+    empty: Vuoto
     filters:
       buttons:
-        filter: "Filtra"
-        clear: "Rimuovi filtri"
+        clear: Rimuovi filtri
+        filter: Filtra
       predicates:
-        from: "Da"
-        to: "A"
+        from: Da
+        to: A
+    has_many_delete: Rimuovi
+    has_many_new: Aggiungi nuovo/a %{model}
+    has_many_remove: Rimuovi
+    index_list:
+      table: Tabella
+    logout: Esci
+    move: Sposta
+    new_model: Aggiungi %{model}
+    next: Prossimo
+    pagination:
+      empty: Nessun risultato per %{model}
+      entry:
+        one: voce
+        other: voci
+      multiple: Mostrando <b>%{from}-%{to}</b> di <b>%{total}</b>
+      multiple_without_total: Mostrando <b>%{from}-%{to}</b>
+      next: Successiva
+      one: Mostrando <b>1</b> di <b>1</b>
+      one_page: Mostrando <b>%{n}</b> %{model}. Lista completa.
+      per_page: 'Oggetti per pagina: '
+      previous: Precedente
+    powered_by: Powered by %{active_admin} %{version}
+    previous: Precedente
     scopes:
-      all: "Tutti"
+      all: Tutti
     search_status:
-      title: "Ricerca corrente"
-      title_with_scope: "Ricerca corrente per %{name}"
-      no_current_filters: "Nessun filtro applicato"
+      no_current_filters: Nessun filtro applicato
+      title: Ricerca corrente
+      title_with_scope: Ricerca corrente per %{name}
+    sidebars:
+      filters: Filtri
+      search_status: Informazioni sulla ricerca
     status_tag:
-      "yes": "Sì"
-      "no": "No"
-      "unset": "Vuoto"
+      'no': 'No'
+      unset: Vuoto
+      'yes': Sì
     toggle_dark_mode: Attiva/Disattiva tema scuro
     toggle_main_navigation_menu: Espandi/Riduci menu di navigazione principale
     toggle_section: Espandi/Riduci sezione
     toggle_user_menu: Espandi/Riduci menu utente
-    logout: "Esci"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filtri"
-      search_status: "Informazioni sulla ricerca"
-    pagination:
-      empty: "Nessun risultato per %{model}"
-      one: "Mostrando <b>1</b> di <b>1</b>"
-      one_page: "Mostrando <b>%{n}</b> %{model}. Lista completa."
-      multiple: "Mostrando <b>%{from}-%{to}</b> di <b>%{total}</b>"
-      multiple_without_total: "Mostrando <b>%{from}-%{to}</b>"
-      per_page: "Oggetti per pagina: "
-      previous: "Precedente"
-      next: "Successiva"
-      entry:
-        one: "voce"
-        other: "voci"
-    any: "Qualsiasi"
-    blank_slate:
-      content: "Non sono presenti %{resource_name}"
-      link: "Crea nuovo/a"
-    batch_actions:
-      button_label: "Azioni multiple"
-      default_confirmation: "Sei sicuro di che voler proseguire?"
-      delete_confirmation: "Sei sicuro di volere cancellare %{plural_model}?"
-      succesfully_destroyed:
-        one: "Eliminato con successo 1 %{model}"
-        other: "Eliminati con successo %{count} %{plural_model}"
-      selection_toggle_explanation: "(cambia selezione)"
-      action_label: "%{title} Selezionati"
-      labels:
-        destroy: "Elimina"
-    comments:
-      created_at: "Creato il"
-      resource_type: "Tipo di risorsa"
-      author_type: "Tipo di Autore"
-      body: "Corpo"
-      author: "Autore"
-      add: "Aggiungi Commento"
-      delete: "Cancella Commento"
-      delete_confirmation: "Sei sicuro di voler cancellare questo commento?"
-      resource: "Risorsa"
-      no_comments_yet: "Nessun commento."
-      author_missing: "Anonimo"
-      title_content: "Commenti (%{count})"
-      errors:
-        empty_text: "Il commento non può essere salvato, il testo è vuoto."
-    devise:
-      username:
-        title: "Nome Utente"
-      email:
-        title: "Email"
-      subdomain:
-        title: "Sottodominio"
-      password:
-        title: "Password"
-      password_confirmation:
-        title: "Conferma password"
-      sign_up:
-        title: "Iscriviti"
-        submit: "Iscriviti"
-      login:
-        title: "Entra"
-        remember_me: "Ricordami"
-        submit: "Entra"
-      reset_password:
-        title: "Dimenticato la password?"
-        submit: "Reimposta la tua password"
-      change_password:
-        title: "Cambia la tua password"
-        submit: "Cambia la mia password"
-      unlock:
-        title: "Invia di nuovo le istruzioni per sbloccare"
-        submit: "Invia di nuovo le istruzioni per sbloccare"
-      resend_confirmation_instructions:
-        title: "Invia di nuovo le istruzioni per la conferma"
-        submit: "Invia di nuovo le istruzioni per la conferma"
-      links:
-        sign_up: "Iscriviti"
-        sign_in: "Entra"
-        forgot_your_password: "Dimenticato la password?"
-        sign_in_with_omniauth_provider: "Collegati a %{provider}"
-        resend_unlock_instructions: "Invia di nuovo le istruzioni per lo sblocco"
-        resend_confirmation_instructions: "Invia di nuovo le istruzioni per la conferma"
-    access_denied:
-      message: "Non hai le autorizzazioni necessarie per eseguire questa azione."
-    index_list:
-      table: "Tabella"
+    view: Mostra
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Tipo di Autore
+        body: Corpo
+        created_at: Creato il
+        namespace: Namespace
+        resource_type: Tipo di risorsa
+        updated_at: Aggiornato il
+    models:
+      active_admin/comment:
+        one: Commento
+        other: Commenti
+      comment:
+        one: Commento
+        other: Commenti

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -59,6 +59,8 @@ ja:
         title: ログイン
       password:
         title: パスワード
+      password_confirmation:
+        title: Confirm Password
       resend_confirmation_instructions:
         submit: 確認方法を再送信する
         title: 確認方法を再送信する
@@ -92,6 +94,7 @@ ja:
     index_list:
       table: テーブル
     logout: ログアウト
+    move: Move
     new_model: "%{model} を作成する"
     next: 次
     pagination:
@@ -101,13 +104,19 @@ ja:
         other: レコード
       multiple: 全 <b>%{total}</b> 件中 <b>%{from}&nbsp;-&nbsp;%{to}</b> 件の %{model} を表示しています
       multiple_without_total: "<b>%{from}&nbsp;-&nbsp;%{to}</b> 件の %{model} を表示しています"
+      next: Next
       one: "<b>1</b> 件の %{model} を表示しています"
       one_page: "<b>全 %{n}</b> 件の %{model} を表示しています"
       per_page: '表示件数: '
+      previous: Previous
     powered_by: Powered by %{active_admin} %{version}
     previous: 前
+    scopes:
+      all: All
     search_status:
       no_current_filters: なし
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: 検索条件
       search_status: 検索状態
@@ -120,3 +129,19 @@ ja:
     toggle_section: セクションを切り替える
     toggle_user_menu: ユーザーメニューを切り替える
     view: 閲覧
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Author type
+        body: Body
+        created_at: Created
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Updated
+    models:
+      active_admin/comment:
+        one: Comment
+        other: Comments
+      comment:
+        one: Comment
+        other: Comments

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,121 +1,122 @@
+---
 ja:
   active_admin:
-    dashboard: "ダッシュボード"
-    view: "閲覧"
-    edit: "編集"
-    delete: "削除"
-    delete_confirmation: "本当に削除しますか？"
-    create_another: "%{model} を続けて作成する"
-    new_model: "%{model} を作成する"
-    edit_model: "%{model} を編集する"
-    delete_model: "%{model} を削除する"
-    details: "%{model} の詳細"
-    cancel: "取り消す"
-    empty: "空"
-    previous: "前"
-    next: "次"
-    download: "ダウンロード:"
-    has_many_new: "%{model} を追加する"
-    has_many_delete: "削除する"
-    has_many_remove: "削除する"
-    filters:
-      buttons:
-        filter: "絞り込む"
-        clear: "条件を削除する"
-      predicates:
-        from: "開始"
-        to: "終了"
-    search_status:
-      no_current_filters: "なし"
-    status_tag:
-      "yes": "はい"
-      "no": "いいえ"
-      "unset": "いいえ"
-    toggle_dark_mode: "ダークモードを切り替える"
-    toggle_main_navigation_menu: "メインナビゲーションメニューを切り替える"
-    toggle_section: "セクションを切り替える"
-    toggle_user_menu: "ユーザーメニューを切り替える"
-    logout: "ログアウト"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "検索条件"
-      search_status: "検索状態"
-    pagination:
-      empty: "%{model} は見つかりませんでした"
-      one: "<b>1</b> 件の %{model} を表示しています"
-      one_page: "<b>全 %{n}</b> 件の %{model} を表示しています"
-      multiple: "全 <b>%{total}</b> 件中 <b>%{from}&nbsp;-&nbsp;%{to}</b> 件の %{model} を表示しています"
-      multiple_without_total: "<b>%{from}&nbsp;-&nbsp;%{to}</b> 件の %{model} を表示しています"
-      per_page: "表示件数: "
-      entry:
-        one: "レコード"
-        other: "レコード"
-    any: "任意"
+    access_denied:
+      message: アクションを実行する権限がありません
+    any: 任意
+    batch_actions:
+      action_label: 選択した行を%{title}
+      button_label: 一括操作
+      default_confirmation: 本当によろしいですか？
+      delete_confirmation: "%{plural_model} を削除してもよろしいですか？"
+      labels:
+        destroy: 削除する
+      selection_toggle_explanation: "(選択)"
+      succesfully_destroyed:
+        one: 1件の %{model} を削除しました
+        other: "%{count}件の %{plural_model} を削除しました"
     blank_slate:
       content: "%{resource_name} はまだありません。"
-      link: "作成する"
-    batch_actions:
-      button_label: "一括操作"
-      default_confirmation: "本当によろしいですか？"
-      delete_confirmation: "%{plural_model} を削除してもよろしいですか？"
-      succesfully_destroyed:
-        one: "1件の %{model} を削除しました"
-        other: "%{count}件の %{plural_model} を削除しました"
-      selection_toggle_explanation: "(選択)"
-      action_label: "選択した行を%{title}"
-      labels:
-        destroy: "削除する"
+      link: 作成する
+    cancel: 取り消す
     comments:
-      created_at: "作成日"
-      resource_type: "リソース種別"
-      author_type: "作成者種別"
-      body: "本文"
-      author: "作成者"
-      add: "コメントを追加"
-      delete: "コメントを削除"
-      delete_confirmation: "本当にコメントを削除しますか？"
-      resource: "リソース"
-      no_comments_yet: "コメントはまだありません。"
-      author_missing: "匿名ユーザ"
-      title_content: "コメント (%{count})"
+      add: コメントを追加
+      author: 作成者
+      author_missing: 匿名ユーザ
+      author_type: 作成者種別
+      body: 本文
+      created_at: 作成日
+      delete: コメントを削除
+      delete_confirmation: 本当にコメントを削除しますか？
       errors:
-        empty_text: "テキストが空のため、コメントは保存されませんでした。"
+        empty_text: テキストが空のため、コメントは保存されませんでした。
+      no_comments_yet: コメントはまだありません。
+      resource: リソース
+      resource_type: リソース種別
+      title_content: コメント (%{count})
+    create_another: "%{model} を続けて作成する"
+    dashboard: ダッシュボード
+    delete: 削除
+    delete_confirmation: 本当に削除しますか？
+    delete_model: "%{model} を削除する"
+    details: "%{model} の詳細"
     devise:
-      username:
-        title: "ユーザ名"
-      email:
-        title: "メールアドレス"
-      subdomain:
-        title: "サブドメイン"
-      password:
-        title: "パスワード"
-      sign_up:
-        title: "登録"
-        submit: "登録"
-      login:
-        title: "ログイン"
-        remember_me: "次回から自動的にログイン"
-        submit: "ログイン"
-      reset_password:
-        title: "パスワードをお忘れですか？"
-        submit: "パスワードをリセットする"
       change_password:
-        title: "パスワードを変更する"
-        submit: "パスワードを変更する"
-      unlock:
-        title: "ロックの解除方法を送る"
-        submit: "ロックの解除方法を送る"
-      resend_confirmation_instructions:
-        title: "確認方法を再送信する"
-        submit: "確認方法を再送信する"
+        submit: パスワードを変更する
+        title: パスワードを変更する
+      email:
+        title: メールアドレス
       links:
-        sign_in: "サインイン"
-        sign_up: "ユーザ登録"
-        forgot_your_password: "パスワードをお忘れですか？"
+        forgot_your_password: パスワードをお忘れですか？
+        resend_confirmation_instructions: ユーザ確認手順を再送する
+        resend_unlock_instructions: ロックの解除方法を再送する
+        sign_in: サインイン
         sign_in_with_omniauth_provider: "%{provider}のアカウントを使ってログイン"
-        resend_confirmation_instructions: "ユーザ確認手順を再送する"
-        resend_unlock_instructions: "ロックの解除方法を再送する"
-    access_denied:
-      message: "アクションを実行する権限がありません"
+        sign_up: ユーザ登録
+      login:
+        remember_me: 次回から自動的にログイン
+        submit: ログイン
+        title: ログイン
+      password:
+        title: パスワード
+      resend_confirmation_instructions:
+        submit: 確認方法を再送信する
+        title: 確認方法を再送信する
+      reset_password:
+        submit: パスワードをリセットする
+        title: パスワードをお忘れですか？
+      sign_up:
+        submit: 登録
+        title: 登録
+      subdomain:
+        title: サブドメイン
+      unlock:
+        submit: ロックの解除方法を送る
+        title: ロックの解除方法を送る
+      username:
+        title: ユーザ名
+    download: 'ダウンロード:'
+    edit: 編集
+    edit_model: "%{model} を編集する"
+    empty: 空
+    filters:
+      buttons:
+        clear: 条件を削除する
+        filter: 絞り込む
+      predicates:
+        from: 開始
+        to: 終了
+    has_many_delete: 削除する
+    has_many_new: "%{model} を追加する"
+    has_many_remove: 削除する
     index_list:
-      table: "テーブル"
+      table: テーブル
+    logout: ログアウト
+    new_model: "%{model} を作成する"
+    next: 次
+    pagination:
+      empty: "%{model} は見つかりませんでした"
+      entry:
+        one: レコード
+        other: レコード
+      multiple: 全 <b>%{total}</b> 件中 <b>%{from}&nbsp;-&nbsp;%{to}</b> 件の %{model} を表示しています
+      multiple_without_total: "<b>%{from}&nbsp;-&nbsp;%{to}</b> 件の %{model} を表示しています"
+      one: "<b>1</b> 件の %{model} を表示しています"
+      one_page: "<b>全 %{n}</b> 件の %{model} を表示しています"
+      per_page: '表示件数: '
+    powered_by: Powered by %{active_admin} %{version}
+    previous: 前
+    search_status:
+      no_current_filters: なし
+    sidebars:
+      filters: 検索条件
+      search_status: 検索状態
+    status_tag:
+      'no': いいえ
+      unset: いいえ
+      'yes': はい
+    toggle_dark_mode: ダークモードを切り替える
+    toggle_main_navigation_menu: メインナビゲーションメニューを切り替える
+    toggle_section: セクションを切り替える
+    toggle_user_menu: ユーザーメニューを切り替える
+    view: 閲覧

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -1,6 +1,8 @@
 ---
 ko:
   active_admin:
+    access_denied:
+      message: You are not authorized to perform this action.
     any: 어떤
     batch_actions:
       action_label: 선택한 항목 %{title}
@@ -20,15 +22,19 @@ ko:
     comments:
       add: 댓글 추가
       author: 글쓴이
+      author_missing: Anonymous
       author_type: 글쓴이 종류
       body: 내용
       created_at: 작성시간
+      delete: Delete Comment
+      delete_confirmation: Are you sure you want to delete this comment?
       errors:
         empty_text: 댓글이 저장되지 않았습니다. 내용을 입력해주세요.
       no_comments_yet: 아직 댓글이 없습니다.
       resource: 첨부파일
       resource_type: 첨부파일 형태
       title_content: 댓글 (%{count})
+    create_another: Create another %{model}
     dashboard: 대시보드
     delete: 삭제
     delete_confirmation: 정말로 삭제 하시겠습니까?
@@ -46,12 +52,15 @@ ko:
         resend_unlock_instructions: 계정 잠금 해제하기
         sign_in: 로그인
         sign_in_with_omniauth_provider: "%{provider} 으로 로그인"
+        sign_up: Sign up
       login:
         remember_me: 내 계정 정보 기억
         submit: 로그인
         title: 로그인
       password:
         title: 비밀번호
+      password_confirmation:
+        title: Confirm Password
       resend_confirmation_instructions:
         submit: 계정 승인 요청하기
         title: 계정 승인 요청하기
@@ -76,10 +85,16 @@ ko:
       buttons:
         clear: 필터 초기화
         filter: 필터
+      predicates:
+        from: From
+        to: To
     has_many_delete: 삭제
     has_many_new: "%{model} 추가"
     has_many_remove: 삭제
+    index_list:
+      table: Table
     logout: 로그아웃
+    move: Move
     new_model: "%{model} 추가"
     next: 다음
     pagination:
@@ -89,12 +104,19 @@ ko:
         other: 항목들
       multiple: "<b>%{total}</b>개 중 <b>%{from}&nbsp;-&nbsp;%{to}</b> %{model} 표시중"
       multiple_without_total: "<b>%{from}&nbsp;-&nbsp;%{to}</b> %{model} 표시중"
+      next: Next
       one: "<b>1</b>개 %{model} 표시중"
       one_page: "<b>%{n}</b>개 %{model} 표시중"
+      per_page: 'Per page '
+      previous: Previous
     powered_by: Powered by %{active_admin} %{version}
     previous: 이전
+    scopes:
+      all: All
     search_status:
       no_current_filters: 현재 적용된 필터가 없습니다
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: 필터 목록
       search_status: 검색 상태
@@ -102,4 +124,24 @@ ko:
       'no': 없음
       unset: 없음
       'yes': 있음
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: 보기
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Author type
+        body: Body
+        created_at: Created
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Updated
+    models:
+      active_admin/comment:
+        one: Comment
+        other: Comments
+      comment:
+        one: Comment
+        other: Comments

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -1,104 +1,105 @@
+---
 ko:
   active_admin:
-    dashboard: "대시보드"
-    view: "보기"
-    edit: "수정"
-    delete: "삭제"
-    delete_confirmation: "정말로 삭제 하시겠습니까?"
-    new_model: "%{model} 추가"
-    edit_model: "%{model} 수정"
+    any: 어떤
+    batch_actions:
+      action_label: 선택한 항목 %{title}
+      button_label: 배치 작업
+      default_confirmation: 확실하십니까?
+      delete_confirmation: "%{plural_model}을/를 삭제하시겠습니까?"
+      labels:
+        destroy: 삭제
+      selection_toggle_explanation: "(선택 항목 바꾸기)"
+      succesfully_destroyed:
+        one: 성공적으로 1개 %{model}을/를 삭제하였습니다
+        other: 성공적으로 %{count}개의 %{plural_model}을/를 삭제하였습니다
+    blank_slate:
+      content: 아직 %{resource_name} 이/가 없습니다.
+      link: 추가하기
+    cancel: 취소
+    comments:
+      add: 댓글 추가
+      author: 글쓴이
+      author_type: 글쓴이 종류
+      body: 내용
+      created_at: 작성시간
+      errors:
+        empty_text: 댓글이 저장되지 않았습니다. 내용을 입력해주세요.
+      no_comments_yet: 아직 댓글이 없습니다.
+      resource: 첨부파일
+      resource_type: 첨부파일 형태
+      title_content: 댓글 (%{count})
+    dashboard: 대시보드
+    delete: 삭제
+    delete_confirmation: 정말로 삭제 하시겠습니까?
     delete_model: "%{model} 삭제"
     details: "%{model} 상세보기"
-    cancel: "취소"
-    empty: "내용이 없습니다"
-    previous: "이전"
-    next: "다음"
-    download: "다운로드:"
-    has_many_new: "%{model} 추가"
-    has_many_delete: "삭제"
-    has_many_remove: "삭제"
+    devise:
+      change_password:
+        submit: 내 비밀번호 변경
+        title: 비밀번호 변경
+      email:
+        title: 이메일
+      links:
+        forgot_your_password: 비밀번호를 잊으셨나요?
+        resend_confirmation_instructions: 계정 승인 요청하기
+        resend_unlock_instructions: 계정 잠금 해제하기
+        sign_in: 로그인
+        sign_in_with_omniauth_provider: "%{provider} 으로 로그인"
+      login:
+        remember_me: 내 계정 정보 기억
+        submit: 로그인
+        title: 로그인
+      password:
+        title: 비밀번호
+      resend_confirmation_instructions:
+        submit: 계정 승인 요청하기
+        title: 계정 승인 요청하기
+      reset_password:
+        submit: 비밀번호 재설정
+        title: 비밀번호를 잊으셨나요?
+      sign_up:
+        submit: 가입하기
+        title: 가입하기
+      subdomain:
+        title: 서브도메인
+      unlock:
+        submit: 계정 잠금 해제하기
+        title: 계정 잠금 해제하기
+      username:
+        title: 아이디
+    download: '다운로드:'
+    edit: 수정
+    edit_model: "%{model} 수정"
+    empty: 내용이 없습니다
     filters:
       buttons:
-        filter: "필터"
-        clear: "필터 초기화"
-    search_status:
-      no_current_filters: "현재 적용된 필터가 없습니다"
-    status_tag:
-      "yes": "있음"
-      "no": "없음"
-      "unset": "없음"
-    logout: "로그아웃"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "필터 목록"
-      search_status: "검색 상태"
+        clear: 필터 초기화
+        filter: 필터
+    has_many_delete: 삭제
+    has_many_new: "%{model} 추가"
+    has_many_remove: 삭제
+    logout: 로그아웃
+    new_model: "%{model} 추가"
+    next: 다음
     pagination:
       empty: "%{model} 이/가 없습니다."
-      one: "<b>1</b>개 %{model} 표시중"
-      one_page: "<b>%{n}</b>개 %{model} 표시중"
+      entry:
+        one: 항목
+        other: 항목들
       multiple: "<b>%{total}</b>개 중 <b>%{from}&nbsp;-&nbsp;%{to}</b> %{model} 표시중"
       multiple_without_total: "<b>%{from}&nbsp;-&nbsp;%{to}</b> %{model} 표시중"
-      entry:
-        one: "항목"
-        other: "항목들"
-    any: "어떤"
-    blank_slate:
-      content: "아직 %{resource_name} 이/가 없습니다."
-      link: "추가하기"
-    batch_actions:
-      button_label: "배치 작업"
-      default_confirmation: "확실하십니까?"
-      delete_confirmation: "%{plural_model}을/를 삭제하시겠습니까?"
-      succesfully_destroyed:
-        one: "성공적으로 1개 %{model}을/를 삭제하였습니다"
-        other: "성공적으로 %{count}개의 %{plural_model}을/를 삭제하였습니다"
-      selection_toggle_explanation: "(선택 항목 바꾸기)"
-      action_label: "선택한 항목 %{title}"
-      labels:
-        destroy: "삭제"
-    comments:
-      created_at: "작성시간"
-      resource_type: "첨부파일 형태"
-      author_type: "글쓴이 종류"
-      body: "내용"
-      author: "글쓴이"
-      add: "댓글 추가"
-      resource: "첨부파일"
-      no_comments_yet: "아직 댓글이 없습니다."
-      title_content: "댓글 (%{count})"
-      errors:
-        empty_text: "댓글이 저장되지 않았습니다. 내용을 입력해주세요."
-    devise:
-      username:
-        title: "아이디"
-      email:
-        title: "이메일"
-      subdomain:
-        title: "서브도메인"
-      password:
-        title: "비밀번호"
-      sign_up:
-        title: "가입하기"
-        submit: "가입하기"
-      login:
-        title: "로그인"
-        remember_me: "내 계정 정보 기억"
-        submit: "로그인"
-      reset_password:
-        title: "비밀번호를 잊으셨나요?"
-        submit: "비밀번호 재설정"
-      change_password:
-        title: "비밀번호 변경"
-        submit: "내 비밀번호 변경"
-      unlock:
-        title: "계정 잠금 해제하기"
-        submit: "계정 잠금 해제하기"
-      resend_confirmation_instructions:
-        title: "계정 승인 요청하기"
-        submit: "계정 승인 요청하기"
-      links:
-        sign_in: "로그인"
-        forgot_your_password: "비밀번호를 잊으셨나요?"
-        sign_in_with_omniauth_provider: "%{provider} 으로 로그인"
-        resend_unlock_instructions: "계정 잠금 해제하기"
-        resend_confirmation_instructions: "계정 승인 요청하기"
+      one: "<b>1</b>개 %{model} 표시중"
+      one_page: "<b>%{n}</b>개 %{model} 표시중"
+    powered_by: Powered by %{active_admin} %{version}
+    previous: 이전
+    search_status:
+      no_current_filters: 현재 적용된 필터가 없습니다
+    sidebars:
+      filters: 필터 목록
+      search_status: 검색 상태
+    status_tag:
+      'no': 없음
+      unset: 없음
+      'yes': 있음
+    view: 보기

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -1,118 +1,119 @@
+---
 lt:
   active_admin:
+    access_denied:
+      message: Jūs nesate įgaliotas atlikti šį veiksmą.
+    any: Bet kokia
+    batch_actions:
+      action_label: "%{title} Pasirinkta"
+      button_label: Veiksmai su pažymėtais
+      default_confirmation: Ar jūs tikrai norite tai padaryti?
+      delete_confirmation: Ar jūs tikrai norite pašalinti šiuos %{plural_model}?
+      labels:
+        destroy: Šalinti
+      selection_toggle_explanation: "(Žymėti)"
+      succesfully_destroyed:
+        one: Sėkmingai pašalintas 1 %{model}
+        other: Sėkmingai pašalinti %{count} %{plural_model}
+    blank_slate:
+      content: Nėra %{resource_name}.
+      link: Sukurti
+    cancel: Atšaukti
+    comments:
+      add: Pridėti komentarą
+      author: Autorius
+      author_missing: Anonimas
+      author_type: Autoriaus Tipas
+      body: Įrašas
+      created_at: Sukurta
+      delete: Trinti komentarą
+      delete_confirmation: Ar tikrai norite ištrinti šį komentarą?
+      errors:
+        empty_text: Komentaras neišsaugotas, tekstas buvo tuščias.
+      no_comments_yet: Dar nėra komentarų.
+      resource: Išteklių
+      resource_type: Resurso Tipas
+      title_content: Komentarai (%{count})
     dashboard: Valdymo skydelis
-    view: 'Žiūrėti'
-    edit: 'Redaguoti'
-    delete: 'Šalinti'
-    delete_confirmation: 'Ar jūs tikrai norite tai pašalinti?'
-    new_model: 'Naujas %{model}'
-    edit_model: 'Redaguoti %{model}'
-    delete_model: 'Pašalinti %{model}'
-    details: '%{model} Informacija'
-    cancel: 'Atšaukti'
-    empty: 'Tuščia'
-    previous: 'Atgal'
-    next: 'Toliau'
-    download: 'Atsisiųsti'
-    has_many_new: 'Pridėti naują %{model}'
-    has_many_delete: 'Šalinti'
-    has_many_remove: 'Pašalinti'
+    delete: Šalinti
+    delete_confirmation: Ar jūs tikrai norite tai pašalinti?
+    delete_model: Pašalinti %{model}
+    details: "%{model} Informacija"
+    devise:
+      change_password:
+        submit: Pakeisti mano slaptažodį
+        title: Slaptažodžio Keitimas
+      email:
+        title: El. paštas
+      links:
+        forgot_your_password: Pamiršote slaptažodį?
+        resend_confirmation_instructions: Persiųsti patvirtinimo instrukcijas
+        resend_unlock_instructions: Persiųsti pakartotinio atrakinimo instrukcijas
+        sign_in: Prisijungti
+        sign_in_with_omniauth_provider: Prisijungti su %{provider}
+        sign_up: Užsiregistruoti
+      login:
+        remember_me: Prisiminti Mane
+        submit: Prisijungti
+        title: Prisijungimas
+      password:
+        title: Slaptažodis
+      password_confirmation:
+        title: Pakartokite slaptažodį
+      resend_confirmation_instructions:
+        submit: Siųsti patvirtinimo instrukcijas
+        title: Patvirtinimo Instrukcijos
+      reset_password:
+        submit: Sukurti Naują Slaptažodį
+        title: Pamiršote slaptažodį?
+      sign_up:
+        submit: Užsiregistruoti
+        title: Registracija
+      subdomain:
+        title: Subdomenas
+      unlock:
+        submit: Pakartotinai siųsti atrakinimo instrukcijas
+        title: Pakartotinio Atrakinimo Instrukcijos
+      username:
+        title: Vartotojo Vardas
+    download: Atsisiųsti
+    edit: Redaguoti
+    edit_model: Redaguoti %{model}
+    empty: Tuščia
     filters:
       buttons:
-        filter: 'Filtras'
-        clear: 'Išvalyti filtrus'
+        clear: Išvalyti filtrus
+        filter: Filtras
       predicates:
-        from: "Nuo"
-        to: "Iki"
-    search_status:
-      no_current_filters: "nėra"
-    status_tag:
-      "yes": "Taip"
-      "no": "Nėra"
-      "unset": "Nėra"
-    logout: 'Išeiti'
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: 'Filtrai'
-      search_status: "Paieškos būsena"
-    pagination:
-      empty: '%{model} nerastas'
-      one: 'Rodoma <B> 1 </ b> %{model}'
-      one_page: 'Rodoma <b>visi %{n} </ b> %{model}'
-      multiple: 'Rodomi %{model} <b>%{from}&nbsp;-&nbsp;%{to} </ b> iš<b>%{total} </ b> iš viso'
-      multiple_without_total: 'Rodomi %{model} <b>%{from}&nbsp;-&nbsp;%{to} </ b> '
-      per_page: "Puslapyje: "
-      entry:
-        one: 'įrašas'
-        other: 'įrašai'
-    any: 'Bet kokia'
-    blank_slate:
-      content: 'Nėra %{resource_name}.'
-      link: 'Sukurti'
-    batch_actions:
-      button_label: 'Veiksmai su pažymėtais'
-      default_confirmation: 'Ar jūs tikrai norite tai padaryti?'
-      delete_confirmation: 'Ar jūs tikrai norite pašalinti šiuos %{plural_model}?'
-      succesfully_destroyed:
-        one: 'Sėkmingai pašalintas 1 %{model}'
-        other: 'Sėkmingai pašalinti %{count} %{plural_model}'
-      selection_toggle_explanation: '(Žymėti)'
-      action_label: '%{title} Pasirinkta'
-      labels:
-        destroy: 'Šalinti'
-    comments:
-      created_at: "Sukurta"
-      resource_type: 'Resurso Tipas'
-      author_type: 'Autoriaus Tipas'
-      body: 'Įrašas'
-      author: 'Autorius'
-      add: 'Pridėti komentarą'
-      delete: "Trinti komentarą"
-      delete_confirmation: "Ar tikrai norite ištrinti šį komentarą?"
-      resource: 'Išteklių'
-      no_comments_yet: 'Dar nėra komentarų.'
-      author_missing: 'Anonimas'
-      title_content: 'Komentarai (%{count})'
-      errors:
-        empty_text: 'Komentaras neišsaugotas, tekstas buvo tuščias.'
-    devise:
-      username:
-        title: 'Vartotojo Vardas'
-      email:
-        title: 'El. paštas'
-      subdomain:
-        title: 'Subdomenas'
-      password:
-        title: 'Slaptažodis'
-      password_confirmation:
-        title: "Pakartokite slaptažodį"
-      sign_up:
-        title: 'Registracija'
-        submit: 'Užsiregistruoti'
-      login:
-        title: 'Prisijungimas'
-        remember_me: 'Prisiminti Mane'
-        submit: 'Prisijungti'
-      reset_password:
-        title: 'Pamiršote slaptažodį?'
-        submit: 'Sukurti Naują Slaptažodį'
-      change_password:
-        title: 'Slaptažodžio Keitimas'
-        submit: 'Pakeisti mano slaptažodį'
-      unlock:
-        title: 'Pakartotinio Atrakinimo Instrukcijos'
-        submit: 'Pakartotinai siųsti atrakinimo instrukcijas'
-      resend_confirmation_instructions:
-        title: 'Patvirtinimo Instrukcijos'
-        submit: 'Siųsti patvirtinimo instrukcijas'
-      links:
-        sign_up: "Užsiregistruoti"
-        sign_in: 'Prisijungti'
-        forgot_your_password: 'Pamiršote slaptažodį?'
-        sign_in_with_omniauth_provider: 'Prisijungti su %{provider}'
-        resend_unlock_instructions: "Persiųsti pakartotinio atrakinimo instrukcijas"
-        resend_confirmation_instructions: "Persiųsti patvirtinimo instrukcijas"
-    access_denied:
-      message: 'Jūs nesate įgaliotas atlikti šį veiksmą.'
+        from: Nuo
+        to: Iki
+    has_many_delete: Šalinti
+    has_many_new: Pridėti naują %{model}
+    has_many_remove: Pašalinti
     index_list:
-      table: "Lentelė"
+      table: Lentelė
+    logout: Išeiti
+    new_model: Naujas %{model}
+    next: Toliau
+    pagination:
+      empty: "%{model} nerastas"
+      entry:
+        one: įrašas
+        other: įrašai
+      multiple: Rodomi %{model} <b>%{from}&nbsp;-&nbsp;%{to} </ b> iš<b>%{total} </ b> iš viso
+      multiple_without_total: 'Rodomi %{model} <b>%{from}&nbsp;-&nbsp;%{to} </ b> '
+      one: Rodoma <B> 1 </ b> %{model}
+      one_page: Rodoma <b>visi %{n} </ b> %{model}
+      per_page: 'Puslapyje: '
+    powered_by: Powered by %{active_admin} %{version}
+    previous: Atgal
+    search_status:
+      no_current_filters: nėra
+    sidebars:
+      filters: Filtrai
+      search_status: Paieškos būsena
+    status_tag:
+      'no': Nėra
+      unset: Nėra
+      'yes': Taip
+    view: Žiūrėti

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -13,6 +13,7 @@ lt:
         destroy: Šalinti
       selection_toggle_explanation: "(Žymėti)"
       succesfully_destroyed:
+        few: Sėkmingai pašalinti %{count} %{plural_model}
         one: Sėkmingai pašalintas 1 %{model}
         other: Sėkmingai pašalinti %{count} %{plural_model}
     blank_slate:
@@ -100,6 +101,7 @@ lt:
     pagination:
       empty: "%{model} nerastas"
       entry:
+        few: įrašai
         one: įrašas
         other: įrašai
       multiple: Rodomi %{model} <b>%{from}&nbsp;-&nbsp;%{to} </ b> iš<b>%{total} </ b> iš viso
@@ -140,8 +142,10 @@ lt:
         updated_at: Updated
     models:
       active_admin/comment:
+        few: Comments
         one: Comment
         other: Comments
       comment:
+        few: Comments
         one: Comment
         other: Comments

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -34,6 +34,7 @@ lt:
       resource: Išteklių
       resource_type: Resurso Tipas
       title_content: Komentarai (%{count})
+    create_another: Create another %{model}
     dashboard: Valdymo skydelis
     delete: Šalinti
     delete_confirmation: Ar jūs tikrai norite tai pašalinti?
@@ -93,6 +94,7 @@ lt:
     index_list:
       table: Lentelė
     logout: Išeiti
+    move: Move
     new_model: Naujas %{model}
     next: Toliau
     pagination:
@@ -102,13 +104,19 @@ lt:
         other: įrašai
       multiple: Rodomi %{model} <b>%{from}&nbsp;-&nbsp;%{to} </ b> iš<b>%{total} </ b> iš viso
       multiple_without_total: 'Rodomi %{model} <b>%{from}&nbsp;-&nbsp;%{to} </ b> '
+      next: Next
       one: Rodoma <B> 1 </ b> %{model}
       one_page: Rodoma <b>visi %{n} </ b> %{model}
       per_page: 'Puslapyje: '
+      previous: Previous
     powered_by: Powered by %{active_admin} %{version}
     previous: Atgal
+    scopes:
+      all: All
     search_status:
       no_current_filters: nėra
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: Filtrai
       search_status: Paieškos būsena
@@ -116,4 +124,24 @@ lt:
       'no': Nėra
       unset: Nėra
       'yes': Taip
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: Žiūrėti
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Author type
+        body: Body
+        created_at: Created
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Updated
+    models:
+      active_admin/comment:
+        one: Comment
+        other: Comments
+      comment:
+        one: Comment
+        other: Comments

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -1,79 +1,80 @@
+---
 lv:
   active_admin:
+    any: Jebkurš
+    batch_actions:
+      action_label: "%{title} Selected"
+      button_label: Batch Actions
+      default_confirmation: Vai tiešām vēlaties to darīt?
+      delete_confirmation: Vai tiešām vēlaties dzēst šos %{plural_model}?
+      labels:
+        destroy: Delete
+      selection_toggle_explanation: "(Toggle Selection)"
+      succesfully_destroyed:
+        one: Successfully deleted 1 %{model}
+        other: Successfully deleted %{count} %{plural_model}
+    blank_slate:
+      content: Sadaļā '%{resource_name}' nav neviena ieraksta.
+      link: Izveidot jaunu
+    cancel: Atcelt
+    comments:
+      add: Pievienot komentāru
+      author: Autors
+      body: Saturs
+      errors:
+        empty_text: Komentārs netika saglabāts - nekas nav ierakstīts
+      no_comments_yet: Nav neviena komentāra.
+      resource: Resurss
+      title_content: Komentāri (%{count})
     dashboard: Panelis
-    view: "Apskatīt"
-    edit: "Labot"
-    delete: "Dzēst"
-    delete_confirmation: "Vai Tu tiešām vēlies dzēst?"
-    new_model: "Pievienot '%{model}' ierakstu"
-    edit_model: "Labot '%{model}' ierakstu"
-    delete_model: "Dzēst '%{model}' ierakstu"
-    details: "Apraksts"
-    cancel: "Atcelt"
-    empty: "Tukšs"
-    previous: "Iepriekšējā"
-    next: "Nākošā"
-    download: "Lejuplādēt:"
-    has_many_new: "Pievienot jaunu '%{model}' ierakstu"
-    has_many_delete: "Dzēst"
-    has_many_remove: "Noņemt"
+    delete: Dzēst
+    delete_confirmation: Vai Tu tiešām vēlies dzēst?
+    delete_model: Dzēst '%{model}' ierakstu
+    details: Apraksts
+    devise:
+      change_password:
+        submit: Nomainīt savu paroli
+        title: Nomainīt paroli
+      links:
+        forgot_your_password: Aizmirsāt savu paroli?
+        sign_in: pierakstīties
+        sign_in_with_omniauth_provider: Pierakstieties ar %{provider}
+      login:
+        remember_me: atcerēties mani
+        submit: Ielogojaties
+        title: Ielogojaties
+      reset_password:
+        submit: Atjaunotu savu paroli
+        title: Aizmirsāt savu paroli?
+    download: 'Lejuplādēt:'
+    edit: Labot
+    edit_model: Labot '%{model}' ierakstu
+    empty: Tukšs
     filters:
       buttons:
-        filter: "Filtrēt"
-        clear: "Novākt filtrus"
-    status_tag:
-      "yes": "Jā"
-      "no": "Nē"
-      "unset": "Nē"
-    logout: "Iziet"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filtri"
+        clear: Novākt filtrus
+        filter: Filtrēt
+    has_many_delete: Dzēst
+    has_many_new: Pievienot jaunu '%{model}' ierakstu
+    has_many_remove: Noņemt
+    logout: Iziet
+    new_model: Pievienot '%{model}' ierakstu
+    next: Nākošā
     pagination:
-      empty: "Nav ierakstu"
-      one: "<b>1</b> ieraksts"
-      one_page: "<b>%{n}</b> ieraksti"
+      empty: Nav ierakstu
+      entry:
+        one: ieraksts
+        other: ieraksti
       multiple: "<b>%{from}&nbsp;-&nbsp;%{to}</b> ieraksti no <b>%{total}</b> kopā"
       multiple_without_total: "<b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      entry:
-        one: "ieraksts"
-        other: "ieraksti"
-    any: "Jebkurš"
-    blank_slate:
-      content: "Sadaļā '%{resource_name}' nav neviena ieraksta."
-      link: "Izveidot jaunu"
-    batch_actions:
-      button_label: "Batch Actions"
-      default_confirmation: "Vai tiešām vēlaties to darīt?"
-      delete_confirmation: "Vai tiešām vēlaties dzēst šos %{plural_model}?"
-      succesfully_destroyed:
-        one: "Successfully deleted 1 %{model}"
-        other: "Successfully deleted %{count} %{plural_model}"
-      selection_toggle_explanation: "(Toggle Selection)"
-      action_label: "%{title} Selected"
-      labels:
-        destroy: "Delete"
-    comments:
-      body: "Saturs"
-      author: "Autors"
-      add: "Pievienot komentāru"
-      resource: "Resurss"
-      no_comments_yet: "Nav neviena komentāra."
-      title_content: "Komentāri (%{count})"
-      errors:
-        empty_text: "Komentārs netika saglabāts - nekas nav ierakstīts"
-    devise:
-      login:
-        title: "Ielogojaties"
-        remember_me: "atcerēties mani"
-        submit: "Ielogojaties"
-      reset_password:
-        title: "Aizmirsāt savu paroli?"
-        submit: "Atjaunotu savu paroli"
-      change_password:
-        title: "Nomainīt paroli"
-        submit: "Nomainīt savu paroli"
-      links:
-        sign_in: "pierakstīties"
-        forgot_your_password: "Aizmirsāt savu paroli?"
-        sign_in_with_omniauth_provider: "Pierakstieties ar %{provider}"
+      one: "<b>1</b> ieraksts"
+      one_page: "<b>%{n}</b> ieraksti"
+    powered_by: Powered by %{active_admin} %{version}
+    previous: Iepriekšējā
+    sidebars:
+      filters: Filtri
+    status_tag:
+      'no': Nē
+      unset: Nē
+      'yes': Jā
+    view: Apskatīt

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -1,6 +1,8 @@
 ---
 lv:
   active_admin:
+    access_denied:
+      message: You are not authorized to perform this action.
     any: Jebkurš
     batch_actions:
       action_label: "%{title} Selected"
@@ -20,12 +22,19 @@ lv:
     comments:
       add: Pievienot komentāru
       author: Autors
+      author_missing: Anonymous
+      author_type: Author Type
       body: Saturs
+      created_at: Created
+      delete: Delete Comment
+      delete_confirmation: Are you sure you want to delete this comment?
       errors:
         empty_text: Komentārs netika saglabāts - nekas nav ierakstīts
       no_comments_yet: Nav neviena komentāra.
       resource: Resurss
+      resource_type: Resource Type
       title_content: Komentāri (%{count})
+    create_another: Create another %{model}
     dashboard: Panelis
     delete: Dzēst
     delete_confirmation: Vai Tu tiešām vēlies dzēst?
@@ -35,17 +44,39 @@ lv:
       change_password:
         submit: Nomainīt savu paroli
         title: Nomainīt paroli
+      email:
+        title: Email
       links:
         forgot_your_password: Aizmirsāt savu paroli?
+        resend_confirmation_instructions: Resend confirmation instructions
+        resend_unlock_instructions: Resend unlock instructions
         sign_in: pierakstīties
         sign_in_with_omniauth_provider: Pierakstieties ar %{provider}
+        sign_up: Sign up
       login:
         remember_me: atcerēties mani
         submit: Ielogojaties
         title: Ielogojaties
+      password:
+        title: Password
+      password_confirmation:
+        title: Confirm Password
+      resend_confirmation_instructions:
+        submit: Resend confirmation instructions
+        title: Resend confirmation instructions
       reset_password:
         submit: Atjaunotu savu paroli
         title: Aizmirsāt savu paroli?
+      sign_up:
+        submit: Sign up
+        title: Sign up
+      subdomain:
+        title: Subdomain
+      unlock:
+        submit: Resend unlock instructions
+        title: Resend unlock instructions
+      username:
+        title: Username
     download: 'Lejuplādēt:'
     edit: Labot
     edit_model: Labot '%{model}' ierakstu
@@ -54,10 +85,16 @@ lv:
       buttons:
         clear: Novākt filtrus
         filter: Filtrēt
+      predicates:
+        from: From
+        to: To
     has_many_delete: Dzēst
     has_many_new: Pievienot jaunu '%{model}' ierakstu
     has_many_remove: Noņemt
+    index_list:
+      table: Table
     logout: Iziet
+    move: Move
     new_model: Pievienot '%{model}' ierakstu
     next: Nākošā
     pagination:
@@ -67,14 +104,44 @@ lv:
         other: ieraksti
       multiple: "<b>%{from}&nbsp;-&nbsp;%{to}</b> ieraksti no <b>%{total}</b> kopā"
       multiple_without_total: "<b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      next: Next
       one: "<b>1</b> ieraksts"
       one_page: "<b>%{n}</b> ieraksti"
+      per_page: 'Per page '
+      previous: Previous
     powered_by: Powered by %{active_admin} %{version}
     previous: Iepriekšējā
+    scopes:
+      all: All
+    search_status:
+      no_current_filters: No filters applied
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: Filtri
+      search_status: Search Status
     status_tag:
       'no': Nē
       unset: Nē
       'yes': Jā
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: Apskatīt
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Author type
+        body: Body
+        created_at: Created
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Updated
+    models:
+      active_admin/comment:
+        one: Comment
+        other: Comments
+      comment:
+        one: Comment
+        other: Comments

--- a/config/locales/mk.yml
+++ b/config/locales/mk.yml
@@ -19,6 +19,21 @@ mk:
       content: Не се креирани записи од типот на %{resource_name}.
       link: Креирај нов
     cancel: Откажи
+    comments:
+      add: Add Comment
+      author: Author
+      author_missing: Anonymous
+      author_type: Author Type
+      body: Body
+      created_at: Created
+      delete: Delete Comment
+      delete_confirmation: Are you sure you want to delete this comment?
+      errors:
+        empty_text: Comment wasn't saved, text was empty.
+      no_comments_yet: No comments yet.
+      resource: Resource
+      resource_type: Resource Type
+      title_content: All Comments (%{count})
     create_another: Креирај нов %{model}
     dashboard: Почетна
     delete: Избриши
@@ -55,6 +70,8 @@ mk:
       sign_up:
         submit: Креирај
         title: Креирај профил
+      subdomain:
+        title: Subdomain
       unlock:
         submit: Испрати инструкции
         title: Повторно испраќање на инструкции за отклучување на профил
@@ -87,13 +104,19 @@ mk:
         other: записи
       multiple: Прикажани %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> од вкупно <b>%{total}</b>
       multiple_without_total: Прикажани %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      next: Next
       one: Прикажан <b>1</b> %{model}
       one_page: Прикажани <b>сите %{n}</b> %{model}
       per_page: 'Прикази на записи по страна:'
+      previous: Previous
     powered_by: Овозможено од %{active_admin} %{version}
     previous: Претходно
+    scopes:
+      all: All
     search_status:
       no_current_filters: Моментално нема филтри
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: Филтри за пребарување
       search_status: Резултати од пребарување
@@ -101,8 +124,20 @@ mk:
       'no': Не
       unset: Не
       'yes': Да
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: Прегледај
   activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Author type
+        body: Body
+        created_at: Created
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Updated
     models:
       active_admin/comment:
         one: Коментар

--- a/config/locales/mk.yml
+++ b/config/locales/mk.yml
@@ -1,111 +1,112 @@
+---
 mk:
-  activerecord:
-    models:
-      comment:
-        one: "Коментар"
-        other: "Коментари"
-      active_admin/comment:
-        one: "Коментар"
-        other: "Коментари"
   active_admin:
-    dashboard: "Почетна"
-    view: "Прегледај"
-    edit: "Измени"
-    delete: "Избриши"
-    delete_confirmation: "Дали сте сигурни дека сакате да го избришете записот?"
-    create_another: "Креирај нов %{model}"
-    new_model: "Додај нов %{model}"
-    edit_model: "Измени %{model}"
-    delete_model: "Избриши %{model}"
-    details: "Детали за %{model}"
-    cancel: "Откажи"
-    empty: "Празно"
-    previous: "Претходно"
-    next: "Следно"
-    download: "Преземи во понудените формати:"
-    has_many_new: "Додај нов %{model}"
-    has_many_delete: "Избриши"
-    has_many_remove: "Отстрани"
-    move: "Премести"
+    access_denied:
+      message: Немате овластување да ја извршите оваа активност.
+    any: Било кој
+    batch_actions:
+      action_label: "%{title} го селектираното"
+      button_label: Групни активности
+      default_confirmation: Дали сте сигурни?
+      delete_confirmation: Дали сте сигурни дека сакате да ги избришете %{plural_model}?
+      labels:
+        destroy: Избриши
+      selection_toggle_explanation: "(Toggle Selection)"
+      succesfully_destroyed:
+        one: Успешно е избришан 1 %{model}
+        other: Успешно се избришани %{count} %{plural_model}
+    blank_slate:
+      content: Не се креирани записи од типот на %{resource_name}.
+      link: Креирај нов
+    cancel: Откажи
+    create_another: Креирај нов %{model}
+    dashboard: Почетна
+    delete: Избриши
+    delete_confirmation: Дали сте сигурни дека сакате да го избришете записот?
+    delete_model: Избриши %{model}
+    details: Детали за %{model}
+    devise:
+      change_password:
+        submit: Промени лозинка
+        title: Променете ја лозинката
+      email:
+        title: Е-маил
+      links:
+        forgot_your_password: Ја заборавивте Вашата лозинка?
+        resend_confirmation_instructions: Повторно испрати инструкции за потврдување на профил
+        resend_unlock_instructions: Повторно испрати инструкции за отклучување на профил
+        sign_in: Најави се
+        sign_in_with_omniauth_provider: Најави се со %{provider}
+        sign_up: Креирај профил
+      login:
+        remember_me: Запомни ме
+        submit: Најави се
+        title: Најави се
+      password:
+        title: Лозинка
+      password_confirmation:
+        title: Потврди Лозинка
+      resend_confirmation_instructions:
+        submit: Инспрати инструкции
+        title: Повторно испраќање на инструкции за потврдување на профил
+      reset_password:
+        submit: Промени лозинка
+        title: Ја заборавивте Вашата лозинка?
+      sign_up:
+        submit: Креирај
+        title: Креирај профил
+      unlock:
+        submit: Испрати инструкции
+        title: Повторно испраќање на инструкции за отклучување на профил
+      username:
+        title: Корисничко име
+    download: 'Преземи во понудените формати:'
+    edit: Измени
+    edit_model: Измени %{model}
+    empty: Празно
     filters:
       buttons:
-        filter: "Пребарај"
-        clear: "Исчисти филтри"
+        clear: Исчисти филтри
+        filter: Пребарај
       predicates:
-        from: "Од"
-        to: "До"
-    search_status:
-      no_current_filters: "Моментално нема филтри"
-    status_tag:
-      "yes": "Да"
-      "no": "Не"
-      "unset": "Не"
-    logout: "Одјави се"
-    powered_by: "Овозможено од %{active_admin} %{version}"
-    sidebars:
-      filters: "Филтри за пребарување"
-      search_status: "Резултати од пребарување"
-    pagination:
-      empty: "Нема пронајдени записи за %{model}"
-      one: "Прикажан <b>1</b> %{model}"
-      one_page: "Прикажани <b>сите %{n}</b> %{model}"
-      multiple: "Прикажани %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> од вкупно <b>%{total}</b>"
-      multiple_without_total: "Прикажани %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      per_page: "Прикази на записи по страна:"
-      entry:
-        one: "запис"
-        other: "записи"
-    any: "Било кој"
-    blank_slate:
-      content: "Не се креирани записи од типот на %{resource_name}."
-      link: "Креирај нов"
-    batch_actions:
-      button_label: "Групни активности"
-      default_confirmation: "Дали сте сигурни?"
-      delete_confirmation: "Дали сте сигурни дека сакате да ги избришете %{plural_model}?"
-      succesfully_destroyed:
-        one: "Успешно е избришан 1 %{model}"
-        other: "Успешно се избришани %{count} %{plural_model}"
-      selection_toggle_explanation: "(Toggle Selection)"
-      action_label: "%{title} го селектираното"
-      labels:
-        destroy: "Избриши"
-    devise:
-      username:
-        title: "Корисничко име"
-      email:
-        title: "Е-маил"
-      password:
-        title: "Лозинка"
-      password_confirmation:
-        title: "Потврди Лозинка"
-      sign_up:
-        title: "Креирај профил"
-        submit: "Креирај"
-      login:
-        title: "Најави се"
-        remember_me: "Запомни ме"
-        submit: "Најави се"
-      reset_password:
-        title: "Ја заборавивте Вашата лозинка?"
-        submit: "Промени лозинка"
-      change_password:
-        title: "Променете ја лозинката"
-        submit: "Промени лозинка"
-      unlock:
-        title: "Повторно испраќање на инструкции за отклучување на профил"
-        submit: "Испрати инструкции"
-      resend_confirmation_instructions:
-        title: "Повторно испраќање на инструкции за потврдување на профил"
-        submit: "Инспрати инструкции"
-      links:
-        sign_up: "Креирај профил"
-        sign_in: "Најави се"
-        forgot_your_password: "Ја заборавивте Вашата лозинка?"
-        sign_in_with_omniauth_provider: "Најави се со %{provider}"
-        resend_unlock_instructions: "Повторно испрати инструкции за отклучување на профил"
-        resend_confirmation_instructions: "Повторно испрати инструкции за потврдување на профил"
-    access_denied:
-      message: "Немате овластување да ја извршите оваа активност."
+        from: Од
+        to: До
+    has_many_delete: Избриши
+    has_many_new: Додај нов %{model}
+    has_many_remove: Отстрани
     index_list:
-      table: "Табела"
+      table: Табела
+    logout: Одјави се
+    move: Премести
+    new_model: Додај нов %{model}
+    next: Следно
+    pagination:
+      empty: Нема пронајдени записи за %{model}
+      entry:
+        one: запис
+        other: записи
+      multiple: Прикажани %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> од вкупно <b>%{total}</b>
+      multiple_without_total: Прикажани %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      one: Прикажан <b>1</b> %{model}
+      one_page: Прикажани <b>сите %{n}</b> %{model}
+      per_page: 'Прикази на записи по страна:'
+    powered_by: Овозможено од %{active_admin} %{version}
+    previous: Претходно
+    search_status:
+      no_current_filters: Моментално нема филтри
+    sidebars:
+      filters: Филтри за пребарување
+      search_status: Резултати од пребарување
+    status_tag:
+      'no': Не
+      unset: Не
+      'yes': Да
+    view: Прегледај
+  activerecord:
+    models:
+      active_admin/comment:
+        one: Коментар
+        other: Коментари
+      comment:
+        one: Коментар
+        other: Коментари

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -7,6 +7,7 @@ nb:
     batch_actions:
       action_label: "%{title} valgt"
       button_label: Gruppehandlinger
+      default_confirmation: Are you sure you want to do this?
       delete_confirmation: Er du sikker på at du vil slette disse %{plural_model}? Dette kan ikke reverseres.
       labels:
         destroy: Slett
@@ -33,6 +34,7 @@ nb:
       resource: Ressurs
       resource_type: Ressurstype
       title_content: Kommentarer (%{count})
+    create_another: Create another %{model}
     dashboard: Oversikt
     delete: Slett
     delete_confirmation: Er du sikker på at du vil slette denne?
@@ -46,14 +48,19 @@ nb:
         title: E-post
       links:
         forgot_your_password: Glemt passord?
+        resend_confirmation_instructions: Resend confirmation instructions
+        resend_unlock_instructions: Resend unlock instructions
         sign_in: Logg inn
         sign_in_with_omniauth_provider: Logg på med %{provider}
+        sign_up: Sign up
       login:
         remember_me: Husk meg
         submit: Logg inn
         title: Innlogging
       password:
         title: Passord
+      password_confirmation:
+        title: Confirm Password
       resend_confirmation_instructions:
         submit: Send bekreftelsesinformasjon på nytt
         title: Send bekreftelsesinformasjon på nytt
@@ -87,6 +94,7 @@ nb:
     index_list:
       table: Tabell
     logout: Logg ut
+    move: Move
     new_model: Ny %{model}
     next: Neste
     pagination:
@@ -96,16 +104,44 @@ nb:
         other: innslag
       multiple: Viser %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> av <b>%{total}</b> totalt
       multiple_without_total: Viser %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      next: Next
       one: Viser <b>1</b> %{model}
       one_page: Viser <b>alle %{n}</b> %{model}
+      per_page: 'Per page '
+      previous: Previous
     powered_by: Powered by %{active_admin} %{version}
     previous: Forrige
+    scopes:
+      all: All
     search_status:
       no_current_filters: Ingen
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: Filtere
+      search_status: Search Status
     status_tag:
       'no': Nei
       unset: Nei
       'yes': Ja
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: Vis
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Author type
+        body: Body
+        created_at: Created
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Updated
+    models:
+      active_admin/comment:
+        one: Comment
+        other: Comments
+      comment:
+        one: Comment
+        other: Comments

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -1,110 +1,111 @@
+---
 nb:
   active_admin:
+    access_denied:
+      message: Du er ikke autorisert til å utføre denne handlingen.
+    any: Alle
+    batch_actions:
+      action_label: "%{title} valgt"
+      button_label: Gruppehandlinger
+      delete_confirmation: Er du sikker på at du vil slette disse %{plural_model}? Dette kan ikke reverseres.
+      labels:
+        destroy: Slett
+      selection_toggle_explanation: "(Toggle Selection)"
+      succesfully_destroyed:
+        one: Slettet én %{model}
+        other: Slettet %{count} %{plural_model}
+    blank_slate:
+      content: Her er det ingen %{resource_name} enda.
+      link: Opprett en
+    cancel: Avbryt
+    comments:
+      add: Legg til kommentar
+      author: Forfatter
+      author_missing: Anonym
+      author_type: Forfattertype
+      body: Brødtekst
+      created_at: Opprettet
+      delete: Slett kommentar
+      delete_confirmation: Er du sikker på at du ønsker å slette kommentaren?
+      errors:
+        empty_text: Kommentar ble ikke lagret, teksten var tom.
+      no_comments_yet: Ingen kommentarer ennå.
+      resource: Ressurs
+      resource_type: Ressurstype
+      title_content: Kommentarer (%{count})
     dashboard: Oversikt
-    view: "Vis"
-    edit: "Rediger"
-    delete: "Slett"
-    delete_confirmation: "Er du sikker på at du vil slette denne?"
-    new_model: "Ny %{model}"
-    edit_model: "Rediger %{model}"
-    delete_model: "Slett %{model}"
+    delete: Slett
+    delete_confirmation: Er du sikker på at du vil slette denne?
+    delete_model: Slett %{model}
     details: "%{model} Detaljer"
-    cancel: "Avbryt"
-    empty: "Tom"
-    previous: "Forrige"
-    next: "Neste"
-    download: "Last ned:"
-    has_many_new: "Legg til ny %{model}"
-    has_many_delete: "Slett"
-    has_many_remove: "Fjern"
+    devise:
+      change_password:
+        submit: Endre mitt passord
+        title: Endre passordet
+      email:
+        title: E-post
+      links:
+        forgot_your_password: Glemt passord?
+        sign_in: Logg inn
+        sign_in_with_omniauth_provider: Logg på med %{provider}
+      login:
+        remember_me: Husk meg
+        submit: Logg inn
+        title: Innlogging
+      password:
+        title: Passord
+      resend_confirmation_instructions:
+        submit: Send bekreftelsesinformasjon på nytt
+        title: Send bekreftelsesinformasjon på nytt
+      reset_password:
+        submit: Tilbakestille passordet mitt
+        title: Glemt passord?
+      sign_up:
+        submit: Opprett
+        title: Opprett brukerkonto
+      subdomain:
+        title: Subdomene
+      unlock:
+        submit: Send info om gjenoppretting på nytt
+        title: Send info om gjenoppretting på nytt
+      username:
+        title: Brukernavn
+    download: 'Last ned:'
+    edit: Rediger
+    edit_model: Rediger %{model}
+    empty: Tom
     filters:
       buttons:
-        filter: "Filter"
-        clear: "Fjern filter"
+        clear: Fjern filter
+        filter: Filter
       predicates:
-        from: "Fra"
-        to: "Til"
-    search_status:
-      no_current_filters: "Ingen"
-    status_tag:
-      "yes": "Ja"
-      "no": "Nei"
-      "unset": "Nei"
-    logout: "Logg ut"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filtere"
-    pagination:
-      empty: "Fant ingen %{model}"
-      one: "Viser <b>1</b> %{model}"
-      one_page: "Viser <b>alle %{n}</b> %{model}"
-      multiple: "Viser %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> av <b>%{total}</b> totalt"
-      multiple_without_total: "Viser %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      entry:
-        one: "innslag"
-        other: "innslag"
-    any: "Alle"
-    blank_slate:
-      content: "Her er det ingen %{resource_name} enda."
-      link: "Opprett en"
-    batch_actions:
-      button_label: "Gruppehandlinger"
-      delete_confirmation: "Er du sikker på at du vil slette disse %{plural_model}? Dette kan ikke reverseres."
-      succesfully_destroyed:
-        one: "Slettet én %{model}"
-        other: "Slettet %{count} %{plural_model}"
-      selection_toggle_explanation: "(Toggle Selection)"
-      action_label: "%{title} valgt"
-      labels:
-        destroy: "Slett"
-    comments:
-      created_at: "Opprettet"
-      resource_type: "Ressurstype"
-      author_type: "Forfattertype"
-      body: "Brødtekst"
-      author: "Forfatter"
-      add: "Legg til kommentar"
-      delete: "Slett kommentar"
-      delete_confirmation: "Er du sikker på at du ønsker å slette kommentaren?"
-      resource: "Ressurs"
-      no_comments_yet: "Ingen kommentarer ennå."
-      author_missing: "Anonym"
-      title_content: "Kommentarer (%{count})"
-      errors:
-        empty_text: "Kommentar ble ikke lagret, teksten var tom."
-    devise:
-      username:
-        title: "Brukernavn"
-      email:
-        title: "E-post"
-      subdomain:
-        title: "Subdomene"
-      password:
-        title: "Passord"
-      sign_up:
-        title: "Opprett brukerkonto"
-        submit: "Opprett"
-      login:
-        title: "Innlogging"
-        remember_me: "Husk meg"
-        submit: "Logg inn"
-      reset_password:
-        title: "Glemt passord?"
-        submit: "Tilbakestille passordet mitt"
-      change_password:
-        title: "Endre passordet"
-        submit: "Endre mitt passord"
-      unlock:
-        title: "Send info om gjenoppretting på nytt"
-        submit: "Send info om gjenoppretting på nytt"
-      resend_confirmation_instructions:
-        title: "Send bekreftelsesinformasjon på nytt"
-        submit: "Send bekreftelsesinformasjon på nytt"
-      links:
-        sign_in: "Logg inn"
-        forgot_your_password: "Glemt passord?"
-        sign_in_with_omniauth_provider: "Logg på med %{provider}"
-    access_denied:
-      message: "Du er ikke autorisert til å utføre denne handlingen."
+        from: Fra
+        to: Til
+    has_many_delete: Slett
+    has_many_new: Legg til ny %{model}
+    has_many_remove: Fjern
     index_list:
-      table: "Tabell"
+      table: Tabell
+    logout: Logg ut
+    new_model: Ny %{model}
+    next: Neste
+    pagination:
+      empty: Fant ingen %{model}
+      entry:
+        one: innslag
+        other: innslag
+      multiple: Viser %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> av <b>%{total}</b> totalt
+      multiple_without_total: Viser %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      one: Viser <b>1</b> %{model}
+      one_page: Viser <b>alle %{n}</b> %{model}
+    powered_by: Powered by %{active_admin} %{version}
+    previous: Forrige
+    search_status:
+      no_current_filters: Ingen
+    sidebars:
+      filters: Filtere
+    status_tag:
+      'no': Nei
+      unset: Nei
+      'yes': Ja
+    view: Vis

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -124,4 +124,24 @@ nl:
       'no': Geen
       unset: Onbekend
       'yes': Ja
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: Bekijk
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Author type
+        body: Body
+        created_at: Created
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Updated
+    models:
+      active_admin/comment:
+        one: Comment
+        other: Comments
+      comment:
+        one: Comment
+        other: Comments

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,126 +1,127 @@
+---
 nl:
   active_admin:
+    access_denied:
+      message: U bent niet gemachtigd voor deze actie.
+    any: Alle
+    batch_actions:
+      action_label: "%{title} geselecteerde"
+      button_label: Batch acties
+      default_confirmation: Weet u zeker dat u dit wilt doen?
+      delete_confirmation: Weet u zeker dat u deze %{plural_model} wilt verwijderen?
+      labels:
+        destroy: Verwijder
+      selection_toggle_explanation: "(Toggle selectie)"
+      succesfully_destroyed:
+        one: 1 %{model} verwijderd.
+        other: "%{count} %{plural_model} verwijderd."
+    blank_slate:
+      content: Er zijn geen %{resource_name} gevonden.
+      link: Maak aan
+    cancel: Annuleren
+    comments:
+      add: Voeg reactie toe
+      author: Auteur
+      author_missing: Anoniem
+      author_type: Auteur Type
+      body: Tekst
+      created_at: Aangemaakt op
+      delete: Verwijder reactie
+      delete_confirmation: Weet u zeker dat u deze reactie wilt verwijderen?
+      errors:
+        empty_text: De reactie is niet opgeslagen, de tekst was leeg.
+      no_comments_yet: Nog geen reacties.
+      resource: Resource
+      resource_type: Resource Type
+      title_content: Alle reacties (%{count})
+    create_another: Maak nog een %{model}
     dashboard: Dashboard
-    view: "Bekijk"
-    edit: "Wijzig"
-    delete: "Verwijder"
-    delete_confirmation: "Weet u zeker dat je dit item wilt verwijderen?"
-    create_another: "Maak nog een %{model}"
-    new_model: "Nieuwe %{model}"
-    edit_model: "Wijzig %{model}"
-    delete_model: "Verwijder %{model}"
+    delete: Verwijder
+    delete_confirmation: Weet u zeker dat je dit item wilt verwijderen?
+    delete_model: Verwijder %{model}
     details: "%{model} details"
-    cancel: "Annuleren"
-    empty: "Leeg"
-    previous: "Vorige"
-    next: "Volgende"
-    download: "Download"
-    has_many_new: "Voeg nieuwe %{model} toe"
-    has_many_delete: "Verwijderen"
-    has_many_remove: "Verwijderen"
-    move: "Verplaats"
+    devise:
+      change_password:
+        submit: Mijn wachtwoord wijzigen
+        title: Wijzig uw wachtwoord
+      email:
+        title: Email
+      links:
+        forgot_your_password: Wachtwoord vergeten?
+        resend_confirmation_instructions: Bevestigingsinstructies opnieuw versturen
+        resend_unlock_instructions: Ontgrendelinstructies opnieuw versturen
+        sign_in: Meld u aan
+        sign_in_with_omniauth_provider: Log in met %{provider}
+        sign_up: Registreren
+      login:
+        remember_me: Onthoud mij
+        submit: Inloggen
+        title: Inloggen
+      password:
+        title: Wachtwoord
+      password_confirmation:
+        title: Bevestig password
+      resend_confirmation_instructions:
+        submit: Verstuur bevestigingsinstructies opnieuw
+        title: Verstuur bevestigingsinstructies opnieuw
+      reset_password:
+        submit: Reset mijn wachtwoord
+        title: Wachtwoord vergeten?
+      sign_up:
+        submit: Registreren
+        title: Registreren
+      subdomain:
+        title: Subdomein
+      unlock:
+        submit: Verstuur ontgrendelinstructies opnieuw
+        title: Verstuur ontgrendelinstructies opnieuw
+      username:
+        title: Gebruikersnaam
+    download: Download
+    edit: Wijzig
+    edit_model: Wijzig %{model}
+    empty: Leeg
     filters:
       buttons:
-        filter: "Filter"
-        clear: "Maak Filters Ongedaan"
+        clear: Maak Filters Ongedaan
+        filter: Filter
       predicates:
         from: Van
         to: Tot
-    scopes:
-      all: "Alle"
-    search_status:
-      title: "Huidige filter"
-      title_with_scope: "Huidige filter voor %{name}"
-      no_current_filters: "Geen"
-    status_tag:
-      "yes": "Ja"
-      "no": "Geen"
-      "unset": "Onbekend"
-    logout: "Uitloggen"
-    powered_by: "Mogelijk gemaakt door %{active_admin} %{version}"
-    sidebars:
-      filters: "Filters"
-      search_status: "Zoek status"
-    pagination:
-      empty: "Geen %{model} gevonden"
-      one: "Toont <b>1</b> van <b>1</b>"
-      one_page: "Toont <b>alle %{n}</b>"
-      multiple: "Toont <b>%{from}-%{to}</b> van <b>%{total}</b>"
-      multiple_without_total: "Toont <b>%{from}-%{to}</b>"
-      per_page: "Per pagina: "
-      previous: "Vorige"
-      next: "Volgende"
-      entry:
-        one: "entry"
-        other: "entries"
-    any: "Alle"
-    blank_slate:
-      content: "Er zijn geen %{resource_name} gevonden."
-      link: "Maak aan"
-    batch_actions:
-      button_label: "Batch acties"
-      default_confirmation: "Weet u zeker dat u dit wilt doen?"
-      delete_confirmation: "Weet u zeker dat u deze %{plural_model} wilt verwijderen?"
-      succesfully_destroyed:
-        one: "1 %{model} verwijderd."
-        other: "%{count} %{plural_model} verwijderd."
-      selection_toggle_explanation: "(Toggle selectie)"
-      action_label: "%{title} geselecteerde"
-      labels:
-        destroy: "Verwijder"
-    comments:
-      created_at: "Aangemaakt op"
-      resource_type: "Resource Type"
-      author_type: "Auteur Type"
-      body: "Tekst"
-      author: "Auteur"
-      add: "Voeg reactie toe"
-      delete: "Verwijder reactie"
-      delete_confirmation: "Weet u zeker dat u deze reactie wilt verwijderen?"
-      resource: "Resource"
-      no_comments_yet: "Nog geen reacties."
-      author_missing: "Anoniem"
-      title_content: "Alle reacties (%{count})"
-      errors:
-        empty_text: "De reactie is niet opgeslagen, de tekst was leeg."
-    devise:
-      username:
-        title: "Gebruikersnaam"
-      email:
-        title: "Email"
-      subdomain:
-        title: "Subdomein"
-      password:
-        title: "Wachtwoord"
-      password_confirmation:
-        title: "Bevestig password"
-      sign_up:
-        title: "Registreren"
-        submit: "Registreren"
-      login:
-        title: "Inloggen"
-        remember_me: "Onthoud mij"
-        submit: "Inloggen"
-      reset_password:
-        title: "Wachtwoord vergeten?"
-        submit: "Reset mijn wachtwoord"
-      change_password:
-        title: "Wijzig uw wachtwoord"
-        submit: "Mijn wachtwoord wijzigen"
-      unlock:
-        title: "Verstuur ontgrendelinstructies opnieuw"
-        submit: "Verstuur ontgrendelinstructies opnieuw"
-      resend_confirmation_instructions:
-        title: "Verstuur bevestigingsinstructies opnieuw"
-        submit: "Verstuur bevestigingsinstructies opnieuw"
-      links:
-        sign_up: "Registreren"
-        sign_in: "Meld u aan"
-        forgot_your_password: "Wachtwoord vergeten?"
-        sign_in_with_omniauth_provider: "Log in met %{provider}"
-        resend_unlock_instructions: "Ontgrendelinstructies opnieuw versturen"
-        resend_confirmation_instructions: "Bevestigingsinstructies opnieuw versturen"
-    access_denied:
-      message: "U bent niet gemachtigd voor deze actie."
+    has_many_delete: Verwijderen
+    has_many_new: Voeg nieuwe %{model} toe
+    has_many_remove: Verwijderen
     index_list:
-      table: "Tabel"
+      table: Tabel
+    logout: Uitloggen
+    move: Verplaats
+    new_model: Nieuwe %{model}
+    next: Volgende
+    pagination:
+      empty: Geen %{model} gevonden
+      entry:
+        one: entry
+        other: entries
+      multiple: Toont <b>%{from}-%{to}</b> van <b>%{total}</b>
+      multiple_without_total: Toont <b>%{from}-%{to}</b>
+      next: Volgende
+      one: Toont <b>1</b> van <b>1</b>
+      one_page: Toont <b>alle %{n}</b>
+      per_page: 'Per pagina: '
+      previous: Vorige
+    powered_by: Mogelijk gemaakt door %{active_admin} %{version}
+    previous: Vorige
+    scopes:
+      all: Alle
+    search_status:
+      no_current_filters: Geen
+      title: Huidige filter
+      title_with_scope: Huidige filter voor %{name}
+    sidebars:
+      filters: Filters
+      search_status: Zoek status
+    status_tag:
+      'no': Geen
+      unset: Onbekend
+      'yes': Ja
+    view: Bekijk

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -102,6 +102,8 @@ pl:
     pagination:
       empty: Nie znaleziono %{model}
       entry:
+        few:
+        many:
         one:
         other:
       multiple: Wyświetlanie %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> z <b>%{total}</b>

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -106,9 +106,11 @@ pl:
         other:
       multiple: Wyświetlanie %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> z <b>%{total}</b>
       multiple_without_total: Wyświetlanie %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      next: Next
       one: Wyświetlanie <b>1</b> %{model}
       one_page: Wyświetlanie <b>wszystkich %{n}</b> %{model}
       per_page: 'Na stronę: '
+      previous: Previous
     powered_by: Powered by %{active_admin} %{version}
     previous: Poprzednia
     scopes:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -1,150 +1,151 @@
+---
 pl:
-  activerecord:
-    models:
-      comment:
-        one: "Komentarz"
-        few: "Komentarze"
-        many: "Komentarzy"
-        other: "Komentarze"
-      active_admin/comment:
-        one: "Komentarz"
-        few: "Komentarze"
-        many: "Komentarzy"
-        other: "Komentarze"
-    attributes:
-      active_admin/comment:
-        author_type: "Typ autora"
-        body: "Treść"
-        created_at: "Utworzony"
-        namespace: "Namespace"
-        resource_type: "Typ zasobu"
-        updated_at: "Zaktualizowany"
   active_admin:
+    access_denied:
+      message: Nie masz uprawnień wystarczających do wykonania tej akcji.
+    any: Jakikolwiek
+    batch_actions:
+      action_label: "%{title} zaznaczone"
+      button_label: Akcje na partiach
+      default_confirmation: Czy na pewno chcesz to zrobić?
+      delete_confirmation: Czy na pewno chcesz usunąć te %{plural_model}?
+      labels:
+        destroy: Usuń
+      selection_toggle_explanation: "(Przełącz zaznaczenie)"
+      succesfully_destroyed:
+        few: Poprawnie usunięto %{count} %{plural_model}
+        many: Poprawnie usunięto %{count} %{plural_model}
+        one: Poprawnie usunięto 1 %{model}
+        other: Poprawnie usunięto %{count} %{plural_model}
+    blank_slate:
+      content: Nie ma jeszcze zasobu %{resource_name}.
+      link: Utwórz go
+    cancel: Anuluj
+    comments:
+      add: Dodaj komentarz
+      author: Autor
+      author_missing: Anonim
+      author_type: Typ autora
+      body: Treść
+      created_at: Utworzony
+      delete: Usuń komentarz
+      delete_confirmation: Czy na pewno chcesz usunąć ten komentarz?
+      errors:
+        empty_text: Komentarz nie został zapisany, zawartość była pusta.
+      no_comments_yet: Nie ma jeszcze komentarzy.
+      resource: Zasób
+      resource_type: Typ zasobu
+      title_content: Komentarze (%{count})
+    create_another: Utwórz kolejny %{model}
     dashboard: Pulpit
-    view: "Podgląd"
-    edit: "Edytuj"
-    delete: "Usuń"
-    delete_confirmation: "Jesteś pewien, że chcesz to usunąć?"
-    create_another: "Utwórz kolejny %{model}"
-    new_model: "Nowy %{model}"
-    edit_model: "Edytuj %{model}"
-    delete_model: "Usuń %{model}"
-    details: "Szczegóły %{model}"
-    cancel: "Anuluj"
-    empty: "Pusty"
-    previous: "Poprzednia"
-    next: "Następna"
-    download: "Pobierz:"
-    has_many_new: "Dodaj nowy %{model}"
-    has_many_delete: "Usuń"
-    has_many_remove: "Usuń"
-    move: "Przenieś"
+    delete: Usuń
+    delete_confirmation: Jesteś pewien, że chcesz to usunąć?
+    delete_model: Usuń %{model}
+    details: Szczegóły %{model}
+    devise:
+      change_password:
+        submit: Zmień hasło
+        title: Zmień hasło
+      email:
+        title: Email
+      links:
+        forgot_your_password: Nie pamiętasz hasła?
+        resend_confirmation_instructions: Ponownie wyślij instrukcje aktywacji
+        resend_unlock_instructions: Ponownie wyślij instrukcję odblokowania konta
+        sign_in: Zaloguj się
+        sign_in_with_omniauth_provider: Zaloguj się z %{provider}
+        sign_up: Zarejestruj się
+      login:
+        remember_me: Zapamiętaj mnie
+        submit: Zaloguj się
+        title: Logowanie
+      password:
+        title: Hasło
+      password_confirmation:
+        title: Powtórz hasło
+      resend_confirmation_instructions:
+        submit: Ponownie wyślij instrukcje aktywacji
+        title: Ponownie wyślij instrukcje aktywacji
+      reset_password:
+        submit: Zresetować hasło
+        title: Nie pamiętasz hasła?
+      sign_up:
+        submit: Zarejestruj się
+        title: Rejestracja
+      subdomain:
+        title: Subdomena
+      unlock:
+        submit: Ponownie wyślij instrukcję odblokowania konta
+        title: Ponownie wyślij instrukcję odblokowania konta
+      username:
+        title: Nazwa użytkownika
+    download: 'Pobierz:'
+    edit: Edytuj
+    edit_model: Edytuj %{model}
+    empty: Pusty
     filters:
       buttons:
-        filter: "Filtruj"
-        clear: "Wyczyść Filtry"
+        clear: Wyczyść Filtry
+        filter: Filtruj
       predicates:
-        from: "Od"
-        to: "Do"
+        from: Od
+        to: Do
+    has_many_delete: Usuń
+    has_many_new: Dodaj nowy %{model}
+    has_many_remove: Usuń
+    index_list:
+      table: Tabela
+    logout: Wyloguj
+    move: Przenieś
+    new_model: Nowy %{model}
+    next: Następna
+    pagination:
+      empty: Nie znaleziono %{model}
+      entry:
+        one:
+        other:
+      multiple: Wyświetlanie %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> z <b>%{total}</b>
+      multiple_without_total: Wyświetlanie %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      one: Wyświetlanie <b>1</b> %{model}
+      one_page: Wyświetlanie <b>wszystkich %{n}</b> %{model}
+      per_page: 'Na stronę: '
+    powered_by: Powered by %{active_admin} %{version}
+    previous: Poprzednia
     scopes:
-      all: "Wszystko"
+      all: Wszystko
     search_status:
-      title: "Wyszukiwanie"
-      title_with_scope: "Wyszukiwanie %{name}"
-      no_current_filters: "Brak"
+      no_current_filters: Brak
+      title: Wyszukiwanie
+      title_with_scope: Wyszukiwanie %{name}
+    sidebars:
+      filters: Filtry
+      search_status: Status wyszukiwania
     status_tag:
-      "yes": "Tak"
-      "no": "Nie"
-      "unset": "Nie"
+      'no': Nie
+      unset: Nie
+      'yes': Tak
     toggle_dark_mode: Przełącz tryb ciemny
     toggle_main_navigation_menu: Przełącz główną nawigację
     toggle_section: Przełącz sekcję
     toggle_user_menu: Przełącz menu użytkownika
-    logout: "Wyloguj"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filtry"
-      search_status: "Status wyszukiwania"
-    pagination:
-      empty: "Nie znaleziono %{model}"
-      one: "Wyświetlanie <b>1</b> %{model}"
-      one_page: "Wyświetlanie <b>wszystkich %{n}</b> %{model}"
-      multiple: "Wyświetlanie %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> z <b>%{total}</b>"
-      multiple_without_total: "Wyświetlanie %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      per_page: "Na stronę: "
-      entry:
-        one:
-        other:
-    any: "Jakikolwiek"
-    blank_slate:
-      content: "Nie ma jeszcze zasobu %{resource_name}."
-      link: "Utwórz go"
-    batch_actions:
-      button_label: "Akcje na partiach"
-      default_confirmation: "Czy na pewno chcesz to zrobić?"
-      delete_confirmation: "Czy na pewno chcesz usunąć te %{plural_model}?"
-      succesfully_destroyed:
-        one: "Poprawnie usunięto 1 %{model}"
-        other: "Poprawnie usunięto %{count} %{plural_model}"
-        many: "Poprawnie usunięto %{count} %{plural_model}"
-        few: "Poprawnie usunięto %{count} %{plural_model}"
-      selection_toggle_explanation: "(Przełącz zaznaczenie)"
-      action_label: "%{title} zaznaczone"
-      labels:
-        destroy: "Usuń"
-    comments:
-      created_at: "Utworzony"
-      resource_type: "Typ zasobu"
-      author_type: "Typ autora"
-      body: "Treść"
-      author: "Autor"
-      add: "Dodaj komentarz"
-      delete: "Usuń komentarz"
-      delete_confirmation: "Czy na pewno chcesz usunąć ten komentarz?"
-      resource: "Zasób"
-      no_comments_yet: "Nie ma jeszcze komentarzy."
-      author_missing: "Anonim"
-      title_content: "Komentarze (%{count})"
-      errors:
-        empty_text: "Komentarz nie został zapisany, zawartość była pusta."
-    devise:
-      username:
-        title: "Nazwa użytkownika"
-      email:
-        title: "Email"
-      subdomain:
-        title: "Subdomena"
-      password:
-        title: "Hasło"
-      password_confirmation:
-        title: "Powtórz hasło"
-      sign_up:
-        title: "Rejestracja"
-        submit: "Zarejestruj się"
-      login:
-        title: "Logowanie"
-        remember_me: "Zapamiętaj mnie"
-        submit: "Zaloguj się"
-      reset_password:
-        title: "Nie pamiętasz hasła?"
-        submit: "Zresetować hasło"
-      change_password:
-        title: "Zmień hasło"
-        submit: "Zmień hasło"
-      unlock:
-        title: "Ponownie wyślij instrukcję odblokowania konta"
-        submit: "Ponownie wyślij instrukcję odblokowania konta"
-      resend_confirmation_instructions:
-        title: "Ponownie wyślij instrukcje aktywacji"
-        submit: "Ponownie wyślij instrukcje aktywacji"
-      links:
-        sign_up: "Zarejestruj się"
-        sign_in: "Zaloguj się"
-        forgot_your_password: "Nie pamiętasz hasła?"
-        sign_in_with_omniauth_provider: "Zaloguj się z %{provider}"
-        resend_unlock_instructions: "Ponownie wyślij instrukcję odblokowania konta"
-        resend_confirmation_instructions: "Ponownie wyślij instrukcje aktywacji"
-    access_denied:
-      message: "Nie masz uprawnień wystarczających do wykonania tej akcji."
-    index_list:
-      table: "Tabela"
+    view: Podgląd
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Typ autora
+        body: Treść
+        created_at: Utworzony
+        namespace: Namespace
+        resource_type: Typ zasobu
+        updated_at: Zaktualizowany
+    models:
+      active_admin/comment:
+        few: Komentarze
+        many: Komentarzy
+        one: Komentarz
+        other: Komentarze
+      comment:
+        few: Komentarze
+        many: Komentarzy
+        one: Komentarz
+        other: Komentarze

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1,119 +1,120 @@
+---
 pt-BR:
   active_admin:
-    dashboard: "Painel Administrativo"
-    view: "Visualizar"
-    edit: "Editar"
-    delete: "Remover"
-    delete_confirmation: "Você tem certeza que deseja remover este item?"
-    create_another: "Criar outro %{model}"
-    new_model: "Novo(a) %{model}"
-    edit_model: "Editar %{model}"
-    delete_model: "Remover %{model}"
-    details: "Detalhes do(a) %{model}"
-    cancel: "Cancelar"
-    empty: "Vazio"
-    previous: "Anterior"
-    next: "Próximo"
-    download: "Baixar:"
-    has_many_new: "Adicionar Novo(a) %{model}"
-    has_many_delete: "Remover"
-    has_many_remove: "Remover"
+    access_denied:
+      message: Você não tem permissão para realizar o solicitado
+    any: Qualquer
+    batch_actions:
+      action_label: "%{title} Selecionado"
+      button_label: Ações em lote
+      default_confirmation: Tem certeza que quer fazer isso?
+      delete_confirmation: Tem certeza que deseja excluir estes %{plural_model}?
+      labels:
+        destroy: Excluir
+      selection_toggle_explanation: "(Alternar Seleção)"
+      succesfully_destroyed:
+        one: Excluiu com sucesso 1 %{model}
+        other: Excluiu com sucesso %{count} %{plural_model}
+    blank_slate:
+      content: Não existem %{resource_name} ainda.
+      link: Novo
+    cancel: Cancelar
+    comments:
+      add: Adicionar Comentário
+      author: Autor
+      author_missing: Anônimo
+      author_type: Tipo de Autor
+      body: Conteúdo
+      created_at: Criado em
+      delete: Deletar comentário
+      delete_confirmation: Tem certeza que deseja excluir este comentário?
+      errors:
+        empty_text: O comentário não foi salvo porque o texto estava vazio.
+      no_comments_yet: Nenhum comentário.
+      resource: Objeto
+      resource_type: Tipo de Objeto
+      title_content: 'Comentários: %{count}'
+    create_another: Criar outro %{model}
+    dashboard: Painel Administrativo
+    delete: Remover
+    delete_confirmation: Você tem certeza que deseja remover este item?
+    delete_model: Remover %{model}
+    details: Detalhes do(a) %{model}
+    devise:
+      change_password:
+        submit: Troque minha senha
+        title: Troque sua senha
+      email:
+        title: E-mail
+      links:
+        forgot_your_password: Esqueceu sua senha?
+        resend_confirmation_instructions: Reenviar instruções de confirmação
+        resend_unlock_instructions: Reenviar instruções de desbloqueio
+        sign_in: Entrar
+        sign_in_with_omniauth_provider: Entre com o %{provider}
+        sign_up: Criar conta
+      login:
+        remember_me: Lembrar da senha
+        submit: Entrar
+        title: Conta
+      password:
+        title: Senha
+      password_confirmation:
+        title: Confirmação de senha
+      resend_confirmation_instructions:
+        submit: Reenviar instruções de confirmação
+        title: Reenviar instruções de confirmação
+      reset_password:
+        submit: Reinicie minha senha
+        title: Esqueceu sua senha?
+      sign_up:
+        submit: Continuar
+        title: Cadastre-se
+      subdomain:
+        title: Subdomínio
+      unlock:
+        submit: Reenviar instruções de desbloqueio
+        title: Reenviar instruções de desbloqueio
+      username:
+        title: Nome de Usuário
+    download: 'Baixar:'
+    edit: Editar
+    edit_model: Editar %{model}
+    empty: Vazio
     filters:
       buttons:
-        filter: "Filtrar"
-        clear: "Limpar Filtros"
+        clear: Limpar Filtros
+        filter: Filtrar
       predicates:
-        from: "A partir de"
-        to: "Até"
-    search_status:
-      no_current_filters: "Nenhum"
-    status_tag:
-      "yes": "Sim"
-      "no": "Não"
-      "unset": "Não"
-    logout: "Sair"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filtros"
-      search_status: "Buscou"
-    pagination:
-      empty: "Nenhum(a) %{model} encontrado(a)"
-      one: "Exibindo <b>1</b> %{model}"
-      one_page: "Exibindo <b>todos(as) os(as) %{n}</b> %{model}"
-      multiple: "Exibindo %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> de um total de <b>%{total}</b>"
-      multiple_without_total: "Exibindo %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      per_page: "Por página: "
-      entry:
-        one: "registro"
-        other: "registros"
-    any: "Qualquer"
-    blank_slate:
-      content: "Não existem %{resource_name} ainda."
-      link: "Novo"
-    batch_actions:
-      button_label: "Ações em lote"
-      default_confirmation: "Tem certeza que quer fazer isso?"
-      delete_confirmation: "Tem certeza que deseja excluir estes %{plural_model}?"
-      succesfully_destroyed:
-        one: "Excluiu com sucesso 1 %{model}"
-        other: "Excluiu com sucesso %{count} %{plural_model}"
-      selection_toggle_explanation: "(Alternar Seleção)"
-      action_label: "%{title} Selecionado"
-      labels:
-        destroy: "Excluir"
-    comments:
-      created_at: "Criado em"
-      resource_type: "Tipo de Objeto"
-      author_type: "Tipo de Autor"
-      body: "Conteúdo"
-      author: "Autor"
-      add: "Adicionar Comentário"
-      delete: "Deletar comentário"
-      delete_confirmation: "Tem certeza que deseja excluir este comentário?"
-      resource: "Objeto"
-      no_comments_yet: "Nenhum comentário."
-      author_missing: "Anônimo"
-      title_content: "Comentários: %{count}"
-      errors:
-        empty_text: "O comentário não foi salvo porque o texto estava vazio."
-    devise:
-      username:
-        title: "Nome de Usuário"
-      email:
-        title: "E-mail"
-      subdomain:
-        title: "Subdomínio"
-      password:
-        title: "Senha"
-      password_confirmation:
-        title: "Confirmação de senha"
-      sign_up:
-        title: "Cadastre-se"
-        submit: "Continuar"
-      login:
-        title: "Conta"
-        remember_me: "Lembrar da senha"
-        submit: "Entrar"
-      reset_password:
-        title: "Esqueceu sua senha?"
-        submit: "Reinicie minha senha"
-      change_password:
-        title: "Troque sua senha"
-        submit: "Troque minha senha"
-      unlock:
-        title: "Reenviar instruções de desbloqueio"
-        submit: "Reenviar instruções de desbloqueio"
-      resend_confirmation_instructions:
-        title: "Reenviar instruções de confirmação"
-        submit: "Reenviar instruções de confirmação"
-      links:
-        sign_up: "Criar conta"
-        sign_in: "Entrar"
-        forgot_your_password: "Esqueceu sua senha?"
-        sign_in_with_omniauth_provider: "Entre com o %{provider}"
-        resend_unlock_instructions: "Reenviar instruções de desbloqueio"
-        resend_confirmation_instructions: "Reenviar instruções de confirmação"
-    access_denied:
-      message: "Você não tem permissão para realizar o solicitado"
+        from: A partir de
+        to: Até
+    has_many_delete: Remover
+    has_many_new: Adicionar Novo(a) %{model}
+    has_many_remove: Remover
     index_list:
-      table: "Tabela"
+      table: Tabela
+    logout: Sair
+    new_model: Novo(a) %{model}
+    next: Próximo
+    pagination:
+      empty: Nenhum(a) %{model} encontrado(a)
+      entry:
+        one: registro
+        other: registros
+      multiple: Exibindo %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> de um total de <b>%{total}</b>
+      multiple_without_total: Exibindo %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      one: Exibindo <b>1</b> %{model}
+      one_page: Exibindo <b>todos(as) os(as) %{n}</b> %{model}
+      per_page: 'Por página: '
+    powered_by: Powered by %{active_admin} %{version}
+    previous: Anterior
+    search_status:
+      no_current_filters: Nenhum
+    sidebars:
+      filters: Filtros
+      search_status: Buscou
+    status_tag:
+      'no': Não
+      unset: Não
+      'yes': Sim
+    view: Visualizar

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -94,6 +94,7 @@ pt-BR:
     index_list:
       table: Tabela
     logout: Sair
+    move: Move
     new_model: Novo(a) %{model}
     next: Próximo
     pagination:
@@ -103,13 +104,19 @@ pt-BR:
         other: registros
       multiple: Exibindo %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> de um total de <b>%{total}</b>
       multiple_without_total: Exibindo %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      next: Next
       one: Exibindo <b>1</b> %{model}
       one_page: Exibindo <b>todos(as) os(as) %{n}</b> %{model}
       per_page: 'Por página: '
+      previous: Previous
     powered_by: Powered by %{active_admin} %{version}
     previous: Anterior
+    scopes:
+      all: All
     search_status:
       no_current_filters: Nenhum
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: Filtros
       search_status: Buscou
@@ -117,4 +124,24 @@ pt-BR:
       'no': Não
       unset: Não
       'yes': Sim
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: Visualizar
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Author type
+        body: Body
+        created_at: Created
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Updated
+    models:
+      active_admin/comment:
+        one: Comment
+        other: Comments
+      comment:
+        one: Comment
+        other: Comments

--- a/config/locales/pt-PT.yml
+++ b/config/locales/pt-PT.yml
@@ -1,79 +1,80 @@
-"pt-PT":
+---
+pt-PT:
   active_admin:
-    dashboard: "Painel de Administração"
-    view: "Visualizar"
-    edit: "Editar"
-    delete: "Remover"
-    delete_confirmation: "Não tem a certeza de que deseja remover este ítem?"
-    new_model: "Novo(a) %{model}"
-    edit_model: "Editar %{model}"
-    delete_model: "Remover %{model}"
-    details: "Detalhes do(a) %{model}"
-    cancel: "Cancelar"
-    empty: "Vazio"
-    previous: "Anterior"
-    next: "Próximo"
-    download: "Baixar:"
-    has_many_new: "Adicionar Novo(a) %{model}"
-    has_many_delete: "Remover"
-    has_many_remove: "Remover"
+    any: Qualquer
+    batch_actions:
+      action_label: "%{title} Selecionado"
+      button_label: Ações em quantidade
+      default_confirmation: Tem a certeza que quer fazer isso?
+      delete_confirmation: Tem a certeza de que deseja excluir estes %{plural_model}?
+      labels:
+        destroy: Excluir
+      selection_toggle_explanation: "(Alternar Seleção)"
+      succesfully_destroyed:
+        one: Excluiu com sucesso 1 %{model}
+        other: Excluiu com sucesso %{count} %{plural_model}
+    blank_slate:
+      content: Ainda não existem %{resource_name}.
+      link: Novo
+    cancel: Cancelar
+    comments:
+      add: Adicionar Comentário
+      author: Autor
+      body: Conteúdo
+      errors:
+        empty_text: O comentário não foi guardado porque o texto estava vazio.
+      no_comments_yet: Nenhum comentário.
+      resource: Objeto
+      title_content: 'Comentários: %{count}'
+    dashboard: Painel de Administração
+    delete: Remover
+    delete_confirmation: Não tem a certeza de que deseja remover este ítem?
+    delete_model: Remover %{model}
+    details: Detalhes do(a) %{model}
+    devise:
+      change_password:
+        submit: Trocar a minha senha
+        title: Troque a sua senha
+      links:
+        forgot_your_password: Esqueceu-se da sua senha?
+        sign_in: Entrar
+        sign_in_with_omniauth_provider: Entre com o %{provider}
+      login:
+        remember_me: Lembrar-me
+        submit: Entrar
+        title: Conta
+      reset_password:
+        submit: Reiniciar a minha senha
+        title: Esqueceu-de da sua senha?
+    download: 'Baixar:'
+    edit: Editar
+    edit_model: Editar %{model}
+    empty: Vazio
     filters:
       buttons:
-        filter: "Filtrar"
-        clear: "Limpar Filtros"
-    status_tag:
-      "yes": "Sim"
-      "no": "Não"
-      "unset": "Não"
-    logout: "Sair"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filtros"
+        clear: Limpar Filtros
+        filter: Filtrar
+    has_many_delete: Remover
+    has_many_new: Adicionar Novo(a) %{model}
+    has_many_remove: Remover
+    logout: Sair
+    new_model: Novo(a) %{model}
+    next: Próximo
     pagination:
-      empty: "Nenhum(a) %{model} encontrado(a)"
-      one: "Mostrando <b>1</b> %{model}"
-      one_page: "Mostrando <b>todos(as) os(as) %{n}</b> %{model}"
-      multiple: "Mostrando %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> de um total de <b>%{total}</b>"
-      multiple_without_total: "Mostrando %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      empty: Nenhum(a) %{model} encontrado(a)
       entry:
-        one: "registro"
-        other: "registros"
-    any: "Qualquer"
-    blank_slate:
-      content: "Ainda não existem %{resource_name}."
-      link: "Novo"
-    batch_actions:
-      button_label: "Ações em quantidade"
-      default_confirmation: "Tem a certeza que quer fazer isso?"
-      delete_confirmation: "Tem a certeza de que deseja excluir estes %{plural_model}?"
-      succesfully_destroyed:
-        one: "Excluiu com sucesso 1 %{model}"
-        other: "Excluiu com sucesso %{count} %{plural_model}"
-      selection_toggle_explanation: "(Alternar Seleção)"
-      action_label: "%{title} Selecionado"
-      labels:
-        destroy: "Excluir"
-    comments:
-      body: "Conteúdo"
-      author: "Autor"
-      add: "Adicionar Comentário"
-      resource: "Objeto"
-      no_comments_yet: "Nenhum comentário."
-      title_content: "Comentários: %{count}"
-      errors:
-        empty_text: "O comentário não foi guardado porque o texto estava vazio."
-    devise:
-      login:
-        title: "Conta"
-        remember_me: "Lembrar-me"
-        submit: "Entrar"
-      reset_password:
-        title: "Esqueceu-de da sua senha?"
-        submit: "Reiniciar a minha senha"
-      change_password:
-        title: "Troque a sua senha"
-        submit: "Trocar a minha senha"
-      links:
-        sign_in: "Entrar"
-        forgot_your_password: "Esqueceu-se da sua senha?"
-        sign_in_with_omniauth_provider: "Entre com o %{provider}"
+        one: registro
+        other: registros
+      multiple: Mostrando %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> de um total de <b>%{total}</b>
+      multiple_without_total: Mostrando %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      one: Mostrando <b>1</b> %{model}
+      one_page: Mostrando <b>todos(as) os(as) %{n}</b> %{model}
+    powered_by: Powered by %{active_admin} %{version}
+    previous: Anterior
+    sidebars:
+      filters: Filtros
+    status_tag:
+      'no': Não
+      unset: Não
+      'yes': Sim
+    view: Visualizar

--- a/config/locales/pt-PT.yml
+++ b/config/locales/pt-PT.yml
@@ -1,6 +1,8 @@
 ---
 pt-PT:
   active_admin:
+    access_denied:
+      message: You are not authorized to perform this action.
     any: Qualquer
     batch_actions:
       action_label: "%{title} Selecionado"
@@ -20,12 +22,19 @@ pt-PT:
     comments:
       add: Adicionar Comentário
       author: Autor
+      author_missing: Anonymous
+      author_type: Author Type
       body: Conteúdo
+      created_at: Created
+      delete: Delete Comment
+      delete_confirmation: Are you sure you want to delete this comment?
       errors:
         empty_text: O comentário não foi guardado porque o texto estava vazio.
       no_comments_yet: Nenhum comentário.
       resource: Objeto
+      resource_type: Resource Type
       title_content: 'Comentários: %{count}'
+    create_another: Create another %{model}
     dashboard: Painel de Administração
     delete: Remover
     delete_confirmation: Não tem a certeza de que deseja remover este ítem?
@@ -35,17 +44,39 @@ pt-PT:
       change_password:
         submit: Trocar a minha senha
         title: Troque a sua senha
+      email:
+        title: Email
       links:
         forgot_your_password: Esqueceu-se da sua senha?
+        resend_confirmation_instructions: Resend confirmation instructions
+        resend_unlock_instructions: Resend unlock instructions
         sign_in: Entrar
         sign_in_with_omniauth_provider: Entre com o %{provider}
+        sign_up: Sign up
       login:
         remember_me: Lembrar-me
         submit: Entrar
         title: Conta
+      password:
+        title: Password
+      password_confirmation:
+        title: Confirm Password
+      resend_confirmation_instructions:
+        submit: Resend confirmation instructions
+        title: Resend confirmation instructions
       reset_password:
         submit: Reiniciar a minha senha
         title: Esqueceu-de da sua senha?
+      sign_up:
+        submit: Sign up
+        title: Sign up
+      subdomain:
+        title: Subdomain
+      unlock:
+        submit: Resend unlock instructions
+        title: Resend unlock instructions
+      username:
+        title: Username
     download: 'Baixar:'
     edit: Editar
     edit_model: Editar %{model}
@@ -54,10 +85,16 @@ pt-PT:
       buttons:
         clear: Limpar Filtros
         filter: Filtrar
+      predicates:
+        from: From
+        to: To
     has_many_delete: Remover
     has_many_new: Adicionar Novo(a) %{model}
     has_many_remove: Remover
+    index_list:
+      table: Table
     logout: Sair
+    move: Move
     new_model: Novo(a) %{model}
     next: Próximo
     pagination:
@@ -67,14 +104,44 @@ pt-PT:
         other: registros
       multiple: Mostrando %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> de um total de <b>%{total}</b>
       multiple_without_total: Mostrando %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      next: Next
       one: Mostrando <b>1</b> %{model}
       one_page: Mostrando <b>todos(as) os(as) %{n}</b> %{model}
+      per_page: 'Per page '
+      previous: Previous
     powered_by: Powered by %{active_admin} %{version}
     previous: Anterior
+    scopes:
+      all: All
+    search_status:
+      no_current_filters: No filters applied
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: Filtros
+      search_status: Search Status
     status_tag:
       'no': Não
       unset: Não
       'yes': Sim
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: Visualizar
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Author type
+        body: Body
+        created_at: Created
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Updated
+    models:
+      active_admin/comment:
+        one: Comment
+        other: Comments
+      comment:
+        one: Comment
+        other: Comments

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -142,8 +142,10 @@ ro:
         updated_at: Updated
     models:
       active_admin/comment:
+        few: Comments
         one: Comment
         other: Comments
       comment:
+        few: Comments
         one: Comment
         other: Comments

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -1,84 +1,85 @@
+---
 ro:
   active_admin:
-    dashboard: "Pagina Principala"
-    view: "Vizualizati"
-    edit: "Modificati"
-    delete: "Stergeti"
-    delete_confirmation: "Sigur vreti sa stergeti?"
-    new_model: "Un nou %{model}"
-    edit_model: "Modificati %{model}"
-    delete_model: "Stergeti %{model}"
-    details: "Detalii %{model}"
-    cancel: "Renuntati"
-    empty: "Gol"
-    previous: "Inapoi"
-    next: "Inainte"
-    download: "Descarcati:"
-    has_many_new: "Adaugati un nou %{model}"
-    has_many_delete: "Stergeti"
-    has_many_remove: "Scoate"
+    any: Oricare
+    batch_actions:
+      action_label: "%{title} Selectat"
+      button_label: Grupare Actiuni
+      default_confirmation: Sunteţi sigur că doriţi să faceţi acest lucru?
+      delete_confirmation: Sunteţi sigur că doriţi să stergeţi aceste %{plural_model}?
+      labels:
+        destroy: Sterge
+      selection_toggle_explanation: "(Modifica Selectia)"
+      succesfully_destroyed:
+        few: "%{count} %{plural_model} sterse"
+        one: 1 %{model} sters
+        other: "%{count} %{plural_model} sterse"
+    blank_slate:
+      content: Momentan nu exista %{resource_name}.
+      link: Creati un
+    cancel: Renuntati
+    comments:
+      add: Adaugati comentariu
+      author: Autor
+      body: Text
+      errors:
+        empty_text: Comentariul nu a fost salvat, textul lipseste.
+      no_comments_yet: Nu exista comentarii.
+      resource: Resursa
+      title_content: Comentarii (%{count})
+    dashboard: Pagina Principala
+    delete: Stergeti
+    delete_confirmation: Sigur vreti sa stergeti?
+    delete_model: Stergeti %{model}
+    details: Detalii %{model}
+    devise:
+      change_password:
+        submit: Schimbă parola
+        title: Schimbați parola
+      links:
+        forgot_your_password: Ați uitat parola?
+        sign_in: Autentificare
+        sign_in_with_omniauth_provider: Conectați-vă cu %{provider}
+      login:
+        remember_me: Tine-ma minte
+        submit: Autentificare
+        title: Autentificare
+      reset_password:
+        submit: Reseta parola
+        title: Ați uitat parola?
+      unlock:
+        submit: Retrimite instrucțiunile de deblocare
+        title: Retrimite instrucțiunile de deblocare
+    download: 'Descarcati:'
+    edit: Modificati
+    edit_model: Modificati %{model}
+    empty: Gol
     filters:
       buttons:
-        filter: "Cautati"
-        clear: "Stergeti filtrele"
-    status_tag:
-      "yes": "Da"
-      "no": "Nu"
-      "unset": "Nu"
-    logout: "Iesire"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filtre"
+        clear: Stergeti filtrele
+        filter: Cautati
+    has_many_delete: Stergeti
+    has_many_new: Adaugati un nou %{model}
+    has_many_remove: Scoate
+    logout: Iesire
+    new_model: Un nou %{model}
+    next: Inainte
     pagination:
-      empty: "Nu am gasit nici un %{model}"
-      one: "Afisare <b>1</b> %{model}"
-      one_page: "Sunt afisate <b>toate %{n}</b> inregistrarile"
-      multiple: "Sunt afisate <b>%{from}&nbsp;-&nbsp;%{to}</b> din <b>%{total}</b> inregistrari"
-      multiple_without_total: "Sunt afisate <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      empty: Nu am gasit nici un %{model}
       entry:
-        one: "înregistrăre"
-        few: "înregistrări"
-        other: "înregistrări"
-    any: "Oricare"
-    blank_slate:
-      content: "Momentan nu exista %{resource_name}."
-      link: "Creati un"
-    batch_actions:
-      button_label: "Grupare Actiuni"
-      default_confirmation: "Sunteţi sigur că doriţi să faceţi acest lucru?"
-      delete_confirmation: "Sunteţi sigur că doriţi să stergeţi aceste %{plural_model}?"
-      succesfully_destroyed:
-        one: "1 %{model} sters"
-        few: "%{count} %{plural_model} sterse"
-        other: "%{count} %{plural_model} sterse"
-      selection_toggle_explanation: "(Modifica Selectia)"
-      action_label: "%{title} Selectat"
-      labels:
-        destroy: "Sterge"
-    comments:
-      body: "Text"
-      author: "Autor"
-      add: "Adaugati comentariu"
-      resource: "Resursa"
-      no_comments_yet: "Nu exista comentarii."
-      title_content: "Comentarii (%{count})"
-      errors:
-        empty_text: "Comentariul nu a fost salvat, textul lipseste."
-    devise:
-      login:
-        title: "Autentificare"
-        remember_me: "Tine-ma minte"
-        submit: "Autentificare"
-      reset_password:
-        title: "Ați uitat parola?"
-        submit: "Reseta parola"
-      change_password:
-        title: "Schimbați parola"
-        submit: "Schimbă parola"
-      unlock:
-        title: "Retrimite instrucțiunile de deblocare"
-        submit: "Retrimite instrucțiunile de deblocare"
-      links:
-        sign_in: "Autentificare"
-        forgot_your_password: "Ați uitat parola?"
-        sign_in_with_omniauth_provider: "Conectați-vă cu %{provider}"
+        few: înregistrări
+        one: înregistrăre
+        other: înregistrări
+      multiple: Sunt afisate <b>%{from}&nbsp;-&nbsp;%{to}</b> din <b>%{total}</b> inregistrari
+      multiple_without_total: Sunt afisate <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      one: Afisare <b>1</b> %{model}
+      one_page: Sunt afisate <b>toate %{n}</b> inregistrarile
+    powered_by: Powered by %{active_admin} %{version}
+    previous: Inapoi
+    sidebars:
+      filters: Filtre
+    status_tag:
+      'no': Nu
+      unset: Nu
+      'yes': Da
+    view: Vizualizati

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -1,6 +1,8 @@
 ---
 ro:
   active_admin:
+    access_denied:
+      message: You are not authorized to perform this action.
     any: Oricare
     batch_actions:
       action_label: "%{title} Selectat"
@@ -21,12 +23,19 @@ ro:
     comments:
       add: Adaugati comentariu
       author: Autor
+      author_missing: Anonymous
+      author_type: Author Type
       body: Text
+      created_at: Created
+      delete: Delete Comment
+      delete_confirmation: Are you sure you want to delete this comment?
       errors:
         empty_text: Comentariul nu a fost salvat, textul lipseste.
       no_comments_yet: Nu exista comentarii.
       resource: Resursa
+      resource_type: Resource Type
       title_content: Comentarii (%{count})
+    create_another: Create another %{model}
     dashboard: Pagina Principala
     delete: Stergeti
     delete_confirmation: Sigur vreti sa stergeti?
@@ -36,20 +45,39 @@ ro:
       change_password:
         submit: Schimbă parola
         title: Schimbați parola
+      email:
+        title: Email
       links:
         forgot_your_password: Ați uitat parola?
+        resend_confirmation_instructions: Resend confirmation instructions
+        resend_unlock_instructions: Resend unlock instructions
         sign_in: Autentificare
         sign_in_with_omniauth_provider: Conectați-vă cu %{provider}
+        sign_up: Sign up
       login:
         remember_me: Tine-ma minte
         submit: Autentificare
         title: Autentificare
+      password:
+        title: Password
+      password_confirmation:
+        title: Confirm Password
+      resend_confirmation_instructions:
+        submit: Resend confirmation instructions
+        title: Resend confirmation instructions
       reset_password:
         submit: Reseta parola
         title: Ați uitat parola?
+      sign_up:
+        submit: Sign up
+        title: Sign up
+      subdomain:
+        title: Subdomain
       unlock:
         submit: Retrimite instrucțiunile de deblocare
         title: Retrimite instrucțiunile de deblocare
+      username:
+        title: Username
     download: 'Descarcati:'
     edit: Modificati
     edit_model: Modificati %{model}
@@ -58,10 +86,16 @@ ro:
       buttons:
         clear: Stergeti filtrele
         filter: Cautati
+      predicates:
+        from: From
+        to: To
     has_many_delete: Stergeti
     has_many_new: Adaugati un nou %{model}
     has_many_remove: Scoate
+    index_list:
+      table: Table
     logout: Iesire
+    move: Move
     new_model: Un nou %{model}
     next: Inainte
     pagination:
@@ -72,14 +106,44 @@ ro:
         other: înregistrări
       multiple: Sunt afisate <b>%{from}&nbsp;-&nbsp;%{to}</b> din <b>%{total}</b> inregistrari
       multiple_without_total: Sunt afisate <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      next: Next
       one: Afisare <b>1</b> %{model}
       one_page: Sunt afisate <b>toate %{n}</b> inregistrarile
+      per_page: 'Per page '
+      previous: Previous
     powered_by: Powered by %{active_admin} %{version}
     previous: Inapoi
+    scopes:
+      all: All
+    search_status:
+      no_current_filters: No filters applied
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: Filtre
+      search_status: Search Status
     status_tag:
       'no': Nu
       unset: Nu
       'yes': Da
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: Vizualizati
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Author type
+        body: Body
+        created_at: Created
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Updated
+    models:
+      active_admin/comment:
+        one: Comment
+        other: Comments
+      comment:
+        one: Comment
+        other: Comments

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -36,6 +36,7 @@ ru:
       resource: Ресурс
       resource_type: Тип ресурса
       title_content: Комментарии (%{count})
+    create_another: Create another %{model}
     dashboard: Панель управления
     delete: Удалить
     delete_confirmation: Вы уверены, что хотите удалить это?
@@ -60,6 +61,8 @@ ru:
         title: Войти
       password:
         title: Пароль
+      password_confirmation:
+        title: Confirm Password
       resend_confirmation_instructions:
         submit: Выслать повторно письмо с активацией
         title: Выслать повторно письмо с активацией
@@ -93,6 +96,7 @@ ru:
     index_list:
       table: Таблица
     logout: Выйти
+    move: Move
     new_model: Создать %{model}
     next: След.
     pagination:
@@ -104,12 +108,19 @@ ru:
         other: записей
       multiple: 'Результат: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> из <b>%{total}</b>'
       multiple_without_total: 'Результат: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>'
+      next: Next
       one: 'Результат: <b>1</b> %{model}'
       one_page: 'Результат: <b>%{n}</b> %{model}'
+      per_page: 'Per page '
+      previous: Previous
     powered_by: Работает на %{active_admin} %{version}
     previous: Пред.
+    scopes:
+      all: All
     search_status:
       no_current_filters: Ни один
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: Фильтры
       search_status: Статус поиска
@@ -117,4 +128,24 @@ ru:
       'no': Нет
       unset: Нет
       'yes': Да
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: Открыть
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Author type
+        body: Body
+        created_at: Created
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Updated
+    models:
+      active_admin/comment:
+        one: Comment
+        other: Comments
+      comment:
+        one: Comment
+        other: Comments

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,119 +1,120 @@
+---
 ru:
   active_admin:
-    dashboard: "Панель управления"
-    view: "Открыть"
-    edit: "Изменить"
-    delete: "Удалить"
-    delete_confirmation: "Вы уверены, что хотите удалить это?"
-    new_model: "Создать %{model}"
-    edit_model: "Изменить %{model}"
-    delete_model: "Удалить %{model}"
+    access_denied:
+      message: Вы не авторизованы для выполнения данного действия.
+    any: Любой
+    batch_actions:
+      action_label: "%{title} выбранное"
+      button_label: Групповые операции
+      default_confirmation: Вы уверены, что вы хотите это сделать?
+      delete_confirmation: Вы уверены, что хотите удалить %{plural_model}?
+      labels:
+        destroy: Удалить
+      selection_toggle_explanation: "(Отметить всё / Снять выделение)"
+      succesfully_destroyed:
+        few: 'Успешно удалено: %{count} %{plural_model}'
+        many: 'Успешно удалено: %{count} %{plural_model}'
+        one: 'Успешно удалено: 1 %{model}'
+        other: 'Успешно удалено: %{count} %{plural_model}'
+    blank_slate:
+      content: Пока нет %{resource_name}.
+      link: Создать
+    cancel: Отмена
+    comments:
+      add: Добавить Комментарий
+      author: Автор
+      author_missing: Аноним
+      author_type: Тип автора
+      body: Текст
+      created_at: Дата создания
+      delete: Удалить Комментарий
+      delete_confirmation: Вы уверены, что хотите удалить этот комментарий?
+      errors:
+        empty_text: Комментарий не сохранен, текст не должен быть пустым.
+      no_comments_yet: Пока нет комментариев.
+      resource: Ресурс
+      resource_type: Тип ресурса
+      title_content: Комментарии (%{count})
+    dashboard: Панель управления
+    delete: Удалить
+    delete_confirmation: Вы уверены, что хотите удалить это?
+    delete_model: Удалить %{model}
     details: "%{model} подробнее"
-    cancel: "Отмена"
-    empty: "Пусто"
-    previous: "Пред."
-    next: "След."
-    download: "Загрузка:"
-    has_many_new: "Добавить %{model}"
-    has_many_delete: "Удалить"
-    has_many_remove: "Убрать"
+    devise:
+      change_password:
+        submit: Изменение пароля
+        title: Изменение пароля
+      email:
+        title: Эл. почта
+      links:
+        forgot_your_password: Забыли пароль?
+        resend_confirmation_instructions: Повторная отправка инструкций подтверждения
+        resend_unlock_instructions: Повторная отправка инструкций разблокировки
+        sign_in: Войти
+        sign_in_with_omniauth_provider: Войти с помощью %{provider}
+        sign_up: Зарегистрироваться
+      login:
+        remember_me: Запомнить меня
+        submit: Войти
+        title: Войти
+      password:
+        title: Пароль
+      resend_confirmation_instructions:
+        submit: Выслать повторно письмо с активацией
+        title: Выслать повторно письмо с активацией
+      reset_password:
+        submit: Сбросить пароль
+        title: Забыли пароль?
+      sign_up:
+        submit: Зарегистрироваться
+        title: Зарегистрироваться
+      subdomain:
+        title: Поддомен
+      unlock:
+        submit: Повторно отправить инструкции по разблокировке
+        title: Повторно отправить инструкции по разблокировке
+      username:
+        title: Имя пользователя
+    download: 'Загрузка:'
+    edit: Изменить
+    edit_model: Изменить %{model}
+    empty: Пусто
     filters:
       buttons:
-        filter: "Фильтровать"
-        clear: "Очистить"
+        clear: Очистить
+        filter: Фильтровать
       predicates:
-        from: "От"
-        to: "До"
-    search_status:
-      no_current_filters: "Ни один"
-    status_tag:
-      "yes": "Да"
-      "no": "Нет"
-      "unset": "Нет"
-    logout: "Выйти"
-    powered_by: "Работает на %{active_admin} %{version}"
-    sidebars:
-      filters: "Фильтры"
-      search_status: "Статус поиска"
+        from: От
+        to: До
+    has_many_delete: Удалить
+    has_many_new: Добавить %{model}
+    has_many_remove: Убрать
+    index_list:
+      table: Таблица
+    logout: Выйти
+    new_model: Создать %{model}
+    next: След.
     pagination:
       empty: "%{model} не найдено"
-      one: "Результат: <b>1</b> %{model}"
-      one_page: "Результат: <b>%{n}</b> %{model}"
-      multiple: "Результат: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> из <b>%{total}</b>"
-      multiple_without_total: "Результат: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
       entry:
-        one: "запись"
-        few: "записи"
-        many: "записей"
-        other: "записей"
-    any: "Любой"
-    blank_slate:
-      content: "Пока нет %{resource_name}."
-      link: "Создать"
-    batch_actions:
-      button_label: "Групповые операции"
-      default_confirmation: "Вы уверены, что вы хотите это сделать?"
-      delete_confirmation: "Вы уверены, что хотите удалить %{plural_model}?"
-      succesfully_destroyed:
-        one: "Успешно удалено: 1 %{model}"
-        few: "Успешно удалено: %{count} %{plural_model}"
-        many: "Успешно удалено: %{count} %{plural_model}"
-        other: "Успешно удалено: %{count} %{plural_model}"
-      selection_toggle_explanation: "(Отметить всё / Снять выделение)"
-      action_label: "%{title} выбранное"
-      labels:
-        destroy: "Удалить"
-    comments:
-      created_at: "Дата создания"
-      resource_type: "Тип ресурса"
-      author_type: "Тип автора"
-      body: "Текст"
-      author: "Автор"
-      add: "Добавить Комментарий"
-      delete: "Удалить Комментарий"
-      delete_confirmation: "Вы уверены, что хотите удалить этот комментарий?"
-      resource: "Ресурс"
-      no_comments_yet: "Пока нет комментариев."
-      author_missing: "Аноним"
-      title_content: "Комментарии (%{count})"
-      errors:
-        empty_text: "Комментарий не сохранен, текст не должен быть пустым."
-    devise:
-      username:
-        title: "Имя пользователя"
-      email:
-        title: "Эл. почта"
-      subdomain:
-        title: "Поддомен"
-      password:
-        title: "Пароль"
-      sign_up:
-        title: "Зарегистрироваться"
-        submit: "Зарегистрироваться"
-      login:
-        title: "Войти"
-        remember_me: "Запомнить меня"
-        submit: "Войти"
-      reset_password:
-        title: "Забыли пароль?"
-        submit: "Сбросить пароль"
-      change_password:
-        title: "Изменение пароля"
-        submit: "Изменение пароля"
-      unlock:
-        title: "Повторно отправить инструкции по разблокировке"
-        submit: "Повторно отправить инструкции по разблокировке"
-      resend_confirmation_instructions:
-        title: "Выслать повторно письмо с активацией"
-        submit: "Выслать повторно письмо с активацией"
-      links:
-        sign_up: "Зарегистрироваться"
-        sign_in: "Войти"
-        forgot_your_password: "Забыли пароль?"
-        sign_in_with_omniauth_provider: "Войти с помощью %{provider}"
-        resend_unlock_instructions: "Повторная отправка инструкций разблокировки"
-        resend_confirmation_instructions: "Повторная отправка инструкций подтверждения"
-    access_denied:
-      message: "Вы не авторизованы для выполнения данного действия."
-    index_list:
-      table: "Таблица"
+        few: записи
+        many: записей
+        one: запись
+        other: записей
+      multiple: 'Результат: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> из <b>%{total}</b>'
+      multiple_without_total: 'Результат: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>'
+      one: 'Результат: <b>1</b> %{model}'
+      one_page: 'Результат: <b>%{n}</b> %{model}'
+    powered_by: Работает на %{active_admin} %{version}
+    previous: Пред.
+    search_status:
+      no_current_filters: Ни один
+    sidebars:
+      filters: Фильтры
+      search_status: Статус поиска
+    status_tag:
+      'no': Нет
+      unset: Нет
+      'yes': Да
+    view: Открыть

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -144,8 +144,12 @@ ru:
         updated_at: Updated
     models:
       active_admin/comment:
+        few: Comments
+        many: Comments
         one: Comment
         other: Comments
       comment:
+        few: Comments
+        many: Comments
         one: Comment
         other: Comments

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -107,14 +107,19 @@ sk:
         other: položky
       multiple: "<b>%{from}&nbsp;-&nbsp;%{to}</b> z <b>%{total}</b>"
       multiple_without_total: "<b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      next: Next
       one: Zobrazená  <b>1</b> položka
       one_page: Počet zobrazených položiek %{n}
+      per_page: 'Per page '
+      previous: Previous
     powered_by: "%{active_admin} %{version}"
     previous: Predchádzajúce
     scopes:
       all: Všetko
     search_status:
       no_current_filters: Žiadne
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: Filtre
       search_status: Stav vyhľadávania
@@ -122,6 +127,10 @@ sk:
       'no': Nie
       unset: Nie
       'yes': Áno
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: Zobraziť
   activerecord:
     attributes:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -1,144 +1,145 @@
+---
 sk:
-  activerecord:
-    models:
-      comment:
-        one: "Komentár"
-        few: "Komentáre"
-        many: "Komentárov"
-        other: "Komentáre"
-      active_admin/comment:
-        one: "Komentár"
-        few: "Komentáre"
-        many: "Komentárov"
-        other: "Komentáre"
-    attributes:
-      active_admin/comment:
-        author_type: "Typ autora"
-        body: "Telo"
-        created_at: "Vytvorený"
-        namespace: "Namespace"
-        resource_type: "Typ komentovanej položky"
-        updated_at: "Upravený"
   active_admin:
+    access_denied:
+      message: Nemáte oprávnenie k vykonaniu tejto akcie.
+    any: Akákoľvek
+    batch_actions:
+      action_label: "%{title}"
+      button_label: Hromadné akcie
+      default_confirmation: Ste si istí, že to chcete spraviť?
+      delete_confirmation: Ste si istí, že chcete zmazať tieto %{plural_model}?
+      labels:
+        destroy: Vymazať
+      selection_toggle_explanation: "(Zmeniť výber)"
+      succesfully_destroyed:
+        few: Úspešne zmazané %{count} %{plural_model}
+        one: Úspešne zmazaný %{model}
+        other: Úspešne zmazaných %{count} %{plural_model}
+        zero: Nebol zmazaný žiaden %{model}
+    blank_slate:
+      content: Zatiaľ tu nie je žiadny obsah.
+      link: Vytvoriť
+    cancel: Zrušiť
+    comments:
+      add: Pridať komentár
+      author: Autor
+      author_missing: Anonymný
+      author_type: Typ autora
+      body: Telo
+      created_at: Vytvorený
+      delete: Zmazať komentár
+      delete_confirmation: Naozaj chcete zmazať tento komentár?
+      errors:
+        empty_text: Komentár nebol uložený, je prázdny.
+      no_comments_yet: Žiadny komentár
+      resource: Zdroj
+      resource_type: Typ zdroja
+      title_content: Komentáre administrátorov (%{count})
+    create_another: Vytvoriť ďalší %{model}
     dashboard: Úvod
-    view: "Zobraziť"
-    edit: "Upraviť"
-    delete: "Zmazať"
-    delete_confirmation: "Ste si istí, že chcete túto položku zmazať?"
-    create_another: "Vytvoriť ďalší %{model}"
-    new_model: "Vytvoriť"
-    edit_model: "Upraviť"
-    delete_model: "Zmazať"
-    details: "Detaily"
-    cancel: "Zrušiť"
-    empty: "Prázdne"
-    previous: "Predchádzajúce"
-    next: "Nasledujúce"
-    download: "Stiahnúť:"
-    has_many_new: "Pridať nový"
-    has_many_delete: "Zmazať"
-    has_many_remove: "Odstrániť"
-    move: "Presunúť"
+    delete: Zmazať
+    delete_confirmation: Ste si istí, že chcete túto položku zmazať?
+    delete_model: Zmazať
+    details: Detaily
+    devise:
+      change_password:
+        submit: Zmeniť svoje heslo
+        title: Zmeniť heslo
+      email:
+        title: Email
+      links:
+        forgot_your_password: Zabudli ste heslo?
+        resend_confirmation_instructions: Preposlať potvrdzovacie inštrukcie
+        resend_unlock_instructions: Poslať znovu inštrukcie na odomknutie účtu
+        sign_in: Prihlásiť sa
+        sign_in_with_omniauth_provider: Prihlásiť sa cez %{provider}
+        sign_up: Registrovať sa
+      login:
+        remember_me: Zapamätať si ma
+        submit: Prihlásiť
+        title: Prihlásenie
+      password:
+        title: Heslo
+      password_confirmation:
+        title: Potvrdenie hesla
+      resend_confirmation_instructions:
+        submit: Preposlať potvrdzovacie inštrukcie
+        title: Preposlanie potvrdzovacie inštrukcie
+      reset_password:
+        submit: Obnoviť heslo
+        title: Zabudli ste heslo?
+      sign_up:
+        submit: Registrovať
+        title: Registrácia
+      subdomain:
+        title: Subdoména
+      unlock:
+        submit: Zaslať inštrukcií k odomknutiu účtu
+        title: Zaslanie inštrukcií k odomknutiu účtu
+      username:
+        title: Užívateľské meno
+    download: 'Stiahnúť:'
+    edit: Upraviť
+    edit_model: Upraviť
+    empty: Prázdne
     filters:
       buttons:
-        filter: "Filtrovať"
-        clear: "Vyčistiť filtre"
+        clear: Vyčistiť filtre
+        filter: Filtrovať
       predicates:
-        from: "Od"
-        to: "Do"
-    scopes:
-      all: "Všetko"
-    search_status:
-      no_current_filters: "Žiadne"
-    status_tag:
-      "yes": "Áno"
-      "no": "Nie"
-      "unset": "Nie"
-    logout: "Odhlásiť"
-    powered_by: "%{active_admin} %{version}"
-    sidebars:
-      filters: "Filtre"
-      search_status: "Stav vyhľadávania"
+        from: Od
+        to: Do
+    has_many_delete: Zmazať
+    has_many_new: Pridať nový
+    has_many_remove: Odstrániť
+    index_list:
+      table: Tabuľka
+    logout: Odhlásiť
+    move: Presunúť
+    new_model: Vytvoriť
+    next: Nasledujúce
     pagination:
-      empty: "Nenájdený."
-      one: "Zobrazená  <b>1</b> položka"
-      one_page: "Počet zobrazených položiek %{n}"
+      empty: Nenájdený.
+      entry:
+        few: položky
+        one: položka
+        other: položky
       multiple: "<b>%{from}&nbsp;-&nbsp;%{to}</b> z <b>%{total}</b>"
       multiple_without_total: "<b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      entry:
-        one: "položka"
-        few: "položky"
-        other: "položky"
-    any: "Akákoľvek"
-    blank_slate:
-      content: "Zatiaľ tu nie je žiadny obsah."
-      link: "Vytvoriť"
-    batch_actions:
-      button_label: "Hromadné akcie"
-      default_confirmation: "Ste si istí, že to chcete spraviť?"
-      delete_confirmation: "Ste si istí, že chcete zmazať tieto %{plural_model}?"
-      succesfully_destroyed:
-        zero: "Nebol zmazaný žiaden %{model}"
-        one: "Úspešne zmazaný %{model}"
-        few: "Úspešne zmazané %{count} %{plural_model}"
-        other: "Úspešne zmazaných %{count} %{plural_model}"
-      selection_toggle_explanation: "(Zmeniť výber)"
-      action_label: "%{title}"
-      labels:
-        destroy: "Vymazať"
-    comments:
-      created_at: "Vytvorený"
-      resource_type: "Typ zdroja"
-      author_type: "Typ autora"
-      body: "Telo"
-      author: "Autor"
-      add: "Pridať komentár"
-      delete: "Zmazať komentár"
-      delete_confirmation: "Naozaj chcete zmazať tento komentár?"
-      resource: "Zdroj"
-      no_comments_yet: "Žiadny komentár"
-      author_missing: "Anonymný"
-      title_content: "Komentáre administrátorov (%{count})"
-      errors:
-        empty_text: "Komentár nebol uložený, je prázdny."
-    devise:
-      username:
-        title: "Užívateľské meno"
-      email:
-        title: "Email"
-      subdomain:
-        title: "Subdoména"
-      password:
-        title: "Heslo"
-      password_confirmation:
-        title: "Potvrdenie hesla"
-      sign_up:
-        title: "Registrácia"
-        submit: "Registrovať"
-      login:
-        title: "Prihlásenie"
-        remember_me: "Zapamätať si ma"
-        submit: "Prihlásiť"
-      reset_password:
-        title: "Zabudli ste heslo?"
-        submit: "Obnoviť heslo"
-      change_password:
-        title: "Zmeniť heslo"
-        submit: "Zmeniť svoje heslo"
-      unlock:
-        title: "Zaslanie inštrukcií k odomknutiu účtu"
-        submit: "Zaslať inštrukcií k odomknutiu účtu"
-      resend_confirmation_instructions:
-        title: "Preposlanie potvrdzovacie inštrukcie"
-        submit: "Preposlať potvrdzovacie inštrukcie"
-      links:
-        sign_in: "Prihlásiť sa"
-        sign_up: "Registrovať sa"
-        forgot_your_password: "Zabudli ste heslo?"
-        sign_in_with_omniauth_provider: "Prihlásiť sa cez %{provider}"
-        resend_unlock_instructions: "Poslať znovu inštrukcie na odomknutie účtu"
-        resend_confirmation_instructions: "Preposlať potvrdzovacie inštrukcie"
-    access_denied:
-      message: "Nemáte oprávnenie k vykonaniu tejto akcie."
-    index_list:
-      table: "Tabuľka"
+      one: Zobrazená  <b>1</b> položka
+      one_page: Počet zobrazených položiek %{n}
+    powered_by: "%{active_admin} %{version}"
+    previous: Predchádzajúce
+    scopes:
+      all: Všetko
+    search_status:
+      no_current_filters: Žiadne
+    sidebars:
+      filters: Filtre
+      search_status: Stav vyhľadávania
+    status_tag:
+      'no': Nie
+      unset: Nie
+      'yes': Áno
+    view: Zobraziť
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Typ autora
+        body: Telo
+        created_at: Vytvorený
+        namespace: Namespace
+        resource_type: Typ komentovanej položky
+        updated_at: Upravený
+    models:
+      active_admin/comment:
+        few: Komentáre
+        many: Komentárov
+        one: Komentár
+        other: Komentáre
+      comment:
+        few: Komentáre
+        many: Komentárov
+        one: Komentár
+        other: Komentáre

--- a/config/locales/sv-SE.yml
+++ b/config/locales/sv-SE.yml
@@ -104,15 +104,19 @@ sv-SE:
         other: inlägg
       multiple: Visar %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> av <b>%{total}</b> totalt
       multiple_without_total: Visar %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      next: Next
       one: Visar <b>1</b> %{model}
       one_page: Visar <b>alla %{n}</b> %{model}
       per_page: 'Per sida: '
+      previous: Previous
     powered_by: Powered by %{active_admin} %{version}
     previous: Föregående
     scopes:
       all: Alla
     search_status:
       no_current_filters: Inga
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: Filter
       search_status: Sökstatus
@@ -120,6 +124,10 @@ sv-SE:
       'no': Nej
       unset: Nej
       'yes': Ja
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: Visa
   activerecord:
     attributes:

--- a/config/locales/sv-SE.yml
+++ b/config/locales/sv-SE.yml
@@ -1,138 +1,139 @@
-"sv-SE":
-  activerecord:
-    models:
-      comment:
-        one: "Kommentar"
-        other: "Kommentarer"
-      active_admin/comment:
-        one: "Kommentar"
-        other: "Kommentarer"
-    attributes:
-      active_admin/comment:
-        author_type: "Författartyp"
-        body: "Innehåll"
-        created_at: "Skapad"
-        namespace: "Namnrymd"
-        resource_type: "Resurstyp"
-        updated_at: "Aktualiserad"
+---
+sv-SE:
   active_admin:
+    access_denied:
+      message: Du har inte behörighet att utföra denna åtgärd.
+    any: Alla
+    batch_actions:
+      action_label: "%{title} markerad"
+      button_label: Batch-åtgärder
+      default_confirmation: Är du säker på att du vill göra detta?
+      delete_confirmation: Är du säker på att du vill radera dessa %{plural_model}?
+      labels:
+        destroy: Radera
+      selection_toggle_explanation: "(Byt markering)"
+      succesfully_destroyed:
+        one: Lyckades radera 1 %{model}
+        other: Lyckades radera %{count} %{plural_model}
+    blank_slate:
+      content: Det finns inga %{resource_name} än.
+      link: Skapa en
+    cancel: Avbryt
+    comments:
+      add: Lägg till kommentar
+      author: Författare
+      author_missing: Anonym
+      author_type: Författartyp
+      body: Innehåll
+      created_at: Skapad
+      delete: Radera kommentar
+      delete_confirmation: Är du säker på att du vill radera dessa kommentarer?
+      errors:
+        empty_text: Kommentaren sparades inte. Textfältet får inte vara tomt.
+      no_comments_yet: Inga kommentarer än.
+      resource: Resurs
+      resource_type: Resurstyp
+      title_content: Kommentarer (%{count})
+    create_another: Skapa en till %{model}
     dashboard: Skrivbord
-    view: "Visa"
-    edit: "Redigera"
-    delete: "Ta bort"
-    delete_confirmation: "Är du säker på att du vill ta bort detta?"
-    create_another: "Skapa en till %{model}"
-    new_model: "Ny %{model}"
-    edit_model: "Redigera %{model}"
-    delete_model: "Ta bort %{model}"
+    delete: Ta bort
+    delete_confirmation: Är du säker på att du vill ta bort detta?
+    delete_model: Ta bort %{model}
     details: "%{model}-detaljer"
-    cancel: "Avbryt"
-    empty: "Tom"
-    previous: "Föregående"
-    next: "Nästa"
-    download: "Ladda ner:"
-    has_many_new: "Skapa en ny %{model}"
-    has_many_delete: "Ta bort"
-    has_many_remove: "Ta bort"
-    move: "Flytta"
+    devise:
+      change_password:
+        submit: Ändra mitt lösenord
+        title: Ändra ditt lösenord
+      email:
+        title: E-post
+      links:
+        forgot_your_password: Glömt ditt lösenord?
+        resend_confirmation_instructions: Skicka bekräftningsinstruktioner igen
+        resend_unlock_instructions: Skicka upplåsningsinstruktioner igen
+        sign_in: Logga in
+        sign_in_with_omniauth_provider: Logga in med %{provider}
+        sign_up: Registera
+      login:
+        remember_me: Kom ihåg mig
+        submit: Inloggning
+        title: Inloggning
+      password:
+        title: Lösenord
+      password_confirmation:
+        title: Bekräfta lösenord
+      resend_confirmation_instructions:
+        submit: Skicka bekräftelseinstruktioner
+        title: Skicka bekräftelseinstruktioner
+      reset_password:
+        submit: Återställ mitt lösenord
+        title: Glömt ditt lösenord?
+      sign_up:
+        submit: Registera
+        title: Registera
+      subdomain:
+        title: Subdomän
+      unlock:
+        submit: Skicka upplåsningsinstruktioner
+        title: Skicka upplåsningsinstruktioner
+      username:
+        title: Användarnamn
+    download: 'Ladda ner:'
+    edit: Redigera
+    edit_model: Redigera %{model}
+    empty: Tom
     filters:
       buttons:
-        filter: "Filtrera"
-        clear: "Rensa filter"
+        clear: Rensa filter
+        filter: Filtrera
       predicates:
-        from: "Från"
-        to: "Till"
-    scopes:
-      all: "Alla"
-    search_status:
-      no_current_filters: "Inga"
-    status_tag:
-      "yes": "Ja"
-      "no": "Nej"
-      "unset": "Nej"
-    logout: "Logga ut"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Filter"
-      search_status: "Sökstatus"
-    pagination:
-      empty: "Ingen %{model} hittades"
-      one: "Visar <b>1</b> %{model}"
-      one_page: "Visar <b>alla %{n}</b> %{model}"
-      multiple: "Visar %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> av <b>%{total}</b> totalt"
-      multiple_without_total: "Visar %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
-      per_page: "Per sida: "
-      entry:
-        one: "inlägg"
-        other: "inlägg"
-    any: "Alla"
-    blank_slate:
-      content: "Det finns inga %{resource_name} än."
-      link: "Skapa en"
-    batch_actions:
-      button_label: "Batch-åtgärder"
-      default_confirmation: "Är du säker på att du vill göra detta?"
-      delete_confirmation: "Är du säker på att du vill radera dessa %{plural_model}?"
-      succesfully_destroyed:
-        one: "Lyckades radera 1 %{model}"
-        other: "Lyckades radera %{count} %{plural_model}"
-      selection_toggle_explanation: "(Byt markering)"
-      action_label: "%{title} markerad"
-      labels:
-        destroy: "Radera"
-    comments:
-      created_at: "Skapad"
-      resource_type: "Resurstyp"
-      author_type: "Författartyp"
-      body: "Innehåll"
-      author: "Författare"
-      add: "Lägg till kommentar"
-      delete: "Radera kommentar"
-      delete_confirmation: "Är du säker på att du vill radera dessa kommentarer?"
-      resource: "Resurs"
-      no_comments_yet: "Inga kommentarer än."
-      author_missing: "Anonym"
-      title_content: "Kommentarer (%{count})"
-      errors:
-        empty_text: "Kommentaren sparades inte. Textfältet får inte vara tomt."
-    devise:
-      username:
-        title: "Användarnamn"
-      email:
-        title: "E-post"
-      subdomain:
-        title: "Subdomän"
-      password:
-        title: "Lösenord"
-      password_confirmation:
-        title: "Bekräfta lösenord"
-      sign_up:
-        title: "Registera"
-        submit: "Registera"
-      login:
-        title: "Inloggning"
-        remember_me: "Kom ihåg mig"
-        submit: "Inloggning"
-      reset_password:
-        title: "Glömt ditt lösenord?"
-        submit: "Återställ mitt lösenord"
-      change_password:
-        title: "Ändra ditt lösenord"
-        submit: "Ändra mitt lösenord"
-      unlock:
-        title: "Skicka upplåsningsinstruktioner"
-        submit: "Skicka upplåsningsinstruktioner"
-      resend_confirmation_instructions:
-        title: "Skicka bekräftelseinstruktioner"
-        submit: "Skicka bekräftelseinstruktioner"
-      links:
-        sign_up: "Registera"
-        sign_in: "Logga in"
-        forgot_your_password: "Glömt ditt lösenord?"
-        sign_in_with_omniauth_provider: "Logga in med %{provider}"
-        resend_unlock_instructions: "Skicka upplåsningsinstruktioner igen"
-        resend_confirmation_instructions: "Skicka bekräftningsinstruktioner igen"
-    access_denied:
-      message: "Du har inte behörighet att utföra denna åtgärd."
+        from: Från
+        to: Till
+    has_many_delete: Ta bort
+    has_many_new: Skapa en ny %{model}
+    has_many_remove: Ta bort
     index_list:
-      table: "Tabell"
+      table: Tabell
+    logout: Logga ut
+    move: Flytta
+    new_model: Ny %{model}
+    next: Nästa
+    pagination:
+      empty: Ingen %{model} hittades
+      entry:
+        one: inlägg
+        other: inlägg
+      multiple: Visar %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> av <b>%{total}</b> totalt
+      multiple_without_total: Visar %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      one: Visar <b>1</b> %{model}
+      one_page: Visar <b>alla %{n}</b> %{model}
+      per_page: 'Per sida: '
+    powered_by: Powered by %{active_admin} %{version}
+    previous: Föregående
+    scopes:
+      all: Alla
+    search_status:
+      no_current_filters: Inga
+    sidebars:
+      filters: Filter
+      search_status: Sökstatus
+    status_tag:
+      'no': Nej
+      unset: Nej
+      'yes': Ja
+    view: Visa
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Författartyp
+        body: Innehåll
+        created_at: Skapad
+        namespace: Namnrymd
+        resource_type: Resurstyp
+        updated_at: Aktualiserad
+    models:
+      active_admin/comment:
+        one: Kommentar
+        other: Kommentarer
+      comment:
+        one: Kommentar
+        other: Kommentarer

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -85,6 +85,9 @@ tr:
       buttons:
         clear: Filtreleri Temizle
         filter: Filtrele
+      predicates:
+        from: From
+        to: To
     has_many_delete: Sil
     has_many_new: Yeni %{model} Ekle
     has_many_remove: Çıkar
@@ -101,13 +104,19 @@ tr:
         other: kayıtlar
       multiple: "<b>%{from}&nbsp;-&nbsp;%{to}</b> arası %{model} görüntüleniyor (toplam %{total} kayıt)"
       multiple_without_total: "<b>%{from}&nbsp;-&nbsp;%{to}</b> arası %{model} görüntüleniyor"
+      next: Next
       one: "<b>1</b> %{model} görüntüleniyor"
       one_page: "<b>%{n}</b> %{model} kaydının tamamı görüntüleniyor"
       per_page: 'Sayfa Başına: '
+      previous: Previous
     powered_by: "%{active_admin} %{version} tarafından desteklenmektedir."
     previous: Önceki
+    scopes:
+      all: All
     search_status:
       no_current_filters: Yok
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: Filtreler
       search_status: Arama Durumu
@@ -115,4 +124,24 @@ tr:
       'no': Hayır
       unset: Hayır
       'yes': Evet
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: Görüntüle
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Author type
+        body: Body
+        created_at: Created
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Updated
+    models:
+      active_admin/comment:
+        one: Comment
+        other: Comments
+      comment:
+        one: Comment
+        other: Comments

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -1,117 +1,118 @@
+---
 tr:
   active_admin:
-    dashboard: "Gösterge Paneli"
-    view: "Görüntüle"
-    edit: "Düzenle"
-    delete: "Sil"
-    delete_confirmation: "Bu kaydı silmek istediğinizden emin misiniz?"
-    create_another: "Başka bir %{model} oluştur"
-    new_model: "Yeni %{model}"
-    edit_model: "%{model} Kaydını Düzenle"
+    access_denied:
+      message: Bu işlemi gerçekleştirmek için yetkiniz yok.
+    any: Herhangi biri
+    batch_actions:
+      action_label: Seçilenleri %{title}
+      button_label: Toplu İşlemler
+      default_confirmation: Bunu yapmak istediğinizden emin misiniz?
+      delete_confirmation: Bu %{plural_model} kayıtlarını silmek istediğinizden emin misiniz?
+      labels:
+        destroy: Sil
+      selection_toggle_explanation: "(Seçimi Değiştir)"
+      succesfully_destroyed:
+        one: 1 %{model} başarıyla silindi
+        other: Toplam %{count} %{plural_model} başarıyla silindi
+    blank_slate:
+      content: Henüz %{resource_name} yok.
+      link: Bir tane oluşturun
+    cancel: İptal
+    comments:
+      add: Yorum Ekle
+      author: Yazar
+      author_missing: Anonim
+      author_type: Yazar Tipi
+      body: Ayrıntı
+      created_at: Oluşturma Tarihi
+      delete: Yorumu Sil
+      delete_confirmation: Bu yorumları silmek istediğinizden emin misiniz?
+      errors:
+        empty_text: Yorum boş olarak kaydedilemez.
+      no_comments_yet: Henüz yorum yok.
+      resource: Kayıt
+      resource_type: Kayıt Tipi
+      title_content: Yorumlar (%{count})
+    create_another: Başka bir %{model} oluştur
+    dashboard: Gösterge Paneli
+    delete: Sil
+    delete_confirmation: Bu kaydı silmek istediğinizden emin misiniz?
     delete_model: "%{model} Kaydını Sil"
     details: "%{model} Ayrıntıları"
-    cancel: "İptal"
-    empty: "Boş"
-    previous: "Önceki"
-    next: "Sonraki"
-    download: "İndir:"
-    has_many_new: "Yeni %{model} Ekle"
-    has_many_delete: "Sil"
-    has_many_remove: "Çıkar"
-    move: "Taşı"
+    devise:
+      change_password:
+        submit: Şifremi değiştir
+        title: Şifrenizi değiştirin
+      email:
+        title: E-posta adresi
+      links:
+        forgot_your_password: Şifrenizi mi unuttunuz?
+        resend_confirmation_instructions: Onaylama talimatlarını tekrar gönder
+        resend_unlock_instructions: Hesap geri açma talimatlarını tekrar gönder
+        sign_in: Giriş yap
+        sign_in_with_omniauth_provider: "%{provider} ile giriş yapın"
+        sign_up: Kaydol
+      login:
+        remember_me: Beni hatırla
+        submit: Giriş yap
+        title: Giriş yap
+      password:
+        title: Şifre
+      password_confirmation:
+        title: Şifreyi Tekrarla
+      resend_confirmation_instructions:
+        submit: Onaylama talimatlarını tekrar gönder
+        title: Onaylama talimatlarını tekrar gönder
+      reset_password:
+        submit: Şifremi sıfırla
+        title: Şifrenizi mi unuttunuz?
+      sign_up:
+        submit: Kaydol
+        title: Kaydol
+      subdomain:
+        title: Alt alan adı
+      unlock:
+        submit: Hesap geri açma talimatlarını tekrar gönder
+        title: Hesap geri açma talimatlarını tekrar gönder
+      username:
+        title: Kullanıcı adı
+    download: 'İndir:'
+    edit: Düzenle
+    edit_model: "%{model} Kaydını Düzenle"
+    empty: Boş
     filters:
       buttons:
-        filter: "Filtrele"
-        clear: "Filtreleri Temizle"
-    search_status:
-      no_current_filters: "Yok"
-    status_tag:
-      "yes": "Evet"
-      "no": "Hayır"
-      "unset": "Hayır"
-    logout: "Çıkış Yap"
-    powered_by: "%{active_admin} %{version} tarafından desteklenmektedir."
-    sidebars:
-      filters: "Filtreler"
-      search_status: "Arama Durumu"
+        clear: Filtreleri Temizle
+        filter: Filtrele
+    has_many_delete: Sil
+    has_many_new: Yeni %{model} Ekle
+    has_many_remove: Çıkar
+    index_list:
+      table: Tablo
+    logout: Çıkış Yap
+    move: Taşı
+    new_model: Yeni %{model}
+    next: Sonraki
     pagination:
-      empty: "Hiç %{model} yok"
-      one: "<b>1</b> %{model} görüntüleniyor"
-      one_page: "<b>%{n}</b> %{model} kaydının tamamı görüntüleniyor"
+      empty: Hiç %{model} yok
+      entry:
+        one: kayıt
+        other: kayıtlar
       multiple: "<b>%{from}&nbsp;-&nbsp;%{to}</b> arası %{model} görüntüleniyor (toplam %{total} kayıt)"
       multiple_without_total: "<b>%{from}&nbsp;-&nbsp;%{to}</b> arası %{model} görüntüleniyor"
-      per_page: "Sayfa Başına: "
-      entry:
-        one: "kayıt"
-        other: "kayıtlar"
-    any: "Herhangi biri"
-    blank_slate:
-      content: "Henüz %{resource_name} yok."
-      link: "Bir tane oluşturun"
-    batch_actions:
-      button_label: "Toplu İşlemler"
-      default_confirmation: "Bunu yapmak istediğinizden emin misiniz?"
-      delete_confirmation: "Bu %{plural_model} kayıtlarını silmek istediğinizden emin misiniz?"
-      succesfully_destroyed:
-        one: "1 %{model} başarıyla silindi"
-        other: "Toplam %{count} %{plural_model} başarıyla silindi"
-      selection_toggle_explanation: "(Seçimi Değiştir)"
-      action_label: "Seçilenleri %{title}"
-      labels:
-        destroy: "Sil"
-    comments:
-      created_at: "Oluşturma Tarihi"
-      resource_type: "Kayıt Tipi"
-      author_type: "Yazar Tipi"
-      body: "Ayrıntı"
-      author: "Yazar"
-      add: "Yorum Ekle"
-      delete: "Yorumu Sil"
-      delete_confirmation: "Bu yorumları silmek istediğinizden emin misiniz?"
-      resource: "Kayıt"
-      no_comments_yet: "Henüz yorum yok."
-      author_missing: "Anonim"
-      title_content: "Yorumlar (%{count})"
-      errors:
-        empty_text: "Yorum boş olarak kaydedilemez."
-    devise:
-      username:
-        title: "Kullanıcı adı"
-      email:
-        title: "E-posta adresi"
-      subdomain:
-        title: "Alt alan adı"
-      password:
-        title: "Şifre"
-      password_confirmation:
-        title: "Şifreyi Tekrarla"
-      sign_up:
-        title: "Kaydol"
-        submit: "Kaydol"
-      login:
-        title: "Giriş yap"
-        remember_me: "Beni hatırla"
-        submit: "Giriş yap"
-      reset_password:
-        title: "Şifrenizi mi unuttunuz?"
-        submit: "Şifremi sıfırla"
-      change_password:
-        title: "Şifrenizi değiştirin"
-        submit: "Şifremi değiştir"
-      unlock:
-        title: "Hesap geri açma talimatlarını tekrar gönder"
-        submit: "Hesap geri açma talimatlarını tekrar gönder"
-      resend_confirmation_instructions:
-        title: "Onaylama talimatlarını tekrar gönder"
-        submit: "Onaylama talimatlarını tekrar gönder"
-      links:
-        sign_up: "Kaydol"
-        sign_in: "Giriş yap"
-        forgot_your_password: "Şifrenizi mi unuttunuz?"
-        sign_in_with_omniauth_provider: "%{provider} ile giriş yapın"
-        resend_unlock_instructions: "Hesap geri açma talimatlarını tekrar gönder"
-        resend_confirmation_instructions: "Onaylama talimatlarını tekrar gönder"
-    access_denied:
-      message: "Bu işlemi gerçekleştirmek için yetkiniz yok."
-    index_list:
-      table: "Tablo"
+      one: "<b>1</b> %{model} görüntüleniyor"
+      one_page: "<b>%{n}</b> %{model} kaydının tamamı görüntüleniyor"
+      per_page: 'Sayfa Başına: '
+    powered_by: "%{active_admin} %{version} tarafından desteklenmektedir."
+    previous: Önceki
+    search_status:
+      no_current_filters: Yok
+    sidebars:
+      filters: Filtreler
+      search_status: Arama Durumu
+    status_tag:
+      'no': Hayır
+      unset: Hayır
+      'yes': Evet
+    view: Görüntüle

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -144,8 +144,12 @@ uk:
         updated_at: Updated
     models:
       active_admin/comment:
+        few: Comments
+        many: Comments
         one: Comment
         other: Comments
       comment:
+        few: Comments
+        many: Comments
         one: Comment
         other: Comments

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -27,12 +27,16 @@ uk:
       author_missing: Анонім
       author_type: Тип автора
       body: Текст
+      created_at: Created
+      delete: Delete Comment
+      delete_confirmation: Are you sure you want to delete this comment?
       errors:
         empty_text: Коментар не збережено, текст не повинен бути пустим.
       no_comments_yet: Поки-що немає коментарів.
       resource: Ресурс
       resource_type: Тип ресурса
       title_content: Коментарі (%{count})
+    create_another: Create another %{model}
     dashboard: Панель керування
     delete: Видалити
     delete_confirmation: Ви впевнені, що хочете це видалити?
@@ -57,6 +61,8 @@ uk:
         title: Вхід
       password:
         title: Пароль
+      password_confirmation:
+        title: Confirm Password
       resend_confirmation_instructions:
         submit: Відправити повторно листа з активацією
         title: Відправити повторно листа з активацією
@@ -90,6 +96,7 @@ uk:
     index_list:
       table: Таблиця
     logout: Вийти
+    move: Move
     new_model: Створити %{model}
     next: Наст.
     pagination:
@@ -101,12 +108,19 @@ uk:
         other: записів
       multiple: 'Результат: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> з <b>%{total}</b>'
       multiple_without_total: 'Результат: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>'
+      next: Next
       one: 'Результат: <b>1</b> %{model}'
       one_page: 'Результат: <b>%{n}</b> %{model}'
+      per_page: 'Per page '
+      previous: Previous
     powered_by: Powered by %{active_admin} %{version}
     previous: Поперед.
+    scopes:
+      all: All
     search_status:
       no_current_filters: Жоден
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: Фільтри
       search_status: Статус пошуку
@@ -114,4 +128,24 @@ uk:
       'no': Ні
       unset: Ні
       'yes': Так
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: Переглянути
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Author type
+        body: Body
+        created_at: Created
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Updated
+    models:
+      active_admin/comment:
+        one: Comment
+        other: Comments
+      comment:
+        one: Comment
+        other: Comments

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -1,116 +1,117 @@
+---
 uk:
   active_admin:
-    dashboard: "Панель керування"
-    view: "Переглянути"
-    edit: "Змінити"
-    delete: "Видалити"
-    delete_confirmation: "Ви впевнені, що хочете це видалити?"
-    new_model: "Створити %{model}"
-    edit_model: "Змінити %{model}"
-    delete_model: "Видалити %{model}"
+    access_denied:
+      message: Ви не авторизовані для виконання даної дії.
+    any: Будь-який
+    batch_actions:
+      action_label: "%{title} вибране"
+      button_label: Групові операції
+      default_confirmation: Ви справді бажаєте це зробити?
+      delete_confirmation: Ви впевнені, що хочете видалити %{plural_model}?
+      labels:
+        destroy: Видалити
+      selection_toggle_explanation: "(Скасувати все / Зняти виділення)"
+      succesfully_destroyed:
+        few: 'Успішно видалено: %{count} %{plural_model}'
+        many: 'Успішно видалено: %{count} %{plural_model}'
+        one: 'Успішно видалено: 1 %{model}'
+        other: 'Успішно видалено: %{count} %{plural_model}'
+    blank_slate:
+      content: Поки-що немає %{resource_name}.
+      link: Створити
+    cancel: Скасувати
+    comments:
+      add: Додати Коментар
+      author: Автор
+      author_missing: Анонім
+      author_type: Тип автора
+      body: Текст
+      errors:
+        empty_text: Коментар не збережено, текст не повинен бути пустим.
+      no_comments_yet: Поки-що немає коментарів.
+      resource: Ресурс
+      resource_type: Тип ресурса
+      title_content: Коментарі (%{count})
+    dashboard: Панель керування
+    delete: Видалити
+    delete_confirmation: Ви впевнені, що хочете це видалити?
+    delete_model: Видалити %{model}
     details: "%{model} детальніше"
-    cancel: "Скасувати"
-    empty: "Пусто"
-    previous: "Поперед."
-    next: "Наст."
-    download: "Завантаження:"
-    has_many_new: "Додати %{model}"
-    has_many_delete: "Прибрати"
-    has_many_remove: "Видалити"
+    devise:
+      change_password:
+        submit: Змінити пароль
+        title: Зміна паролю
+      email:
+        title: Електронна пошта
+      links:
+        forgot_your_password: Забули пароль?
+        resend_confirmation_instructions: Повторна відправка інструкцій підтвердження
+        resend_unlock_instructions: Повторна відправка інструкцій розблокування
+        sign_in: Увійти
+        sign_in_with_omniauth_provider: Увійти з допомогою %{provider}
+        sign_up: Зареєструватись
+      login:
+        remember_me: Запам'ятати мене
+        submit: Увійти
+        title: Вхід
+      password:
+        title: Пароль
+      resend_confirmation_instructions:
+        submit: Відправити повторно листа з активацією
+        title: Відправити повторно листа з активацією
+      reset_password:
+        submit: Скинути пароль
+        title: Забули пароль?
+      sign_up:
+        submit: Зареєструватися
+        title: Зареєструватися
+      subdomain:
+        title: Піддомен
+      unlock:
+        submit: Відправити повторно інструкції з розблокування
+        title: Відправити повторно інструкції з розблокування
+      username:
+        title: Ім'я користувача
+    download: 'Завантаження:'
+    edit: Змінити
+    edit_model: Змінити %{model}
+    empty: Пусто
     filters:
       buttons:
-        filter: "Фільтрувати"
-        clear: "Очистити"
+        clear: Очистити
+        filter: Фільтрувати
       predicates:
-        from: "від"
-        to: "до"
-    search_status:
-      no_current_filters: "Жоден"
-    status_tag:
-      "yes": "Так"
-      "no": "Ні"
-      "unset": "Ні"
-    logout: "Вийти"
-    powered_by: "Powered by %{active_admin} %{version}"
-    sidebars:
-      filters: "Фільтри"
-      search_status: "Статус пошуку"
+        from: від
+        to: до
+    has_many_delete: Прибрати
+    has_many_new: Додати %{model}
+    has_many_remove: Видалити
+    index_list:
+      table: Таблиця
+    logout: Вийти
+    new_model: Створити %{model}
+    next: Наст.
     pagination:
       empty: "%{model} не знайдено"
-      one: "Результат: <b>1</b> %{model}"
-      one_page: "Результат: <b>%{n}</b> %{model}"
-      multiple: "Результат: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> з <b>%{total}</b>"
-      multiple_without_total: "Результат: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
       entry:
-        one: "запис"
-        few: "записи"
-        many: "записів"
-        other: "записів"
-    any: "Будь-який"
-    blank_slate:
-      content: "Поки-що немає %{resource_name}."
-      link: "Створити"
-    batch_actions:
-      button_label: "Групові операції"
-      default_confirmation: "Ви справді бажаєте це зробити?"
-      delete_confirmation: "Ви впевнені, що хочете видалити %{plural_model}?"
-      succesfully_destroyed:
-        one: "Успішно видалено: 1 %{model}"
-        few: "Успішно видалено: %{count} %{plural_model}"
-        many: "Успішно видалено: %{count} %{plural_model}"
-        other: "Успішно видалено: %{count} %{plural_model}"
-      selection_toggle_explanation: "(Скасувати все / Зняти виділення)"
-      action_label: "%{title} вибране"
-      labels:
-        destroy: "Видалити"
-    comments:
-      resource_type: "Тип ресурса"
-      author_type: "Тип автора"
-      body: "Текст"
-      author: "Автор"
-      add: "Додати Коментар"
-      resource: "Ресурс"
-      no_comments_yet: "Поки-що немає коментарів."
-      author_missing: "Анонім"
-      title_content: "Коментарі (%{count})"
-      errors:
-        empty_text: "Коментар не збережено, текст не повинен бути пустим."
-    devise:
-      username:
-        title: "Ім'я користувача"
-      email:
-        title: "Електронна пошта"
-      subdomain:
-        title: "Піддомен"
-      password:
-        title: "Пароль"
-      sign_up:
-        title: "Зареєструватися"
-        submit: "Зареєструватися"
-      login:
-        title: "Вхід"
-        remember_me: "Запам'ятати мене"
-        submit: "Увійти"
-      reset_password:
-        title: "Забули пароль?"
-        submit: "Скинути пароль"
-      change_password:
-        title: "Зміна паролю"
-        submit: "Змінити пароль"
-      unlock:
-        title: "Відправити повторно інструкції з розблокування"
-        submit: "Відправити повторно інструкції з розблокування"
-      resend_confirmation_instructions:
-        title: "Відправити повторно листа з активацією"
-        submit: "Відправити повторно листа з активацією"
-      links:
-        sign_up: "Зареєструватись"
-        sign_in: "Увійти"
-        forgot_your_password: "Забули пароль?"
-        sign_in_with_omniauth_provider: "Увійти з допомогою %{provider}"
-        resend_unlock_instructions: "Повторна відправка інструкцій розблокування"
-        resend_confirmation_instructions: "Повторна відправка інструкцій підтвердження"
-    access_denied:
-      message: "Ви не авторизовані для виконання даної дії."
-    index_list:
-      table: "Таблиця"
+        few: записи
+        many: записів
+        one: запис
+        other: записів
+      multiple: 'Результат: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> з <b>%{total}</b>'
+      multiple_without_total: 'Результат: %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>'
+      one: 'Результат: <b>1</b> %{model}'
+      one_page: 'Результат: <b>%{n}</b> %{model}'
+    powered_by: Powered by %{active_admin} %{version}
+    previous: Поперед.
+    search_status:
+      no_current_filters: Жоден
+    sidebars:
+      filters: Фільтри
+      search_status: Статус пошуку
+    status_tag:
+      'no': Ні
+      unset: Ні
+      'yes': Так
+    view: Переглянути

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -104,15 +104,19 @@ vi:
         other: entries
       multiple: Đang hiển thị %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> of <b>%{total}</b> trong tất cả.
       multiple_without_total: Đang hiển thị %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>.
+      next: Next
       one: Đang hiển thị <b>1</b> %{model}
       one_page: Đang hiển thị <b>tất cả %{n}</b> %{model}
       per_page: 'Mỗi trang: '
+      previous: Previous
     powered_by: Bản quyền bởi %{active_admin} %{version}
     previous: Trước
     scopes:
       all: Tất cả
     search_status:
       no_current_filters: Không có
+      title: Active Search
+      title_with_scope: Active Search for %{name}
     sidebars:
       filters: Bộ Lọc
       search_status: Trạng thái tìm kiếm
@@ -120,6 +124,10 @@ vi:
       'no': Không Có
       unset: Không Có
       'yes': Có
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: Xem
   activerecord:
     attributes:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -1,138 +1,139 @@
+---
 vi:
-  activerecord:
-    models:
-      comment:
-        one: "Bình luận"
-        other: "Các bình luận"
-      active_admin/comment:
-        one: "Bình luận"
-        other: "Các bình luận"
-    attributes:
-      active_admin/comment:
-        author_type: "Loại tác giả"
-        body: "Nội dung"
-        created_at: "Đã tạo"
-        namespace: "Namespace"
-        resource_type: "Resource type"
-        updated_at: "Đã cập nhật"
   active_admin:
+    access_denied:
+      message: Bạn không có quyền thực hiện tính năng này
+    any: Bất kỳ
+    batch_actions:
+      action_label: "%{title} đã được chọn"
+      button_label: Hành động hàng loạt
+      default_confirmation: Bạn có chắc bạn muốn làm điều này?
+      delete_confirmation: Bạn có chắc chắn muốn xóa những %{plural_model}?
+      labels:
+        destroy: Xóa
+      selection_toggle_explanation: "(Thay đổi lựa chọn)"
+      succesfully_destroyed:
+        one: Đã xóa thành công 1 %{model}
+        other: Đã xóa thành công %{count} %{plural_model}
+    blank_slate:
+      content: Chưa có %{resource_name}.
+      link: Tạo mới
+    cancel: Hủy
+    comments:
+      add: Thêm bình luận
+      author: Tác giả
+      author_missing: Vô danh
+      author_type: Loại tác giả
+      body: Nội dung
+      created_at: Đã tạo
+      delete: Xoá bình luận
+      delete_confirmation: Bạn có chắc chắn muốn xóa những bình luận này?
+      errors:
+        empty_text: Lời bình luận chưa được lưu, vì nội dung còn trống.
+      no_comments_yet: Chưa có bình luận.
+      resource: Resource
+      resource_type: Resource Type
+      title_content: Bình luận (%{count})
+    create_another: Tạo thêm %{model}
     dashboard: Bảng điều khiển
-    view: "Xem"
-    edit: "Chỉnh sửa"
-    delete: "Xóa"
-    delete_confirmation: "Bạn có chắc chắn rằng mình muốn xóa không?"
-    new_model: "Tạo mới %{model}"
-    edit_model: "Chỉnh sửa %{model}"
-    delete_model: "Xóa %{model}"
-    create_another: "Tạo thêm %{model}"
+    delete: Xóa
+    delete_confirmation: Bạn có chắc chắn rằng mình muốn xóa không?
+    delete_model: Xóa %{model}
     details: "%{model} Chi tiết"
-    cancel: "Hủy"
-    empty: "Trống"
-    previous: "Trước"
-    next: "Sau"
-    download: "Tải về:"
-    has_many_new: "Thêm mới %{model}"
-    has_many_delete: "Xóa"
-    has_many_remove: "Hủy bỏ"
-    move: "Di chuyển"
+    devise:
+      change_password:
+        submit: Thay đổi mật khẩu của tôi
+        title: Thay đổi mật khẩu của bạn
+      email:
+        title: Email
+      links:
+        forgot_your_password: Quên mật khẩu của bạn?
+        resend_confirmation_instructions: Gửi lại hướng dẫn xác nhận
+        resend_unlock_instructions: Gửi lại hướng dẫn mở khoá
+        sign_in: Đăng nhập
+        sign_in_with_omniauth_provider: Đăng nhập với %{provider}
+        sign_up: Đăng ký
+      login:
+        remember_me: Ghi nhớ tôi
+        submit: Đăng nhập
+        title: Đăng nhập
+      password:
+        title: Mật khẩu
+      password_confirmation:
+        title: Mật khẩu xác nhận
+      resend_confirmation_instructions:
+        submit: Gửi lại hướng dẫn xác nhận
+        title: Gửi lại hướng dẫn xác nhận
+      reset_password:
+        submit: Thiết lập lại mật khẩu của tôi
+        title: Quên mật khẩu của bạn?
+      sign_up:
+        submit: Đăng ký
+        title: Đăng ký
+      subdomain:
+        title: Tên miền phụ
+      unlock:
+        submit: Gửi lại hướng dẫn mở khoá
+        title: Gửi lại hướng dẫn mở khoá
+      username:
+        title: Tên người dùng
+    download: 'Tải về:'
+    edit: Chỉnh sửa
+    edit_model: Chỉnh sửa %{model}
+    empty: Trống
     filters:
       buttons:
-        filter: "Lọc"
-        clear: "Xóa dữ liệu lọc"
+        clear: Xóa dữ liệu lọc
+        filter: Lọc
       predicates:
-        from: "Từ"
-        to: "Đến"
-    scopes:
-      all: "Tất cả"
-    search_status:
-      no_current_filters: "Không có"
-    status_tag:
-      "yes": "Có"
-      "no": "Không Có"
-      "unset": "Không Có"
-    logout: "Đăng xuất"
-    powered_by: "Bản quyền bởi %{active_admin} %{version}"
-    sidebars:
-      filters: "Bộ Lọc"
-      search_status: "Trạng thái tìm kiếm"
-    pagination:
-      empty: "Không có %{model} nào được tìm thấy"
-      one: "Đang hiển thị <b>1</b> %{model}"
-      one_page: "Đang hiển thị <b>tất cả %{n}</b> %{model}"
-      multiple: "Đang hiển thị %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> of <b>%{total}</b> trong tất cả."
-      multiple_without_total: "Đang hiển thị %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>."
-      per_page: "Mỗi trang: "
-      entry:
-        one: "entry"
-        other: "entries"
-    any: "Bất kỳ"
-    blank_slate:
-      content: "Chưa có %{resource_name}."
-      link: "Tạo mới"
-    batch_actions:
-      button_label: "Hành động hàng loạt"
-      default_confirmation: "Bạn có chắc bạn muốn làm điều này?"
-      delete_confirmation: "Bạn có chắc chắn muốn xóa những %{plural_model}?"
-      succesfully_destroyed:
-        one: "Đã xóa thành công 1 %{model}"
-        other: "Đã xóa thành công %{count} %{plural_model}"
-      selection_toggle_explanation: "(Thay đổi lựa chọn)"
-      action_label: "%{title} đã được chọn"
-      labels:
-        destroy: "Xóa"
-    comments:
-      created_at: "Đã tạo"
-      resource_type: "Resource Type"
-      author_type: "Loại tác giả"
-      body: "Nội dung"
-      author: "Tác giả"
-      add: "Thêm bình luận"
-      delete: "Xoá bình luận"
-      delete_confirmation: "Bạn có chắc chắn muốn xóa những bình luận này?"
-      resource: "Resource"
-      no_comments_yet: "Chưa có bình luận."
-      author_missing: "Vô danh"
-      title_content: "Bình luận (%{count})"
-      errors:
-        empty_text: "Lời bình luận chưa được lưu, vì nội dung còn trống."
-    devise:
-      username:
-        title: "Tên người dùng"
-      email:
-        title: "Email"
-      subdomain:
-        title: "Tên miền phụ"
-      password:
-        title: "Mật khẩu"
-      password_confirmation:
-        title: "Mật khẩu xác nhận"
-      sign_up:
-        title: "Đăng ký"
-        submit: "Đăng ký"
-      login:
-        title: "Đăng nhập"
-        remember_me: "Ghi nhớ tôi"
-        submit: "Đăng nhập"
-      reset_password:
-        title: "Quên mật khẩu của bạn?"
-        submit: "Thiết lập lại mật khẩu của tôi"
-      change_password:
-        title: "Thay đổi mật khẩu của bạn"
-        submit: "Thay đổi mật khẩu của tôi"
-      unlock:
-        title: "Gửi lại hướng dẫn mở khoá"
-        submit: "Gửi lại hướng dẫn mở khoá"
-      resend_confirmation_instructions:
-        title: "Gửi lại hướng dẫn xác nhận"
-        submit: "Gửi lại hướng dẫn xác nhận"
-      links:
-        sign_up: "Đăng ký"
-        sign_in: "Đăng nhập"
-        forgot_your_password: "Quên mật khẩu của bạn?"
-        sign_in_with_omniauth_provider: "Đăng nhập với %{provider}"
-        resend_unlock_instructions: "Gửi lại hướng dẫn mở khoá"
-        resend_confirmation_instructions: "Gửi lại hướng dẫn xác nhận"
-    access_denied:
-      message: "Bạn không có quyền thực hiện tính năng này"
+        from: Từ
+        to: Đến
+    has_many_delete: Xóa
+    has_many_new: Thêm mới %{model}
+    has_many_remove: Hủy bỏ
     index_list:
-      table: "Bảng"
+      table: Bảng
+    logout: Đăng xuất
+    move: Di chuyển
+    new_model: Tạo mới %{model}
+    next: Sau
+    pagination:
+      empty: Không có %{model} nào được tìm thấy
+      entry:
+        one: entry
+        other: entries
+      multiple: Đang hiển thị %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> of <b>%{total}</b> trong tất cả.
+      multiple_without_total: Đang hiển thị %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>.
+      one: Đang hiển thị <b>1</b> %{model}
+      one_page: Đang hiển thị <b>tất cả %{n}</b> %{model}
+      per_page: 'Mỗi trang: '
+    powered_by: Bản quyền bởi %{active_admin} %{version}
+    previous: Trước
+    scopes:
+      all: Tất cả
+    search_status:
+      no_current_filters: Không có
+    sidebars:
+      filters: Bộ Lọc
+      search_status: Trạng thái tìm kiếm
+    status_tag:
+      'no': Không Có
+      unset: Không Có
+      'yes': Có
+    view: Xem
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: Loại tác giả
+        body: Nội dung
+        created_at: Đã tạo
+        namespace: Namespace
+        resource_type: Resource type
+        updated_at: Đã cập nhật
+    models:
+      active_admin/comment:
+        one: Bình luận
+        other: Các bình luận
+      comment:
+        one: Bình luận
+        other: Các bình luận

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -124,6 +124,10 @@ zh-CN:
       'no': 否
       unset: 否
       'yes': 是
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu
     view: 查看
   activerecord:
     attributes:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -1,142 +1,143 @@
-"zh-CN":
-  activerecord:
-    models:
-      comment:
-        one: "评论"
-        other: "评论"
-      active_admin/comment:
-        one: "评论"
-        other: "评论"
-    attributes:
-      active_admin/comment:
-        author_type: "作者类型"
-        body: "内容"
-        created_at: "创建"
-        namespace: "Namespace"
-        resource_type: "Resource 类型"
-        updated_at: "更新"
+---
+zh-CN:
   active_admin:
-    dashboard: "控制面板"
-    view: "查看"
-    edit: "编辑"
-    delete: "删除"
-    delete_confirmation: "确定删除?"
-    create_another: "新增另一个%{model}"
-    new_model: "新增%{model}"
-    edit_model: "编辑%{model}"
-    delete_model: "删除%{model}"
+    access_denied:
+      message: 您无权处理此操作
+    any: 任何
+    batch_actions:
+      action_label: "%{title} 被选中"
+      button_label: 批处理
+      default_confirmation: 你确定要这样做？
+      delete_confirmation: 你确定要删除这些%{plural_model}？
+      labels:
+        destroy: 删除
+      selection_toggle_explanation: "(切换选择)"
+      succesfully_destroyed:
+        one: 成功删除 1 %{model}
+        other: 成功删除 %{count} %{plural_model}
+    blank_slate:
+      content: 暂时还没有%{resource_name}。
+      link: 新增一个
+    cancel: 取消
+    comments:
+      add: 添加评论
+      author: 作者
+      author_missing: 匿名
+      author_type: 作者类型
+      body: 内容
+      created_at: 创建于
+      delete: 删除评论
+      delete_confirmation: 你确定删除这些评论？
+      errors:
+        empty_text: 评论保存失败，内空不能为空。
+      no_comments_yet: 暂时没有评论
+      resource: 资源
+      resource_type: 资源类型
+      title_content: "(%{count})条评论"
+    create_another: 新增另一个%{model}
+    dashboard: 控制面板
+    delete: 删除
+    delete_confirmation: 确定删除?
+    delete_model: 删除%{model}
     details: "%{model}详情"
-    cancel: "取消"
-    empty: "未定义"
-    previous: "上一个"
-    next: "下一个"
-    download: "下载："
-    has_many_new: "新增一个%{model}"
-    has_many_delete: "删除"
-    has_many_remove: "清除"
-    move: "移动"
+    devise:
+      change_password:
+        submit: 修改密码
+        title: 修改密码
+      email:
+        title: 邮箱
+      links:
+        forgot_your_password: 忘记了密码？
+        resend_confirmation_instructions: 重发确认邮件
+        resend_unlock_instructions: 重发解锁邮件
+        sign_in: 登录
+        sign_in_with_omniauth_provider: 通过%{provider}登录
+        sign_up: 注册
+      login:
+        remember_me: 记住我
+        submit: 登录
+        title: 登录
+      password:
+        title: 密码
+      password_confirmation:
+        title: 确认密码
+      resend_confirmation_instructions:
+        submit: " 重新发送确认说明"
+        title: " 重新发送确认说明"
+      reset_password:
+        submit: 重置我的密码
+        title: 忘记了密码？
+      sign_up:
+        submit: 注册
+        title: 注册
+      subdomain:
+        title: 子域
+      unlock:
+        submit: 重新发送送解锁命令
+        title: 重新发送送解锁命令
+      username:
+        title: 用户名
+    download: 下载：
+    edit: 编辑
+    edit_model: 编辑%{model}
+    empty: 未定义
     filters:
       buttons:
-        filter: "过滤"
-        clear: "清除条件"
+        clear: 清除条件
+        filter: 过滤
       predicates:
-        from: "起"
-        to: "止"
-    scopes:
-      all: "所有"
-    search_status:
-      title: "搜索条件"
-      title_with_scope: "搜索条件 %{name}"
-      no_current_filters: "无"
-    status_tag:
-      "yes": "是"
-      "no": "否"
-      "unset": "否"
-    logout: "退出"
-    powered_by: "构建程序为 %{active_admin} %{version}"
-    sidebars:
-      filters: "所有条件"
-      search_status: "搜索条件"
-    pagination:
-      empty: "暂时没有%{model}"
-      one: "显示 <b>1</b> %{model}"
-      one_page: "显示 <b>所有 %{n}</b> %{model}"
-      multiple: "显示所有 <b>%{total}</b> %{model}中的<b>%{from}&nbsp;-&nbsp;%{to}</b> 条"
-      multiple_without_total: "%{model}中的<b>%{from}&nbsp;-&nbsp;%{to}</b> 条"
-      per_page: "每页："
-      previous: "上一页"
-      next: "下一页"
-      entry:
-        one: "条目"
-        other: "条目"
-    any: "任何"
-    blank_slate:
-      content: "暂时还没有%{resource_name}。"
-      link: "新增一个"
-    batch_actions:
-      button_label: "批处理"
-      default_confirmation: "你确定要这样做？"
-      delete_confirmation: "你确定要删除这些%{plural_model}？"
-      succesfully_destroyed:
-        one: "成功删除 1 %{model}"
-        other: "成功删除 %{count} %{plural_model}"
-      selection_toggle_explanation: "(切换选择)"
-      action_label: "%{title} 被选中"
-      labels:
-        destroy: "删除"
-    comments:
-      created_at: "创建于"
-      resource_type: "资源类型"
-      author_type: "作者类型"
-      body: "内容"
-      author: "作者"
-      add: "添加评论"
-      delete: "删除评论"
-      delete_confirmation: "你确定删除这些评论？"
-      resource: "资源"
-      no_comments_yet: "暂时没有评论"
-      author_missing: "匿名"
-      title_content: "(%{count})条评论"
-      errors:
-        empty_text: "评论保存失败，内空不能为空。"
-    devise:
-      username:
-        title: "用户名"
-      email:
-        title: "邮箱"
-      subdomain:
-        title: "子域"
-      password:
-        title: "密码"
-      password_confirmation:
-        title: "确认密码"
-      sign_up:
-        title: "注册"
-        submit: "注册"
-      login:
-        title: "登录"
-        remember_me: "记住我"
-        submit: "登录"
-      reset_password:
-        title: "忘记了密码？"
-        submit: "重置我的密码"
-      change_password:
-        title: "修改密码"
-        submit: "修改密码"
-      unlock:
-        title: "重新发送送解锁命令"
-        submit: "重新发送送解锁命令"
-      resend_confirmation_instructions:
-        title: " 重新发送确认说明"
-        submit: " 重新发送确认说明"
-      links:
-        sign_up: "注册"
-        sign_in: "登录"
-        forgot_your_password: "忘记了密码？"
-        sign_in_with_omniauth_provider: "通过%{provider}登录"
-        resend_unlock_instructions: "重发解锁邮件"
-        resend_confirmation_instructions: "重发确认邮件"
-    access_denied:
-      message: "您无权处理此操作"
+        from: 起
+        to: 止
+    has_many_delete: 删除
+    has_many_new: 新增一个%{model}
+    has_many_remove: 清除
     index_list:
-      table: "表格"
+      table: 表格
+    logout: 退出
+    move: 移动
+    new_model: 新增%{model}
+    next: 下一个
+    pagination:
+      empty: 暂时没有%{model}
+      entry:
+        one: 条目
+        other: 条目
+      multiple: 显示所有 <b>%{total}</b> %{model}中的<b>%{from}&nbsp;-&nbsp;%{to}</b> 条
+      multiple_without_total: "%{model}中的<b>%{from}&nbsp;-&nbsp;%{to}</b> 条"
+      next: 下一页
+      one: 显示 <b>1</b> %{model}
+      one_page: 显示 <b>所有 %{n}</b> %{model}
+      per_page: 每页：
+      previous: 上一页
+    powered_by: 构建程序为 %{active_admin} %{version}
+    previous: 上一个
+    scopes:
+      all: 所有
+    search_status:
+      no_current_filters: 无
+      title: 搜索条件
+      title_with_scope: 搜索条件 %{name}
+    sidebars:
+      filters: 所有条件
+      search_status: 搜索条件
+    status_tag:
+      'no': 否
+      unset: 否
+      'yes': 是
+    view: 查看
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: 作者类型
+        body: 内容
+        created_at: 创建
+        namespace: Namespace
+        resource_type: Resource 类型
+        updated_at: 更新
+    models:
+      active_admin/comment:
+        one: 评论
+        other: 评论
+      comment:
+        one: 评论
+        other: 评论

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -1,146 +1,147 @@
-"zh-TW":
-  activerecord:
-    models:
-      comment:
-        one: "評論"
-        other: "評論"
-      active_admin/comment:
-        one: "評論"
-        other: "評論"
-    attributes:
-      active_admin/comment:
-        author_type: "作者類型"
-        body: "內容"
-        created_at: "建立時間"
-        namespace: "命名空間"
-        resource_type: "資源類型"
-        updated_at: "更新時間"
+---
+zh-TW:
   active_admin:
-    dashboard: "儀表板"
-    view: "檢視"
-    edit: "編輯"
-    delete: "刪除"
-    delete_confirmation: "你確定要刪除嗎？"
-    create_another: "新增另一個 %{model}"
-    new_model: "新增 %{model}"
-    edit_model: "編輯 %{model}"
-    delete_model: "刪除 %{model}"
+    access_denied:
+      message: 你沒有權限執行此項操作
+    any: 任何
+    batch_actions:
+      action_label: "%{title} 已選取"
+      button_label: 批次操作
+      default_confirmation: 你確定要這樣做嗎？
+      delete_confirmation: 你確定要刪除這些 %{plural_model} 嗎？
+      labels:
+        destroy: 刪除
+      selection_toggle_explanation: "（切換選取）"
+      succesfully_destroyed:
+        one: 成功刪除 1 %{model}
+        other: 成功刪除 %{count} %{plural_model}
+    blank_slate:
+      content: 尚無 %{resource_name}。
+      link: 建立一筆
+    cancel: 取消
+    comments:
+      add: 新增評論
+      author: 作者
+      author_missing: 匿名
+      author_type: 作者身份
+      body: 內文
+      created_at: 建立時間
+      delete: 刪除評論
+      delete_confirmation: 你確定要刪除這個評論嗎？
+      errors:
+        empty_text: 評論儲存失敗，不允許空白的內容。
+      no_comments_yet: 尚無評論
+      resource: 資源
+      resource_type: 資源類型
+      title_content: "%{count} 則評論"
+    create_another: 新增另一個 %{model}
+    dashboard: 儀表板
+    delete: 刪除
+    delete_confirmation: 你確定要刪除嗎？
+    delete_model: 刪除 %{model}
     details: "%{model} 明細"
-    cancel: "取消"
-    empty: "空的"
-    previous: "前一個"
-    next: "下一個"
-    download: "下載："
-    has_many_new: "增加新的 %{model}"
-    has_many_delete: "刪除"
-    has_many_remove: "移除"
-    move: "移動"
+    devise:
+      change_password:
+        submit: 更改我的密碼
+        title: 更改你的密碼
+      email:
+        title: 電子郵件信箱
+      links:
+        forgot_your_password: 忘記密碼？
+        resend_confirmation_instructions: 重新發送確認信
+        resend_unlock_instructions: 重新發送解鎖指示
+        sign_in: 登入
+        sign_in_with_omniauth_provider: 使用 %{provider} 登入
+        sign_up: 註冊
+      login:
+        remember_me: 記住我
+        submit: 登入
+        title: 登入
+      password:
+        title: 密碼
+      password_confirmation:
+        title: 確認密碼
+      resend_confirmation_instructions:
+        submit: 重新發送確認信
+        title: 重新發送確認信
+      reset_password:
+        submit: 重設密碼
+        title: 忘記密碼？
+      sign_up:
+        submit: 註冊
+        title: 註冊
+      subdomain:
+        title: 子網域
+      unlock:
+        submit: 重新發送解鎖指示
+        title: 重新發送解鎖指示
+      username:
+        title: 帳號
+    download: 下載：
+    edit: 編輯
+    edit_model: 編輯 %{model}
+    empty: 空的
     filters:
       buttons:
-        filter: "篩選"
-        clear: "清除篩選條件"
+        clear: 清除篩選條件
+        filter: 篩選
       predicates:
-        from: "從"
-        to: "到"
-    scopes:
-      all: "全部"
-    search_status:
-      title: "進行中的搜尋"
-      title_with_scope: "正在搜尋 %{name}"
-      no_current_filters: "未套用篩選條件"
-    status_tag:
-      "yes": "是"
-      "no": "否"
-      "unset": "未知"
-    toggle_dark_mode: "切換暗黑模式"
-    toggle_main_navigation_menu: "切換主要導覽"
-    toggle_section: "切換區塊"
-    toggle_user_menu: "切換使用者選單"
-    logout: "登出"
-    powered_by: "由 %{active_admin} %{version} 提供"
-    sidebars:
-      filters: "篩選條件"
-      search_status: "搜尋狀態"
-    pagination:
-      empty: "找不到 %{model}"
-      one: "顯示 <b>1</b> %{model}"
-      one_page: "顯示 <b>全部 %{n}</b> %{model}"
-      multiple: "總計 <b>%{total}</b> 顯示 %{model} 中<b>%{from}&nbsp;-&nbsp;%{to}</b> 筆"
-      multiple_without_total: "顯示 %{model} 中<b>%{from}&nbsp;-&nbsp;%{to}</b> 筆"
-      per_page: "每頁 "
-      previous: "前一個"
-      next: "下一個"
-      entry:
-        one: "筆"
-        other: "筆"
-    any: "任何"
-    blank_slate:
-      content: "尚無 %{resource_name}。"
-      link: "建立一筆"
-    batch_actions:
-      button_label: "批次操作"
-      default_confirmation: "你確定要這樣做嗎？"
-      delete_confirmation: "你確定要刪除這些 %{plural_model} 嗎？"
-      succesfully_destroyed:
-        one: "成功刪除 1 %{model}"
-        other: "成功刪除 %{count} %{plural_model}"
-      selection_toggle_explanation: "（切換選取）"
-      action_label: "%{title} 已選取"
-      labels:
-        destroy: "刪除"
-    comments:
-      created_at: "建立時間"
-      resource_type: "資源類型"
-      author_type: "作者身份"
-      body: "內文"
-      author: "作者"
-      add: "新增評論"
-      delete: "刪除評論"
-      delete_confirmation: "你確定要刪除這個評論嗎？"
-      resource: "資源"
-      no_comments_yet: "尚無評論"
-      author_missing: "匿名"
-      title_content: "%{count} 則評論"
-      errors:
-        empty_text: "評論儲存失敗，不允許空白的內容。"
-    devise:
-      username:
-        title: "帳號"
-      email:
-        title: "電子郵件信箱"
-      subdomain:
-        title: "子網域"
-      password:
-        title: "密碼"
-      password_confirmation:
-        title: "確認密碼"
-      sign_up:
-        title: "註冊"
-        submit: "註冊"
-      login:
-        title: "登入"
-        remember_me: "記住我"
-        submit: "登入"
-      reset_password:
-        title: "忘記密碼？"
-        submit: "重設密碼"
-      change_password:
-        title: "更改你的密碼"
-        submit: "更改我的密碼"
-      unlock:
-        title: "重新發送解鎖指示"
-        submit: "重新發送解鎖指示"
-      resend_confirmation_instructions:
-        title: "重新發送確認信"
-        submit: "重新發送確認信"
-      links:
-        sign_up: "註冊"
-        sign_in: "登入"
-        forgot_your_password: "忘記密碼？"
-        sign_in_with_omniauth_provider: "使用 %{provider} 登入"
-        resend_unlock_instructions: "重新發送解鎖指示"
-        resend_confirmation_instructions: "重新發送確認信"
-    access_denied:
-      message: "你沒有權限執行此項操作"
+        from: 從
+        to: 到
+    has_many_delete: 刪除
+    has_many_new: 增加新的 %{model}
+    has_many_remove: 移除
     index_list:
-      table: "表格"
+      table: 表格
+    logout: 登出
+    move: 移動
+    new_model: 新增 %{model}
+    next: 下一個
+    pagination:
+      empty: 找不到 %{model}
+      entry:
+        one: 筆
+        other: 筆
+      multiple: 總計 <b>%{total}</b> 顯示 %{model} 中<b>%{from}&nbsp;-&nbsp;%{to}</b> 筆
+      multiple_without_total: 顯示 %{model} 中<b>%{from}&nbsp;-&nbsp;%{to}</b> 筆
+      next: 下一個
+      one: 顯示 <b>1</b> %{model}
+      one_page: 顯示 <b>全部 %{n}</b> %{model}
+      per_page: '每頁 '
+      previous: 前一個
+    powered_by: 由 %{active_admin} %{version} 提供
+    previous: 前一個
+    scopes:
+      all: 全部
+    search_status:
+      no_current_filters: 未套用篩選條件
+      title: 進行中的搜尋
+      title_with_scope: 正在搜尋 %{name}
+    sidebars:
+      filters: 篩選條件
+      search_status: 搜尋狀態
+    status_tag:
+      'no': 否
+      unset: 未知
+      'yes': 是
+    toggle_dark_mode: 切換暗黑模式
+    toggle_main_navigation_menu: 切換主要導覽
+    toggle_section: 切換區塊
+    toggle_user_menu: 切換使用者選單
+    view: 檢視
+  activerecord:
+    attributes:
+      active_admin/comment:
+        author_type: 作者類型
+        body: 內容
+        created_at: 建立時間
+        namespace: 命名空間
+        resource_type: 資源類型
+        updated_at: 更新時間
+    models:
+      active_admin/comment:
+        one: 評論
+        other: 評論
+      comment:
+        one: 評論
+        other: 評論


### PR DESCRIPTION
Scary number of changes, but it's almost all automatic and there are separate commits

- Ran `i18n-tasks normalize` (auto) 
- Run `i18n-tasks add-missing` (auto)
- Add locale-specific pluralization keys - like "few" for `ro.yml` (manual)
- Add a new GitHub action to check health