### PR TITLE
Disable full automatic source scanning by Tailwind

### DIFF
--- a/lib/generators/active_admin/assets/templates/active_admin.css
+++ b/lib/generators/active_admin/assets/templates/active_admin.css
@@ -1,3 +1,3 @@
-@import "tailwindcss";
+@import "tailwindcss" source(none);
 
 @config "../../../tailwind-active_admin.config.js";


### PR DESCRIPTION
I don't know if this is something you want, but I thought I'd make the suggestion since I ran into this while upgrading and it took me a while to figure out. One way or another, this is probably something to document in the Tailwind setup instructions.

By default Tailwind will scan just about everything in your app code. For us, this meant things like the `log` dir, which made Tailwind exceptionally noisy, plus extra declarations in our admin stylesheet we didn't need. Most people aren't going to want their non-admin source code to be considered for the AA stylesheet, and since you have explicit `content` declarations in the `tailwind-active_admin.config.js` file, we don't really need Tailwind to be guessing any locations, so this seems like a good default to me.