### PR TITLE
Fix deprecation warning in Ruby 3.4

### DIFF
--- a/lib/active_admin/inputs/filters/select_input.rb
+++ b/lib/active_admin/inputs/filters/select_input.rb
@@ -15,7 +15,7 @@ module ActiveAdmin
           if searchable_has_many_through?
             "#{reflection.through_reflection.name}_#{reflection.foreign_key}"
           else
-            reflection_searchable? ? "#{name}_#{reflection.association_primary_key}" : name
+            reflection_searchable? ? "#{method}_#{reflection.association_primary_key}" : method
           end
         end
 

--- a/lib/active_admin/inputs/filters/select_input.rb
+++ b/lib/active_admin/inputs/filters/select_input.rb
@@ -15,9 +15,7 @@ module ActiveAdmin
           if searchable_has_many_through?
             "#{reflection.through_reflection.name}_#{reflection.foreign_key}"
           else
-            name = method.to_s
-            name.concat "_#{reflection.association_primary_key}" if reflection_searchable?
-            name
+            "#{name}_#{reflection.association_primary_key}" if reflection_searchable?
           end
         end
 

--- a/lib/active_admin/inputs/filters/select_input.rb
+++ b/lib/active_admin/inputs/filters/select_input.rb
@@ -15,7 +15,7 @@ module ActiveAdmin
           if searchable_has_many_through?
             "#{reflection.through_reflection.name}_#{reflection.foreign_key}"
           else
-            "#{name}_#{reflection.association_primary_key}" if reflection_searchable?
+            reflection_searchable? ? "#{name}_#{reflection.association_primary_key}" : name
           end
         end
 

--- a/lib/active_admin/inputs/filters/select_input.rb
+++ b/lib/active_admin/inputs/filters/select_input.rb
@@ -15,7 +15,7 @@ module ActiveAdmin
           if searchable_has_many_through?
             "#{reflection.through_reflection.name}_#{reflection.foreign_key}"
           else
-            reflection_searchable? ? "#{method}_#{reflection.association_primary_key}" : method
+            reflection_searchable? ? "#{method}_#{reflection.association_primary_key}" : method.to_s
           end
         end
 


### PR DESCRIPTION
After upgrade to Ruby 3.4, our test suite outputs the following warning:

```
~/.rvm/gems/ruby-3.4.1/gems/activeadmin-3.2.5/lib/active_admin/inputs/filters/select_input.rb:19: warning: string returned by <Symbol>.to_s will be frozen in the future
```

This PR should fix it.