### PR TITLE
Ensure DEBUG is unset when executing `bundle show`

### DIFF
--- a/lib/generators/active_admin/assets/templates/tailwind.config.js
+++ b/lib/generators/active_admin/assets/templates/tailwind.config.js
@@ -1,7 +1,12 @@
 import { execSync } from 'child_process';
 import activeAdminPlugin from '@activeadmin/activeadmin/plugin';
 
-const activeAdminPath = execSync('unset DEBUG; bundle show activeadmin', { encoding: 'utf-8' }).trim();
+// Remove DEBUG to prevent bundler from outputting extra text
+const { DEBUG: _, ...env } = { ...process.env };
+const activeAdminPath = execSync('bundle show activeadmin', {
+  encoding: 'utf-8',
+  env
+}).trim();
 
 export default {
   content: [


### PR DESCRIPTION
This was an unpleasant bug I ran into while trying to get my source compilation sorted out (cruelly, I had turned DEBUG on to help me troubleshoot a _different_ problem).

If DEBUG is set at all in the environment, even as an empty string with `DEBUG=`, bundler will output an extra message:
> Found no changes, using resolution from the lockfile

Because this goes to stdout, it gets included in the path the config file is using and asset compilation fails. Given that other people may well have this set in their envs for legitimate reasons, it seems wise to take precautions to ensure it doesn't blow up asset compilation.