### PR TITLE
Fix Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,8 +56,6 @@ updates:
         patterns:
           - "*"
     ignore:
-      - dependency-name: erb
-        versions: ">= 5"
       - dependency-name: rails
         versions: ">= 7.2.0"
       - dependency-name: rails-i18n
@@ -76,8 +74,6 @@ updates:
         patterns:
           - "*"
     ignore:
-      - dependency-name: erb
-        versions: ">= 5"
       - dependency-name: rails
         versions: ">= 8.0.0"
       - dependency-name: rails-i18n


### PR DESCRIPTION
Ruby 3.1 compatibility has been dropped. It is now possible to remove `erb` from ignore patterns
