### PR TITLE
Add page anchor to comments form view

### DIFF
--- a/app/views/active_admin/shared/_resource_comments.html.erb
+++ b/app/views/active_admin/shared/_resource_comments.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-[700px]">
+<div id="active-admin-comments-form" class="max-w-[700px]">
   <div class="font-bold py-3 border-b border-gray-200 dark:border-gray-600">
     <%= ActiveAdmin::Comment.model_name.human(count: 2.1) %>
   </div>


### PR DESCRIPTION
This adds a page anchor to the comments form view so it can be linked (jumped) to.