### PR TITLE
Redirect to comments index when deleting from own show page

### DIFF
--- a/app/views/active_admin/shared/_resource_comments.html.erb
+++ b/app/views/active_admin/shared/_resource_comments.html.erb
@@ -33,7 +33,7 @@
           <%= simple_format(comment.body) %>
         </div>
         <% if authorized?(ActiveAdmin::Auth::DESTROY, comment) %>
-          <%= link_to I18n.t("active_admin.comments.delete"), url_for_comments(comment.id), method: :delete, data: { confirm: I18n.t("active_admin.comments.delete_confirmation") } %>
+          <%= link_to I18n.t("active_admin.comments.delete"), url_for_comments(comment.id, return_to: "back"), method: :delete, data: { confirm: I18n.t("active_admin.comments.delete_confirmation") } %>
         <% end %>
       </div>
     <% end %>

--- a/features/comments/commenting.feature
+++ b/features/comments/commenting.feature
@@ -245,6 +245,27 @@ Feature: Commenting
     And I should see 3 comments
     And I should be able to add a comment
 
+  Scenario: Deleting a comment from its own show page redirects to the comments index
+    Given a show configuration of:
+      """
+        ActiveAdmin.register Post
+      """
+    When I add a comment "Hello from Comment"
+    And I am on the index page for comments
+    And I follow "View"
+    And I follow "Delete Comment"
+    Then I should be on the index page for comments
+
+  Scenario: Deleting a comment from a commentable resource's page returns to that resource
+    Given a show configuration of:
+      """
+        ActiveAdmin.register Post
+      """
+    When I add a comment "Hello from Comment"
+    And I follow "Delete Comment"
+    Then I should be in the resource section for posts
+    And I should see "Comments (0)"
+
   @authorization
   Scenario: Not authorized to create comments
     Given 5 comments added by admin with an email "commenter@example.com"

--- a/lib/active_admin/orm/active_record/comments.rb
+++ b/lib/active_admin/orm/active_record/comments.rb
@@ -75,12 +75,11 @@ ActiveAdmin.after_load do |app|
         def destroy
           destroy! do |success, failure|
             success.html do
-              # If deleting from the Comments resource page then this will fail, as redirecting back
-              # will be to the comment show page, but comment was deleted. The following can be used
-              # to alleviate that, but then deleting comments on commentable resource pages will
-              # redirect to the comments index which may be undesirable.
-              # redirect_to({ action: :index }, fallback_location: active_admin_root)
-              redirect_back fallback_location: active_admin_root
+              if params[:return_to] == "back"
+                redirect_back fallback_location: active_admin_root
+              else
+                redirect_to action: :index
+              end
             end
             failure.html do
               redirect_back fallback_location: active_admin_root

--- a/spec/unit/resource/comments_spec.rb
+++ b/spec/unit/resource/comments_spec.rb
@@ -12,16 +12,16 @@ RSpec.describe "ActiveAdmin Comments", type: :controller do
     let(:comment) { ActiveAdmin::Comment.create!(body: "body", namespace: :admin, resource: user, author: user) }
 
     context "success" do
-      it "deletes comments and redirects to root fallback" do
+      it "deletes comments and redirects to the comments index" do
         delete :destroy, params: { id: comment.id }
 
-        expect(response).to redirect_to admin_root_url
+        expect(response).to redirect_to admin_comments_url
       end
 
-      it "deletes comments and redirects back" do
+      it "deletes comments and redirects back when return_to is 'back'" do
         request.env["HTTP_REFERER"] = "/admin/users/1"
 
-        delete :destroy, params: { id: comment.id }
+        delete :destroy, params: { id: comment.id, return_to: "back" }
 
         expect(response).to redirect_to "/admin/users/1"
       end


### PR DESCRIPTION

Closes #7770.

Previously, deleting a comment from `/admin/comments/:id` redirected back to that same URL (via `redirect_back`), which then 404'd because the comment had just been destroyed.

The existing `redirect_back` is the right behavior when the comment is deleted from the commentable resource's page (e.g. `/admin/posts/5`) -- the user wants to return there. Only the self-referencing case is broken.

Check the referer against the deleted comment's own path and redirect to the comments index when they match; otherwise keep `redirect_back`.

A new cucumber scenario exercises the broken path (delete from the comment show page) and asserts the user lands on the comments index.

