### PR TITLE
Re-enable bug report template workflow

### DIFF
--- a/.github/workflows/bug-report-template.yml
+++ b/.github/workflows/bug-report-template.yml
@@ -17,7 +17,7 @@ jobs:
   bug_report_template_test:
     name: Run bug report template
     # Don't run scheduled workflow on forks
-    if: ${{ false && (github.event_name == 'pull_request' || github.repository_owner == 'activeadmin') }}
+    if: ${{ (github.event_name == 'pull_request' || github.repository_owner == 'activeadmin') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
I had to disable this in #8934 due to an upstream issue https://github.com/ruby/rubygems/issues/9284 which has since been resolved. This re-enables the bug report template workflow which should run successfully now.
