### PR TITLE
Enhance main navbar to improve bouncing on macOS

### DIFF
--- a/app/views/active_admin/_site_header.html.erb
+++ b/app/views/active_admin/_site_header.html.erb
@@ -1,4 +1,4 @@
-<div class="border-b border-gray-200 dark:border-white/10 dark:bg-gray-950/75 px-4 py-2 flex items-center sticky top-0 z-20 h-16 w-full backdrop-blur-md">
+<div class="border-b border-gray-200 dark:border-white/10 dark:bg-gray-950/75 px-4 py-2 flex items-center fixed top-0 z-20 h-16 w-full backdrop-blur-md">
   <button class="xl:hidden pe-3 inline-flex items-center w-8 h-8 justify-center text-sm text-gray-500 dark:text-gray-400 focus-visible:outline-none focus-visible:ring-ring focus-visible:bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0" data-drawer-target="main-menu" data-drawer-show="main-menu" aria-controls="main-menu" aria-label="<%= t('active_admin.toggle_main_navigation_menu') %>">
     <svg class="w-5 h-5 text-gray-800 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 17 14"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M1 1h15M1 7h15M1 13h15"/></svg>
   </button>

--- a/app/views/layouts/active_admin.html.erb
+++ b/app/views/layouts/active_admin.html.erb
@@ -6,7 +6,7 @@
 </head>
 <body class="bg-white dark:bg-gray-950/95 text-gray-950 dark:text-gray-100 antialiased">
   <%= render "active_admin/site_header", title: site_title %>
-  <div class="xl:ms-60">
+  <div class="xl:ms-60 pt-16">
     <%= render "active_admin/main_navigation" %>
     <%= render "active_admin/page_header", title: @page_title || page_title %>
     <%= render "active_admin/flash_messages" %>


### PR DESCRIPTION
As specified in the Flowbite documentation, the sticky navbar should
utilize the `fixed` class instead of the `sticky` class.

This was causing a poor bouncing effect on macOS on all browser except
Safari.

This commit:
- Replaces the `sticky` class with the `fixed` class, to improve
  bouncing effect
- Adds a top padding to the main body element, to take into
  consideration the space used by the fixed navbar

NOTE: Flowbite documentation suggests to use the `aside` tag instead
for the sidebar, but this breaks the see-through effect, so `div` is
being preserved

Close https://github.com/activeadmin/activeadmin/issues/8726

Ref:
- https://flowbite.com/docs/components/sidebar/#sidebar-with-navbar