### PR TITLE
Remove redundant safe navigation operator

### DIFF
--- a/app/helpers/active_admin/display_helper.rb
+++ b/app/helpers/active_admin/display_helper.rb
@@ -24,7 +24,7 @@ module ActiveAdmin
     def display_name(resource)
       unless resource.nil?
         result = render_in_context(resource, display_name_method_for(resource))
-        if result.to_s&.strip&.present?
+        if result.to_s.strip.present?
           ERB::Util.html_escape(result)
         else
           ERB::Util.html_escape(render_in_context(resource, DISPLAY_NAME_FALLBACK))


### PR DESCRIPTION
Remove redundant safe navigation operator (`&.`) in `result.to_s.strip.present?` check, as `to_s` handles `nil` gracefully by converting it to an empty string.

This makes the code cleaner and more idiomatic without altering behavior.

Ref: https://ruby-doc.org/core-3.1.0/Object.html#method-i-to_s
