### PR TITLE
Single query with `pagination_total: false`

### DIFF
--- a/spec/unit/views/components/paginated_collection_spec.rb
+++ b/spec/unit/views/components/paginated_collection_spec.rb
@@ -230,41 +230,28 @@ RSpec.describe ActiveAdmin::Views::PaginatedCollection do
     end
 
     describe "when pagination_total is false" do
-      it "makes no expensive COUNT queries" do
-        undecorated_collection = Post.all.page(1).per(30)
-
-        expect { paginated_collection(undecorated_collection, pagination_total: false) }
-          .not_to perform_database_query("SELECT COUNT(*) FROM \"posts\"")
-
-        decorated_collection = controller_with_decorator("index", PostDecorator).apply_collection_decorator(undecorated_collection.reset)
-
-        expect { paginated_collection(decorated_collection, pagination_total: false) }
-          .not_to perform_database_query("SELECT COUNT(*) FROM \"posts\"")
-      end
-
-      it "makes a performant COUNT query to figure out if we are on the last page" do
-        # "SELECT COUNT(*) FROM (SELECT 1". Let's make sure the subquery has LIMIT and OFFSET. It shouldn't have ORDER BY
-        count_query = %r{SELECT COUNT\(\*\) FROM \(SELECT 1 .*FROM "posts" (?=.*OFFSET \?)(?=.*LIMIT \?)(?!.*ORDER BY)}
+      it "performs no COUNT queries" do
+        count_query = %r{SELECT COUNT}
 
         undecorated_collection = Post.all.page(1).per(30)
 
         expect { paginated_collection(undecorated_collection, pagination_total: false) }
-          .to perform_database_query(count_query)
+          .not_to perform_database_query(count_query)
 
         undecorated_sorted_collection = undecorated_collection.reset.order(id: :desc)
 
         expect { paginated_collection(undecorated_sorted_collection, pagination_total: false) }
-          .to perform_database_query(count_query)
+          .not_to perform_database_query(count_query)
 
         decorated_collection = controller_with_decorator("index", PostDecorator).apply_collection_decorator(undecorated_collection.reset)
 
         expect { paginated_collection(decorated_collection, pagination_total: false) }
-          .to perform_database_query(count_query)
+          .not_to perform_database_query(count_query)
 
         decorated_sorted_collection = controller_with_decorator("index", PostDecorator).apply_collection_decorator(undecorated_sorted_collection.reset)
 
         expect { paginated_collection(decorated_sorted_collection, pagination_total: false) }
-          .to perform_database_query(count_query)
+          .not_to perform_database_query(count_query)
       end
     end
 


### PR DESCRIPTION
Use a trick similar to Kaminari to perform just one query when paginating without a total. This is done by fetching an extra row to determine if there's a next page. 

The goal here is performance. Typically `pagination_total: false` is used on large tables, so cutting out a query is desirable.

Code reference from Kaminari:
https://github.com/kaminari/kaminari/blob/76511e3c2c09d8adcd3a686d2c3ec6829a98f37e/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb#L85-L101
<!--

Thanks for contributing to ActiveAdmin!

You can find the instructions in our contributing guide: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md

Before submitting your PR make sure that:
* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are separated.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all CI checks are passing, but feel free to ask for early feedback if you need guidance.

[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->
