### PR TITLE
Update dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :development, :test do
   gem "pundit"
 
   gem "draper"
-  gem "devise"
+  gem "devise", "~> 4.9" # TODO: relax this dependency when formtastic/formtastic#1401 will be fixed
 
   gem "rails", "~> 8.1.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,13 +139,13 @@ GEM
       cucumber-gherkin (> 36, < 40)
       cucumber-messages (> 31, < 33)
       cucumber-tag-expressions (> 6, < 9)
-    cucumber-cucumber-expressions (18.0.1)
+    cucumber-cucumber-expressions (19.0.0)
       bigdecimal
-    cucumber-gherkin (37.0.1)
-      cucumber-messages (>= 31, < 32)
+    cucumber-gherkin (38.0.0)
+      cucumber-messages (>= 31, < 33)
     cucumber-html-formatter (22.3.0)
       cucumber-messages (> 23, < 33)
-    cucumber-messages (31.2.0)
+    cucumber-messages (32.0.1)
     cucumber-rails (4.0.0)
       capybara (>= 3.25, < 4)
       cucumber (>= 7, < 11)
@@ -247,8 +247,8 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
-    kramdown (2.5.1)
-      rexml (>= 3.3.9)
+    kramdown (2.5.2)
+      rexml (>= 3.4.4)
     language_server-protocol (3.17.0.5)
     launchy (3.1.1)
       addressable (~> 2.8)
@@ -300,13 +300,13 @@ GEM
     parallel (1.27.0)
     parallel_tests (5.5.0)
       parallel
-    parser (3.3.10.0)
+    parser (3.3.10.1)
       ast (~> 2.4.1)
       racc
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
-    prism (1.8.0)
+    prism (1.9.0)
     psych (5.3.1)
       date
       stringio
@@ -361,7 +361,7 @@ GEM
       activerecord (>= 7.2)
       activesupport (>= 7.2)
       i18n
-    rdoc (7.0.3)
+    rdoc (7.1.0)
       erb
       psych (>= 4.0.0)
       tsort
@@ -390,8 +390,8 @@ GEM
       rspec-expectations (~> 3.13)
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
-    rspec-support (3.13.6)
-    rubocop (1.82.1)
+    rspec-support (3.13.7)
+    rubocop (1.84.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -399,7 +399,7 @@ GEM
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.48.0, < 2.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
     rubocop-ast (1.49.0)
@@ -495,7 +495,7 @@ DEPENDENCIES
   cucumber-rails
   cuprite
   database_cleaner-active_record
-  devise
+  devise (~> 4.9)
   draper
   formtastic (>= 5.0.0)
   i18n-spec
@@ -523,4 +523,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-  4.0.3
+  4.0.5

--- a/gemfiles/rails_61/Gemfile.lock
+++ b/gemfiles/rails_61/Gemfile.lock
@@ -272,7 +272,7 @@ GEM
     parallel (1.27.0)
     parallel_tests (4.10.1)
       parallel
-    parser (3.3.10.0)
+    parser (3.3.10.1)
       ast (~> 2.4.1)
       racc
     public_suffix (6.0.2)
@@ -345,7 +345,7 @@ GEM
       rspec-expectations (~> 3.13)
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
-    rspec-support (3.13.6)
+    rspec-support (3.13.7)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     sassc (2.4.0)

--- a/gemfiles/rails_70/Gemfile
+++ b/gemfiles/rails_70/Gemfile
@@ -8,7 +8,7 @@ group :development, :test do
   gem "pundit"
 
   gem "draper"
-  gem "devise"
+  gem "devise", "~> 4.9" # TODO: relax this dependency when formtastic/formtastic#1401 will be fixed
 
   gem "rails", "~> 7.0.0"
 

--- a/gemfiles/rails_70/Gemfile.lock
+++ b/gemfiles/rails_70/Gemfile.lock
@@ -275,10 +275,10 @@ GEM
     parallel (1.27.0)
     parallel_tests (5.5.0)
       parallel
-    parser (3.3.10.0)
+    parser (3.3.10.1)
       ast (~> 2.4.1)
       racc
-    prism (1.8.0)
+    prism (1.9.0)
     public_suffix (6.0.2)
     pundit (2.5.2)
       activesupport (>= 3.0.0)
@@ -348,7 +348,7 @@ GEM
       rspec-expectations (~> 3.13)
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
-    rspec-support (3.13.6)
+    rspec-support (3.13.7)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     sassc (2.4.0)
@@ -418,7 +418,7 @@ DEPENDENCIES
   cucumber-rails
   cuprite
   database_cleaner-active_record
-  devise
+  devise (~> 4.9)
   draper
   i18n-spec
   i18n-tasks

--- a/gemfiles/rails_71/Gemfile
+++ b/gemfiles/rails_71/Gemfile
@@ -8,7 +8,7 @@ group :development, :test do
   gem "pundit"
 
   gem "draper"
-  gem "devise"
+  gem "devise", "~> 4.9" # TODO: relax this dependency when formtastic/formtastic#1401 will be fixed
 
   gem "rails", "~> 7.1.0"
 

--- a/gemfiles/rails_71/Gemfile.lock
+++ b/gemfiles/rails_71/Gemfile.lock
@@ -255,8 +255,8 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
-    kramdown (2.5.1)
-      rexml (>= 3.3.9)
+    kramdown (2.5.2)
+      rexml (>= 3.4.4)
     language_server-protocol (3.17.0.5)
     launchy (3.1.1)
       addressable (~> 2.8)
@@ -308,13 +308,13 @@ GEM
     parallel (1.27.0)
     parallel_tests (5.5.0)
       parallel
-    parser (3.3.10.0)
+    parser (3.3.10.1)
       ast (~> 2.4.1)
       racc
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
-    prism (1.8.0)
+    prism (1.9.0)
     psych (5.3.1)
       date
       stringio
@@ -370,7 +370,7 @@ GEM
       activerecord (>= 7.1)
       activesupport (>= 7.1)
       i18n
-    rdoc (7.0.3)
+    rdoc (7.1.0)
       erb
       psych (>= 4.0.0)
       tsort
@@ -399,8 +399,8 @@ GEM
       rspec-expectations (~> 3.13)
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
-    rspec-support (3.13.6)
-    rubocop (1.82.1)
+    rspec-support (3.13.7)
+    rubocop (1.84.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -408,7 +408,7 @@ GEM
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.48.0, < 2.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
     rubocop-ast (1.49.0)
@@ -503,7 +503,7 @@ DEPENDENCIES
   cucumber-rails
   cuprite
   database_cleaner-active_record
-  devise
+  devise (~> 4.9)
   draper
   formtastic (>= 5.0.0)
   i18n-spec

--- a/gemfiles/rails_72/Gemfile
+++ b/gemfiles/rails_72/Gemfile
@@ -8,7 +8,7 @@ group :development, :test do
   gem "pundit"
 
   gem "draper"
-  gem "devise"
+  gem "devise", "~> 4.9" # TODO: relax this dependency when formtastic/formtastic#1401 will be fixed
 
   gem "rails", "~> 7.2.0"
 

--- a/gemfiles/rails_72/Gemfile.lock
+++ b/gemfiles/rails_72/Gemfile.lock
@@ -249,8 +249,8 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
-    kramdown (2.5.1)
-      rexml (>= 3.3.9)
+    kramdown (2.5.2)
+      rexml (>= 3.4.4)
     language_server-protocol (3.17.0.5)
     launchy (3.1.1)
       addressable (~> 2.8)
@@ -301,13 +301,13 @@ GEM
     parallel (1.27.0)
     parallel_tests (5.5.0)
       parallel
-    parser (3.3.10.0)
+    parser (3.3.10.1)
       ast (~> 2.4.1)
       racc
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
-    prism (1.8.0)
+    prism (1.9.0)
     psych (5.3.1)
       date
       stringio
@@ -363,7 +363,7 @@ GEM
       activerecord (>= 7.2)
       activesupport (>= 7.2)
       i18n
-    rdoc (7.0.3)
+    rdoc (7.1.0)
       erb
       psych (>= 4.0.0)
       tsort
@@ -392,8 +392,8 @@ GEM
       rspec-expectations (~> 3.13)
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
-    rspec-support (3.13.6)
-    rubocop (1.82.1)
+    rspec-support (3.13.7)
+    rubocop (1.84.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -401,7 +401,7 @@ GEM
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.48.0, < 2.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
     rubocop-ast (1.49.0)
@@ -497,7 +497,7 @@ DEPENDENCIES
   cucumber-rails
   cuprite
   database_cleaner-active_record
-  devise
+  devise (~> 4.9)
   draper
   formtastic (>= 5.0.0)
   i18n-spec

--- a/gemfiles/rails_80/Gemfile
+++ b/gemfiles/rails_80/Gemfile
@@ -8,7 +8,7 @@ group :development, :test do
   gem "pundit"
 
   gem "draper"
-  gem "devise"
+  gem "devise", "~> 4.9" # TODO: relax this dependency when formtastic/formtastic#1401 will be fixed
 
   gem "rails", "~> 8.0.0"
 

--- a/gemfiles/rails_80/Gemfile.lock
+++ b/gemfiles/rails_80/Gemfile.lock
@@ -134,13 +134,13 @@ GEM
       cucumber-gherkin (> 36, < 40)
       cucumber-messages (> 31, < 33)
       cucumber-tag-expressions (> 6, < 9)
-    cucumber-cucumber-expressions (18.0.1)
+    cucumber-cucumber-expressions (19.0.0)
       bigdecimal
-    cucumber-gherkin (37.0.1)
-      cucumber-messages (>= 31, < 32)
+    cucumber-gherkin (38.0.0)
+      cucumber-messages (>= 31, < 33)
     cucumber-html-formatter (22.3.0)
       cucumber-messages (> 23, < 33)
-    cucumber-messages (31.2.0)
+    cucumber-messages (32.0.1)
     cucumber-rails (4.0.0)
       capybara (>= 3.25, < 4)
       cucumber (>= 7, < 11)
@@ -291,13 +291,13 @@ GEM
     parallel (1.27.0)
     parallel_tests (5.5.0)
       parallel
-    parser (3.3.10.0)
+    parser (3.3.10.1)
       ast (~> 2.4.1)
       racc
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
-    prism (1.8.0)
+    prism (1.9.0)
     psych (5.3.1)
       date
       stringio
@@ -352,7 +352,7 @@ GEM
       activerecord (>= 7.2)
       activesupport (>= 7.2)
       i18n
-    rdoc (7.0.3)
+    rdoc (7.1.0)
       erb
       psych (>= 4.0.0)
       tsort
@@ -381,7 +381,7 @@ GEM
       rspec-expectations (~> 3.13)
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
-    rspec-support (3.13.6)
+    rspec-support (3.13.7)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     sassc (2.4.0)
@@ -464,7 +464,7 @@ DEPENDENCIES
   cucumber-rails
   cuprite
   database_cleaner-active_record
-  devise
+  devise (~> 4.9)
   draper
   formtastic (>= 5.0.0)
   i18n-spec
@@ -485,4 +485,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-  4.0.3
+  4.0.5

--- a/spec/tasks/gemfile_spec.rb
+++ b/spec/tasks/gemfile_spec.rb
@@ -1,5 +1,26 @@
 # frozen_string_literal: true
 RSpec.describe "Gemfile sanity" do
+  # Strips the BUNDLED WITH section from a Gemfile.lock content string.
+  # This section only contains the Bundler version used and can differ between environments
+  # without affecting the actual dependency resolution.
+  #
+  # Handles various edge cases:
+  # - Different line endings (\n, \r\n)
+  # - Any amount of whitespace before the version number
+  # - Missing BUNDLED WITH section
+  # - Different formatting
+  def strip_bundled_with(lockfile_content)
+    # Normalize line endings to Unix style for consistent comparison
+    normalized = lockfile_content.gsub(/\r\n/, "\n")
+
+    # Remove the BUNDLED WITH section and everything after it
+    # The regex matches:
+    # - Optional newline before BUNDLED WITH
+    # - The BUNDLED WITH line itself
+    # - Any content after it (version number with any whitespace/line endings)
+    normalized.gsub(/\n?BUNDLED WITH\n.*\z/m, '').strip
+  end
+
   it "is up to date" do
     gemfile = ENV["BUNDLE_GEMFILE"] || "Gemfile"
     current_lockfile = File.read("#{gemfile}.lock")
@@ -10,6 +31,8 @@ RSpec.describe "Gemfile sanity" do
 
     msg = "Please update #{gemfile}'s lock file with `BUNDLE_GEMFILE=#{gemfile} bundle install` and commit the result"
 
-    expect(current_lockfile).to eq(new_lockfile), msg
+    # Compare lockfiles without the BUNDLED WITH section to avoid false failures
+    # when only the Bundler version differs between environments
+    expect(strip_bundled_with(current_lockfile)).to eq(strip_bundled_with(new_lockfile)), msg
   end
 end


### PR DESCRIPTION
Ruby versions used for gem update:
- Rails 6.1: Ruby 3.0
- Rails 7.0/7.1/7.2: Ruby 3.1
- Rails 8.0/8.1: Ruby 3.2

Additionally:
- Lock Devise to 4.9 because of formtastic/formtastic#1401
- Backport #8920 to v3
