### PR TITLE
Use ESM syntax in tailwind template

### DIFF
--- a/lib/generators/active_admin/assets/templates/tailwind.config.js
+++ b/lib/generators/active_admin/assets/templates/tailwind.config.js
@@ -1,7 +1,9 @@
-const execSync = require('child_process').execSync;
+import { execSync } from 'child_process';
+import plugin from '@activeadmin/activeadmin/plugin';
+
 const activeAdminPath = execSync('bundle show activeadmin', { encoding: 'utf-8' }).trim();
 
-module.exports = {
+export default {
   content: [
     `${activeAdminPath}/vendor/javascript/flowbite.js`,
     `${activeAdminPath}/plugin.js`,
@@ -14,6 +16,6 @@ module.exports = {
   ],
   darkMode: "selector",
   plugins: [
-    require(`@activeadmin/activeadmin/plugin`)
+    plugin
   ]
 }


### PR DESCRIPTION
Recent syntax [change](https://github.com/activeadmin/activeadmin/pull/8536) in plugin.js causes tailwind watch to break. It runs successfully on first run, but then it builds only partially - it doesn't crash, but the output files don't contain all the CSS they should.

I'm not entirely sure what causes it to break only on reloads, but the current version on tailwind config produces this warning:
```
ExperimentalWarning: CommonJS module /Users/wrozka/Projects/orders/tailwind-active_admin.config.js is loading ES Module /Users/wrozka/Projects/orders/node_modules/@activeadmin/activeadmin/plugin.js using require().
```

This PR fixes the broken tailwind watch by migrating tailwind config from CJS to ESM, but it doesn't resolve the warning, it just moves it one level up the stack trace:
```
ExperimentalWarning: CommonJS module /Users/wrozka/Projects/orders/node_modules/tailwindcss/lib/lib/load-config.js is loading ES Module /Users/wrozka/Projects/orders/tailwind-active_admin.config.js using require().
```

I don't think this is the final fix, but at least it fixes the watch problem.