### PR TITLE
Set <select> children bg color in dark mode for Windows browsers

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -194,6 +194,11 @@ export default plugin(
       [['[type=datetime-local]', '[type=month]', '[type=week]', '[type=search]', '[type=date]', '[type=email]', '[type=number]', '[type=password]', '[type=tel]', '[type=text]', '[type=time]', '[type=url]', 'select', 'textarea']]: {
         '@apply bg-gray-50 border border-gray-300 text-gray-900 placeholder:text-gray-400 rounded-md focus:ring-blue-500 focus:border-blue-500 w-full dark:bg-white/5 dark:border-white/10 dark:text-white dark:placeholder:text-gray-500 dark:focus:ring-blue-500 dark:focus:border-blue-500': {}
       },
+      [':where(select:not([multiple]))']: {
+        'option, optgroup': {
+          '@apply dark:bg-gray-800': {}
+        }
+      },
       'a': {
         '@apply text-blue-600 dark:text-blue-500 underline underline-offset-[.2rem]': {}
       },


### PR DESCRIPTION
This sets an explicit background color on the select element (drop down) children to fix the display issue on Windows based browsers (e.g. Chrome) when in dark mode. This doesn't apply on Mac. For added confirmation, Tailwind does this in their example form layout for the Country drop down https://tailwindcss.com/plus/ui-blocks/application-ui/forms/form-layouts
