### PR TITLE
Update RuboCop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,43 +36,49 @@ AllCops:
 Capybara:
   Enabled: true
 
-Capybara/ClickLinkOrButtonStyle:
+Capybara/AssertStyle:
   Enabled: true
 
-Capybara/CurrentPathExpectation:
+Capybara/ClickLinkOrButtonStyle:
   Enabled: true
 
 Capybara/FindAllFirst:
   Enabled: true
 
-Capybara/MatchStyle:
-  Enabled: true
-
-Capybara/NegationMatcher:
-  Enabled: true
-
-Capybara/NegationMatcherAfterVisit:
-  Enabled: true
-
 Capybara/RedundantWithinFind:
+  Enabled: true
+
+Capybara/RSpec/CurrentPathExpectation:
+  Enabled: true
+
+Capybara/RSpec/HaveContent:
   Enabled: true
 
 Capybara/RSpec/HaveSelector:
   Enabled: true
 
+Capybara/RSpec/MatchStyle:
+  Enabled: true
+
+Capybara/RSpec/NegationMatcher:
+  Enabled: true
+
+Capybara/RSpec/NegationMatcherAfterVisit:
+  Enabled: true
+
 Capybara/RSpec/PredicateMatcher:
+  Enabled: true
+
+Capybara/RSpec/SpecificMatcher:
+  Enabled: true
+
+Capybara/RSpec/VisibilityMatcher:
   Enabled: true
 
 Capybara/SpecificActions:
   Enabled: true
 
 Capybara/SpecificFinders:
-  Enabled: true
-
-Capybara/SpecificMatcher:
-  Enabled: true
-
-Capybara/VisibilityMatcher:
   Enabled: true
 
 Layout/EndAlignment:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,7 +172,7 @@ GEM
       request_store (>= 1.0)
       ruby2_keywords
     drb (2.2.3)
-    erb (6.0.3)
+    erb (6.0.4)
     erubi (1.13.1)
     ferrum (0.17.2)
       addressable (~> 2.5)
@@ -220,7 +220,7 @@ GEM
       railties (>= 7.0)
       responders (>= 2)
     io-console (0.8.2)
-    irb (1.17.0)
+    irb (1.18.0)
       pp (>= 0.6.0)
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
@@ -264,7 +264,7 @@ GEM
       drb (~> 2.0)
       prism (~> 1.5)
     multi_test (1.1.0)
-    net-imap (0.6.3)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)
@@ -274,16 +274,16 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
-    nokogiri (1.19.2-aarch64-linux-gnu)
+    nokogiri (1.19.3-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.2-arm64-darwin)
+    nokogiri (1.19.3-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.2-x86_64-darwin)
+    nokogiri (1.19.3-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.2-x86_64-linux-gnu)
+    nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
     orm_adapter (0.5.0)
-    parallel (2.0.1)
+    parallel (2.1.0)
     parallel_tests (5.7.0)
       parallel
     parser (3.3.11.1)
@@ -391,9 +391,9 @@ GEM
     rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
-    rubocop-capybara (2.22.1)
+    rubocop-capybara (2.23.0)
       lint_roller (~> 1.1)
-      rubocop (~> 1.72, >= 1.72.1)
+      rubocop (~> 1.81)
     rubocop-packaging (0.6.0)
       lint_roller (~> 1.1.0)
       rubocop (>= 1.72.1, < 2.0)
@@ -502,4 +502,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-  4.0.9
+  4.0.11

--- a/features/step_definitions/additional_web_steps.rb
+++ b/features/step_definitions/additional_web_steps.rb
@@ -53,7 +53,7 @@ end
 
 Then(/^I should see the page title "([^"]*)"$/) do |title|
   within("[data-test-page-header]") do
-    expect(page).to have_content title
+    expect(page).to have_text title
   end
 end
 

--- a/features/step_definitions/format_steps.rb
+++ b/features/step_definitions/format_steps.rb
@@ -63,5 +63,5 @@ Then(/^the CSV file should start with BOM$/) do
 end
 
 Then(/^access denied$/) do
-  expect(page).to have_content(I18n.t("active_admin.access_denied.message"))
+  expect(page).to have_text(I18n.t("active_admin.access_denied.message"))
 end

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -85,7 +85,7 @@ end
 
 Then(/^I should( not)? see( the element)? "([^"]*)"$/) do |negate, is_css, text|
   should = negate ? :not_to : :to
-  have = is_css ? have_css(text) : have_content(text)
+  have = is_css ? have_css(text) : have_text(text)
   expect(page).send should, have
 end
 
@@ -132,5 +132,5 @@ Then(/^I should see content "(.*?)" above other content "(.*?)"$/) do |top_title
 end
 
 Then(/^I should see a flash with "([^"]*)"$/) do |text|
-  expect(page).to have_content text
+  expect(page).to have_text text
 end

--- a/gemfiles/rails_72/Gemfile.lock
+++ b/gemfiles/rails_72/Gemfile.lock
@@ -459,4 +459,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-  4.0.9
+  4.0.11

--- a/gemfiles/rails_80/Gemfile.lock
+++ b/gemfiles/rails_80/Gemfile.lock
@@ -458,4 +458,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-  4.0.9
+  4.0.11


### PR DESCRIPTION
- Move `Capybara` cops to their new `Capybara/RSpec` counterpart
- Add missing new cops
- Fix new `Capybara/RSpec/HaveContent` offenses
