### PR TITLE
Backport Support sortable argument in id_column

### DIFF
--- a/lib/active_admin/views/index_as_table.rb
+++ b/lib/active_admin/views/index_as_table.rb
@@ -291,9 +291,9 @@ module ActiveAdmin
         end
 
         # Display a column for the id
-        def id_column
+        def id_column(sortable: resource_class.primary_key)
           raise "#{resource_class.name} has no primary_key!" unless resource_class.primary_key
-          column(resource_class.human_attribute_name(resource_class.primary_key), sortable: resource_class.primary_key) do |resource|
+          column(resource_class.human_attribute_name(resource_class.primary_key), sortable: sortable) do |resource|
             if controller.action_methods.include?("show")
               link_to resource.id, resource_path(resource), class: "resource_id_link"
             elsif controller.action_methods.include?("edit")

--- a/spec/unit/views/components/index_table_for_spec.rb
+++ b/spec/unit/views/components/index_table_for_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe ActiveAdmin::Views::IndexAsTable::IndexTableFor do
     let(:assigns) do
       {
         collection: collection,
-        active_admin_config: active_admin_config
+        active_admin_config: active_admin_config,
+        resource_class: User,
       }
     end
     let(:helpers) { mock_action_view }
@@ -41,6 +42,36 @@ RSpec.describe ActiveAdmin::Views::IndexAsTable::IndexTableFor do
         it "not sortable" do
           expect(header.attributes[:class]).not_to include "sortable"
         end
+      end
+    end
+
+    context "when creating an id column" do
+      before { allow(helpers).to receive(:url_for).and_return("routing_stub") }
+
+      def build_index_table(&block)
+        render_arbre_component assigns, helpers do
+          insert_tag(ActiveAdmin::Views::IndexAsTable::IndexTableFor, collection, { sortable: true }) do
+            instance_exec(&block)
+          end
+        end
+      end
+
+      it "is sortable by default" do
+        table = build_index_table { id_column }
+        header = table.find_by_tag("th").first
+        expect(header.attributes[:class]).to include("sortable")
+      end
+
+      it "supports sortable: false" do
+        table = build_index_table { id_column sortable: false }
+        header = table.find_by_tag("th").first
+        expect(header.attributes[:class]).not_to include("sortable")
+      end
+
+      it "supports sortable column names" do
+        table = build_index_table { id_column sortable: :created_at }
+        header = table.find_by_tag("th").first
+        expect(header.attributes[:class]).to include("sortable")
       end
     end
 


### PR DESCRIPTION
Backport https://github.com/activeadmin/activeadmin/pull/8639

---------------------

This is mostly useful to prevent sorting on tables with uuid PKs.

Sorting by uuid isn't very useful, and it can have problematic performance if the table is very large, even if there is an index.