### PR TITLE
Use safe navigation for `pundit_default_policy`

### DIFF
--- a/lib/active_admin/pundit_adapter.rb
+++ b/lib/active_admin/pundit_adapter.rb
@@ -23,7 +23,7 @@ module ActiveAdmin
       # which means there is no way how to scope other actions
       Pundit.policy_scope!(user, namespace(collection))
     rescue Pundit::NotDefinedError => e
-      if default_policy_class && default_policy_class.const_defined?(:Scope)
+      if default_policy_class&.const_defined?(:Scope)
         default_policy_class::Scope.new(user, collection).resolve
       else
         raise e
@@ -95,7 +95,7 @@ module ActiveAdmin
     end
 
     def default_policy_class
-      ActiveAdmin.application.pundit_default_policy && ActiveAdmin.application.pundit_default_policy.constantize
+      ActiveAdmin.application.pundit_default_policy&.constantize
     end
 
     def default_policy(subject)


### PR DESCRIPTION
Use the safe navigation operator (`&.`) to streamline the
`pundit_default_policy` constantization check, removing the need for a
redundant `&&`.

This change is now possible as the codebase no longer requires Ruby 2.3
support, which did not yet support safe navigation.

The previous implementation was added in commit https://github.com/activeadmin/activeadmin/commit/c93f6f49c6d4a7f35c98466fc1bc1cd0e1c826c5 to ensure
compatibility with older Ruby versions.