### PR TITLE
Enable some Lint cops to prevent warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -75,13 +75,7 @@ Layout/EndAlignment:
 Layout/HashAlignment:
   Enabled: true
 
-Lint/ParenthesesAsGroupedExpression:
-  Enabled: true
-
 Layout/AccessModifierIndentation:
-  Enabled: true
-
-Lint/AmbiguousOperator:
   Enabled: true
 
 Layout/ArgumentAlignment:
@@ -132,6 +126,21 @@ Layout/ParameterAlignment:
 Layout/IndentationStyle:
   Enabled: true
   EnforcedStyle: spaces
+
+Lint/AmbiguousOperator:
+  Enabled: true
+
+Lint/AmbiguousRegexpLiteral:
+  Enabled: true
+
+Lint/ParenthesesAsGroupedExpression:
+  Enabled: true
+
+Lint/UselessAccessModifier:
+  Enabled: true
+
+Lint/UselessAssignment:
+  Enabled: true
 
 Packaging/BundlerSetupInTests:
   Enabled: true
@@ -291,6 +300,9 @@ Performance/StringInclude:
 Performance/StringReplacement:
   Enabled: true
 
+Performance/StringBytesize:
+  Enabled: true
+
 Performance/Sum:
   Enabled: false
 
@@ -393,7 +405,4 @@ Layout/SpaceInsideHashLiteralBraces:
   Enabled: true
 
 Layout/SpaceInsideParens:
-  Enabled: true
-
-Lint/UselessAccessModifier:
   Enabled: true

--- a/features/step_definitions/action_item_steps.rb
+++ b/features/step_definitions/action_item_steps.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
-Then /^I should see an action item link to "([^"]*)"$/ do |link|
+Then(/^I should see an action item link to "([^"]*)"$/) do |link|
   expect(page).to have_css("[data-test-action-items] > a", text: link)
 end
 
-Then /^I should not see an action item link to "([^"]*)"$/ do |link|
+Then(/^I should not see an action item link to "([^"]*)"$/) do |link|
   expect(page).to have_no_css("[data-test-action-items] > a", text: link)
 end

--- a/features/step_definitions/action_link_steps.rb
+++ b/features/step_definitions/action_link_steps.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
-Then /^I should see a member link to "([^"]*)"$/ do |name|
+Then(/^I should see a member link to "([^"]*)"$/) do |name|
   expect(page).to have_css(".data-table-resource-actions > a", text: name)
 end
 
-Then /^I should not see a member link to "([^"]*)"$/ do |name|
+Then(/^I should not see a member link to "([^"]*)"$/) do |name|
   %{Then I should not see "#{name}" within ".data-table-resource-actions > a"}
 end
 
-Then /^I should see the actions column with the class "([^"]*)" and the title "([^"]*)"$/ do |klass, title|
+Then(/^I should see the actions column with the class "([^"]*)" and the title "([^"]*)"$/) do |klass, title|
   expect(page).to have_css "th#{'.' + klass}", text: title
 end

--- a/features/step_definitions/additional_web_steps.rb
+++ b/features/step_definitions/additional_web_steps.rb
@@ -1,39 +1,39 @@
 # frozen_string_literal: true
-Then /^I should see a table header with "([^"]*)"$/ do |content|
+Then(/^I should see a table header with "([^"]*)"$/) do |content|
   expect(page).to have_xpath "//th", text: content
 end
 
-Then /^I should not see a table header with "([^"]*)"$/ do |content|
+Then(/^I should not see a table header with "([^"]*)"$/) do |content|
   expect(page).to have_no_xpath "//th", text: content
 end
 
-Then /^I should see a sortable table header with "([^"]*)"$/ do |content|
+Then(/^I should see a sortable table header with "([^"]*)"$/) do |content|
   expect(page).to have_css "th[data-sortable]", text: content
 end
 
-Then /^I should not see a sortable table header with "([^"]*)"$/ do |content|
+Then(/^I should not see a sortable table header with "([^"]*)"$/) do |content|
   expect(page).to have_no_css "th[data-sortable]", text: content
 end
 
-Then /^I should not see a sortable table header$/ do
+Then(/^I should not see a sortable table header$/) do
   step %{I should not see "th[data-sortable]"}
 end
 
-Then /^the table "([^"]*)" should have (\d+) rows/ do |selector, count|
+Then(/^the table "([^"]*)" should have (\d+) rows/) do |selector, count|
   trs = page.find(selector).all :css, "tr"
   expect(trs.size).to eq count.to_i
 end
 
-Then /^the table "([^"]*)" should have (\d+) columns/ do |selector, count|
+Then(/^the table "([^"]*)" should have (\d+) columns/) do |selector, count|
   tds = page.find(selector).find("tr:first").all :css, "td"
   expect(tds.size).to eq count.to_i
 end
 
-Then /^there should be (\d+) "([^"]*)" tags?$/ do |count, tag|
+Then(/^there should be (\d+) "([^"]*)" tags?$/) do |count, tag|
   expect(page.all(:css, tag).size).to eq count.to_i
 end
 
-Then /^I should see a link to "([^"]*)"$/ do |link|
+Then(/^I should see a link to "([^"]*)"$/) do |link|
   if Capybara.current_driver == Capybara.javascript_driver
     expect(page).to have_xpath "//a", text: link, wait: 30
   else
@@ -41,39 +41,39 @@ Then /^I should see a link to "([^"]*)"$/ do |link|
   end
 end
 
-Then /^an "([^"]*)" exception should be raised when I follow "([^"]*)"$/ do |error, link|
+Then(/^an "([^"]*)" exception should be raised when I follow "([^"]*)"$/) do |error, link|
   expect do
     step "I follow \"#{link}\""
   end.to raise_error(error.constantize)
 end
 
-Then /^I should be in the resource section for (.+)$/ do |resource_name|
+Then(/^I should be in the resource section for (.+)$/) do |resource_name|
   expect(current_url).to include resource_name.tr(" ", "").underscore.pluralize
 end
 
-Then /^I should see the page title "([^"]*)"$/ do |title|
+Then(/^I should see the page title "([^"]*)"$/) do |title|
   within("[data-test-page-header]") do
     expect(page).to have_content title
   end
 end
 
-Then /^I should see a fieldset titled "([^"]*)"$/ do |title|
+Then(/^I should see a fieldset titled "([^"]*)"$/) do |title|
   expect(page).to have_css "fieldset legend", text: title
 end
 
-Then /^the "([^"]*)" field should contain the option "([^"]*)"$/ do |field, option|
+Then(/^the "([^"]*)" field should contain the option "([^"]*)"$/) do |field, option|
   field = find_field(field)
   expect(field).to have_css "option", text: option
 end
 
-Then /^I should see the content "([^"]*)"$/ do |content|
+Then(/^I should see the content "([^"]*)"$/) do |content|
   expect(page).to have_css "[data-test-page-content]", text: content
 end
 
-Then /^I should see a validation error "([^"]*)"$/ do |error_message|
+Then(/^I should see a validation error "([^"]*)"$/) do |error_message|
   expect(page).to have_css ".inline-errors", text: error_message
 end
 
-Then /^I should see a table with id "([^"]*)"$/ do |dom_id|
+Then(/^I should see a table with id "([^"]*)"$/) do |dom_id|
   page.find("table##{dom_id}")
 end

--- a/features/step_definitions/attribute_steps.rb
+++ b/features/step_definitions/attribute_steps.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-Then /^I should( not)? see the attribute "([^"]*)" with "([^"]*)"$/ do |negate, title, value|
+Then(/^I should( not)? see the attribute "([^"]*)" with "([^"]*)"$/) do |negate, title, value|
   elems = all ".attributes-table th:contains('#{title}') ~ td:contains('#{value}')"
 
   if negate
@@ -9,11 +9,11 @@ Then /^I should( not)? see the attribute "([^"]*)" with "([^"]*)"$/ do |negate, 
   end
 end
 
-Then /^I should see the attribute "([^"]*)" with a nicely formatted datetime$/ do |title|
+Then(/^I should see the attribute "([^"]*)" with a nicely formatted datetime$/) do |title|
   text = all(".attributes-table th:contains('#{title}') ~ td").first.text
-  expect(text).to match /\w+ \d{1,2}, \d{4} \d{2}:\d{2}/
+  expect(text).to match(/\w+ \d{1,2}, \d{4} \d{2}:\d{2}/)
 end
 
-Then /^I should not see the attribute "([^"]*)"$/ do |title|
+Then(/^I should not see the attribute "([^"]*)"$/) do |title|
   expect(page).to have_no_css ".attributes-table th", text: title
 end

--- a/features/step_definitions/batch_action_steps.rb
+++ b/features/step_definitions/batch_action_steps.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-Then /^I (should|should not) see the batch action :([^\s]*) "([^"]*)"$/ do |maybe, sym, title|
+Then(/^I (should|should not) see the batch action :([^\s]*) "([^"]*)"$/) do |maybe, sym, title|
   selector = "[data-batch-action-item]"
   selector += "[href='#'][data-action='#{sym}']" if maybe == "should"
 
@@ -7,20 +7,20 @@ Then /^I (should|should not) see the batch action :([^\s]*) "([^"]*)"$/ do |mayb
   expect(page).send verb, have_css(selector, text: title)
 end
 
-Then /^the (\d+)(?:st|nd|rd|th) batch action should be "([^"]*)"$/ do |index, title|
+Then(/^the (\d+)(?:st|nd|rd|th) batch action should be "([^"]*)"$/) do |index, title|
   batch_action = page.all("[data-batch-action-item]")[index.to_i - 1]
   expect(batch_action.text).to match title
 end
 
-When /^I check the (\d+)(?:st|nd|rd|th) record$/ do |index|
+When(/^I check the (\d+)(?:st|nd|rd|th) record$/) do |index|
   page.all(".batch-actions-resource-selection")[index.to_i].set true
 end
 
-Then /^I should see that the batch action button is disabled$/ do
+Then(/^I should see that the batch action button is disabled$/) do
   expect(page).to have_css ".batch-actions-dropdown button[disabled]"
 end
 
-Then /^I (should|should not) see the batch action (button|selector)$/ do |maybe, type|
+Then(/^I (should|should not) see the batch action (button|selector)$/) do |maybe, type|
   selector = ".batch-actions-dropdown"
   selector += " button" if maybe == "should" && type == "button"
 
@@ -28,11 +28,11 @@ Then /^I (should|should not) see the batch action (button|selector)$/ do |maybe,
   expect(page).send verb, have_css(selector)
 end
 
-Then /^I should see the batch action popover$/ do
+Then(/^I should see the batch action popover$/) do
   expect(page).to have_css ".batch-actions-dropdown"
 end
 
-Given /^I submit the batch action form with "([^"]*)"$/ do |action|
+Given(/^I submit the batch action form with "([^"]*)"$/) do |action|
   page.find_by_id('batch_action', visible: false).set action
   form = page.find_by_id 'collection_selection'
   params = page.all("#collection_selection input", visible: false).each_with_object({}) do |input, obj|
@@ -47,12 +47,12 @@ Given /^I submit the batch action form with "([^"]*)"$/ do |action|
   page.driver.submit form["method"], form["action"], params
 end
 
-When /^I click "(.*?)" and accept confirmation$/ do |link|
+When(/^I click "(.*?)" and accept confirmation$/) do |link|
   accept_confirm do
     click_on(link)
   end
 end
 
-Then /^I should not see checkboxes in the table$/ do
+Then(/^I should not see checkboxes in the table$/) do
   expect(page).to have_no_css ".paginated-collection table input[type=checkbox]"
 end

--- a/features/step_definitions/breadcrumb_steps.rb
+++ b/features/step_definitions/breadcrumb_steps.rb
@@ -9,6 +9,6 @@ Around "@breadcrumb" do |scenario, block|
   end
 end
 
-Then /^I should see a link to "([^"]*)" in the breadcrumb$/ do |text|
+Then(/^I should see a link to "([^"]*)" in the breadcrumb$/) do |text|
   expect(page).to have_css "nav[aria-label=breadcrumb] a", text: text
 end

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
-Then /^I should see a comment by "([^"]*)"$/ do |name|
+Then(/^I should see a comment by "([^"]*)"$/) do |name|
   step %{I should see "#{name}" within "[data-test-comment-container]"}
 end
 
-Then /^I should( not)? be able to add a comment$/ do |negate|
+Then(/^I should( not)? be able to add a comment$/) do |negate|
   should = negate ? :not_to : :to
   expect(page).send should, have_button("Add Comment")
 end
 
-When /^I add a comment "([^"]*)"$/ do |comment|
+When(/^I add a comment "([^"]*)"$/) do |comment|
   step %{I fill in "comment_body" with "#{comment}"}
   step %{I press "Add Comment"}
 end
 
-Given /^(a|\d+) comments added by admin with an email "([^"]+)"?$/ do |number, email|
+Given(/^(a|\d+) comments added by admin with an email "([^"]+)"?$/) do |number, email|
   number = number == "a" ? 1 : number.to_i
   admin_user = ensure_user_created(email)
 
@@ -30,6 +30,6 @@ Given /^(a|\d+) comments added by admin with an email "([^"]+)"?$/ do |number, e
   end
 end
 
-Then /^I should see (\d+) comments?$/ do |number|
+Then(/^I should see (\d+) comments?$/) do |number|
   expect(page).to have_css("[data-test-comment-container]", count: number.to_i)
 end

--- a/features/step_definitions/configuration_steps.rb
+++ b/features/step_definitions/configuration_steps.rb
@@ -11,7 +11,7 @@ end
 
 World(ActiveAdminReloading)
 
-Given /^a(?:n? (index|show))? configuration of:$/ do |action, config_content|
+Given(/^a(?:n? (index|show))? configuration of:$/) do |action, config_content|
   load_aa_config(config_content)
 
   case action

--- a/features/step_definitions/factory_steps.rb
+++ b/features/step_definitions/factory_steps.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 def create_user(name, type = "User")
   first_name, last_name = name.split(" ")
-  user = type.camelize.constantize.where(first_name: first_name, last_name: last_name).first_or_create(username: name.tr(" ", "").underscore)
+  type.camelize.constantize.where(first_name: first_name, last_name: last_name).first_or_create(username: name.tr(" ", "").underscore)
 end
 
-Given /^(a|\d+)( published)?( unstarred|starred)? posts?(?: with the title "([^"]*)")?(?: and body "([^"]*)")?(?: written by "([^"]*)")?(?: in category "([^"]*)")? exists?$/ do |count, published, starred, title, body, user, category_name|
+Given(/^(a|\d+)( published)?( unstarred|starred)? posts?(?: with the title "([^"]*)")?(?: and body "([^"]*)")?(?: written by "([^"]*)")?(?: in category "([^"]*)")? exists?$/) do |count, published, starred, title, body, user, category_name|
   count = count == "a" ? 1 : count.to_i
   published = Time.now if published
   starred = starred == " starred" if starred
@@ -16,29 +16,29 @@ Given /^(a|\d+)( published)?( unstarred|starred)? posts?(?: with the title "([^"
   end
 end
 
-Given /^a category named "([^"]*)" exists$/ do |name|
+Given(/^a category named "([^"]*)" exists$/) do |name|
   Category.create! name: name
 end
 
-Given /^a (user|publisher) named "([^"]*)" exists$/ do |type, name|
+Given(/^a (user|publisher) named "([^"]*)" exists$/) do |type, name|
   create_user name, type
 end
 
-Given /^a store named "([^"]*)" exists$/ do |name|
+Given(/^a store named "([^"]*)" exists$/) do |name|
   Store.create! name: name
 end
 
-Given /^a tag named "([^"]*)" exists$/ do |name|
+Given(/^a tag named "([^"]*)" exists$/) do |name|
   Tag.create! name: name
 end
 
-Given /^a company named "([^"]*)"(?: with a store named "([^"]*)")? exists$/ do |name, store_name|
+Given(/^a company named "([^"]*)"(?: with a store named "([^"]*)")? exists$/) do |name, store_name|
   store = Store.create! name: store_name if store_name
 
   Company.create! name: name, stores: [store].compact
 end
 
-Given /^I create a new post with the title "([^"]*)"$/ do |title|
+Given(/^I create a new post with the title "([^"]*)"$/) do |title|
   first(:link, "Posts").click
   click_on "New Post"
   fill_in "post_title", with: title

--- a/features/step_definitions/filesystem_steps.rb
+++ b/features/step_definitions/filesystem_steps.rb
@@ -42,7 +42,7 @@ After "@changes-filesystem or @requires-reloading" do
   rollback!
 end
 
-Given /^"([^"]*)" contains:$/ do |filename, contents|
+Given(/^"([^"]*)" contains:$/) do |filename, contents|
   path = Rails.root + filename
   FileUtils.mkdir_p File.dirname path
   record path
@@ -50,10 +50,10 @@ Given /^"([^"]*)" contains:$/ do |filename, contents|
   File.open(path, "w+") { |f| f << contents }
 end
 
-Given /^I add "([^"]*)" to the "([^"]*)" model$/ do |code, model_name|
+Given(/^I add "([^"]*)" to the "([^"]*)" model$/) do |code, model_name|
   path = Rails.root.join "app", "models", "#{model_name}.rb"
   record path
 
-  str = File.read(path).gsub /^(class .+)$/, "\\1\n  #{code}\n"
+  str = File.read(path).gsub(/^(class .+)$/, "\\1\n  #{code}\n")
   File.open(path, "w+") { |f| f << str }
 end

--- a/features/step_definitions/filter_steps.rb
+++ b/features/step_definitions/filter_steps.rb
@@ -9,23 +9,23 @@ Around "@filters" do |scenario, block|
   end
 end
 
-Then /^I should see a select filter for "([^"]*)"$/ do |label|
+Then(/^I should see a select filter for "([^"]*)"$/) do |label|
   expect(page).to have_css ".filters-form-field.select label", text: label
 end
 
-Then /^I should see a string filter for "([^"]*)"$/ do |label|
+Then(/^I should see a string filter for "([^"]*)"$/) do |label|
   expect(page).to have_css ".filters-form-field.string label", text: label
 end
 
-Then /^I should see a date range filter for "([^"]*)"$/ do |label|
+Then(/^I should see a date range filter for "([^"]*)"$/) do |label|
   expect(page).to have_css ".filters-form-field.date_range label", text: label
 end
 
-Then /^I should see a number filter for "([^"]*)"$/ do |label|
+Then(/^I should see a number filter for "([^"]*)"$/) do |label|
   expect(page).to have_css ".filters-form-field.numeric label", text: label
 end
 
-Then /^I should see the following filters:$/ do |table|
+Then(/^I should see the following filters:$/) do |table|
   table.rows_hash.each do |label, type|
     step %{I should see a #{type} filter for "#{label}"}
   end
@@ -43,15 +43,15 @@ Then(/^I should have parameter "([^"]*)" with value "([^"]*)"$/) do |key, value|
   expect(params[key]).to eq value
 end
 
-Then /^I should see current filter "([^"]*)" equal to "([^"]*)" with label "([^"]*)"$/ do |name, value, label|
+Then(/^I should see current filter "([^"]*)" equal to "([^"]*)" with label "([^"]*)"$/) do |name, value, label|
   expect(page).to have_css ".active-filters [data-filter='#{name}'] span", text: label
   expect(page).to have_css ".active-filters [data-filter='#{name}'] strong", text: value
 end
 
-Then /^I should see current filter "([^"]*)" equal to "([^"]*)"$/ do |name, value|
+Then(/^I should see current filter "([^"]*)" equal to "([^"]*)"$/) do |name, value|
   expect(page).to have_css ".active-filters [data-filter='#{name}'] strong", text: value
 end
 
-Then /^I should see link "([^"]*)" in current filters/ do |label|
+Then(/^I should see link "([^"]*)" in current filters/) do |label|
   expect(page).to have_css ".active-filters [data-filter] strong a", text: label
 end

--- a/features/step_definitions/format_steps.rb
+++ b/features/step_definitions/format_steps.rb
@@ -14,22 +14,22 @@ Around "@csv" do |scenario, block|
 end
 
 Then "I should see nicely formatted datetimes" do
-  expect(page.body).to match /\w+ \d{1,2}, \d{4} \d{2}:\d{2}/
+  expect(page.body).to match(/\w+ \d{1,2}, \d{4} \d{2}:\d{2}/)
 end
 
-Then /^I should( not)? see a link to download "([^"]*)"$/ do |negate, format|
+Then(/^I should( not)? see a link to download "([^"]*)"$/) do |negate, format|
   method = negate ? :to_not : :to
   expect(page).send method, have_css("a", text: format)
 end
 
 # Check first rows of the displayed CSV.
-Then /^I should download a CSV file with "([^"]*)" separator for "([^"]*)" containing:$/ do |sep, resource_name, table|
+Then(/^I should download a CSV file with "([^"]*)" separator for "([^"]*)" containing:$/) do |sep, resource_name, table|
   body = page.driver.response.body
   content_type_header, content_disposition_header, last_modified_header = %w[Content-Type Content-Disposition Last-Modified].map do |header_name|
     page.response_headers[header_name]
   end
   expect(content_type_header).to eq "text/csv; charset=utf-8"
-  expect(content_disposition_header).to match /\Aattachment; filename=".+?\.csv"\z/
+  expect(content_disposition_header).to match(/\Aattachment; filename=".+?\.csv"\z/)
   expect(last_modified_header).to_not be_nil
   expect(Date.strptime(last_modified_header, "%a, %d %b %Y %H:%M:%S GMT")).to be_a(Date)
 
@@ -40,28 +40,28 @@ Then /^I should download a CSV file with "([^"]*)" separator for "([^"]*)" conta
       if expected_cell.blank?
         expect(cell).to eq nil
       else
-        expect(cell || "").to match /#{expected_cell}/
+        expect(cell || "").to match(/#{expected_cell}/)
       end
     end
   end
 end
 
-Then /^I should download a CSV file for "([^"]*)" containing:$/ do |resource_name, table|
+Then(/^I should download a CSV file for "([^"]*)" containing:$/) do |resource_name, table|
   step %{I should download a CSV file with "," separator for "#{resource_name}" containing:}, table
 end
 
-Then /^the CSV file should contain "([^"]*)" in quotes$/ do |text|
-  expect(page.driver.response.body).to match /"#{text}"/
+Then(/^the CSV file should contain "([^"]*)" in quotes$/) do |text|
+  expect(page.driver.response.body).to match(/"#{text}"/)
 end
 
-Then /^the encoding of the CSV file should be "([^"]*)"$/ do |text|
+Then(/^the encoding of the CSV file should be "([^"]*)"$/) do |text|
   expect(page.driver.response.body.encoding).to be Encoding.find(Encoding.aliases[text] || text)
 end
 
-Then /^the CSV file should start with BOM$/ do
+Then(/^the CSV file should start with BOM$/) do
   expect(page.driver.response.body.bytes).to start_with(239, 187, 191)
 end
 
-Then /^access denied$/ do
+Then(/^access denied$/) do
   expect(page).to have_content(I18n.t("active_admin.access_denied.message"))
 end

--- a/features/step_definitions/i18n_steps.rb
+++ b/features/step_definitions/i18n_steps.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
-When /^I set my locale to "([^"]*)"$/ do |lang|
+When(/^I set my locale to "([^"]*)"$/) do |lang|
   I18n.locale = lang
 end

--- a/features/step_definitions/index_scope_steps.rb
+++ b/features/step_definitions/index_scope_steps.rb
@@ -1,25 +1,25 @@
 # frozen_string_literal: true
-Then /^I should( not)? see the scope "([^"]*)"( selected)?$/ do |negate, name, selected|
+Then(/^I should( not)? see the scope "([^"]*)"( selected)?$/) do |negate, name, selected|
   should = "I should#{' not' if negate}"
   scope = ".scopes#{' .index-button-selected' if selected}"
   step %{#{should} see "#{name}" within "#{scope}"}
 end
 
-Then /^I should see the scope "([^"]*)" not selected$/ do |name|
+Then(/^I should see the scope "([^"]*)" not selected$/) do |name|
   step %{I should see the scope "#{name}"}
   expect(page).to have_no_css ".scopes .index-button-selected", text: name
 end
 
-Then /^I should see the scope "([^"]*)" with the count (\d+)$/ do |name, count|
+Then(/^I should see the scope "([^"]*)" with the count (\d+)$/) do |name, count|
   expect(page).to have_css ".scopes a", text: name
   expect(page).to have_css ".scopes-count", text: count
 end
 
-Then /^I should see the scope with label "([^"]*)"$/ do |label|
+Then(/^I should see the scope with label "([^"]*)"$/) do |label|
   expect(page).to have_link(label)
 end
 
-Then /^I should see the scope "([^"]*)" with no count$/ do |name|
+Then(/^I should see the scope "([^"]*)" with no count$/) do |name|
   expect(page).to have_css ".scopes a", text: name
   expect(page).to have_no_css ".scopes-count"
 end

--- a/features/step_definitions/menu_steps.rb
+++ b/features/step_definitions/menu_steps.rb
@@ -1,24 +1,24 @@
 # frozen_string_literal: true
-Then /^I should see a menu item for "([^"]*)"$/ do |name|
+Then(/^I should see a menu item for "([^"]*)"$/) do |name|
   expect(page).to have_css "#main-menu li a", text: name
 end
 
-Then /^I should not see a menu item for "([^"]*)"$/ do |name|
+Then(/^I should not see a menu item for "([^"]*)"$/) do |name|
   expect(page).to have_no_css "#main-menu li a", text: name
 end
 
-Then /^the "([^"]*)" menu item should be hidden$/ do |name|
+Then(/^the "([^"]*)" menu item should be hidden$/) do |name|
   expect(page).to have_css "#main-menu .hidden a", text: name
 end
 
-Then /^I should see a menu parent for "([^"]*)"$/ do |name|
+Then(/^I should see a menu parent for "([^"]*)"$/) do |name|
   expect(page).to have_css "#main-menu li button", text: name
 end
 
-Then /^I should see a nested menu item for "([^"]*)"$/ do |name|
+Then(/^I should see a nested menu item for "([^"]*)"$/) do |name|
   expect(page).to have_css "#main-menu li li a", text: name
 end
 
-Then /^the "([^"]*)" menu item should be selected$/ do |name|
+Then(/^the "([^"]*)" menu item should be selected$/) do |name|
   expect(page).to have_css "#main-menu li a.selected", text: name
 end

--- a/features/step_definitions/pagination_steps.rb
+++ b/features/step_definitions/pagination_steps.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
-Then /^I should not see pagination$/ do
+Then(/^I should not see pagination$/) do
   expect(page).to have_no_css "[data-test-pagination]"
 end
 
-Then /^I should see pagination page (\d+) link$/ do |num|
+Then(/^I should see pagination page (\d+) link$/) do |num|
   expect(page).to have_css "[data-test-pagination] a", text: num, count: 1
 end
 
-Then /^I should see the pagination "Next" link/ do
+Then(/^I should see the pagination "Next" link/) do
   expect(page).to have_css "[data-test-pagination] a", text: "Next"
 end
 
-Then /^I should not see the pagination "Next" link/ do
+Then(/^I should not see the pagination "Next" link/) do
   expect(page).to have_no_css "[data-test-pagination] a", text: "Next"
 end

--- a/features/step_definitions/site_title_steps.rb
+++ b/features/step_definitions/site_title_steps.rb
@@ -9,6 +9,6 @@ Around "@site_title" do |scenario, block|
   end
 end
 
-Then /^I should see the site title "([^"]*)"$/ do |title|
+Then(/^I should see the site title "([^"]*)"$/) do |title|
   expect(page).to have_css "[data-test-site-title]", text: title
 end

--- a/features/step_definitions/table_steps.rb
+++ b/features/step_definitions/table_steps.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-Then /^I should see (\d+) ([\w]*) in the table$/ do |count, resource_type|
+Then(/^I should see (\d+) ([\w]*) in the table$/) do |count, resource_type|
   expect(page).to have_css(".data-table tr > td:first-child", count: count.to_i)
 end
 
@@ -11,7 +11,7 @@ Then("I should not see {string} in the table") do |string|
   expect(page).to have_no_css(".data-table tr > td", text: string)
 end
 
-Then /^I should see an id_column link to edit page$/ do
+Then(/^I should see an id_column link to edit page$/) do
   expect(page).to have_css(".data-table a[href*='/edit']", text: /^\d+$/)
 end
 
@@ -41,7 +41,7 @@ class HtmlTableToTextHelper
       str += input_to_string(input)
     end
 
-    str += td.content.strip.tr("\n", " ")
+    str + td.content.strip.tr("\n", " ")
   end
 
   def input_to_string(input)
@@ -90,7 +90,7 @@ module TableMatchHelper
 
   def assert_cells_match(cell, expected_cell)
     if /^\/.*\/$/.match?(expected_cell)
-      expect(cell).to match /#{expected_cell[1..-2]}/
+      expect(cell).to match(/#{expected_cell[1..-2]}/)
     else
       expect((cell || "").strip).to eq expected_cell
     end
@@ -106,7 +106,7 @@ World(TableMatchHelper)
 #     |    /\d+/     | 27/01/12 |       $30.00 |
 #     |    /\d+/     | 12/02/12 |       $25.00 |
 #
-Then /^I should see the "([^"]*)" table:$/ do |table_id, expected_table|
+Then(/^I should see the "([^"]*)" table:$/) do |table_id, expected_table|
   expect(page).to have_css "table##{table_id}"
 
   assert_tables_match(

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -3,16 +3,16 @@ def ensure_user_created(email)
   AdminUser.create_with(password: "password", password_confirmation: "password").find_or_create_by!(email: email)
 end
 
-Given /^(?:I am logged|log) out$/ do
+Given(/^(?:I am logged|log) out$/) do
   click_on "Sign out" if page.all(:css, "a", text: "Sign out").any?
 end
 
-Given /^I am logged in$/ do
+Given(/^I am logged in$/) do
   logout(:user)
   login_as ensure_user_created "admin@example.com"
 end
 
-Given /^I am logged in with capybara$/ do
+Given(/^I am logged in with capybara$/) do
   ensure_user_created "admin@example.com"
   step "log out"
 
@@ -22,11 +22,11 @@ Given /^I am logged in with capybara$/ do
   click_on "Sign In"
 end
 
-Given /^an admin user "([^"]*)" exists$/ do |email|
+Given(/^an admin user "([^"]*)" exists$/) do |email|
   ensure_user_created(email)
 end
 
-Given /^"([^"]*)" requests a password reset with token "([^"]*)"( but it expires)?$/ do |email, token, expired|
+Given(/^"([^"]*)" requests a password reset with token "([^"]*)"( but it expires)?$/) do |email, token, expired|
   visit new_admin_user_password_path
   fill_in "Email", with: email
   allow(Devise).to receive(:friendly_token).and_return(token)
@@ -35,13 +35,13 @@ Given /^"([^"]*)" requests a password reset with token "([^"]*)"( but it expires
   AdminUser.where(email: email).first.update_attribute :reset_password_sent_at, 1.month.ago if expired
 end
 
-Given /^override locale "([^"]*)" with "([^"]*)"$/ do |path, value|
+Given(/^override locale "([^"]*)" with "([^"]*)"$/) do |path, value|
   keys_value = path.split(".") + [value]
   locale_hash = keys_value.reverse.inject { |a, n| { n => a } }
   I18n.available_locales
   I18n.backend.store_translations(I18n.locale, locale_hash)
 end
 
-When /^I fill in the password field with "([^"]*)"$/ do |password|
+When(/^I fill in the password field with "([^"]*)"$/) do |password|
   fill_in "admin_user_password", with: password
 end

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -43,61 +43,61 @@ module WithinHelpers
 end
 World(WithinHelpers)
 
-When /^(.*) within (.*)$/ do |step_name, parent|
+When(/^(.*) within (.*)$/) do |step_name, parent|
   with_scope(parent) { step step_name }
 end
 
-Given /^I am on (.+)$/ do |page_name|
+Given(/^I am on (.+)$/) do |page_name|
   visit path_to(page_name)
 end
 
-When /^I go to (.+)$/ do |page_name|
+When(/^I go to (.+)$/) do |page_name|
   visit path_to(page_name)
 end
 
-When /^I visit (.+) twice$/ do |page_name|
+When(/^I visit (.+) twice$/) do |page_name|
   2.times { visit path_to(page_name) }
 end
 
-When /^I press "([^"]*)"$/ do |button|
+When(/^I press "([^"]*)"$/) do |button|
   click_on(button)
 end
 
-When /^I follow "([^"]*)"$/ do |link|
+When(/^I follow "([^"]*)"$/) do |link|
   first(:link, link).click
 end
 
-When /^I click "(.*?)"$/ do |link|
+When(/^I click "(.*?)"$/) do |link|
   click_on(link)
 end
 
-When /^I fill in "([^"]*)" with "([^"]*)"$/ do |field, value|
+When(/^I fill in "([^"]*)" with "([^"]*)"$/) do |field, value|
   fill_in(field, with: value)
 end
 
-When /^I select "([^"]*)" from "([^"]*)"$/ do |value, field|
+When(/^I select "([^"]*)" from "([^"]*)"$/) do |value, field|
   select(value, from: field)
 end
 
-When /^I (check|uncheck) "([^"]*)"$/ do |action, field|
+When(/^I (check|uncheck) "([^"]*)"$/) do |action, field|
   send action, field
 end
 
-Then /^I should( not)? see( the element)? "([^"]*)"$/ do |negate, is_css, text|
+Then(/^I should( not)? see( the element)? "([^"]*)"$/) do |negate, is_css, text|
   should = negate ? :not_to : :to
   have = is_css ? have_css(text) : have_content(text)
   expect(page).send should, have
 end
 
-Then /^I should see the select "([^"]*)" with options "([^"]+)"?$/ do |label, with_options|
+Then(/^I should see the select "([^"]*)" with options "([^"]+)"?$/) do |label, with_options|
   expect(page).to have_select(label, with_options: with_options.split(", "))
 end
 
-Then /^I should see the field "([^"]*)" of type "([^"]+)"?$/ do |label, of_type|
+Then(/^I should see the field "([^"]*)" of type "([^"]+)"?$/) do |label, of_type|
   expect(page).to have_field(label, type: of_type)
 end
 
-Then /^the "([^"]*)" field(?: within (.*))? should contain "([^"]*)"$/ do |field, parent, value|
+Then(/^the "([^"]*)" field(?: within (.*))? should contain "([^"]*)"$/) do |field, parent, value|
   with_scope(parent) do
     field = find_field(field)
     value = field.tag_name == "textarea" ? field.text : field.value
@@ -106,13 +106,13 @@ Then /^the "([^"]*)" field(?: within (.*))? should contain "([^"]*)"$/ do |field
   end
 end
 
-Then /^the "([^"]*)" select(?: within (.*))? should have "([^"]+)" selected$/ do |label, parent, option|
+Then(/^the "([^"]*)" select(?: within (.*))? should have "([^"]+)" selected$/) do |label, parent, option|
   with_scope(parent) do
     expect(page).to have_select(label, selected: option)
   end
 end
 
-Then /^the "([^"]*)" checkbox(?: within (.*))? should( not)? be checked$/ do |label, parent, negate|
+Then(/^the "([^"]*)" checkbox(?: within (.*))? should( not)? be checked$/) do |label, parent, negate|
   with_scope(parent) do
     checkbox = find_field(label)
     if negate
@@ -123,7 +123,7 @@ Then /^the "([^"]*)" checkbox(?: within (.*))? should( not)? be checked$/ do |la
   end
 end
 
-Then /^I should be on (.+)$/ do |page_name|
+Then(/^I should be on (.+)$/) do |page_name|
   expect(URI.parse(current_url).path).to eq path_to page_name
 end
 
@@ -131,6 +131,6 @@ Then(/^I should see content "(.*?)" above other content "(.*?)"$/) do |top_title
   expect(page).to have_css %Q(div:contains('#{top_title}') + div:contains('#{bottom_title}'))
 end
 
-Then /^I should see a flash with "([^"]*)"$/ do |text|
+Then(/^I should see a flash with "([^"]*)"$/) do |text|
   expect(page).to have_content text
 end

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -63,7 +63,7 @@ module NavigationHelpers
         path_components = $1.split(/\s+/)
         self.send path_components.push("path").join("_")
         # :nocov:
-      rescue Object => e
+      rescue Object
         raise "Can't find mapping from \"#{page_name}\" to a path.\n" +
           "Now, go and add a mapping in #{__FILE__}"
         # :nocov:

--- a/lib/active_admin/resource/naming.rb
+++ b/lib/active_admin/resource/naming.rb
@@ -5,7 +5,7 @@ module ActiveAdmin
     module Naming
       def resource_name
         @resource_name ||= begin
-          as = @options[:as].gsub /\s/, "" if @options[:as]
+          as = @options[:as].gsub(/\s/, "") if @options[:as]
 
           if as || !resource_class.respond_to?(:model_name)
             Name.new resource_class, as

--- a/spec/helpers/display_helper_spec.rb
+++ b/spec/helpers/display_helper_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe ActiveAdmin::DisplayHelper, type: :helper do
 
       value = helper.format_attribute post, :author
 
-      expect(value).to match /<a href="\/admin\/users\/\d+">User \#\d+<\/a>/
+      expect(value).to match(/<a href="\/admin\/users\/\d+">User \#\d+<\/a>/)
     end
 
     it "auto-links ActiveRecord records & uses a display_name method" do
@@ -212,7 +212,7 @@ RSpec.describe ActiveAdmin::DisplayHelper, type: :helper do
 
       value = helper.format_attribute post, :author
 
-      expect(value).to match /<a href="\/admin\/users\/\d+">A B<\/a>/
+      expect(value).to match(/<a href="\/admin\/users\/\d+">A B<\/a>/)
     end
 
     it "calls status_tag for boolean values" do

--- a/spec/unit/comments_spec.rb
+++ b/spec/unit/comments_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe "Comments" do
       let(:namespace_name) { "admin" }
 
       it "should assign child class as commented resource" do
-        comment = ActiveAdmin::Comment.create!(
+        ActiveAdmin::Comment.create!(
           author: user,
           resource: publisher,
           body: "Lorem Ipsum",

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe ActiveAdmin::FormBuilder do
   def form_html(options = {}, form_object = Post.new, &block)
     options = { url: helpers.posts_path }.merge(options)
 
-    form = render_arbre_component({ form_object: form_object, form_options: options, form_block: block }, helpers) do
+    render_arbre_component({ form_object: form_object, form_options: options, form_block: block }, helpers) do
       active_admin_form_for(assigns[:form_object], assigns[:form_options], &assigns[:form_block])
     end.to_s
   end

--- a/spec/unit/namespace/register_resource_spec.rb
+++ b/spec/unit/namespace/register_resource_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe ActiveAdmin::Namespace, "registering a resource" do
     end
 
     it "should return the resource if it and it's parent were registered" do
-      user = namespace.register User
+      namespace.register User
       publisher = namespace.register Publisher
       expect(namespace.resource_for(Publisher)).to eq publisher
     end

--- a/tasks/release.rake
+++ b/tasks/release.rake
@@ -4,7 +4,7 @@ require "open3"
 namespace :release do
   desc "Publish npm package"
   task :npm_push do
-    npm_version, error, status = Open3.capture3("npm pkg get version")
+    npm_version, _error, _status = Open3.capture3("npm pkg get version")
     npm_tag = npm_version.include?("-") ? "pre" : "latest"
     system "npm", "publish", "--tag", npm_tag, exception: true
   end


### PR DESCRIPTION
- Lint/AmbiguousRegexpLiteral
- Lint/UselessAssignment

All cops are marked as safe to autocorrect

Additionally:
- Sort Lint cops in RuboCop configuration file
- Enable new `Performance/StringBytesize` to silence a warning

Ref: #8597
