### PR TITLE
Add typos workflow

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,0 +1,17 @@
+name: Typos
+
+on:
+  pull_request:
+
+jobs:
+  typos:
+    name: Run typos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: reviewdog/action-typos@v1
+        with:
+          fail_level: any
+          filter_mode: nofilter # added (default), diff_context, file, nofilter
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-check

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -188,7 +188,7 @@ Note that `@post` can also be used here but make sure to call `authorize!` on it
 
 ### Localization Updates
 
-This release includes several locale changes. Please [reivew the en.yml locale](https://github.com/activeadmin/activeadmin/blob/master/config/locales/en.yml) for the latest translations.
+This release includes several locale changes. Please [review the en.yml locale](https://github.com/activeadmin/activeadmin/blob/master/config/locales/en.yml) for the latest translations.
 
 - The `dashboard_welcome`, `dropdown_actions`, `main_content` and `unsupported_browser` keys have been removed.
 - The `active_admin.pagination` keys have been rewritten to be less verbose and include new entries: next and previous.

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,18 @@
+# https://github.com/crate-ci/typos#false-positives
+[default]
+extend-ignore-identifiers-re = [
+  "succesfully_destroyed"
+]
+
+[default.extend-identifiers]
+
+[default.extend-words]
+rememberable = "rememberable"
+
+[files]
+extend-exclude = [
+  "config/locales/*",
+  "!config/locales/en*.yml",
+  "features/step_definitions/batch_action_steps.rb",
+  "vendor/*"
+]

--- a/docs/4-csv-format.md
+++ b/docs/4-csv-format.md
@@ -15,7 +15,7 @@ ActiveAdmin.register Post do
   csv do
     column :title
     column(:author) { |post| post.author.full_name }
-    column('bODY', humanize_name: false) # preserve case
+    column('body', humanize_name: false) # preserves case of column title
   end
 end
 ```

--- a/features/index/filters.feature
+++ b/features/index/filters.feature
@@ -31,9 +31,9 @@ Feature: Index Filtering
         filter :title
       end
     """
-    When I fill in "Title" with "<script>alert('hax')</script>"
+    When I fill in "Title" with "<script>alert('hack')</script>"
     And I press "Filter"
-    Then I should see current filter "title_cont" equal to "<script>alert('hax')</script>" with label "Title contains"
+    Then I should see current filter "title_cont" equal to "<script>alert('hack')</script>" with label "Title contains"
 
   Scenario: Filtering posts with no results
     Given 3 posts exist

--- a/lib/active_admin/filters/active.rb
+++ b/lib/active_admin/filters/active.rb
@@ -11,7 +11,7 @@ module ActiveAdmin
       # @param resource [ActiveAdmin::Resource] current resource
       # @param search [Ransack::Search] search object
       #
-      # @see ActiveAdmin::ResourceController::DataAcces#apply_filtering
+      # @see ActiveAdmin::ResourceController::DataAccess#apply_filtering
       def initialize(resource, search)
         @resource = resource
         @filters = build_filters(search.conditions)

--- a/spec/unit/views/components/attributes_table_spec.rb
+++ b/spec/unit/views/components/attributes_table_spec.rb
@@ -65,9 +65,9 @@ RSpec.describe ActiveAdmin::Views::AttributesTable do
           end
         end
       },
-    }.each do |context_title, table_decleration|
+    }.each do |context_title, table_declaration|
       context context_title do
-        let(:table) { instance_eval(&table_decleration) }
+        let(:table) { instance_eval(&table_declaration) }
 
         it "should render a div wrapper with the class '.attributes-table'" do
           expect(table.tag_name).to eq "div"


### PR DESCRIPTION
This adds a workflow to [run typos CLI using Reviewdog](https://github.com/reviewdog/action-typos) and includes a `_typos.toml` configuration to address false positives. The "succesfully_destroyed" typo is ignored here so the workflow will go green as the typo correction will be addressed in #8712.