### PR TITLE
Remove no-wrap from table columns

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -246,7 +246,7 @@ export default plugin(
         '@apply w-full text-sm text-gray-800 dark:text-gray-300': {}
       },
       '.data-table :where(thead > tr > th)': {
-        '@apply px-3 py-3.5 whitespace-nowrap font-semibold text-start text-xs uppercase border-b border-gray-200 text-gray-700 bg-gray-50 dark:bg-gray-950/50 dark:border-gray-800 dark:text-white': {}
+        '@apply px-3 py-3.5 font-semibold text-start text-xs uppercase border-b border-gray-200 text-gray-700 bg-gray-50 dark:bg-gray-950/50 dark:border-gray-800 dark:text-white': {}
       },
       '.data-table :where(thead > tr > th > a)': {
         '@apply text-inherit no-underline inline-flex items-center gap-2': {}


### PR DESCRIPTION
Let table columns adjust naturally even if the column heading is long but the content isn't, for either index tables or `table_for` usages as it's a better default. This can be changed as a base style or per column if users prefer. This won't cause the table to scroll offscreen in the case of `table_for` by default for small tables.