### PR TITLE
Allow supplied HTML in table_for column header

### DIFF
--- a/lib/active_admin/views/components/table_for.rb
+++ b/lib/active_admin/views/components/table_for.rb
@@ -83,9 +83,9 @@ module ActiveAdmin
         if sort_key
           th(attributes) do
             link_to params: params, order: "#{sort_key}_#{order_for_sort_key(sort_key)}" do
-              svg = '<svg class="data-table-sorted-icon" fill="none" viewBox="0 0 10 6"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 4 4 4-4"/></svg>'
+              svg = '<svg class="data-table-sorted-icon" fill="none" viewBox="0 0 10 6"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 4 4 4-4"/></svg>'.html_safe
 
-              (col.pretty_title + svg).html_safe
+              safe_join([col.pretty_title, svg])
             end
           end
         else

--- a/spec/unit/views/components/table_for_spec.rb
+++ b/spec/unit/views/components/table_for_spec.rb
@@ -229,6 +229,27 @@ RSpec.describe ActiveAdmin::Views::TableFor do
       end
     end
 
+    context "when adding an image to a sortable column header" do
+      before { allow(helpers).to receive(:url_target) { "routing_stub" } }
+
+      let(:active_admin_config) { ActiveAdmin::Namespace.new(ActiveAdmin::Application.new, :admin) }
+      let(:assigns) { { collection: collection, active_admin_config: active_admin_config } }
+      let(:table) do
+        render_arbre_component assigns, helpers do
+          svg = content_tag :svg, width: "20", height: "20" do
+            content_tag :use, nil, href: "path/to/some.svg#main"
+          end
+          table_for(collection, sortable: true) do
+            column(svg, sortable: :title) { |post| post.title }
+          end
+        end
+      end
+
+      it "should not contain an escaped content" do
+        expect(table.find_by_tag("th").first.content).not_to include("&lt;")
+      end
+    end
+
     context "when using a single record instead of a collection" do
       let(:table) do
         render_arbre_component nil, helpers do

--- a/spec/unit/views/components/table_for_spec.rb
+++ b/spec/unit/views/components/table_for_spec.rb
@@ -245,7 +245,7 @@ RSpec.describe ActiveAdmin::Views::TableFor do
         end
       end
 
-      it "should not contain an escaped content" do
+      it "should not contain escaped content" do
         expect(table.find_by_tag("th").first.content).not_to include("&lt;")
       end
     end

--- a/spec/unit/views/components/table_for_spec.rb
+++ b/spec/unit/views/components/table_for_spec.rb
@@ -229,24 +229,23 @@ RSpec.describe ActiveAdmin::Views::TableFor do
       end
     end
 
-    context "when adding an image to a sortable column header" do
+    context "when adding html to a sortable column header" do
       before { allow(helpers).to receive(:url_target) { "routing_stub" } }
 
       let(:active_admin_config) { ActiveAdmin::Namespace.new(ActiveAdmin::Application.new, :admin) }
       let(:assigns) { { collection: collection, active_admin_config: active_admin_config } }
       let(:table) do
         render_arbre_component assigns, helpers do
-          svg = content_tag :svg, width: "20", height: "20" do
-            content_tag :use, nil, href: "path/to/some.svg#main"
-          end
+          span = content_tag :span, 'Title'
           table_for(collection, sortable: true) do
-            column(svg, sortable: :title) { |post| post.title }
+            column(span, sortable: :title) { |post| post.title }
           end
         end
       end
 
-      it "should not contain escaped content" do
-        expect(table.find_by_tag("th").first.content).not_to include("&lt;")
+      it "should not escape the inner html" do
+        expect(table.find_by_tag("th").first.content).to include("<span")
+        expect(table.find_by_tag("th").first.content).to include("<svg")
       end
     end
 


### PR DESCRIPTION
This fixes the issue when you pass an image to column title – in that case arrow svg is shown as raw html in header cell. What I do in my index block:

```ruby
svg = content_tag :svg, width: '20', height: '20' do
  content_tag :use, nil, href: image_path("icons/key.svg#main")
end
column(svg, sortable: :access_level) { |r| r.access_level }
```

Besides I think here is a security issue as well – here title is not escaped but marked as `html_safe` after svg is added.

This patch safely joins both title and arrow svg.