### PR TITLE
Do not apply authorization scope when building new resources

### DIFF
--- a/app/controllers/active_admin/resource_controller/data_access.rb
+++ b/app/controllers/active_admin/resource_controller/data_access.rb
@@ -127,9 +127,15 @@ module ActiveAdmin
       # Builds a new resource. This method uses the method_for_build provided
       # by Inherited Resources.
       #
+      # Authorization scoping is intentionally not applied here because
+      # scope conditions (e.g. where clauses) would be propagated as
+      # attributes on the new record by Active Record.
+      # Authorization for new resources is handled by authorize_resource!
+      # in build_resource instead.
+      #
       # @return [ActiveRecord::Base] An un-saved active record base object
       def build_new_resource
-        apply_authorization_scope(scoped_collection).send(
+        scoped_collection.send(
           method_for_build,
           *resource_params.map { |params| params.slice(active_admin_config.resource_class.inheritance_column) }
         )

--- a/spec/unit/resource_controller/data_access_spec.rb
+++ b/spec/unit/resource_controller/data_access_spec.rb
@@ -266,11 +266,9 @@ RSpec.describe ActiveAdmin::ResourceController::DataAccess do
     context "given authorization scope" do
       let(:authorization) { controller.send(:active_admin_authorization) }
 
-      it "should apply authorization scope" do
-        expect(authorization).to receive(:scope_collection) do |collection|
-          collection.where(age: "42")
-        end
-        expect(subject.age).to eq(42)
+      it "should not apply authorization scope to avoid scoped attributes leaking into new records" do
+        expect(authorization).not_to receive(:scope_collection)
+        subject
       end
     end
   end


### PR DESCRIPTION
This is a possible fix for [#8969](https://github.com/activeadmin/activeadmin/issues/8969). 

It stops using `apply_authorization_scope` in `build_new_resource` to avoid copying scoped attributes to the new records that are created.

All tests pass but I'm unsure if it's possible there is reliance on this quirk by any users. 