### PR TITLE
Introducing Active Admin Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ creating elegant backends for website administration.
 [![Github Actions][actions_badge]][actions]
 [![Coverage][coverage_badge]][coverage]
 [![Tidelift][tidelift_badge]][tidelift]
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Active%20Admin%20Guru-006BFF)](https://gurubase.io/g/active-admin)
 
 ## Goals
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Active Admin Guru](https://gurubase.io/g/active-admin) to Gurubase. Active Admin Guru uses the data from this repo and data from the [docs](https://activeadmin.info/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Active Admin Guru", which highlights that Active Admin now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Active Admin Guru in Gurubase, just let me know that's totally fine.
