### PR TITLE
Restore pointer cursor on eligible buttons

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -165,7 +165,11 @@ export default plugin(
         )}")`,
         'print-color-adjust': `exact`,
       },
-      [`[type='file']`]: {
+      [[
+        `button:not(:disabled)`,
+        `[role='button']:not(:disabled)`,
+        `[type='file']`,
+      ]]: {
         cursor: 'pointer',
       },
       [`[type=file]::file-selector-button`]: {


### PR DESCRIPTION
In v4.0.0.beta19 we lost the global `cursor: pointer` styling for interactive navbar links and buttons.

This regression stems from Tailwind's removal of the default pointer cursor on buttons and elements with `role="button"`.

Update plugin.js to explicitly set `cursor: pointer` for:
- `button:not(:disabled)`
- `[role='button']:not(:disabled)`

This restores expected hover behavior in the admin navbar and other interactive controls, aligning beta19 with beta18 UX.

Refs:
- tailwindlabs/tailwindcss#15773
- tailwindlabs/tailwindcss.com#2023

Fixes #8877
