### PR TITLE
Fix: Ensure Unique Tab IDs for Non-Latin Titles

### DIFF
--- a/lib/active_admin/views/components/tabs.rb
+++ b/lib/active_admin/views/components/tabs.rb
@@ -15,6 +15,7 @@ module ActiveAdmin
         add_class "tabs"
         @menu = nav(class: "tabs-nav", role: "tablist", "data-tabs-toggle": "#tabs-container-#{object_id}")
         @tabs_content = div(class: "tabs-content", id: "tabs-container-#{object_id}")
+        @fragments = {}
       end
 
       def build_menu_item(title, options, &block)
@@ -33,7 +34,7 @@ module ActiveAdmin
       private
 
       def fragmentize(string)
-        "tabs-#{string.parameterize}-#{object_id}"
+        @fragments[string] ||= "tabs-#{string.parameterize.presence || SecureRandom.hex.first(8)}-#{object_id}"
       end
     end
   end

--- a/spec/unit/views/components/tabs_spec.rb
+++ b/spec/unit/views/components/tabs_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe ActiveAdmin::Views::Tabs do
       end
 
       it "should handle fragmentizing non-English title" do
-        expect(subject).not_to have_css("[data-tabs-target='#tabs--#{tabs.object_id}']")
+        expect(subject).to have_no_css("[data-tabs-target='#tabs--#{tabs.object_id}']")
       end
     end
 

--- a/spec/unit/views/components/tabs_spec.rb
+++ b/spec/unit/views/components/tabs_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe ActiveAdmin::Views::Tabs do
           tabs do
             tab :overview
             tab "Sample", id: :something_unique, html_options: { class: :some_css_class }
+            tab "عبدالله"
+            tab "اليحيى"
           end
         end
       end
@@ -37,6 +39,10 @@ RSpec.describe ActiveAdmin::Views::Tabs do
 
       it "should have button with specific css class" do
         expect(subject).to have_link(class: "some_css_class")
+      end
+
+      it "should handle fragmentizing non-English title" do
+        expect(subject).not_to have_css("[data-tabs-target='#tabs--#{tabs.object_id}']")
       end
     end
 


### PR DESCRIPTION
Fix: Ensure Unique Tab IDs for Non-Latin Titles
---

**This PR fixes an issue that occurs when using non-Latin titles for tabs without specifying a custom id** 

## Issue:

When using non-Latin titles for tabs without specifying a custom id, the generated HTML assigns duplicate id values due to `String#parameterize` returning an empty string for non-Latin characters.

## Example:

```ruby
tabs do
  tab "عبدالله" do
    span "tab 1"
  end
  tab "خالد" do
    span "tab 2"
  end
end
```
 
**Generates:**
```html
<nav class="tabs-nav" role="tablist" data-tabs-toggle="#tabs-container-32328">
  <a data-tabs-target="#tabs--32328" role="tab" aria-controls="tabs--32328" href="#" class="text-blue-600 hover:text-blue-600 dark:text-blue-500 dark:hover:text-blue-500 border-blue-600 dark:border-blue-500" aria-selected="true">عبدالله</a>
  <a data-tabs-target="#tabs--32328" role="tab" aria-controls="tabs--32328" href="#" class="dark:border-transparent text-gray-500 hover:text-gray-600 dark:text-gray-400 border-gray-100 hover:border-gray-300 dark:border-gray-700 dark:hover:text-gray-300" aria-selected="false">خالد</a>
</nav>

```

Since both tabs receive the same id, tab navigation breaks.

## Cause

string.parameterize ignores non-Latin characters and returns an empty string:
```ruby
string = "عبدالله"
string.parameterize #=> ""
```

## Fix:

If parameterize returns an empty string, we now generate a random string using `SecureRandom.hex.first(8)` to ensure uniqueness. A new instance variable, `@fragments`, tracks generated IDs to maintain reference consistency.

Changes
	•	Ensured unique tab id generation when parameterize results in an empty string.
	•	Introduced @fragments to store generated IDs.
	•	Added a test case to verify correctness.