### PR TITLE
Remove `frozen_string_literal` comment from `.arb`

### DIFF
--- a/app/views/active_admin/page/index.html.arb
+++ b/app/views/active_admin/page/index.html.arb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 div class: "main-content-container" do
   if page_presenter.block
     instance_exec(&page_presenter.block)

--- a/app/views/active_admin/resource/_form.html.arb
+++ b/app/views/active_admin/resource/_form.html.arb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 div class: "main-content-container" do
   if page_presenter.block
     options = {

--- a/app/views/active_admin/resource/_form_default.html.arb
+++ b/app/views/active_admin/resource/_form_default.html.arb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 options = {
   url: resource.persisted? ? resource_path(resource) : collection_path,
   as: active_admin_config.param_key

--- a/app/views/active_admin/resource/_index_as_table_default.html.arb
+++ b/app/views/active_admin/resource/_index_as_table_default.html.arb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 insert_tag(ActiveAdmin::Views::IndexAsTable::IndexTableFor, collection, table_options) do |t|
   selectable_column
   id_column if resource_class.primary_key

--- a/app/views/active_admin/resource/_show_default.html.arb
+++ b/app/views/active_admin/resource/_show_default.html.arb
@@ -1,3 +1,2 @@
-# frozen_string_literal: true
 attributes_table_for(resource, *active_admin_config.resource_columns)
 active_admin_comments_for(resource) if active_admin_config.comments?

--- a/app/views/active_admin/resource/edit.html.arb
+++ b/app/views/active_admin/resource/edit.html.arb
@@ -1,2 +1,1 @@
-# frozen_string_literal: true
 render "form"

--- a/app/views/active_admin/resource/index.html.arb
+++ b/app/views/active_admin/resource/index.html.arb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 def wrap_with_batch_action_form(&block)
   if active_admin_config.batch_actions.any?
     insert_tag(ActiveAdmin::BatchActions::BatchActionForm, &block)

--- a/app/views/active_admin/resource/new.html.arb
+++ b/app/views/active_admin/resource/new.html.arb
@@ -1,2 +1,1 @@
-# frozen_string_literal: true
 render "form"

--- a/app/views/active_admin/resource/show.html.arb
+++ b/app/views/active_admin/resource/show.html.arb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 def attributes_table(*args, &block)
   attributes_table_for resource, *args, &block
 end

--- a/app/views/active_admin/shared/_sidebar_section.html.arb
+++ b/app/views/active_admin/shared/_sidebar_section.html.arb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 if section.block
   result = instance_exec(&section.block)
   text_node result unless result.is_a?(Arbre::Element)


### PR DESCRIPTION
The suggestion to add the `# frozen_string_literal: true` comment at
the top of `.arb` files was a false positive for the following reasons:

- It produced a warning.
- It did not have any effect because `.arb` files are evaluated in a
  different context.

To make this work correctly, the comment should be added at the
framework level instead.

This change eliminates the warning when running specs with
`RUBYOPT="-w"`.

Closes #8597

References:
- rails/rails#43725
- rubocop/rubocop#13699