### PR TITLE
Revert i18n-tasks upgrade to fix flaky specs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,9 @@ updates:
       rails_default:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: i18n-tasks
+        versions: ">= 1.1.0"
   - package-ecosystem: npm
     directory: /
     schedule:
@@ -36,6 +39,8 @@ updates:
         patterns:
           - "*"
     ignore:
+      - dependency-name: i18n-tasks
+        versions: ">= 1.1.0"
       - dependency-name: rails
         versions: ">= 7.1.0"
       - dependency-name: rails-i18n
@@ -56,6 +61,8 @@ updates:
         patterns:
           - "*"
     ignore:
+      - dependency-name: i18n-tasks
+        versions: ">= 1.1.0"
       - dependency-name: rails
         versions: ">= 7.2.0"
       - dependency-name: rails-i18n
@@ -76,6 +83,8 @@ updates:
         patterns:
           - "*"
     ignore:
+      - dependency-name: i18n-tasks
+        versions: ">= 1.1.0"
       - dependency-name: rails
         versions: ">= 8.0.0"
       - dependency-name: rails-i18n
@@ -92,6 +101,8 @@ updates:
         patterns:
           - "*"
     ignore:
+      - dependency-name: i18n-tasks
+        versions: ">= 1.1.0"
       - dependency-name: rails
         versions: ">= 8.1.0"
       - dependency-name: rails-i18n

--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ group :test do
   gem "sqlite3", platform: :mri
 
   # Translations
-  gem "i18n-tasks"
+  gem "i18n-tasks", "~> 1.0.15" # See activeadmin/activeadmin#8851, glebm/i18n-tasks#682
   gem "i18n-spec"
   gem "rails-i18n" # Provides default i18n for many languages
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,14 +198,13 @@ GEM
       concurrent-ruby (~> 1.0)
     i18n-spec (0.6.0)
       iso
-    i18n-tasks (1.1.0)
+    i18n-tasks (1.0.15)
       activesupport (>= 4.0.2)
       ast (>= 2.1.0)
       erubi
-      highline (>= 3.0.0)
+      highline (>= 2.0.0)
       i18n
       parser (>= 3.2.2.1)
-      prism
       rails-i18n
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.8, >= 1.8.1)
@@ -477,7 +476,7 @@ DEPENDENCIES
   draper
   formtastic (>= 5.0.0)
   i18n-spec
-  i18n-tasks
+  i18n-tasks (~> 1.0.15)
   importmap-rails
   launchy
   parallel_tests

--- a/gemfiles/rails_70/Gemfile
+++ b/gemfiles/rails_70/Gemfile
@@ -34,7 +34,7 @@ group :test do
   gem "sqlite3", "~> 1.7", platform: :mri
 
   # Translations
-  gem "i18n-tasks"
+  gem "i18n-tasks", "~> 1.0.15" # See activeadmin/activeadmin#8851, glebm/i18n-tasks#682
   gem "i18n-spec"
   gem "rails-i18n" # Provides default i18n for many languages
 end

--- a/gemfiles/rails_70/Gemfile.lock
+++ b/gemfiles/rails_70/Gemfile.lock
@@ -195,14 +195,13 @@ GEM
       concurrent-ruby (~> 1.0)
     i18n-spec (0.6.0)
       iso
-    i18n-tasks (1.1.0)
+    i18n-tasks (1.0.15)
       activesupport (>= 4.0.2)
       ast (>= 2.1.0)
       erubi
-      highline (>= 3.0.0)
+      highline (>= 2.0.0)
       i18n
       parser (>= 3.2.2.1)
-      prism
       rails-i18n
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.8, >= 1.8.1)
@@ -278,7 +277,6 @@ GEM
     parser (3.3.10.0)
       ast (~> 2.4.1)
       racc
-    prism (1.6.0)
     public_suffix (6.0.2)
     pundit (2.5.2)
       activesupport (>= 3.0.0)
@@ -413,7 +411,7 @@ DEPENDENCIES
   devise
   draper
   i18n-spec
-  i18n-tasks
+  i18n-tasks (~> 1.0.15)
   importmap-rails
   launchy
   parallel_tests

--- a/gemfiles/rails_71/Gemfile
+++ b/gemfiles/rails_71/Gemfile
@@ -36,7 +36,7 @@ group :test do
   gem "sqlite3", platform: :mri
 
   # Translations
-  gem "i18n-tasks"
+  gem "i18n-tasks", "~> 1.0.15" # See activeadmin/activeadmin#8851, glebm/i18n-tasks#682
   gem "i18n-spec"
   gem "rails-i18n" # Provides default i18n for many languages
 end

--- a/gemfiles/rails_71/Gemfile.lock
+++ b/gemfiles/rails_71/Gemfile.lock
@@ -204,14 +204,13 @@ GEM
       concurrent-ruby (~> 1.0)
     i18n-spec (0.6.0)
       iso
-    i18n-tasks (1.1.0)
+    i18n-tasks (1.0.15)
       activesupport (>= 4.0.2)
       ast (>= 2.1.0)
       erubi
-      highline (>= 3.0.0)
+      highline (>= 2.0.0)
       i18n
       parser (>= 3.2.2.1)
-      prism
       rails-i18n
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.8, >= 1.8.1)
@@ -293,7 +292,6 @@ GEM
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
-    prism (1.6.0)
     psych (5.2.6)
       date
       stringio
@@ -446,7 +444,7 @@ DEPENDENCIES
   draper
   formtastic (>= 5.0.0)
   i18n-spec
-  i18n-tasks
+  i18n-tasks (~> 1.0.15)
   importmap-rails
   launchy
   parallel_tests

--- a/gemfiles/rails_72/Gemfile
+++ b/gemfiles/rails_72/Gemfile
@@ -36,7 +36,7 @@ group :test do
   gem "sqlite3", platform: :mri
 
   # Translations
-  gem "i18n-tasks"
+  gem "i18n-tasks", "~> 1.0.15" # See activeadmin/activeadmin#8851, glebm/i18n-tasks#682
   gem "i18n-spec"
   gem "rails-i18n" # Provides default i18n for many languages
 end

--- a/gemfiles/rails_72/Gemfile.lock
+++ b/gemfiles/rails_72/Gemfile.lock
@@ -198,14 +198,13 @@ GEM
       concurrent-ruby (~> 1.0)
     i18n-spec (0.6.0)
       iso
-    i18n-tasks (1.1.0)
+    i18n-tasks (1.0.15)
       activesupport (>= 4.0.2)
       ast (>= 2.1.0)
       erubi
-      highline (>= 3.0.0)
+      highline (>= 2.0.0)
       i18n
       parser (>= 3.2.2.1)
-      prism
       rails-i18n
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.8, >= 1.8.1)
@@ -286,7 +285,6 @@ GEM
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
-    prism (1.6.0)
     psych (5.2.6)
       date
       stringio
@@ -440,7 +438,7 @@ DEPENDENCIES
   draper
   formtastic (>= 5.0.0)
   i18n-spec
-  i18n-tasks
+  i18n-tasks (~> 1.0.15)
   importmap-rails
   launchy
   parallel_tests

--- a/gemfiles/rails_80/Gemfile
+++ b/gemfiles/rails_80/Gemfile
@@ -36,7 +36,7 @@ group :test do
   gem "sqlite3", platform: :mri
 
   # Translations
-  gem "i18n-tasks"
+  gem "i18n-tasks", "~> 1.0.15" # See activeadmin/activeadmin#8851, glebm/i18n-tasks#682
   gem "i18n-spec"
   gem "rails-i18n" # Provides default i18n for many languages
 end

--- a/gemfiles/rails_80/Gemfile.lock
+++ b/gemfiles/rails_80/Gemfile.lock
@@ -195,14 +195,13 @@ GEM
       concurrent-ruby (~> 1.0)
     i18n-spec (0.6.0)
       iso
-    i18n-tasks (1.1.0)
+    i18n-tasks (1.0.15)
       activesupport (>= 4.0.2)
       ast (>= 2.1.0)
       erubi
-      highline (>= 3.0.0)
+      highline (>= 2.0.0)
       i18n
       parser (>= 3.2.2.1)
-      prism
       rails-i18n
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.8, >= 1.8.1)
@@ -283,7 +282,6 @@ GEM
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
-    prism (1.6.0)
     psych (5.2.6)
       date
       stringio
@@ -437,7 +435,7 @@ DEPENDENCIES
   draper
   formtastic (>= 5.0.0)
   i18n-spec
-  i18n-tasks
+  i18n-tasks (~> 1.0.15)
   importmap-rails
   launchy
   parallel_tests


### PR DESCRIPTION
Rolls back the i18n-tasks update that introduced nondeterministic spec
failures.

The regression was bisected to glebm/i18n-tasks#644
(glebm/i18n-tasks@0c3697b) and is tracked upstream in
glebm/i18n-tasks#682.

Reproducible on Ruby 3.2, 3.3. Ruby 3.4 unaffected

Close #8851