### PR TITLE
Convert plugin.js to ESM because package.json has type set to module

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -1,6 +1,6 @@
-const plugin = require('tailwindcss/plugin')
-const defaultTheme = require('tailwindcss/defaultTheme');
-const colors = require('tailwindcss/colors');
+import plugin from 'tailwindcss/plugin';
+import defaultTheme from 'tailwindcss/defaultTheme';
+import colors from 'tailwindcss/colors';
 const { spacing, borderWidth, borderRadius } = defaultTheme;
 
 // https://github.com/tailwindlabs/tailwindcss/discussions/9336
@@ -28,7 +28,7 @@ const svgToTinyDataUri = (() => {
   return svgToTinyDataUri;
 })();
 
-module.exports = plugin(
+export default plugin(
   function({ addBase, addComponents, theme }) {
     addBase({
       [[


### PR DESCRIPTION
<!--

Thanks for contributing to ActiveAdmin!

You can find the instructions in our contributing guide: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md

Before submitting your PR make sure that:
* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are separated.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all CI checks are passing, but feel free to ask for early feedback if you need guidance.

[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->
This PR makes `plugin.js` use ESM syntax instead of CJS, because `package.json` has `"type": "module"` which causes issues when using bundlers.

I've tested this change against activeadmin demo repo, replacing the file in node_modules, and it works fine with the oldest non-EOL version of node, `18.20.4`.

Looks like autogenerated tailwind config can `require()` ESM version just fine, so probably there is no need to ship both CJS and ESM versions.

Fixes #8534