### PR TITLE
Update dark mode CSS styles

### DIFF
--- a/app/views/active_admin/_flash_messages.html.erb
+++ b/app/views/active_admin/_flash_messages.html.erb
@@ -3,17 +3,17 @@
     <% flash_messages.each do |type, message| %>
       <% if type == "error" %>
         <div class="flex items-center gap-3 p-4 mb-2 rounded-lg bg-red-50 text-red-800 dark:bg-red-800 dark:text-red-300">
-          <svg class="w-5 h-5 shrink-0" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20"><path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM10 15a1 1 0 1 1 0-2 1 1 0 0 1 0 2Zm1-4a1 1 0 0 1-2 0V6a1 1 0 0 1 2 0v5Z"/></svg>
+          <svg class="w-5 h-5 shrink-0 text-red-400 dark:text-red-300" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20"><path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM10 15a1 1 0 1 1 0-2 1 1 0 0 1 0 2Zm1-4a1 1 0 0 1-2 0V6a1 1 0 0 1 2 0v5Z"/></svg>
           <%= message %>
         </div>
       <% elsif type == "alert" %>
         <div class="flex items-center gap-3 p-4 mb-2 rounded-lg bg-yellow-50 text-yellow-800 dark:bg-yellow-800 dark:text-yellow-300">
-          <svg class="w-5 h-5 shrink-0 rtl:-scale-x-100" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20"><path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z"/></svg>
+          <svg class="w-5 h-5 shrink-0 rtl:-scale-x-100 text-yellow-400 dark:text-yellow-300" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20"><path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z"/></svg>
           <%= message %>
         </div>
       <% elsif type == "notice" %>
-        <div class="flex items-center gap-3 p-4 mb-2 rounded-lg bg-green-50 text-green-800 dark:bg-green-800 dark:text-green-400">
-          <svg class="w-5 h-5 shrink-0 rtl:-scale-x-100" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20"><path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z"/></svg>
+        <div class="flex items-center gap-3 p-4 mb-2 rounded-lg bg-green-50 text-green-800 dark:bg-green-800 dark:text-green-300">
+          <svg class="w-5 h-5 shrink-0 rtl:-scale-x-100 text-green-400 dark:text-green-300" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20"><path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z"/></svg>
           <%= message %>
         </div>
       <% end %>

--- a/app/views/active_admin/_site_header.html.erb
+++ b/app/views/active_admin/_site_header.html.erb
@@ -18,11 +18,11 @@
     <svg class="w-7 h-7" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20"><path d="M10 0a10 10 0 1 0 10 10A10.011 10.011 0 0 0 10 0Zm0 5a3 3 0 1 1 0 6 3 3 0 0 1 0-6Zm0 13a8.949 8.949 0 0 1-4.951-1.488A3.987 3.987 0 0 1 9 13h2a3.987 3.987 0 0 1 3.951 3.512A8.949 8.949 0 0 1 10 18Z"/></svg>
   </button>
 
-  <div id="user-menu" class="z-50 hidden min-w-max bg-white rounded shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-gray-700 py-1 text-sm text-gray-700 dark:text-gray-200" aria-labelledby="user-menu-button">
+  <div id="user-menu" class="z-50 hidden min-w-max rounded shadow-lg outline outline-1 outline-black/5 dark:-outline-offset-1 dark:outline-white/10 focus:outline-none py-1 text-sm bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300" aria-labelledby="user-menu-button">
     <ul>
       <% if current_active_admin_user? %>
-        <li><%= auto_link current_active_admin_user, class: "block px-2.5 py-2 no-underline text-gray-700 hover:bg-gray-100 hover:text-gray-900 dark:text-white dark:hover:bg-gray-600 dark:hover:text-white" %></li>
-        <li><%= link_to I18n.t("active_admin.logout"), auto_logout_link_path, class: "block px-2.5 py-2 no-underline text-gray-700 hover:bg-gray-100 hover:text-gray-900 dark:text-white dark:hover:bg-gray-600 dark:hover:text-white", data: { method: :delete } %></li>
+        <li><%= auto_link current_active_admin_user, class: "block px-2.5 py-2 no-underline text-gray-700 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-white/5 dark:hover:text-white" %></li>
+        <li><%= link_to I18n.t("active_admin.logout"), auto_logout_link_path, class: "block px-2.5 py-2 no-underline text-gray-700 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-white/5 dark:hover:text-white", data: { method: :delete } %></li>
       <% end %>
     </ul>
   </div>

--- a/app/views/active_admin/devise/confirmations/new.html.erb
+++ b/app/views/active_admin/devise/confirmations/new.html.erb
@@ -1,4 +1,4 @@
-<div class="p-6 sm:p-8 space-y-4 md:space-y-6 w-full sm:max-w-md bg-white sm:rounded-md shadow dark:border dark:bg-gray-800 dark:border-gray-700">
+<div class="p-6 sm:p-8 space-y-4 md:space-y-6 w-full sm:max-w-md bg-white sm:rounded-md shadow dark:border dark:bg-gray-800/50 dark:border-gray-800">
   <h2 class="text-xl font-bold text-gray-900 md:text-2xl dark:text-white">
     <%= active_admin_application.site_title(self) %> <%= set_page_title t('active_admin.devise.resend_confirmation_instructions.title') %>
   </h2>

--- a/app/views/active_admin/devise/passwords/edit.html.erb
+++ b/app/views/active_admin/devise/passwords/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="p-6 sm:p-8 space-y-4 md:space-y-6 w-full sm:max-w-md bg-white sm:rounded-md shadow dark:border dark:bg-gray-800 dark:border-gray-700">
+<div class="p-6 sm:p-8 space-y-4 md:space-y-6 w-full sm:max-w-md bg-white sm:rounded-md shadow dark:border dark:bg-gray-800/50 dark:border-gray-800">
   <h2 class="text-xl font-bold text-gray-900 md:text-2xl dark:text-white">
     <%= active_admin_application.site_title(self) %> <%= set_page_title t('active_admin.devise.change_password.title') %>
   </h2>

--- a/app/views/active_admin/devise/passwords/new.html.erb
+++ b/app/views/active_admin/devise/passwords/new.html.erb
@@ -1,4 +1,4 @@
-<div class="p-6 sm:p-8 space-y-4 md:space-y-6 w-full sm:max-w-md bg-white sm:rounded-md shadow dark:border dark:bg-gray-800 dark:border-gray-700">
+<div class="p-6 sm:p-8 space-y-4 md:space-y-6 w-full sm:max-w-md bg-white sm:rounded-md shadow dark:border dark:bg-gray-800/50 dark:border-gray-800">
   <h2 class="text-xl font-bold text-gray-900 md:text-2xl dark:text-white">
     <%= active_admin_application.site_title(self) %> <%= set_page_title t('active_admin.devise.reset_password.title') %>
   </h2>

--- a/app/views/active_admin/devise/registrations/new.html.erb
+++ b/app/views/active_admin/devise/registrations/new.html.erb
@@ -1,4 +1,4 @@
-<div class="p-6 sm:p-8 space-y-4 md:space-y-6 w-full sm:max-w-md bg-white sm:rounded-md shadow dark:border dark:bg-gray-800 dark:border-gray-700">
+<div class="p-6 sm:p-8 space-y-4 md:space-y-6 w-full sm:max-w-md bg-white sm:rounded-md shadow dark:border dark:bg-gray-800/50 dark:border-gray-800">
   <h2 class="text-xl font-bold text-gray-900 md:text-2xl dark:text-white">
     <%= active_admin_application.site_title(self) %> <%= set_page_title t('active_admin.devise.sign_up.title') %>
   </h2>

--- a/app/views/active_admin/devise/sessions/new.html.erb
+++ b/app/views/active_admin/devise/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<div class="p-6 sm:p-8 space-y-4 md:space-y-6 w-full sm:max-w-md bg-white sm:rounded-md shadow dark:border dark:bg-gray-800 dark:border-gray-700">
+<div class="p-6 sm:p-8 space-y-4 md:space-y-6 w-full sm:max-w-md bg-white sm:rounded-md shadow dark:border dark:bg-gray-800/50 dark:border-gray-800">
   <h2 class="text-xl font-bold text-gray-900 md:text-2xl dark:text-white">
     <%= site_title %> <%= set_page_title t('active_admin.devise.login.title') %>
   </h2>

--- a/app/views/active_admin/devise/unlocks/new.html.erb
+++ b/app/views/active_admin/devise/unlocks/new.html.erb
@@ -1,4 +1,4 @@
-<div class="p-6 sm:p-8 space-y-4 md:space-y-6 w-full sm:max-w-md bg-white sm:rounded-md shadow dark:border dark:bg-gray-800 dark:border-gray-700">
+<div class="p-6 sm:p-8 space-y-4 md:space-y-6 w-full sm:max-w-md bg-white sm:rounded-md shadow dark:border dark:bg-gray-800/50 dark:border-gray-800">
   <h2 class="text-xl font-bold text-gray-900 md:text-2xl dark:text-white">
     <%= site_title %> <%= set_page_title t('active_admin.devise.unlock.title') %>
   </h2>

--- a/plugin.js
+++ b/plugin.js
@@ -301,16 +301,16 @@ export default plugin(
         '@apply relative': {}
       },
       '.batch-actions-dropdown-toggle': {
-        '@apply transition-opacity rounded-md inline-flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-gray-900 bg-white border border-gray-200 hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-2 focus:ring-blue-700 focus:text-blue-700 dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:hover:text-white dark:hover:bg-gray-600 dark:focus:ring-blue-500 dark:focus:text-white disabled:text-gray-400 disabled:border-gray-200/70 dark:disabled:bg-gray-900 dark:disabled:text-gray-700 dark:disabled:border-gray-800 disabled:pointer-events-none': {}
+        '@apply transition-opacity rounded-md inline-flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-gray-900 bg-white border border-gray-200 hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-2 focus:ring-blue-700 focus:text-blue-700 dark:bg-gray-800 dark:border-gray-700 dark:text-white dark:hover:text-white dark:hover:bg-gray-700 dark:focus:ring-blue-500 dark:focus:text-white disabled:text-gray-400 disabled:border-gray-200/70 dark:disabled:bg-gray-900 dark:disabled:text-gray-700 dark:disabled:border-gray-800 disabled:pointer-events-none': {}
       },
       '.batch-actions-dropdown-arrow': {
         '@apply w-2.5 h-2.5': {}
       },
       '.batch-actions-dropdown-menu': {
-        '@apply z-10 hidden min-w-[7rem] bg-white rounded-md shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-gray-700 py-1 text-sm text-gray-700 dark:text-gray-200': {}
+        '@apply z-10 hidden min-w-[7rem] bg-white rounded-md shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-gray-800 py-1 text-sm text-gray-700 dark:text-gray-200': {}
       },
       '.batch-actions-dropdown-menu :where(li > a)': {
-        '@apply block px-2.5 py-2 no-underline text-gray-700 hover:bg-gray-100 hover:text-gray-900 dark:text-white dark:hover:bg-gray-600 dark:hover:text-white': {}
+        '@apply block px-2.5 py-2 no-underline text-gray-700 hover:bg-gray-100 hover:text-gray-900 dark:text-white dark:hover:bg-gray-700 dark:hover:text-white': {}
       },
       '.panel': {
         '@apply mb-6 border border-gray-200 rounded-md shadow-sm dark:border-gray-800': {}

--- a/plugin.js
+++ b/plugin.js
@@ -328,7 +328,7 @@ export default plugin(
         '@apply w-full text-sm text-gray-800 dark:text-gray-300': {}
       },
       '.attributes-table :where(tbody > tr)': {
-        '@apply border-b dark:border-gray-800 last:border-b-0': {}
+        '@apply border-b dark:border-gray-800 last:border-b-0 align-baseline': {}
       },
       '.attributes-table :where(tbody > tr > th)': {
         '@apply w-32 sm:w-40 text-start text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-800/60 dark:text-gray-300': {}

--- a/plugin.js
+++ b/plugin.js
@@ -331,13 +331,13 @@ export default plugin(
         '@apply border-b dark:border-gray-800 last:border-b-0 align-baseline': {}
       },
       '.attributes-table :where(tbody > tr > th)': {
-        '@apply w-32 sm:w-40 text-start text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-800/60 dark:text-gray-300': {}
+        '@apply w-32 sm:w-40 text-start text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-950/50 dark:text-gray-300': {}
       },
       '.attributes-table :where(tbody > tr > th, tbody > tr > td)': {
         '@apply p-3': {}
       },
       '.attributes-table-empty-value': {
-        '@apply text-gray-400/50 dark:text-gray-700/60 text-xs uppercase font-semibold': {}
+        '@apply text-gray-400/50 dark:text-gray-600/50 text-xs uppercase font-semibold': {}
       },
       '.status-tag': {
         '@apply bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-400 inline-flex items-center rounded-full text-sm font-medium px-2.5 py-0.5 whitespace-nowrap': {}

--- a/plugin.js
+++ b/plugin.js
@@ -73,10 +73,6 @@ export default plugin(
           'border-color': theme('colors.blue.600', colors.blue[600]),
         },
       },
-      [['input::placeholder', 'textarea::placeholder']]: {
-        color: theme('colors.gray.500', colors.gray[500]),
-        opacity: '1',
-      },
       ['::-webkit-datetime-edit']: {
         display: 'inline-flex',
       },
@@ -231,7 +227,7 @@ export default plugin(
         '@apply w-4 h-4 bg-gray-100 border-gray-300 focus:ring-2 focus:ring-blue-300 dark:focus:ring-blue-600 dark:focus:bg-blue-600 dark:bg-white/5 dark:border-white/10': {}
       },
       [['[type=datetime-local]', '[type=month]', '[type=week]', '[type=search]', '[type=date]', '[type=email]', '[type=number]', '[type=password]', '[type=tel]', '[type=text]', '[type=time]', '[type=url]', 'select', 'textarea']]: {
-        '@apply bg-gray-50 border border-gray-300 text-gray-900 rounded-md focus:ring-blue-500 focus:border-blue-500 w-full dark:bg-white/5 dark:border-white/10 dark:placeholder-gray-500 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500': {}
+        '@apply bg-gray-50 border border-gray-300 text-gray-900 placeholder:text-gray-400 rounded-md focus:ring-blue-500 focus:border-blue-500 w-full dark:bg-white/5 dark:border-white/10 dark:text-white dark:placeholder:text-gray-500 dark:focus:ring-blue-500 dark:focus:border-blue-500': {}
       },
       'a': {
         '@apply text-blue-600 dark:text-blue-500 underline underline-offset-[.2rem]': {}

--- a/plugin.js
+++ b/plugin.js
@@ -209,40 +209,20 @@ export default plugin(
         'background-color': 'currentColor',
       },
       [`[type='file']`]: {
-        background: 'unset',
-        'border-color': 'inherit',
-        'border-width': '0',
-        'border-radius': '0',
-        padding: '0',
-        'font-size': 'unset',
-        'line-height': 'inherit',
-      },
-      [`[type='file']:focus`]: {
-        outline: `1px auto inherit`,
-      },
-      [[`input[type=file]::file-selector-button`]]: {
-        color: 'white',
-        background: theme('colors.gray.800', colors.gray[800]),
-        border: 0,
-        'font-weight': theme('fontWeight.medium'),
-        'font-size': theme('fontSize.sm'),
         cursor: 'pointer',
-        'padding-top': spacing[2.5],
-        'padding-bottom': spacing[2.5],
-        'padding-inline-start': spacing[8],
-        'padding-inline-end': spacing[4],
-        'margin-inline-start': '-1rem',
-        'margin-inline-end': '1rem',
+      },
+      [`[type=file]::file-selector-button`]: {
+        'background-color': theme('colors.gray.100', colors.gray[100]),
+        'border': `${borderWidth['DEFAULT']} solid ${theme('colors.gray.200', colors.gray[200])}`,
+        'border-radius': borderRadius['DEFAULT'],
+        cursor: 'pointer',
+        'padding': `${spacing[2]} ${spacing[3]}`,
         '&:hover': {
-          background: theme('colors.gray.700', colors.gray[700]),
+          'background-color': theme('colors.gray.200', colors.gray[200]),
         },
       },
-      [[`.dark input[type=file]::file-selector-button`]]: {
-        color: 'white',
-        background: theme('colors.gray.600', colors.gray[600]),
-        '&:hover': {
-          background: theme('colors.gray.500', colors.gray[500]),
-        },
+      [`.dark [type=file]::file-selector-button`]: {
+        '@apply bg-white/5 border-white/5 text-white hover:bg-white/10': {}
       },
       '[type=checkbox]': {
         '@apply w-4 h-4 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-white/5 dark:border-white/10': {}

--- a/plugin.js
+++ b/plugin.js
@@ -112,26 +112,14 @@ export default plugin(
       },
       [[`[type='checkbox']`, `[type='radio']`]]: {
         appearance: 'none',
-        padding: '0',
-        'print-color-adjust': 'exact',
-        display: 'inline-block',
-        'vertical-align': 'middle',
         'background-origin': 'border-box',
-        'user-select': 'none',
-        'flex-shrink': '0',
-        height: spacing[4],
-        width: spacing[4],
         color: theme('colors.blue.600', colors.blue[600]),
-        'background-color': '#fff',
-        'border-color': theme('colors.gray.500', colors.gray[500]),
-        'border-width': borderWidth['DEFAULT'],
+        display: 'inline-block',
+        'flex-shrink': '0',
+        'print-color-adjust': 'exact',
+        'user-select': 'none',
+        'vertical-align': 'middle',
         '--tw-shadow': '0 0 #0000',
-      },
-      [`[type='checkbox']`]: {
-        'border-radius': borderRadius['none'],
-      },
-      [`[type='radio']`]: {
-        'border-radius': '100%',
       },
       [[`[type='checkbox']:focus`, `[type='radio']:focus`]]: {
         outline: '2px solid transparent',
@@ -146,56 +134,35 @@ export default plugin(
       },
       [[
         `[type='checkbox']:checked`,
+        `[type='checkbox']:indeterminate`,
         `[type='radio']:checked`,
-        `.dark [type='checkbox']:checked`,
-        `.dark [type='checkbox']:indeterminate`,
-        `.dark [type='radio']:checked`,
       ]]: {
-        'border-color': `transparent`,
         'background-color': `currentColor`,
-        'background-size': `0.65rem 0.65rem`,
         'background-position': `center`,
         'background-repeat': `no-repeat`,
+        'background-size': `100% 100%`,
+        'border-color': `transparent`,
       },
       [`[type='checkbox']:checked`]: {
         'background-image': `url("${svgToTinyDataUri(
-          `<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 12">
-            <path stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M1 5.917 5.724 10.5 15 1.5"/>
+          `<svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M4 8 L7 11 L12 5" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
           </svg>`
         )}")`,
-        'background-repeat': `no-repeat`,
-        'background-size': `0.65rem 0.65rem`,
         'print-color-adjust': `exact`,
       },
       [`[type='radio']:checked`]: {
         'background-image': `url("${svgToTinyDataUri(
           `<svg viewBox="0 0 16 16" fill="white" xmlns="http://www.w3.org/2000/svg"><circle cx="8" cy="8" r="3"/></svg>`
         )}")`,
-        'background-size': `1rem 1rem`,
-      },
-      [`.dark [type='radio']:checked`]: {
-        'background-image': `url("${svgToTinyDataUri(
-          `<svg viewBox="0 0 16 16" fill="white" xmlns="http://www.w3.org/2000/svg"><circle cx="8" cy="8" r="3"/></svg>`
-        )}")`,
-        'background-size': `1rem 1rem`,
       },
       [`[type='checkbox']:indeterminate`]: {
         'background-image': `url("${svgToTinyDataUri(
-          `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16"><path stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="4" d="M2 8h12"/></svg>`
+          `<svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M4 8 L12 8" stroke="white" stroke-linecap="round" stroke-width="2.5" />
+          </svg>`
         )}")`,
-        'background-color': `currentColor`,
-        'border-color': `transparent`,
-        'background-position': `center`,
-        'background-repeat': `no-repeat`,
-        'background-size': `.65rem .65rem`,
         'print-color-adjust': `exact`,
-      },
-      [[
-        `[type='checkbox']:indeterminate:hover`,
-        `[type='checkbox']:indeterminate:focus`,
-      ]]: {
-        'border-color': 'transparent',
-        'background-color': 'currentColor',
       },
       [`[type='file']`]: {
         cursor: 'pointer',
@@ -214,10 +181,10 @@ export default plugin(
         '@apply bg-white/5 border-white/5 text-white hover:bg-white/10': {}
       },
       '[type=checkbox]': {
-        '@apply w-4 h-4 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-white/5 dark:border-white/10': {}
+        '@apply w-4 h-4 bg-gray-100 border border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-white/5 dark:border-white/10': {}
       },
       '[type=radio]': {
-        '@apply w-4 h-4 bg-gray-100 border-gray-300 focus:ring-2 focus:ring-blue-300 dark:focus:ring-blue-600 dark:focus:bg-blue-600 dark:bg-white/5 dark:border-white/10': {}
+        '@apply w-4 h-4 bg-gray-100 border border-gray-300 rounded-full focus:ring-2 focus:ring-blue-300 dark:focus:ring-blue-600 dark:focus:bg-blue-600 dark:bg-white/5 dark:border-white/10': {}
       },
       [['[type=datetime-local]', '[type=month]', '[type=week]', '[type=search]', '[type=date]', '[type=email]', '[type=number]', '[type=password]', '[type=tel]', '[type=text]', '[type=time]', '[type=url]', 'select', 'textarea']]: {
         '@apply bg-gray-50 border border-gray-300 text-gray-900 placeholder:text-gray-400 rounded-md focus:ring-blue-500 focus:border-blue-500 w-full dark:bg-white/5 dark:border-white/10 dark:text-white dark:placeholder:text-gray-500 dark:focus:ring-blue-500 dark:focus:border-blue-500': {}

--- a/plugin.js
+++ b/plugin.js
@@ -217,7 +217,7 @@ export default plugin(
         '@apply bg-gray-100 hover:bg-gray-100 dark:bg-gray-800 dark:hover:bg-gray-800': {}
       },
       '.scopes-count': {
-        '@apply inline-flex items-center justify-center rounded-full bg-indigo-200/80 text-indigo-800 dark:bg-indigo-800 dark:text-indigo-200 px-1.5 py-1 text-xs font-normal ms-2 leading-none': {}
+        '@apply inline-flex items-center justify-center rounded-full bg-indigo-100 text-indigo-700 dark:bg-indigo-800/60 dark:text-indigo-400 px-1.5 py-1 text-xs font-normal ms-2 leading-none': {}
       },
       '.paginated-collection': {
         '@apply border border-gray-200 dark:border-gray-800 rounded-md shadow-sm overflow-hidden': {}

--- a/plugin.js
+++ b/plugin.js
@@ -195,7 +195,7 @@ export default plugin(
     });
     addComponents({
       '.action-item-button': {
-        '@apply py-2 px-3 text-sm font-medium no-underline text-gray-900 focus:outline-none bg-white rounded-md border border-gray-200 hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700': {}
+        '@apply py-2 px-3 text-sm font-medium no-underline text-gray-900 focus:outline-none bg-white rounded-md border border-gray-200 hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-700 dark:hover:text-white dark:hover:bg-gray-700': {}
       },
       '.index-data-table-toolbar': {
         '@apply flex flex-col lg:flex-row gap-4 mb-4': {}

--- a/plugin.js
+++ b/plugin.js
@@ -47,15 +47,8 @@ export default plugin(
         'textarea',
         'select',
       ]]: {
-        appearance: 'none',
-        'background-color': '#fff',
-        'border-color': theme('colors.gray.500', colors.gray[500]),
-        'border-width': borderWidth['DEFAULT'],
-        'border-radius': borderRadius.none,
-        'padding-top': spacing[2],
-        'padding-right': spacing[3],
-        'padding-bottom': spacing[2],
-        'padding-left': spacing[3],
+        'appearance': 'none',
+        'padding': `${spacing[2]} ${spacing[3]}`,
         '--tw-shadow': '0 0 #0000',
         '&:focus': {
           outline: '2px solid transparent',

--- a/plugin.js
+++ b/plugin.js
@@ -316,7 +316,7 @@ export default plugin(
         '@apply mb-6 border border-gray-200 rounded-md shadow-sm dark:border-gray-800': {}
       },
       '.panel-title': {
-        '@apply font-bold bg-gray-100 dark:bg-gray-900 rounded-t-md p-3': {}
+        '@apply font-bold bg-gray-100 dark:bg-gray-950/50 rounded-t-md p-3': {}
       },
       '.panel-body': {
         '@apply py-5 px-3': {}

--- a/plugin.js
+++ b/plugin.js
@@ -245,13 +245,13 @@ export default plugin(
         },
       },
       '[type=checkbox]': {
-        '@apply w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600': {}
+        '@apply w-4 h-4 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-white/5 dark:border-white/10': {}
       },
       '[type=radio]': {
-        '@apply w-4 h-4 border-gray-300 focus:ring-2 focus:ring-blue-300 dark:focus:ring-blue-600 dark:focus:bg-blue-600 dark:bg-gray-700 dark:border-gray-600': {}
+        '@apply w-4 h-4 bg-gray-100 border-gray-300 focus:ring-2 focus:ring-blue-300 dark:focus:ring-blue-600 dark:focus:bg-blue-600 dark:bg-white/5 dark:border-white/10': {}
       },
       [['[type=datetime-local]', '[type=month]', '[type=week]', '[type=search]', '[type=date]', '[type=email]', '[type=number]', '[type=password]', '[type=tel]', '[type=text]', '[type=time]', '[type=url]', 'select', 'textarea']]: {
-        '@apply bg-gray-50 border border-gray-300 text-gray-900 rounded-md focus:ring-blue-500 focus:border-blue-500 w-full dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500': {}
+        '@apply bg-gray-50 border border-gray-300 text-gray-900 rounded-md focus:ring-blue-500 focus:border-blue-500 w-full dark:bg-white/5 dark:border-white/10 dark:placeholder-gray-500 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500': {}
       },
       'a': {
         '@apply text-blue-600 dark:text-blue-500 underline underline-offset-[.2rem]': {}

--- a/plugin.js
+++ b/plugin.js
@@ -340,10 +340,10 @@ export default plugin(
         '@apply text-gray-400/50 dark:text-gray-600/50 text-xs uppercase font-semibold': {}
       },
       '.status-tag': {
-        '@apply bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-400 inline-flex items-center rounded-full text-sm font-medium px-2.5 py-0.5 whitespace-nowrap': {}
+        '@apply bg-gray-200 text-gray-600 dark:bg-gray-400/20 dark:text-gray-400 inline-flex items-center rounded-full text-sm font-medium px-2.5 py-0.5 whitespace-nowrap': {}
       },
       '.status-tag:where([data-status=yes])': {
-        '@apply bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300': {}
+        '@apply bg-green-100 text-green-700 dark:bg-green-400/20 dark:text-green-400': {}
       },
       // Forms
       '.formtastic': {

--- a/plugin.js
+++ b/plugin.js
@@ -377,16 +377,16 @@ export default plugin(
         '@apply text-gray-500 dark:text-gray-400 mt-2': {}
       },
       '.formtastic :where(.errors)': {
-        '@apply p-4 mb-6 rounded-md space-y-2 bg-red-50 text-red-800 dark:bg-red-800 dark:text-red-300': {}
+        '@apply p-4 mb-6 rounded-md space-y-2 bg-red-50 text-red-800 dark:bg-red-500/15 dark:text-red-200': {}
       },
       '.formtastic :where(.errors > li)': {
         '@apply list-disc ms-4': {}
       },
       '.formtastic :where(.inline-errors)': {
-        '@apply font-bold mt-2 text-red-600 dark:text-red-300': {}
+        '@apply font-bold mt-2 text-red-600 dark:text-red-400': {}
       },
-      '.formtastic :where(.error [type=email], .error [type=number], .error [type=password], .error [type=tel], .error [type=text], .error [type=url], .error textarea)': {
-        '@apply border-red-500': {}
+      '.formtastic :where(.error [type=email], .error [type=number], .error [type=password], .error [type=tel], .error [type=text], .error [type=url], .error select, .error textarea)': {
+        '@apply border-red-500/50': {}
       },
       '.formtastic :where(.buttons, .actions)': {
         '@apply mt-3': {}

--- a/spec/support/templates/views/admin/posts/_starred_batch_action_form.html.erb
+++ b/spec/support/templates/views/admin/posts/_starred_batch_action_form.html.erb
@@ -4,9 +4,9 @@
   data-batch-action-modal>
   <div class="relative w-full max-w-md max-h-full">
     <!-- Modal content -->
-    <div class="relative bg-white rounded-lg shadow dark:bg-gray-700">
+    <div class="relative bg-white rounded-lg shadow dark:bg-gray-800 dark:border dark:border-white/10">
       <button type="button"
-        class="absolute top-3 end-2.5 text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm p-1.5 ml-auto inline-flex items-center dark:hover:bg-gray-800 dark:hover:text-white"
+        class="absolute top-3 end-2.5 bg-transparent text-gray-400 hover:text-gray-500 rounded-lg text-sm p-1.5 ml-auto inline-flex items-center dark:hover:text-gray-300"
         data-modal-hide="starred-batch-action-modal">
         <svg aria-hidden="true" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20"
           xmlns="http://www.w3.org/2000/svg">
@@ -20,11 +20,10 @@
         <h3 class="mb-4 text-xl font-medium text-gray-900 dark:text-white">Toggle Starred</h3>
         <%= form_tag false, "data-batch-action-form": "" do %>
           <div class="py-6 flex items-center gap-2">
-            <input name="starred" id="starred-checkbox" type="checkbox" value="true" class="w-4 h-4 border border-gray-300 rounded bg-gray-50 focus:ring-3 focus:ring-blue-300 dark:bg-gray-600 dark:border-gray-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 dark:focus:ring-offset-gray-800" />
-            <label for="starred-checkbox" class="text-gray-900 dark:text-gray-300">Starred</label>
+            <input name="starred" id="starred-checkbox" type="checkbox" value="true" />
+            <label for="starred-checkbox" class="text-gray-900 dark:text-gray-100">Starred</label>
           </div>
-          <button type="submit"
-            class="w-full text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">
+          <button type="submit" class="w-full text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">
             Submit
           </button>
         <% end %>

--- a/spec/support/templates_with_data/admin/kitchen_sink.rb
+++ b/spec/support/templates_with_data/admin/kitchen_sink.rb
@@ -50,34 +50,34 @@ ActiveAdmin.register_page "KitchenSink" do
 
   sidebar "Sample Sidebar" do
     div class: "pb-6" do
-      h3 "Applicant Information", class: "text-base/7 font-semibold text-gray-900"
-      para "A sidebar can also be used on a custom page.", class: "mt-1 text-sm/6 text-gray-500"
+      h3 "Applicant Information", class: "text-base/7 font-semibold text-gray-900 dark:text-white"
+      para "A sidebar can also be used on a custom page.", class: "mt-1 text-sm/6 text-gray-500 dark:text-gray-400"
     end
     dl do
-      div class: "border-t border-gray-100 py-4" do
-        dt "Full name", class: "text-sm/6 font-medium text-gray-900"
-        dd "Margot Foster", class: "mt-1 text-sm/6 text-gray-700"
+      div class: "border-t border-gray-100 dark:border-white/10 py-4" do
+        dt "Full name", class: "text-sm/6 font-medium text-gray-900 dark:text-gray-100"
+        dd "Margot Foster", class: "mt-1 text-sm/6 text-gray-700 dark:text-gray-400"
       end
-      div class: "border-t border-gray-100 py-4" do
-        dt "Application for", class: "text-sm/6 font-medium text-gray-900"
-        dd "Backend Developer", class: "mt-1 text-sm/6 text-gray-700"
+      div class: "border-t border-gray-100 dark:border-white/10 py-4" do
+        dt "Application for", class: "text-sm/6 font-medium text-gray-900 dark:text-gray-100"
+        dd "Backend Developer", class: "mt-1 text-sm/6 text-gray-700 dark:text-gray-400"
       end
-      div class: "border-t border-gray-100 py-4" do
-        dt "Email address", class: "text-sm/6 font-medium text-gray-900"
-        dd "margotfoster@example.com", class: "mt-1 text-sm/6 text-gray-700"
+      div class: "border-t border-gray-100 dark:border-white/10 py-4" do
+        dt "Email address", class: "text-sm/6 font-medium text-gray-900 dark:text-gray-100"
+        dd "margotfoster@example.com", class: "mt-1 text-sm/6 text-gray-700 dark:text-gray-400"
       end
-      div class: "border-t border-gray-100 py-4" do
-        dt "Attachments", class: "text-sm/6 font-medium text-gray-900"
-        dd class: "mt-1 text-sm/6 text-gray-700" do
-          ul class: "divide-y divide-gray-200 rounded-md border border-gray-200", role: "list" do
+      div class: "border-t border-gray-100 dark:border-white/10 py-4" do
+        dt "Attachments", class: "text-sm/6 font-medium text-gray-900 dark:text-gray-100"
+        dd class: "mt-1 text-sm/6 text-gray-700 dark:text-gray-400" do
+          ul class: "divide-y divide-gray-100 rounded-md border border-gray-200 dark:divide-white/5 dark:border-white/10", role: "list" do
             li class: "flex items-center justify-between py-3 pl-3 pr-4 text-sm/6" do
               div class: "flex w-0 flex-1 items-center" do
-                text_node '<svg viewBox="0 0 20 20" fill="currentColor" data-slot="icon" aria-hidden="true" class="size-5 shrink-0 text-gray-400"><path d="M15.621 4.379a3 3 0 0 0-4.242 0l-7 7a3 3 0 0 0 4.241 4.243h.001l.497-.5a.75.75 0 0 1 1.064 1.057l-.498.501-.002.002a4.5 4.5 0 0 1-6.364-6.364l7-7a4.5 4.5 0 0 1 6.368 6.36l-3.455 3.553A2.625 2.625 0 1 1 9.52 9.52l3.45-3.451a.75.75 0 1 1 1.061 1.06l-3.45 3.451a1.125 1.125 0 0 0 1.587 1.595l3.454-3.553a3 3 0 0 0 0-4.242Z" clip-rule="evenodd" fill-rule="evenodd" /></svg>'.html_safe
+                text_node '<svg viewBox="0 0 20 20" fill="currentColor" data-slot="icon" aria-hidden="true" class="size-5 shrink-0 text-gray-400 dark:text-gray-500"><path d="M15.621 4.379a3 3 0 0 0-4.242 0l-7 7a3 3 0 0 0 4.241 4.243h.001l.497-.5a.75.75 0 0 1 1.064 1.057l-.498.501-.002.002a4.5 4.5 0 0 1-6.364-6.364l7-7a4.5 4.5 0 0 1 6.368 6.36l-3.455 3.553A2.625 2.625 0 1 1 9.52 9.52l3.45-3.451a.75.75 0 1 1 1.061 1.06l-3.45 3.451a1.125 1.125 0 0 0 1.587 1.595l3.454-3.553a3 3 0 0 0 0-4.242Z" clip-rule="evenodd" fill-rule="evenodd" /></svg>'.html_safe
                 div class: "ms-2 flex min-w-0 flex-1 gap-2" do
-                  span class: "truncate font-medium text-gray-900" do
+                  span class: "truncate font-medium text-gray-900 dark:text-white" do
                     "resume_back_end_developer.pdf"
                   end
-                  span class: "shrink-0 text-gray-400" do
+                  span class: "shrink-0 text-gray-400 dark:text-gray-500" do
                     "2.4mb"
                   end
                 end
@@ -85,12 +85,12 @@ ActiveAdmin.register_page "KitchenSink" do
             end
             li class: "flex items-center justify-between py-3 pl-3 pr-4 text-sm/6" do
               div class: "flex w-0 flex-1 items-center" do
-                text_node '<svg viewBox="0 0 20 20" fill="currentColor" data-slot="icon" aria-hidden="true" class="size-5 shrink-0 text-gray-400"><path d="M15.621 4.379a3 3 0 0 0-4.242 0l-7 7a3 3 0 0 0 4.241 4.243h.001l.497-.5a.75.75 0 0 1 1.064 1.057l-.498.501-.002.002a4.5 4.5 0 0 1-6.364-6.364l7-7a4.5 4.5 0 0 1 6.368 6.36l-3.455 3.553A2.625 2.625 0 1 1 9.52 9.52l3.45-3.451a.75.75 0 1 1 1.061 1.06l-3.45 3.451a1.125 1.125 0 0 0 1.587 1.595l3.454-3.553a3 3 0 0 0 0-4.242Z" clip-rule="evenodd" fill-rule="evenodd" /></svg>'.html_safe
+                text_node '<svg viewBox="0 0 20 20" fill="currentColor" data-slot="icon" aria-hidden="true" class="size-5 shrink-0 text-gray-400 dark:text-gray-500"><path d="M15.621 4.379a3 3 0 0 0-4.242 0l-7 7a3 3 0 0 0 4.241 4.243h.001l.497-.5a.75.75 0 0 1 1.064 1.057l-.498.501-.002.002a4.5 4.5 0 0 1-6.364-6.364l7-7a4.5 4.5 0 0 1 6.368 6.36l-3.455 3.553A2.625 2.625 0 1 1 9.52 9.52l3.45-3.451a.75.75 0 1 1 1.061 1.06l-3.45 3.451a1.125 1.125 0 0 0 1.587 1.595l3.454-3.553a3 3 0 0 0 0-4.242Z" clip-rule="evenodd" fill-rule="evenodd" /></svg>'.html_safe
                 div class: "ms-2 flex min-w-0 flex-1 gap-2" do
-                  span class: "truncate font-medium text-gray-900" do
+                  span class: "truncate font-medium text-gray-900 dark:text-white" do
                     "coverletter_back_end_developer.pdf"
                   end
-                  span class: "shrink-0 text-gray-400" do
+                  span class: "shrink-0 text-gray-400 dark:text-gray-500" do
                     "4.5mb"
                   end
                 end


### PR DESCRIPTION
The CSS dark mode styles remained incomplete. For example, the form controls were still using the initial values I took from Flowbite but they were too bright when compared to general dark mode implementations. Other elements I had already changed to a darker set of colors.
