### PR TITLE
3.5: Replace deprecated `dialogClass` with `classes`

### DIFF
--- a/app/assets/javascripts/active_admin/base.js
+++ b/app/assets/javascripts/active_admin/base.js
@@ -69,7 +69,9 @@
       open: function open(_event, _ui) {
         $("body").trigger("modal_dialog:after_open", [ form ]);
       },
-      dialogClass: "active_admin_dialog",
+      classes: {
+        "ui-dialog": "active_admin_dialog"
+      },
       buttons: {
         OK: function OK() {
           callback($(this).serializeObject());

--- a/app/javascript/active_admin/lib/modal-dialog.js
+++ b/app/javascript/active_admin/lib/modal-dialog.js
@@ -47,7 +47,7 @@ function ModalDialog(message, inputs, callback){
     open(_event, _ui) {
       $('body').trigger('modal_dialog:after_open', [form]);
     },
-    dialogClass: 'active_admin_dialog',
+    classes: { 'ui-dialog': 'active_admin_dialog' },
     buttons: {
       OK() {
         callback($(this).serializeObject());


### PR DESCRIPTION
jQuery UI 1.14 sets $.uiBackCompat to false by default, which disables the deprecated dialogClass option. This caused the 'active_admin_dialog' class to no longer be applied to the dialog wrapper, breaking the CSS selector that hides the titlebar close button.

Migrate to the classes option, which is the non-deprecated API for adding custom classes to widget elements.

Closes #8977

## Screenshot

http://localhost:3000/admin/admin_users > Select All > Delete selected

### Before (`3-0-stable`)

<img width="395" height="195" alt="image" src="https://github.com/user-attachments/assets/399be6d8-9d96-466f-9e2d-03c9dcb13998" />

### After (this branch)

<img width="446" height="252" alt="image" src="https://github.com/user-attachments/assets/540101a6-6d0b-4467-87b7-d9f822fa540e" />
