### PR TITLE
resource: allow resource_class to be passed as a String

### DIFF
--- a/spec/unit/namespace/register_resource_spec.rb
+++ b/spec/unit/namespace/register_resource_spec.rb
@@ -31,6 +31,16 @@ RSpec.describe ActiveAdmin::Namespace, "registering a resource" do
     end
   end
 
+  context "when resource class is a string" do
+    before do
+      namespace.register 'Category'
+    end
+
+    it "should store the namespaced registered configuration" do
+      expect(namespace.resources.keys).to include("Category")
+    end
+  end
+
   context "with a block configuration" do
     it "should be evaluated in the dsl" do
       expect do |block|

--- a/spec/unit/resource/action_items_spec.rb
+++ b/spec/unit/resource/action_items_spec.rb
@@ -71,14 +71,4 @@ RSpec.describe ActiveAdmin::Resource::ActionItems do
       expect(resource.action_items.size).to eq 2
     end
   end
-
-  it "allows registering with string" do
-    namespace = ActiveAdmin::Namespace.new(ActiveAdmin::Application.new, :admin)
-    resource = namespace.register("Post")
-    resource.clear_action_items!
-    resource.add_action_item :empty do
-      # Empty ...
-    end
-    expect(resource.action_items.size).to eq 1
-  end
 end


### PR DESCRIPTION
the current pattern of using the class directly loads all models bound to activeadmin before using them, needlessly. besides that, the only purpose of it is to store the class name

this patch allows one to pass the class name directly instead, kind of like how activerecord avoids eager-loading association classes.

