### PR TITLE
Rename method to add_default_destroy_action_item for accuracy

### DIFF
--- a/lib/active_admin/resource/action_items.rb
+++ b/lib/active_admin/resource/action_items.rb
@@ -59,7 +59,7 @@ module ActiveAdmin
       def add_default_action_items
         add_default_new_action_item
         add_default_edit_action_item
-        add_default_show_action_item
+        add_default_destroy_action_item
       end
 
       # Adds the default New link on index
@@ -79,7 +79,7 @@ module ActiveAdmin
       end
 
       # Adds the default Destroy link on show
-      def add_default_show_action_item
+      def add_default_destroy_action_item
         add_action_item :destroy, only: :show, if: -> { destroy_action_authorized?(resource) } do
           localizer = ActiveAdmin::Localizers.resource(active_admin_config)
           link_to(


### PR DESCRIPTION
**This PR renames `ActionItems#add_default_show_action_item` to `ActionItems#add_default_destroy_action_item` for Consistency**


## Issue:

The method responsible for adding the default destroy action is inconsistently named as `add_default_show_action_item`, while similar methods follow a clear naming pattern:
* `add_default_new_action_item`
* `add_default_edit_action_item`
* `add_default_show_action_item` (incorrectly named, actually adds destroy action)

This inconsistency may cause confusion when reading or maintaining the code.

## Fix:

This PR renames `add_default_show_action_item` to `add_default_destroy_action_item` to align with the naming convention used for other default actions.

## Changes: 
* Renamed `ActionItems#add_default_show_action_item` → `ActionItems#add_default_destroy_action_item`.