### PR TITLE
Add go-to-page input to pagination controls

### DIFF
--- a/app/javascript/active_admin.js
+++ b/app/javascript/active_admin.js
@@ -6,5 +6,6 @@ import "active_admin/features/has_many"
 import "active_admin/features/filters"
 import "active_admin/features/main_menu"
 import "active_admin/features/per_page"
+import "active_admin/features/go_to_page"
 
 Rails.start()

--- a/app/javascript/active_admin/features/go_to_page.js
+++ b/app/javascript/active_admin/features/go_to_page.js
@@ -1,0 +1,20 @@
+import Rails from '@rails/ujs';
+
+const goToPage = function(event) {
+  if (event.key !== "Enter") return;
+
+  const input = this;
+  const page = parseInt(input.value, 10);
+  const totalPages = parseInt(input.dataset.totalPages, 10);
+
+  if (isNaN(page) || page < 1 || page > totalPages) {
+    input.value = input.defaultValue;
+    return;
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  params.set("page", page);
+  window.location.search = params;
+}
+
+Rails.delegate(document, ".pagination-go-to-page", "keydown", goToPage);

--- a/app/views/active_admin/kaminari/_paginator.html.erb
+++ b/app/views/active_admin/kaminari/_paginator.html.erb
@@ -7,7 +7,7 @@
     paginator:     the paginator that renders the pagination tags inside
 -%>
 <%= paginator.render do -%>
-  <nav data-test-pagination class="inline-flex flex-wrap -space-x-px text-sm gap-1">
+  <nav data-test-pagination class="inline-flex flex-wrap items-center text-sm gap-1">
     <%= prev_page_tag unless current_page.first? %>
     <% each_page do |page| -%>
       <% if page.display_tag? -%>
@@ -18,6 +18,14 @@
     <% end -%>
     <% unless current_page.out_of_range? %>
       <%= next_page_tag unless current_page.last? %>
+    <% end %>
+    <% if total_pages > 1 %>
+      <span class="flex items-center justify-center px-2.5 py-3 h-8 leading-tight text-gray-500 dark:text-gray-400">
+        <%= t('active_admin.pagination.go_to_page') %>
+      </span>
+      <input type="number" min="1" max="<%= total_pages %>" value="<%= current_page %>"
+             class="pagination-go-to-page w-14 h-8 px-2 py-1 text-sm text-center text-gray-500 dark:text-gray-400 border border-gray-300 rounded bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:ring-blue-500 focus:border-blue-500"
+             data-total-pages="<%= total_pages %>" />
     <% end %>
   </nav>
 <% end -%>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -107,6 +107,7 @@ en:
       next: Next
       one: Showing <b>1</b> of <b>1</b>
       one_page: Showing <b>all %{n}</b>
+      go_to_page: 'Go to'
       per_page: 'Per page '
       previous: Previous
       truncate: "&hellip;"


### PR DESCRIPTION
- Adds a page number input field to the pagination bar on index pages
- Users can type a page number and press Enter to jump directly to that page
- Follows established patterns from Ant Design / Element UI (quick jumper)
- Input placed after the next-page arrow, using the same spacing as other pagination elements
