### PR TITLE
Remove double bottom border on last table row

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -352,7 +352,7 @@ export default plugin(
         '@apply overflow-x-auto': {}
       },
       '.paginated-collection-pagination': {
-        '@apply p-2 lg:p-3 flex flex-col-reverse lg:flex-row gap-4 items-center justify-between': {}
+        '@apply p-2 lg:p-3 flex flex-col-reverse lg:flex-row gap-4 items-center justify-between border-t border-gray-200 dark:border-gray-800': {}
       },
       '.paginated-collection-footer': {
         '@apply p-3 flex gap-2 items-center justify-between text-sm border-t border-gray-200 dark:border-gray-800': {}
@@ -382,7 +382,7 @@ export default plugin(
         '@apply rotate-180': {}
       },
       '.data-table :where(tbody > tr)': {
-        '@apply border-b dark:border-gray-800': {}
+        '@apply border-b dark:border-gray-800 last:border-b-0': {}
       },
       '.data-table :where(td)': {
         '@apply px-3 py-4': {}
@@ -454,7 +454,7 @@ export default plugin(
         '@apply w-full text-sm text-gray-800 dark:text-gray-300': {}
       },
       '.attributes-table :where(tbody > tr)': {
-        '@apply border-b dark:border-gray-800': {}
+        '@apply border-b dark:border-gray-800 last:border-b-0': {}
       },
       '.attributes-table :where(tbody > tr > th)': {
         '@apply w-32 sm:w-40 text-start text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-800/60 dark:text-gray-300': {}


### PR DESCRIPTION
The double bottom border issue became apparent on using the table_for component in the dev app kitchen_sink page. This removes the bottom border on the last table row for a consistent display and so the table itself can get a simple border when needed. Since the paginated-collection-pagination element is optional we have to apply the top border just like we do for the paginated-collection-footer which follows it to maintain the same display as before.
