### PR TITLE
Add I18n scope for Ransack predicate translations

### DIFF
--- a/lib/active_admin/filters/active_filter.rb
+++ b/lib/active_admin/filters/active_filter.rb
@@ -5,6 +5,10 @@ module ActiveAdmin
     class ActiveFilter
       attr_reader :resource, :condition, :related_class
 
+      def self.predicate_name(name)
+        I18n.t("active_admin.ransack.predicates.#{name}", default: Ransack::Translate.predicate(name))
+      end
+
       # Instantiate a `ActiveFilter`
       #
       # @param resource [ActiveAdmin::Resource] current resource
@@ -38,9 +42,7 @@ module ActiveAdmin
       end
 
       def predicate_name
-        I18n.t(
-          "ransack.predicates.#{condition.predicate.name}",
-          default: ransack_predicate_name)
+        self.class.predicate_name(condition.predicate.name)
       end
 
       def html_options
@@ -76,10 +78,6 @@ module ActiveAdmin
 
       def name
         condition_attribute.attr_name
-      end
-
-      def ransack_predicate_name
-        Ransack::Translate.predicate(condition.predicate.name)
       end
 
       def find_class?

--- a/lib/active_admin/inputs/filters/base/search_method_select.rb
+++ b/lib/active_admin/inputs/filters/base/search_method_select.rb
@@ -63,7 +63,7 @@ module ActiveAdmin
 
           def filter_options
             filters.collect do |filter|
-              [I18n.t("ransack.predicates.#{filter}").capitalize, "#{method}_#{filter}"]
+              [ActiveAdmin::Filters::ActiveFilter.predicate_name(filter).capitalize, "#{method}_#{filter}"]
             end
           end
 

--- a/spec/support/templates/en.yml
+++ b/spec/support/templates/en.yml
@@ -7,3 +7,6 @@ en:
         other: Bookstores
   active_admin:
     download: "Export:"
+    ransack:
+      predicates:
+        not_eq: "not equal to (custom)"

--- a/spec/unit/filters/active_filter_spec.rb
+++ b/spec/unit/filters/active_filter_spec.rb
@@ -50,6 +50,16 @@ RSpec.describe ActiveAdmin::Filters::ActiveFilter do
     expect(subject.predicate_name).to eq(I18n.t("ransack.predicates.eq"))
   end
 
+  context "with custom predicate name translation" do
+    let(:search) do
+      Post.ransack(custom_category_id_not_eq: category.id)
+    end
+
+    it "should pick key in active admin scope" do
+      expect(subject.predicate_name).to eq("not equal to (custom)")
+    end
+  end
+
   context "search by belongs_to association" do
     let(:search) do
       Post.ransack(custom_category_id_eq: category.id)


### PR DESCRIPTION
This change introduces a custom `active_admin` I18n scope for predicate translations, allowing ActiveAdmin to override Ransack's defaults while still falling back to them when necessary.

It addresses discussions about improving localization (#8699) and resolves potential leftover logic from earlier implementations (#8010)
