### PR TITLE
Enable Lint/RedundantStringCoercion cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -142,6 +142,9 @@ Lint/AmbiguousRegexpLiteral:
 Lint/ParenthesesAsGroupedExpression:
   Enabled: true
 
+Lint/RedundantStringCoercion:
+  Enabled: true
+
 Lint/UselessAccessModifier:
   Enabled: true
 

--- a/app/controllers/active_admin/resource_controller/streaming.rb
+++ b/app/controllers/active_admin/resource_controller/streaming.rb
@@ -31,7 +31,7 @@ module ActiveAdmin
       end
 
       def csv_filename
-        "#{resource_collection_name.to_s.tr('_', '-')}-#{Time.zone.now.to_date.to_s}.csv"
+        "#{resource_collection_name.to_s.tr('_', '-')}-#{Time.zone.now.to_date}.csv"
       end
 
       def stream_csv


### PR DESCRIPTION
This cop does not introduce a performance gain, but it removes visual noise from the codebase.

String interpolation handles coercion automatically, so explicit `.to_s` calls are redundant and can be safely removed for better readability.
