### PR TITLE
[v3]: Allow resource_class to be passed as a String

### DIFF
--- a/lib/active_admin/resource.rb
+++ b/lib/active_admin/resource.rb
@@ -70,7 +70,7 @@ module ActiveAdmin
     module Base
       def initialize(namespace, resource_class, options = {})
         @namespace = namespace
-        @resource_class_name = "::#{resource_class.name}"
+        @resource_class_name = resource_class.respond_to?(:name) ? "::#{resource_class.name}" : resource_class.to_s
         @options = options
         @sort_order = options[:sort_order]
         @member_actions = []

--- a/spec/unit/namespace/register_resource_spec.rb
+++ b/spec/unit/namespace/register_resource_spec.rb
@@ -31,6 +31,16 @@ RSpec.describe ActiveAdmin::Namespace, "registering a resource" do
     end
   end
 
+  context "when resource class is a string" do
+    before do
+      namespace.register 'Category'
+    end
+
+    it "should store the namespaced registered configuration" do
+      expect(namespace.resources.keys).to include("Category")
+    end
+  end
+
   context "with a block configuration" do
     it "should be evaluated in the dsl" do
       expect do |block|


### PR DESCRIPTION
the current pattern of using the class directly loads all models bound to activeadmin before using them, needlessly. besides that, the only purpose of it is to store the class name

this patch allows one to pass the class name directly instead, kind of like how activerecord avoids eager-loading association classes.
