### PR TITLE
Use keyword `to:` in `page_routes`

### DIFF
--- a/lib/active_admin/router.rb
+++ b/lib/active_admin/router.rb
@@ -68,7 +68,7 @@ module ActiveAdmin
       router.get "/#{page}", to: "#{page}#index"
       config.page_actions.each do |action|
         Array.wrap(action.http_verb).each do |verb|
-          build_route(verb, "/#{page}/#{action.name}" => "#{page}##{action.name}")
+          build_route(verb, "/#{page}/#{action.name}", to: "#{page}##{action.name}")
         end
       end
     end


### PR DESCRIPTION
Convert the remaining hash-form route call in `ActiveAdmin::Router#page_routes` to the keyword `to:` form for uniformity with other route invocations and as a cleanup left over from #8837.

This change is purely stylistic, it does not remove any observed Rails 8.1 deprecation warnings, does not seem to alter Rails 8.2 (edge) compatibility, and has no runtime behavior changes.
