### PR TITLE
Add "type: module" to generated package.json

### DIFF
--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -107,6 +107,10 @@ inject_into_file "config/application.rb", after: "class Application < Rails::App
   "\n    config.action_controller.action_on_unpermitted_parameters = :raise\n"
 end
 
+inject_into_file "package.json", after: '"private": "true",' do
+  "\n  \"type\": \"module\",\n"
+end
+
 # Add some translations
 append_file "config/locales/en.yml", File.read(File.expand_path("templates/en.yml", __dir__))
 


### PR DESCRIPTION
This change injects `"type": "module"` into the generated package.json via rails_template.rb.

This avoids the [MODULE_TYPELESS_PACKAGE_JSON] Node.js warning in CI about ES module syntax parsing.

With this update, the generated test app will have a clearer module type, improving dev experience and eliminating performance warnings during test runs.

Close #8899
