### PR TITLE
Bump dependencies to match master

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,7 +272,8 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
+      net-protocol
     netrc (0.11.0)
     nio4r (2.7.4)
     nokogiri (1.18.2)

--- a/gemfiles/rails_61/Gemfile.lock
+++ b/gemfiles/rails_61/Gemfile.lock
@@ -251,7 +251,7 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
     nio4r (2.7.4-java)

--- a/gemfiles/rails_71/Gemfile.lock
+++ b/gemfiles/rails_71/Gemfile.lock
@@ -279,7 +279,8 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
+      net-protocol
     netrc (0.11.0)
     nio4r (2.7.4)
     nokogiri (1.18.2)

--- a/gemfiles/rails_72/Gemfile.lock
+++ b/gemfiles/rails_72/Gemfile.lock
@@ -272,7 +272,8 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
+      net-protocol
     netrc (0.11.0)
     nio4r (2.7.4)
     nokogiri (1.18.2)


### PR DESCRIPTION
Be able to reuse caches.

Check https://github.com/activeadmin/activeadmin/actions/runs/13732558140/job/38412049031.

![image](https://github.com/user-attachments/assets/7cfdfb82-14b0-4236-a1c4-6c021e1c8d31)

Problem found while working in https://github.com/activeadmin/activeadmin/pull/8650
