### PR TITLE
Use safe navigation operator in layout helper

### DIFF
--- a/app/helpers/active_admin/layout_helper.rb
+++ b/app/helpers/active_admin/layout_helper.rb
@@ -22,7 +22,7 @@ module ActiveAdmin
 
     def action_items_for_action
       @action_items_for_action ||= begin
-        if active_admin_config && active_admin_config.action_items?
+        if active_admin_config&.action_items?
           active_admin_config.action_items_for(params[:action], self)
         else
           []
@@ -32,7 +32,7 @@ module ActiveAdmin
 
     def sidebar_sections_for_action
       @sidebar_sections_for_action ||= begin
-        if active_admin_config && active_admin_config.sidebar_sections?
+        if active_admin_config&.sidebar_sections?
           active_admin_config.sidebar_sections_for(params[:action], self)
         else
           []


### PR DESCRIPTION
Replace a logic `&&` with safe navigation operator now that Ruby < 2.3 support is not required anymore

Ref: #8530

---

NOTE: there is also an (unsafe) cop to detect this use case

https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/SafeNavigation

there are a few more occurrences