### PR TITLE
Bump Formtastic to 5.0 and remove legacy code

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,8 +4,8 @@ PATH
     activeadmin (4.0.0.beta15)
       arbre (~> 2.0)
       csv
-      formtastic (>= 3.1)
-      formtastic_i18n (>= 0.4)
+      formtastic (>= 5.0)
+      formtastic_i18n (>= 0.7)
       inherited_resources (~> 2.0)
       kaminari (>= 1.2.1)
       railties (>= 7.0)

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -33,8 +33,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency "arbre", "~> 2.0"
   s.add_dependency "csv"
-  s.add_dependency "formtastic", ">= 3.1"
-  s.add_dependency "formtastic_i18n", ">= 0.4"
+  s.add_dependency "formtastic", ">= 5.0"
+  s.add_dependency "formtastic_i18n", ">= 0.7"
   s.add_dependency "inherited_resources", "~> 2.0"
   s.add_dependency "kaminari", ">= 1.2.1"
   s.add_dependency "railties", ">= 7.0"

--- a/gemfiles/rails_70/Gemfile.lock
+++ b/gemfiles/rails_70/Gemfile.lock
@@ -4,8 +4,8 @@ PATH
     activeadmin (4.0.0.beta15)
       arbre (~> 2.0)
       csv
-      formtastic (>= 3.1)
-      formtastic_i18n (>= 0.4)
+      formtastic (>= 5.0)
+      formtastic_i18n (>= 0.7)
       inherited_resources (~> 2.0)
       kaminari (>= 1.2.1)
       railties (>= 7.0)

--- a/gemfiles/rails_71/Gemfile.lock
+++ b/gemfiles/rails_71/Gemfile.lock
@@ -4,8 +4,8 @@ PATH
     activeadmin (4.0.0.beta15)
       arbre (~> 2.0)
       csv
-      formtastic (>= 3.1)
-      formtastic_i18n (>= 0.4)
+      formtastic (>= 5.0)
+      formtastic_i18n (>= 0.7)
       inherited_resources (~> 2.0)
       kaminari (>= 1.2.1)
       railties (>= 7.0)

--- a/gemfiles/rails_72/Gemfile.lock
+++ b/gemfiles/rails_72/Gemfile.lock
@@ -4,8 +4,8 @@ PATH
     activeadmin (4.0.0.beta15)
       arbre (~> 2.0)
       csv
-      formtastic (>= 3.1)
-      formtastic_i18n (>= 0.4)
+      formtastic (>= 5.0)
+      formtastic_i18n (>= 0.7)
       inherited_resources (~> 2.0)
       kaminari (>= 1.2.1)
       railties (>= 7.0)

--- a/lib/active_admin/filters/forms.rb
+++ b/lib/active_admin/filters/forms.rb
@@ -7,9 +7,6 @@ module ActiveAdmin
       include ::ActiveAdmin::Filters::FormtasticAddons
       self.input_namespaces = [::Object, ::ActiveAdmin::Inputs::Filters, ::ActiveAdmin::Inputs, ::Formtastic::Inputs]
 
-      # TODO: remove input class finders after formtastic 4 (where it will be default)
-      self.input_class_finder = ::Formtastic::InputClassFinder
-
       def filter(method, options = {})
         if method.present? && options[:as] ||= default_input_type(method)
           template.concat input(method, options)

--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -17,10 +17,6 @@ module ActiveAdmin
 
     self.input_namespaces = [::Object, ::ActiveAdmin::Inputs, ::Formtastic::Inputs]
 
-    # TODO: remove both class finders after formtastic 4 (where it will be default)
-    self.input_class_finder = ::Formtastic::InputClassFinder
-    self.action_class_finder = ::Formtastic::ActionClassFinder
-
     def cancel_link(url = { action: "index" }, html_options = {}, li_attrs = {})
       li_attrs[:class] ||= "action cancel"
       html_options[:class] ||= "cancel-link"


### PR DESCRIPTION
This commit addresses TODO notes in the code related to Formtastic < 4
and sets the minimum required Formtastic version to >= 5.0

Confirmed defaults:
- https://github.com/formtastic/formtastic/blob/473f5cef34de5ffe8812a3b0b07f167a22f8c4b9/lib/formtastic/form_builder.rb#L46
- https://github.com/formtastic/formtastic/blob/473f5cef34de5ffe8812a3b0b07f167a22f8c4b9/lib/formtastic/form_builder.rb#L49

---

Should be also backported to v3