### PR TITLE
Defer the inclusion until after ActiveRecord has been fully loaded, i…

### DIFF
--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -136,8 +136,11 @@ module ActiveAdmin
     #
     # @param rails_router [ActionDispatch::Routing::Mapper]
     def routes(rails_router)
-      load!
-      Router.new(router: rails_router, namespaces: namespaces).apply
+      ActiveSupport.on_load(:active_record) do
+        app = ActiveAdmin.application
+        app.load!
+        Router.new(router: rails_router, namespaces: app.namespaces).apply
+      end
     end
 
     # Adds before, around and after filters to all controllers.


### PR DESCRIPTION
## Issue Description
The current implementation references `ActiveRecord` on gem load which triggers premature loading of Active Record. This can significantly slow down application boot time, especially in development and test environments.

## Solution

Use Rails recommended [ActiveSupport.on_load(:active_record)](https://edgeapi.rubyonrails.org/classes/ActiveSupport/LazyLoadHooks.html) hook to defer module inclusion until after `ActiveRecord` is fully loaded. This improves boot performance and avoids potential load order issues in edge cases.