### PR TITLE
Ignore extra bundler output when DEBUG is set

### DIFF
--- a/lib/generators/active_admin/assets/templates/tailwind.config.js
+++ b/lib/generators/active_admin/assets/templates/tailwind.config.js
@@ -1,11 +1,7 @@
 import { execSync } from 'child_process';
 import activeAdminPlugin from '@activeadmin/activeadmin/plugin';
 
-// Ensure only the last line of output is used from `bundle show activeadmin`,
-// in case bundler prints extra lines (e.g., DEBUG enabled).
-// Keep this assignment on a single line so that the Rails template `gsub_file`
-// matches and replaces it correctly.
-// Ref: https://github.com/activeadmin/activeadmin/pull/8891
+// Always use the last line of output since Bundler's DEBUG env will print additional lines.
 const activeAdminPath = execSync('bundle show activeadmin', { encoding: 'utf-8' }).trim().split(/\r?\n/).pop();
 
 export default {


### PR DESCRIPTION
When the DEBUG environment variable is set (even if empty), bundler may output additional messages to stdout, such as "Found no changes, using resolution from the lockfile". This can interfere with asset compilation, as scripts expecting a single path may instead receive multiple output lines, causing path corruption.

This commit adjusts the logic to always use the last line of the output from `bundle show activeadmin`, preventing such issues even if extraneous lines are present due to DEBUG or other future messaging changes.

Ref: https://github.com/activeadmin/activeadmin/pull/8891

<!--

Thanks for contributing to ActiveAdmin!

You can find the instructions in our contributing guide: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md

Before submitting your PR make sure that:
* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are separated.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all CI checks are passing, but feel free to ask for early feedback if you need guidance.

[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->
