### PR TITLE
Backport Support sortable argument in id_column

### DIFF
--- a/lib/active_admin/views/index_as_table.rb
+++ b/lib/active_admin/views/index_as_table.rb
@@ -291,9 +291,14 @@ module ActiveAdmin
         end
 
         # Display a column for the id
-        def id_column(sortable: resource_class.primary_key)
+        def id_column(*args)
           raise "#{resource_class.name} has no primary_key!" unless resource_class.primary_key
-          column(resource_class.human_attribute_name(resource_class.primary_key), sortable: sortable) do |resource|
+
+          options = args.extract_options!
+          title = args[0].presence || resource_class.human_attribute_name(resource_class.primary_key)
+          sortable = options.fetch(:sortable, resource_class.primary_key)
+
+          column(title, sortable: sortable) do |resource|
             if controller.action_methods.include?("show")
               link_to resource.id, resource_path(resource), class: "resource_id_link"
             elsif controller.action_methods.include?("edit")

--- a/spec/unit/views/components/index_table_for_spec.rb
+++ b/spec/unit/views/components/index_table_for_spec.rb
@@ -56,6 +56,18 @@ RSpec.describe ActiveAdmin::Views::IndexAsTable::IndexTableFor do
         end
       end
 
+      it "use primary key as title by default" do
+        table = build_index_table { id_column }
+        header = table.find_by_tag("th").first
+        expect(header.content).to include("Id")
+      end
+
+      it "supports title customization" do
+        table = build_index_table { id_column "Res. Id" }
+        header = table.find_by_tag("th").first
+        expect(header.content).to include("Res. Id")
+      end
+
       it "is sortable by default" do
         table = build_index_table { id_column }
         header = table.find_by_tag("th").first
@@ -71,6 +83,13 @@ RSpec.describe ActiveAdmin::Views::IndexAsTable::IndexTableFor do
       it "supports sortable column names" do
         table = build_index_table { id_column sortable: :created_at }
         header = table.find_by_tag("th").first
+        expect(header.attributes[:class]).to include("sortable")
+      end
+
+      it "supports title customization and options" do
+        table = build_index_table { id_column "Res. Id", sortable: :created_at }
+        header = table.find_by_tag("th").first
+        expect(header.content).to include("Res. Id")
         expect(header.attributes[:class]).to include("sortable")
       end
     end


### PR DESCRIPTION
Backport https://github.com/activeadmin/activeadmin/pull/8641

---------------------

I'm building the index page of a resource. I must display the resource id as the first column but with a different title than "Id".

Using I18n to affect `id`'s `human_attribute_name` is not a valid solution because that's a global change. The only workaround is to write the full column myself.

This PR adds support to customize `id_column` title.