### PR TITLE
Docs: Refer to menu order with first-last

### DIFF
--- a/docs/2-resource-customization.md
+++ b/docs/2-resource-customization.md
@@ -207,7 +207,7 @@ You can easily customize this:
 
 ```ruby
 ActiveAdmin.register Post do
-  menu priority: 1 # so it's the first shown menu item
+  menu priority: 1 # so it's the first menu item visible
 end
 ```
 

--- a/docs/2-resource-customization.md
+++ b/docs/2-resource-customization.md
@@ -201,7 +201,7 @@ end
 ### Menu Priority
 
 Menu items are sorted first by their numeric priority, then alphabetically. Since
-every menu by default has the same priority of `10`, the menu is by default sorted alphabetically.
+menu item has a default priority of `10`.
 
 You can easily customize this:
 

--- a/docs/2-resource-customization.md
+++ b/docs/2-resource-customization.md
@@ -201,13 +201,13 @@ end
 ### Menu Priority
 
 Menu items are sorted first by their numeric priority, then alphabetically. Since
-every menu by default has a priority of `10`, the menu is normally alphabetical.
+every menu by default has the same priority of `10`, the menu is by default sorted alphabetically.
 
 You can easily customize this:
 
 ```ruby
 ActiveAdmin.register Post do
-  menu priority: 1 # so it's on the very left
+  menu priority: 1 # so it's the first shown menu item
 end
 ```
 

--- a/docs/2-resource-customization.md
+++ b/docs/2-resource-customization.md
@@ -200,7 +200,7 @@ end
 
 ### Menu Priority
 
-Menu items are sorted first by their numeric priority, then alphabetically. Since
+Menu items are sorted first by their numeric priority, then alphabetically. Every
 menu item has a default priority of `10`.
 
 You can customize this with:

--- a/docs/2-resource-customization.md
+++ b/docs/2-resource-customization.md
@@ -203,7 +203,7 @@ end
 Menu items are sorted first by their numeric priority, then alphabetically. Since
 menu item has a default priority of `10`.
 
-You can easily customize this:
+You can customize this with:
 
 ```ruby
 ActiveAdmin.register Post do


### PR DESCRIPTION
I noticed that in the docs, `menu priority: 1` mentions that that menu item is "left most". But the new AA menu is in the sidebar, not top bar, which is top to bottom. To fix this, and not make it layout-dependent, I replaced "left" with "first" and made some other minot tweaks.