### PR TITLE
Fix issue CSRF protection not enabled

### DIFF
--- a/tasks/bug_report_template.rb
+++ b/tasks/bug_report_template.rb
@@ -62,6 +62,7 @@ end
 
 class ApplicationController < ActionController::Base
   include Rails.application.routes.url_helpers
+  protect_from_forgery with: :exception
 end
 
 class ApplicationRecord < ActiveRecord::Base


### PR DESCRIPTION
https://github.com/activeadmin/activeadmin/blob/01f1430df290f117a3adcef9b772a61ec1bfe5b2/tasks/bug_report_template.rb#L63-L65
fix the CSRF vulnerability, add a call to `protect_from_forgery with: :exception` inside the `ApplicationController` class. This will ensure that Rails raises an exception if a request is made with an invalid or missing CSRF token, which is the recommended secure default. The change should be made directly inside the `ApplicationController` class definition in `tasks/bug_report_template.rb`, after the `include Rails.application.routes.url_helpers` line. No additional imports or dependencies are required, as this is standard Rails functionality.

### References
- [When Rails' protect_from_forgery Fails](https://www.veracode.com/blog/managing-appsec/when-rails-protectfromforgery-fails)
- [Cross-site request forgery](https://en.wikipedia.org/wiki/Cross-site_request_forgery)
- [Cross-site request forgery](https://owasp.org/www-community/attacks/csrf)
- [Cross-Site Request Forgery (CSRF)](https://guides.rubyonrails.org/security.html#cross-site-request-forgery-csrf)
- [CWE-352](https://cwe.mitre.org/data/definitions/352.html)