### PR TITLE
Add missing :fr locales

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -59,6 +59,8 @@ fr:
         title: Connexion
       password:
         title: Mot de passe
+      password_confirmation:
+        title: Confirmer le mot de passe
       resend_confirmation_instructions:
         submit: Renvoyer les instructions de confirmation
         title: Renvoyer les instructions de confirmation
@@ -92,6 +94,7 @@ fr:
     index_list:
       table: Tableau
     logout: Déconnexion
+    move: Déplacer
     new_model: Créer %{model}
     next: Suivant
     pagination:
@@ -106,8 +109,11 @@ fr:
       one_page: Affichage de <b>tous les %{n}</b>
       per_page: 'Par page '
       previous: Précédent
+      truncate: "&hellip;"
     powered_by: Propulsé par %{active_admin} %{version}
     previous: Précédent
+    scopes:
+      all: Tout
     search_status:
       no_current_filters: Aucun filtre appliqué
       title: Recherche active
@@ -119,6 +125,10 @@ fr:
       'no': Non
       unset: Inconnu
       'yes': Oui
+    toggle_main_navigation_menu: Bascule de menu principal
+    toggle_section: Bascule de Section
+    toggle_dark_mode: Bascule de Mode Sombre
+    toggle_user_menu: Bascule de Menu Utilisateur
     view: Voir
   activerecord:
     attributes:


### PR DESCRIPTION
This PR adds a few missing locales for the french languages. Some of them are for `aria-label` tags, which somewhat breaks the display.

Note: The `truncate` field is not stricly necessary but I felt keeping the french locales matching the english one line by line would allow for easier maintenance

<!--

Thanks for contributing to ActiveAdmin!

You can find the instructions in our contributing guide: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md

Before submitting your PR make sure that:
* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are separated.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all CI checks are passing, but feel free to ask for early feedback if you need guidance.

[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->
