### PR TITLE
Fix Rails 8.1 hash-arg deprecation in page_routes

### DIFF
--- a/lib/active_admin/router.rb
+++ b/lib/active_admin/router.rb
@@ -68,7 +68,7 @@ module ActiveAdmin
       router.get "/#{page}", to: "#{page}#index"
       config.page_actions.each do |action|
         Array.wrap(action.http_verb).each do |verb|
-          build_route(verb, "/#{page}/#{action.name}" => "#{page}##{action.name}")
+          build_route(verb, "/#{page}/#{action.name}", to: "#{page}##{action.name}")
         end
       end
     end

--- a/spec/unit/routing_spec.rb
+++ b/spec/unit/routing_spec.rb
@@ -222,5 +222,52 @@ RSpec.describe "Routing", type: :routing do
         expect(admin_log_path).to eq "/admin/log"
       end
     end
+
+    context "with page_actions" do
+      around do |example|
+        with_resources_during(example) do
+          ActiveAdmin.register_page("Log") do
+            page_action :archive, method: :post
+            page_action :stats, method: :get
+          end
+        end
+      end
+
+      it "routes a POST page_action" do
+        expect({ post: "/admin/log/archive" }).to \
+          route_to({ controller: "admin/log", action: "archive" })
+      end
+
+      it "routes a GET page_action" do
+        expect({ get: "/admin/log/stats" }).to \
+          route_to({ controller: "admin/log", action: "stats" })
+      end
+    end
+
+    # Regression coverage for the Rails 8.1 deprecation that `Router#page_routes`
+    # used to emit via `build_route(verb, "/path" => "controller#action")`.
+    # Reproduces by intercepting `ActionDispatch.deprecator.warn` during route
+    # registration and asserting no "received a hash argument" message fires.
+    context "when registering a page with page_actions" do
+      it "does not emit a hash-argument deprecation from the routing DSL" do
+        deprecations = []
+        allow(ActionDispatch.deprecator).to receive(:warn) do |message, *|
+          deprecations << message.to_s
+        end
+
+        load_resources do
+          ActiveAdmin.register_page("Log") do
+            page_action :archive, method: :post
+            page_action :stats, method: :get
+          end
+        end
+
+        hash_arg_warnings = deprecations.grep(/received a hash argument/)
+        expect(hash_arg_warnings).to be_empty,
+          "expected no 'received a hash argument' deprecation, got: #{hash_arg_warnings.inspect}"
+      ensure
+        load_resources {}
+      end
+    end
   end
 end


### PR DESCRIPTION
## What this PR does

Converts the last remaining hash-form routing-DSL call in `Router#page_routes` to keyword form, eliminating the `<verb> received a hash argument` deprecation warning that fires on every `page_action` declaration under Rails 8.1.

```ruby
# before
build_route(verb, "/#{page}/#{action.name}" => "#{page}##{action.name}")

# after
build_route(verb, "/#{page}/#{action.name}", to: "#{page}##{action.name}")
```

`build_route` already uses Ruby's `(verbs, ...)` argument forwarding, so the only change here is at the call site.

## Why

Rails 8.1 deprecated passing a hash as the second positional argument to the routing DSL methods (`get`/`post`/`match`/etc.) and will remove the form entirely in Rails 8.2. PR #8837 ("Add Rails 8.1.0 compatibility") fixed the surrounding `router.get` and `router.namespace` calls but missed this one inside `page_routes`. As a result, any application with `page_action :foo, method: :post` declarations still emits one warning per declaration at boot under 8.1, and will break under 8.2 unless this lands first.

I confirmed the line is unchanged on `master`, on `v3.5.1` (latest stable), and on `v4.0.0.beta22`.

## Risk

Generated routes are identical — `match`/`get`/`post` accept both forms today; only the invocation syntax changes. No behaviour change at runtime.

## Test

Adds a regression test in `spec/unit/routing_spec.rb` that registers a page with both a POST and a GET `page_action` and asserts they route correctly. (Existing routing specs only exercised the page index route, not the per-action routes — which is why the deprecation slipped through.)
