### PR TITLE
Drop Ruby 3.2 support

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,7 +14,7 @@ Active Admin is a Ruby on Rails framework for creating elegant backends for webs
 
 ## Ruby Conventions
 
-- Minimum Ruby version: 3.2+ (required)
+- Minimum Ruby version: 3.3+ (required)
 - Minimum Rails version: 7.2+ (required by gemspec)
 - Current development uses Rails ~> 8.1.0
 - Follow RuboCop style guide (configuration in `.rubocop.yml`)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,6 @@ jobs:
           - "4.0"
           - "3.4"
           - "3.3"
-          - "3.2"
         os:
           - ubuntu-latest
         rails:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ plugins:
 
 AllCops:
   DisabledByDefault: true
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
   TargetRailsVersion: 7.2
 
   Exclude:

--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
     "wiki_uri" => "https://github.com/activeadmin/activeadmin/wiki"
   }
 
-  s.required_ruby_version = ">= 3.2"
+  s.required_ruby_version = ">= 3.3"
 
   s.add_dependency "arbre", "~> 2.0"
   s.add_dependency "csv"


### PR DESCRIPTION
This drops support for end-of-life Ruby 3.2.