### PR TITLE
Introduce ActiveAdmin::ActionPolicyAdapter

### DIFF
--- a/lib/active_admin/action_policy_adapter.rb
+++ b/lib/active_admin/action_policy_adapter.rb
@@ -1,0 +1,44 @@
+module ActiveAdmin
+  class ActionPolicyAdapter < AuthorizationAdapter
+    def authorized?(action, subject = nil)
+      target = policy_target(subject)
+      policy = ActionPolicy.lookup(target)
+      action = format_action(action, subject)
+      policy.new(target, user: user).apply(action)
+    end
+
+    def scope_collection(collection, _action = Auth::READ)
+      target = policy_target(collection)
+      policy = ActionPolicy.lookup(target)
+      policy.new(user: user).apply_scope(collection, type: :active_admin)
+    end
+
+    def format_action(action, subject)
+      case action
+      when Auth::CREATE
+        :create?
+      when Auth::UPDATE
+        :update?
+      when Auth::READ
+        subject.is_a?(Class) ? :index? : :show?
+      when Auth::DESTROY
+        subject.is_a?(Class) ? :destroy_all? : :destroy?
+      else
+        "#{action}?"
+      end
+    end
+
+    private
+
+    def policy_target(subject)
+      case subject
+      when nil
+        resource.resource_class
+      when Class
+        subject.new
+      else
+        subject
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces a new ActiveAdmin::ActionPolicyAdapter to enable integration with the [Action Policy](https://actionpolicy.evilmartians.io/) authorization framework. The adapter implements both #authorized? and #scope_collection methods, mapping ActiveAdmin’s internal permissions to Action Policy’s rules and scopes.

ActiveAdmin supports a pluggable authorization system, but out of the box, it only provides adapters for popular frameworks like Pundit and CanCanCan. As more teams adopt [Action Policy](https://actionpolicy.evilmartians.io/) for its performance, flexibility, and first-class Rails support, it’s increasingly desirable to make ActiveAdmin compatible with it out of the box.

References:
- https://gist.github.com/amkisko/c704c1a6462d573dfa4820ae07d807a6
- https://actionpolicy.evilmartians.io

<!--

Thanks for contributing to ActiveAdmin!

You can find the instructions in our contributing guide: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md

Before submitting your PR make sure that:
* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are separated.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all CI checks are passing, but feel free to ask for early feedback if you need guidance.

[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->
