### PR TITLE
Add `string_input_filters` resource & namespace setting

### DIFF
--- a/docs/3-index-pages.md
+++ b/docs/3-index-pages.md
@@ -111,6 +111,29 @@ To override options for string or numeric filter pass `filters` option.
   filter :title, filters: [:start, :end]
 ```
 
+To set the same options for every string filter at once, instead of passing the
+`filters` option on each one, use `string_input_filters` at the namespace or
+resource level. A resource-level setting overrides the namespace one, and the
+per-filter `filters` option still takes precedence over both.
+
+```ruby
+# config/initializers/active_admin.rb
+ActiveAdmin.setup do |config|
+
+  # Namespace level:
+  config.namespace :admin do |admin|
+    admin.string_input_filters = [:eq, :cont]
+  end
+end
+
+# app/admin/post.rb
+ActiveAdmin.register Post do
+
+  # Resource level:
+  string_input_filters [:eq, :cont]
+end
+```
+
 Also, if you don't need the select with the options 'cont', 'eq', 'start' or
 'end' just add the option to the filter name with an underscore.
 

--- a/docs/3-index-pages.md
+++ b/docs/3-index-pages.md
@@ -111,16 +111,14 @@ To override options for string or numeric filter pass `filters` option.
   filter :title, filters: [:start, :end]
 ```
 
-To set the same options for every string filter at once, instead of passing the
-`filters` option on each one, use `string_input_filters` at the namespace or
+To set the same options for every string filter, instead of passing the `filters`
+option on each, use the `string_input_filters` config at the namespace or
 resource level. A resource-level setting overrides the namespace one, and the
 per-filter `filters` option still takes precedence over both.
 
 ```ruby
 # config/initializers/active_admin.rb
 ActiveAdmin.setup do |config|
-
-  # Namespace level:
   config.namespace :admin do |admin|
     admin.string_input_filters = [:eq, :cont]
   end
@@ -128,8 +126,6 @@ end
 
 # app/admin/post.rb
 ActiveAdmin.register Post do
-
-  # Resource level:
   string_input_filters [:eq, :cont]
 end
 ```

--- a/lib/active_admin/inputs/filters/base/search_method_select.rb
+++ b/lib/active_admin/inputs/filters/base/search_method_select.rb
@@ -51,7 +51,7 @@ module ActiveAdmin
           end
 
           def filters
-            options[:filters] || self.class.filters
+            options[:filters] || resource_default_filters || namespace_default_filters || self.class.filters
           end
 
           def current_filter
@@ -65,6 +65,18 @@ module ActiveAdmin
             filters.collect do |filter|
               [Ransack::Translate.predicate(filter).capitalize, "#{method}_#{filter}"]
             end
+          end
+
+          private
+
+          def resource_default_filters
+            template.respond_to?(:active_admin_config) &&
+              template.active_admin_config&.string_input_filters
+          end
+
+          def namespace_default_filters
+            template.respond_to?(:active_admin_config) &&
+              template.active_admin_config&.namespace.string_input_filters
           end
 
         end

--- a/lib/active_admin/namespace_settings.rb
+++ b/lib/active_admin/namespace_settings.rb
@@ -29,6 +29,11 @@ module ActiveAdmin
     # Whether filters are enabled
     register :filters, true
 
+    # Default `filters` list for string filters
+    # (e.g. `[:cont, :eq, :start, :end]`). When nil, the global
+    # `ActiveAdmin::Inputs::Filters::StringInput.filters` list is used.
+    register :string_input_filters, nil
+
     # The namespace root
     register :root_to, "dashboard#index"
 

--- a/lib/active_admin/namespace_settings.rb
+++ b/lib/active_admin/namespace_settings.rb
@@ -29,9 +29,8 @@ module ActiveAdmin
     # Whether filters are enabled
     register :filters, true
 
-    # Default `filters` list for string filters
-    # (e.g. `[:cont, :eq, :start, :end]`). When nil, the global
-    # `ActiveAdmin::Inputs::Filters::StringInput.filters` list is used.
+    # Default `filters` list for string filters in the namespace.
+    # When `nil`, the global `ActiveAdmin::Inputs::Filters::StringInput.filters` list is used.
     register :string_input_filters, nil
 
     # The namespace root

--- a/lib/active_admin/resource.rb
+++ b/lib/active_admin/resource.rb
@@ -68,6 +68,10 @@ module ActiveAdmin
     # nil to not decorate.
     attr_accessor :decorator_class_name
 
+    # Default `filters` list for string filters on this resource.
+    # When nil, the namespace setting (and then the global default) is used.
+    attr_accessor :string_input_filters
+
     module Base
       def initialize(namespace, resource_class, options = {})
         @namespace = namespace

--- a/lib/active_admin/resource.rb
+++ b/lib/active_admin/resource.rb
@@ -69,7 +69,7 @@ module ActiveAdmin
     attr_accessor :decorator_class_name
 
     # Default `filters` list for string filters on this resource.
-    # When nil, the namespace setting (and then the global default) is used.
+    # If `nil`, then uses the namespace setting, otherwise uses the global default.
     attr_accessor :string_input_filters
 
     module Base

--- a/lib/active_admin/resource_dsl.rb
+++ b/lib/active_admin/resource_dsl.rb
@@ -154,6 +154,19 @@ module ActiveAdmin
       action config.collection_actions, name, options, &block
     end
 
+    # Set the default `filters` list for this resource's string filters.
+    # Takes priority over the namespace-level `string_input_filters` setting.
+    #
+    # For example:
+    #
+    #   ActiveAdmin.register Post do
+    #     string_input_filters [:eq, :cont]
+    #   end
+    #
+    def string_input_filters(value)
+      config.string_input_filters = value
+    end
+
     def decorate_with(decorator_class)
       # Force storage as a string. This will help us with reloading issues.
       # Assuming decorator_class.to_s will return the name of the class allows

--- a/spec/helpers/filter_form_helper_spec.rb
+++ b/spec/helpers/filter_form_helper_spec.rb
@@ -121,6 +121,59 @@ RSpec.describe ActiveAdmin::FormHelper, type: :helper do
         end
       end
     end
+
+    context "with namespace-level string_input_filters" do
+      let(:body) do
+        admin = ActiveAdmin.application.namespace(:admin)
+        admin.string_input_filters = [:eq, :cont]
+        allow(helper).to receive(:active_admin_config)
+          .and_return(double(string_input_filters: nil, namespace: admin))
+        filter :title
+      ensure
+        admin.string_input_filters = nil
+      end
+
+      it "uses the namespace operators (subset and order) instead of the global default" do
+        expect(body).to have_css("option[value=title_eq]", text: "Equals")
+        expect(body).to have_css("option[value=title_cont]", text: "Contains")
+        expect(body).to have_no_css("option[value=title_start]")
+        expect(body).to have_no_css("option[value=title_end]")
+      end
+    end
+
+    context "with resource-level string_input_filters" do
+      let(:body) do
+        allow(helper).to receive(:active_admin_config)
+          .and_return(double(string_input_filters: [:eq, :cont], namespace: nil))
+        filter :title
+      end
+
+      it "uses the resource operators (subset and order) instead of the global default" do
+        expect(body).to have_css("option[value=title_eq]", text: "Equals")
+        expect(body).to have_css("option[value=title_cont]", text: "Contains")
+        expect(body).to have_no_css("option[value=title_start]")
+        expect(body).to have_no_css("option[value=title_end]")
+      end
+    end
+
+    context "with both resource-level and namespace-level string_input_filters" do
+      let(:body) do
+        admin = ActiveAdmin.application.namespace(:admin)
+        admin.string_input_filters = [:cont, :start, :end]
+        allow(helper).to receive(:active_admin_config)
+          .and_return(double(string_input_filters: [:eq, :cont], namespace: admin))
+        filter :title
+      ensure
+        admin.string_input_filters = nil
+      end
+
+      it "lets the resource setting take priority over the namespace setting" do
+        expect(body).to have_css("option[value=title_eq]", text: "Equals")
+        expect(body).to have_css("option[value=title_cont]", text: "Contains")
+        expect(body).to have_no_css("option[value=title_start]")
+        expect(body).to have_no_css("option[value=title_end]")
+      end
+    end
   end
 
   describe "string attribute ended with ransack predicate" do

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -64,6 +64,24 @@ module ActiveAdmin
       end
     end
 
+    describe "#string_input_filters" do
+      it "returns nil by default" do
+        expect(config.string_input_filters).to eq nil
+      end
+
+      context "when set via the DSL" do
+        around do |example|
+          with_resources_during(example) { resource }
+        end
+
+        let(:resource) { namespace.register(Post) { string_input_filters [:eq, :cont] } }
+
+        it "returns the configured filters" do
+          expect(resource.string_input_filters).to eq [:eq, :cont]
+        end
+      end
+    end
+
     describe "controller name" do
       it "should return a namespaced controller name" do
         expect(config.controller_name).to eq "Admin::CategoriesController"


### PR DESCRIPTION
Allow setting the default filters list for string filters, so you don't have to repeat the per-filter filters option
  everywhere. It can be set at the namespace or resource level.

  Precedence (highest to lowest):
  
  1. per-filter filters: option
  2. resource-level string_input_filters
  3. namespace-level string_input_filters
  4. the class default ActiveAdmin::Inputs::Filters::StringInput.filters

```
  # config/initializers/active_admin.rb
  ActiveAdmin.setup do |config|
  
    # Namespace level:
    config.namespace :admin do |admin|
      admin.string_input_filters = [:eq, :cont]
    end
  end
  ```
  
  ```
  # app/admin/post.rb
  ActiveAdmin.register Post do

    # Resource level:
    string_input_filters [:eq, :cont]
  end
  ```
