### PR TITLE
Improve v3 docs regarding compatibility with vite_rails

### DIFF
--- a/docs/0-installation.md
+++ b/docs/0-installation.md
@@ -136,6 +136,17 @@ You can **opt-in to using Webpacker for ActiveAdmin assets** as well by updating
   rails g active_admin:webpacker
   ```
 
+## vite_rails
+
+To use Active Admin with Vite, make sure the `@activeadmin/activeadmin` dependency is added to your `package.json` using e.g. Yarn:
+
+```sh
+yarn add @activeadmin/activeadmin@^3
+```
+
+Then follow the steps outlined in this discussion comment: https://github.com/activeadmin/activeadmin/discussions/7947#discussioncomment-5867902
+
+
 [CHANGELOG]: https://github.com/activeadmin/activeadmin/blob/master/CHANGELOG.md
 [dashboard.rb]: https://github.com/activeadmin/activeadmin/blob/master/lib/generators/active_admin/install/templates/dashboard.rb
 [active_admin.rb]: https://github.com/activeadmin/activeadmin/blob/master/lib/generators/active_admin/install/templates/active_admin.rb.erb

--- a/docs/14-gotchas.md
+++ b/docs/14-gotchas.md
@@ -76,6 +76,14 @@ one, you can do one of these things:
 * You can remove all `require_tree` commands from your root level css files,
   where the `active_admin.scss` is in the tree.
 
+## Deprecation warnings with modern sass build tools
+
+Active Admin v3's SCSS is written for [sassc](https://rubygems.org/gems/sassc), which follows an older version of the SCSS specification. If you use a Node-based build system like esbuild, webpacker, or vite, you may encounter deprecation warnings for color functions like this when compiling assets:
+
+> DEPRECATION WARNING: lighten() is deprecated
+
+As a quick workaround, you may be able to silence these warnings by passing the `quietDeps` scss compilation option in your build system. With vite, follow these instructions: <https://github.com/vitejs/vite/discussions/4013#discussioncomment-10793687> (note this requires installing the `sass-embedded` dependency).
+
 ## Conflicts
 
 ### With gems that provides a `search` class method on a model


### PR DESCRIPTION
Active Admin v3 can be used with the vite_rails gem, but the instructions for doing so are buried in a discussion comment.

Also, using a modern build system like Vite will often lead to deprecation warnings due to the older color functions used in Active Admin's SCSS assets.

To address these issues, I've made some small improvements to Active Admin's docs. Namely:

- Add a vite_rails section to the installation document.
- Mention the SCSS deprecation warnings in the "gotchas" document, with a workaround that specifically works with Vite.

As discussed in <https://github.com/activeadmin/activeadmin/discussions/8492>, it would be great to solve the deprecation warnings rather than just hiding them, but that will require some significant refactoring, which can be a separate PR. In the meantime I wanted to improve the documentation to at least point users in the right direction.
