### PR TITLE
Adds padding to button unordered lists

### DIFF
--- a/app/views/active_admin/_main_navigation.html.erb
+++ b/app/views/active_admin/_main_navigation.html.erb
@@ -10,7 +10,7 @@
               <path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" />
             </svg>
           </button>
-          <ul role="list" class="mt-1 space-y-1 hidden group-data-[open]:block">
+          <ul role="list" class="mt-1 space-y-1 hidden group-data-[open]:block pl-3">
             <% children.each do |j| %>
               <li data-item-id="<%= j.id %>">
                 <%= link_to j.label(self), j.url(self), j.html_options.merge(class: "text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white block rounded-md py-1.5 px-2 text-sm no-underline #{(current_menu_item?(j) ? "bg-gray-100 dark:bg-white/5 text-gray-900 dark:text-white selected" : "")}") %>


### PR DESCRIPTION
This tiny PR adds some padding to the unordered lists that represent a buttons children. 

Having recently upgraded to the latest version, I noticed that when there is a large amount of items in the left hand navigation it becomes hard to get a visual lock on which item on the left hand menu is selected.  Without rewriting all the colors you use, I think this small padding tweak gets around the majority of the issue.

Before:

<img width="218" alt="image" src="https://github.com/user-attachments/assets/bee60ef7-5d56-4d14-83b8-6f715cd8be68" />

After:

<img width="222" alt="image" src="https://github.com/user-attachments/assets/f1c24006-3a4f-4117-91ad-51dc59f29842" />
