### PR TITLE
Enable `Lint/AmbiguousOperator` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -81,6 +81,9 @@ Lint/ParenthesesAsGroupedExpression:
 Layout/AccessModifierIndentation:
   Enabled: true
 
+Lint/AmbiguousOperator:
+  Enabled: true
+
 Layout/ArgumentAlignment:
   Enabled: true
 

--- a/app/controllers/active_admin/resource_controller/data_access.rb
+++ b/app/controllers/active_admin/resource_controller/data_access.rb
@@ -236,7 +236,7 @@ module ActiveAdmin
 
       def apply_includes(chain)
         if active_admin_config.includes.any?
-          chain.includes *active_admin_config.includes
+          chain.includes(*active_admin_config.includes)
         else
           chain
         end

--- a/app/controllers/active_admin/resource_controller/streaming.rb
+++ b/app/controllers/active_admin/resource_controller/streaming.rb
@@ -26,7 +26,7 @@ module ActiveAdmin
         if ActiveAdmin.application.disable_streaming_in.include? Rails.env
           self.response_body = block[String.new] # rubocop:disable Performance/UnfreezeString to preserve encoding
         else
-          self.response_body = Enumerator.new &block
+          self.response_body = Enumerator.new(&block)
         end
       end
 
@@ -37,7 +37,7 @@ module ActiveAdmin
       def stream_csv
         headers["Content-Type"] = "text/csv; charset=utf-8" # In Rails 5 it's set to HTML??
         headers["Content-Disposition"] = %{attachment; filename="#{csv_filename}"}
-        stream_resource &active_admin_config.csv_builder.method(:build).to_proc.curry[self]
+        stream_resource(&active_admin_config.csv_builder.method(:build).to_proc.curry[self])
       end
 
     end

--- a/app/helpers/active_admin/form_helper.rb
+++ b/app/helpers/active_admin/form_helper.rb
@@ -29,7 +29,7 @@ module ActiveAdmin
     #
     def fields_for_params(params, options = {})
       namespace = options[:namespace]
-      except = Array.wrap(options[:except]).map &:to_s
+      except = Array.wrap(options[:except]).map(&:to_s)
 
       params.flat_map do |k, v|
         next if namespace.nil? && RESERVED_PARAMS.include?(k.to_s)

--- a/app/views/active_admin/page/index.html.arb
+++ b/app/views/active_admin/page/index.html.arb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 div class: "main-content-container" do
   if page_presenter.block
-    instance_exec &page_presenter.block
+    instance_exec(&page_presenter.block)
   end
 end

--- a/features/step_definitions/configuration_steps.rb
+++ b/features/step_definitions/configuration_steps.rb
@@ -5,7 +5,7 @@ module ActiveAdminReloading
     eval(config_content)
     ActiveSupport::Notifications.instrument ActiveAdmin::Application::AfterLoadEvent, { active_admin_application: ActiveAdmin.application }
     Rails.application.reload_routes!
-    ActiveAdmin.application.namespaces.each &:reset_menu!
+    ActiveAdmin.application.namespaces.each(&:reset_menu!)
   end
 end
 

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -101,7 +101,7 @@ module ActiveAdmin
     # Removes all defined controllers from memory. Useful in
     # development, where they are reloaded on each request.
     def unload!
-      namespaces.each &:unload!
+      namespaces.each(&:unload!)
       @@loaded = false
     end
 
@@ -155,7 +155,7 @@ module ActiveAdmin
 
     def controllers_for_filters
       controllers = [BaseController]
-      controllers.push *Devise.controllers_for_filters if Dependency.devise?
+      controllers.push(*Devise.controllers_for_filters) if Dependency.devise?
       controllers
     end
 

--- a/lib/active_admin/csv_builder.rb
+++ b/lib/active_admin/csv_builder.rb
@@ -64,7 +64,7 @@ module ActiveAdmin
     def exec_columns(view_context = nil)
       @view_context = view_context
       @columns = [] # we want to re-render these every instance
-      instance_exec &@block if @block.present?
+      instance_exec(&@block) if @block.present?
       columns
     end
 

--- a/lib/active_admin/dsl.rb
+++ b/lib/active_admin/dsl.rb
@@ -13,7 +13,7 @@ module ActiveAdmin
 
     # Runs the registration block inside this object
     def run_registration_block(&block)
-      instance_exec &block if block
+      instance_exec(&block) if block
     end
 
     # The instance of ActiveAdmin::Resource that's being registered

--- a/lib/active_admin/filters/resource_extension.rb
+++ b/lib/active_admin/filters/resource_extension.rb
@@ -146,7 +146,7 @@ module ActiveAdmin
             filters = poly.map(&:foreign_type) + low_arity.map(&:name) + high_arity
           end
 
-          filters.map &:to_sym
+          filters.map(&:to_sym)
         else
           []
         end

--- a/lib/active_admin/helpers/optional_display.rb
+++ b/lib/active_admin/helpers/optional_display.rb
@@ -23,7 +23,7 @@ module ActiveAdmin
       when Symbol, String
         render_context.public_send condition
       when Proc
-        render_context.instance_exec &condition
+        render_context.instance_exec(&condition)
       else
         true
       end

--- a/lib/active_admin/inputs/filters/base/search_method_select.rb
+++ b/lib/active_admin/inputs/filters/base/search_method_select.rb
@@ -26,7 +26,7 @@ module ActiveAdmin
             attr_reader :filters
 
             def filter(*filters)
-              (@filters ||= []).push *filters
+              (@filters ||= []).push(*filters)
             end
           end
 

--- a/lib/active_admin/resource.rb
+++ b/lib/active_admin/resource.rb
@@ -177,7 +177,7 @@ module ActiveAdmin
     end
 
     def find_resource(id)
-      resource = resource_class.public_send *method_for_find(id)
+      resource = resource_class.public_send(*method_for_find(id))
       (decorator_class && resource) ? decorator_class.new(resource) : resource
     end
 

--- a/lib/active_admin/resource_collection.rb
+++ b/lib/active_admin/resource_collection.rb
@@ -22,7 +22,7 @@ module ActiveAdmin
 
     # Changes `each` to pass in the value, instead of both the key and value.
     def each(&block)
-      values.each &block
+      values.each(&block)
     end
 
     def [](obj)

--- a/lib/active_admin/resource_dsl.rb
+++ b/lib/active_admin/resource_dsl.rb
@@ -40,7 +40,7 @@ module ActiveAdmin
 
     # Store relations that should be included
     def includes(*args)
-      config.includes.push *args
+      config.includes.push(*args)
     end
 
     #
@@ -193,7 +193,7 @@ module ActiveAdmin
 
     standard_rails_filters =
       AbstractController::Callbacks::ClassMethods.public_instance_methods.select { |m| m.end_with?('_action') }
-    delegate *standard_rails_filters, to: :controller
+    delegate(*standard_rails_filters, to: :controller)
 
     # Specify which actions to create in the controller
     #

--- a/lib/active_admin/view_helpers/method_or_proc_helper.rb
+++ b/lib/active_admin/view_helpers/method_or_proc_helper.rb
@@ -91,7 +91,7 @@ module MethodOrProcHelper
     context = self if context.nil? # default to `self` only when nil
     case obj
     when Proc
-      context.instance_exec *args, &obj
+      context.instance_exec(*args, &obj)
     when Symbol
       context.public_send obj, *args
     else

--- a/lib/active_admin/views/components/table_for.rb
+++ b/lib/active_admin/views/components/table_for.rb
@@ -94,7 +94,7 @@ module ActiveAdmin
       end
 
       def build_table_body
-        @tbody = tbody **(@tbody_html || {}) do
+        @tbody = tbody(**(@tbody_html || {})) do
           # Build enough rows for our collection
           @collection.each do |elem|
             html_options = @row_html&.call(elem) || {}

--- a/spec/helpers/filter_form_helper_spec.rb
+++ b/spec/helpers/filter_form_helper_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ActiveAdmin::FormHelper, type: :helper do
     render_arbre_component({ filter_args: [search, filters] }, helper) do
       args = assigns[:filter_args]
       kwargs = args.pop if args.last.is_a?(Hash)
-      text_node active_admin_filters_form_for *args, **kwargs
+      text_node active_admin_filters_form_for(*args, **kwargs)
     end.to_s
   end
 

--- a/spec/unit/resource_controller_spec.rb
+++ b/spec/unit/resource_controller_spec.rb
@@ -273,7 +273,7 @@ RSpec.describe "A specific resource controller", type: :controller do
   end
 
   describe "performing batch_action" do
-    let(:batch_action) { ActiveAdmin::BatchAction.new *batch_action_args, &batch_action_block }
+    let(:batch_action) { ActiveAdmin::BatchAction.new(*batch_action_args, &batch_action_block) }
     let(:batch_action_block) { proc { self.instance_variable_set :@block_context, self.class } }
     let(:params) { ActionController::Parameters.new(http_params) }
 

--- a/spec/unit/views/components/attributes_table_spec.rb
+++ b/spec/unit/views/components/attributes_table_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe ActiveAdmin::Views::AttributesTable do
       },
     }.each do |context_title, table_decleration|
       context context_title do
-        let(:table) { instance_eval &table_decleration }
+        let(:table) { instance_eval(&table_decleration) }
 
         it "should render a div wrapper with the class '.attributes-table'" do
           expect(table.tag_name).to eq "div"


### PR DESCRIPTION
Running the spec suite with `RUBYOPT='-w'` to validate PR #8593 revealed numerous warnings related to ambiguous operators.

To address these warnings, the `Lint/AmbiguousOperator` cop has been enabled and `rubocop -a` has been run to fix the offenses.

---

This PR removes 122 warnings from the spec suite