### PR TITLE
Refactor ActiveFilter's predicate name translation

### DIFF
--- a/lib/active_admin/filters/active_filter.rb
+++ b/lib/active_admin/filters/active_filter.rb
@@ -38,9 +38,7 @@ module ActiveAdmin
       end
 
       def predicate_name
-        I18n.t(
-          "ransack.predicates.#{condition.predicate.name}",
-          default: ransack_predicate_name)
+        Ransack::Translate.predicate(condition.predicate.name)
       end
 
       def html_options
@@ -76,10 +74,6 @@ module ActiveAdmin
 
       def name
         condition_attribute.attr_name
-      end
-
-      def ransack_predicate_name
-        Ransack::Translate.predicate(condition.predicate.name)
       end
 
       def find_class?

--- a/lib/active_admin/inputs/filters/base/search_method_select.rb
+++ b/lib/active_admin/inputs/filters/base/search_method_select.rb
@@ -63,7 +63,7 @@ module ActiveAdmin
 
           def filter_options
             filters.collect do |filter|
-              [I18n.t("ransack.predicates.#{filter}").capitalize, "#{method}_#{filter}"]
+              [Ransack::Translate.predicate(filter).capitalize, "#{method}_#{filter}"]
             end
           end
 


### PR DESCRIPTION
Simplify `ActiveFilter#predicate_name` by leveraging `Ransack::Translate.predicate`, removing redundant implementation logic.

Close #8699
