### PR TITLE
Improve text color contrast

### DIFF
--- a/app/views/active_admin/shared/_resource_comments.html.erb
+++ b/app/views/active_admin/shared/_resource_comments.html.erb
@@ -25,7 +25,7 @@
           <span class="font-semibold">
             <%= comment.author ? auto_link(comment.author) : I18n.t("active_admin.comments.author_missing") %>
           </span>
-          <span class="text-xs text-gray-400">
+          <span class="text-xs text-gray-500 dark:text-gray-400">
             <%= pretty_format comment.created_at %>
           </span>
         </div>

--- a/plugin.js
+++ b/plugin.js
@@ -316,7 +316,7 @@ export default plugin(
         '@apply bg-gray-50 border border-gray-300 text-gray-900 rounded-md focus:ring-blue-500 focus:border-blue-500 w-full dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500': {}
       },
       'a': {
-        '@apply text-blue-600 underline underline-offset-[.2rem]': {}
+        '@apply text-blue-600 dark:text-blue-500 underline underline-offset-[.2rem]': {}
       },
     });
     addComponents({
@@ -500,7 +500,7 @@ export default plugin(
         '@apply sr-only': {}
       },
       '.formtastic :where(.inline-hints)': {
-        '@apply text-gray-500 mt-2': {}
+        '@apply text-gray-500 dark:text-gray-400 mt-2': {}
       },
       '.formtastic :where(.errors)': {
         '@apply p-4 mb-6 rounded-md space-y-2 bg-red-50 text-red-800 dark:bg-red-800 dark:text-red-300': {}


### PR DESCRIPTION
Address accessibility issues identified by Lighthouse, focusing on
improving the readability of form hint text in dark mode.

- Enhance readability by making extra-small text darker in light mode
- Refine dark theme color palette for improved contrast on non-black
  backgrounds:  
  - Change some text colors from `gray-500` to `gray-400`
  - Update link color from `blue-600` to `blue-500`

### Before vs After

#### Form (dark) (Lighthouse Score: 92 -> 96)

URL: `http://localhost:5000/admin/stores/new`

```diff
- f.input :name
+ f.input :name, hint: 'Enter name'
```

![image](https://github.com/user-attachments/assets/f2d0dbc2-749e-4846-b451-a625e7abc2c0) ![image](https://github.com/user-attachments/assets/2f6dff0e-932e-4eef-aafd-b133e4f793a3)

<details>
<summary>Lighthouse Report</summary>

>  **Low-contrast text is difficult or impossible for many users to read. Learn how to provide sufficient color contrast.**
>
>  Failing Elements
>  - `p.inline-hints`

</details>

#### Comment (light) (Lighthouse Score: 88 -> 88)

URL: `http://localhost:5000/admin/categories/2`

![image](https://github.com/user-attachments/assets/0b40add4-13f9-48ba-beea-99d9da9aeb88) ![image](https://github.com/user-attachments/assets/9fbddab3-c37b-4d02-9756-4c1a36018bf8)

#### Comment (dark) (Lighthouse Score: 88 -> 88)

URL: `http://localhost:5000/admin/categories/2`

![image](https://github.com/user-attachments/assets/1230cc32-7536-47ab-b708-6c36894ffde9) ![image](https://github.com/user-attachments/assets/cbd72679-0b74-49f1-9051-67036fff4506)

<details>
<summary>Lighthouse Report</summary>

>  **Low-contrast text is difficult or impossible for many users to read. Learn how to provide sufficient color contrast.**
>
>  Failing Elements
>  - `a`

</details>
