### PR TITLE
Backport Fix circular require warning in belongs_to.rb

### DIFF
--- a/lib/active_admin/resource/belongs_to.rb
+++ b/lib/active_admin/resource/belongs_to.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "active_admin/resource"
 
 module ActiveAdmin
   class Resource


### PR DESCRIPTION
When running specs with `RUBYOPTS='-w'`, numerous warnings are generated due to a circular require between:
- `lib/active_admin/resource/belongs_to.rb`
- `lib/active_admin/resource.rb`

The warning message is:

```
warning: loading in progress, circular require considered harmful - ./lib/active_admin/resource.rb

```

Based on the code history, there is no specific reason for the inverse require from `belongs_to` to `resource`.

This change removes the unnecessary require to eliminate the warnings.
