### PR TITLE
Add Devise 5 and Formtastic 6 support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Now install the development dependencies:
 
 ```sh
 gem install foreman
-bundle install
+bundle install --all
 yarn install
 ```
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,13 +8,13 @@ group :development, :test do
   gem "pundit"
 
   gem "draper"
-  gem "devise", "~> 4.9" # TODO: relax this dependency when formtastic/formtastic#1401 will be fixed
+  gem "devise"
 
   gem "rails", "~> 8.1.0"
 
   gem "sprockets-rails"
   gem "ransack", ">= 4.2.0"
-  gem "formtastic", ">= 5.0.0"
+  gem "formtastic", ">= 6.0.0"
 
   gem "cssbundling-rails"
   gem "importmap-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     activeadmin (4.0.0.beta21)
       arbre (~> 2.0)
       csv
-      formtastic (>= 5.0)
+      formtastic (>= 6.0)
       formtastic_i18n (>= 0.7)
       inherited_resources (~> 2.0)
       kaminari (>= 1.2.1)
@@ -156,10 +156,10 @@ GEM
       database_cleaner-core (~> 2.0)
     database_cleaner-core (2.0.1)
     date (3.5.1)
-    devise (4.9.4)
+    devise (5.0.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0)
+      railties (>= 7.0)
       responders
       warden (~> 1.2.3)
     diff-lcs (1.6.2)
@@ -482,9 +482,9 @@ DEPENDENCIES
   cucumber-rails
   cuprite
   database_cleaner-active_record
-  devise (~> 4.9)
+  devise
   draper
-  formtastic (>= 5.0.0)
+  formtastic (>= 6.0.0)
   i18n-spec
   i18n-tasks
   importmap-rails

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "arbre", "~> 2.0"
   s.add_dependency "csv"
-  s.add_dependency "formtastic", ">= 5.0"
+  s.add_dependency "formtastic", ">= 6.0"
   s.add_dependency "formtastic_i18n", ">= 0.7"
   s.add_dependency "inherited_resources", "~> 2.0"
   s.add_dependency "kaminari", ">= 1.2.1"

--- a/gemfiles/rails_72/Gemfile
+++ b/gemfiles/rails_72/Gemfile
@@ -8,13 +8,13 @@ group :development, :test do
   gem "pundit"
 
   gem "draper"
-  gem "devise", "~> 4.9" # TODO: relax this dependency when formtastic/formtastic#1401 will be fixed
+  gem "devise"
 
   gem "rails", "~> 7.2.0"
 
   gem "sprockets-rails"
   gem "ransack", ">= 4.2.0"
-  gem "formtastic", ">= 5.0.0"
+  gem "formtastic", ">= 6.0.0"
 
   gem "cssbundling-rails"
   gem "importmap-rails"

--- a/gemfiles/rails_72/Gemfile.lock
+++ b/gemfiles/rails_72/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     activeadmin (4.0.0.beta21)
       arbre (~> 2.0)
       csv
-      formtastic (>= 5.0)
+      formtastic (>= 6.0)
       formtastic_i18n (>= 0.7)
       inherited_resources (~> 2.0)
       kaminari (>= 1.2.1)
@@ -157,10 +157,10 @@ GEM
       database_cleaner-core (~> 2.0)
     database_cleaner-core (2.0.1)
     date (3.5.1)
-    devise (4.9.4)
+    devise (5.0.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0)
+      railties (>= 7.0)
       responders
       warden (~> 1.2.3)
     diff-lcs (1.6.2)
@@ -442,9 +442,9 @@ DEPENDENCIES
   cucumber-rails
   cuprite
   database_cleaner-active_record
-  devise (~> 4.9)
+  devise
   draper
-  formtastic (>= 5.0.0)
+  formtastic (>= 6.0.0)
   i18n-spec
   i18n-tasks
   importmap-rails

--- a/gemfiles/rails_80/Gemfile
+++ b/gemfiles/rails_80/Gemfile
@@ -8,13 +8,13 @@ group :development, :test do
   gem "pundit"
 
   gem "draper"
-  gem "devise", "~> 4.9" # TODO: relax this dependency when formtastic/formtastic#1401 will be fixed
+  gem "devise"
 
   gem "rails", "~> 8.0.0"
 
   gem "sprockets-rails"
   gem "ransack", ">= 4.2.0"
-  gem "formtastic", ">= 5.0.0"
+  gem "formtastic", ">= 6.0.0"
 
   gem "cssbundling-rails"
   gem "importmap-rails"

--- a/gemfiles/rails_80/Gemfile.lock
+++ b/gemfiles/rails_80/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     activeadmin (4.0.0.beta21)
       arbre (~> 2.0)
       csv
-      formtastic (>= 5.0)
+      formtastic (>= 6.0)
       formtastic_i18n (>= 0.7)
       inherited_resources (~> 2.0)
       kaminari (>= 1.2.1)
@@ -154,10 +154,10 @@ GEM
       database_cleaner-core (~> 2.0)
     database_cleaner-core (2.0.1)
     date (3.5.1)
-    devise (4.9.4)
+    devise (5.0.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0)
+      railties (>= 7.0)
       responders
       warden (~> 1.2.3)
     diff-lcs (1.6.2)
@@ -439,9 +439,9 @@ DEPENDENCIES
   cucumber-rails
   cuprite
   database_cleaner-active_record
-  devise (~> 4.9)
+  devise
   draper
-  formtastic (>= 5.0.0)
+  formtastic (>= 6.0.0)
   i18n-spec
   i18n-tasks
   importmap-rails

--- a/lib/active_admin/dependency.rb
+++ b/lib/active_admin/dependency.rb
@@ -2,7 +2,7 @@
 module ActiveAdmin
   module Dependency
     module Requirements
-      DEVISE = ">= 4.0", "< 5"
+      DEVISE = ">= 4.0", "< 6"
     end
 
     # Provides a clean interface to check for gem dependencies at runtime.

--- a/spec/tasks/gemfile_spec.rb
+++ b/spec/tasks/gemfile_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Gemfile sanity" do
       `bundle lock --print`
     end
 
-    msg = "Please update #{gemfile}'s lock file with `BUNDLE_GEMFILE=#{gemfile} bundle install` and commit the result"
+    msg = "Please update #{gemfile}'s lock file with `BUNDLE_GEMFILE=#{gemfile} bundle install --all` and commit the result"
 
     # Compare lockfiles without the BUNDLED WITH section to avoid false failures
     # when only the Bundler version differs between environments


### PR DESCRIPTION
Keep Devise minimum unchanged to avoid unnecessary breakage for
downstream apps. Raising the required versions would force upgrades
without a strict need, since Devise 4 remains supported.

Formtastic instead is required to be >= 6. It matches ActiveAdmin's
minimum Ruby requirement and is compatible with both Devise 4 and 5.

CI, however, will run the test matrix only against Devise 5 to validate
compatibility with current versions.

Additionally, update bundle syntax in spec for v4

Close https://github.com/activeadmin/activeadmin/issues/8906