### PR TITLE
Bump minimum required Ruby version to 3.0

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
     "wiki_uri" => "https://github.com/activeadmin/activeadmin/wiki"
   }
 
-  s.required_ruby_version = ">= 2.6"
+  s.required_ruby_version = ">= 3.0"
 
   s.add_dependency "arbre", "~> 1.2", ">= 1.2.1"
   s.add_dependency "csv"


### PR DESCRIPTION
The changes introduced in #8839 dropped support for all Ruby versions below 3.0, but the gemspec had not yet reflected this.

Update the gemspec to set the minimum required Ruby version to 3.0, aligning documentation and configuration with the currently supported runtime.

<!--

Thanks for contributing to ActiveAdmin!

You can find the instructions in our contributing guide: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md

Before submitting your PR make sure that:
* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are separated.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all CI checks are passing, but feel free to ask for early feedback if you need guidance.

[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->
