### PR TITLE
Support Non-ActiveRecord resources

### DIFF
--- a/features/index/non_activerecord_filters.feature
+++ b/features/index/non_activerecord_filters.feature
@@ -27,8 +27,8 @@ Feature: Filters on non-ActiveRecord resources
         end
 
         controller do
-          # Non-AR resources override `find_collection`; Kaminari.paginate_array
-          # adapts the API response for AA's pagination UI.
+          # Non-ActiveRecord resources override `find_collection`; Kaminari.paginate_array
+          # adapts the API response for ActiveAdmin's pagination UI.
           def find_collection(*)
             q = params[:q] || {}
             @search = ApiPost::Search.new(

--- a/features/index/non_ar_filters.feature
+++ b/features/index/non_ar_filters.feature
@@ -1,0 +1,97 @@
+@filters
+Feature: Filters on non-ActiveRecord resources
+
+  ActiveAdmin should let admins use the `filter` DSL on resources that
+  aren't ActiveRecord-backed, without monkey-patching.
+
+  Known limitation: the "Active Search" sidebar is coupled to Ransack,
+  so for a non-Ransack `@search` it renders empty ("No filters applied")
+  instead of filter chips. The filter form, "Clear Filters" link,
+  pagination, and table are unaffected.
+
+  Background:
+    Given I am logged in
+    And a configuration of:
+    """
+      ActiveAdmin.register ApiPost do
+        actions :index
+
+        filter :title_cont, as: :string, label: "Title contains"
+        filter :status_eq,  as: :select, label: "Status",
+               collection: %w[active inactive]
+
+        index do
+          column :id
+          column :title
+          column :status
+        end
+
+        controller do
+          # Non-AR resources override `find_collection`; Kaminari.paginate_array
+          # adapts the API response for AA's pagination UI.
+          def find_collection(*)
+            q = params[:q] || {}
+            @search = ApiPost::Search.new(
+              title_cont: q[:title_cont],
+              status_eq: q[:status_eq]
+            )
+            page = (params[:page] || 1).to_i
+            per_page = 5
+
+            result = ApiPost.fetch(
+              page: page,
+              per_page: per_page,
+              title_cont: @search.title_cont,
+              status_eq: @search.status_eq
+            )
+
+            Kaminari.paginate_array(
+              result.records,
+              total_count: result.total_count,
+              limit:       result.limit,
+              offset:      result.offset
+            ).page(page).per(per_page)
+          end
+        end
+      end
+    """
+
+  Scenario: Server-side pagination across multiple pages
+    When I am on the index page for api_posts
+    Then I should see "Alpha"
+    And I should see "Epsilon"
+    And I should not see "Zeta"
+    And I should see "Showing 1-5 of 7"
+    And I should see pagination page 2 link
+    And I should see the following filters:
+      | Title contains | string |
+      | Status         | select |
+
+    When I follow "2"
+    Then I should see "Zeta"
+    And I should see "Eta"
+    And I should see "Showing 6-7 of 7"
+    And I should not see "Alpha"
+
+  Scenario: Filter narrows the result set to a single page (no pagination)
+    When I am on the index page for api_posts
+    Then I should see pagination page 2 link
+
+    When I select "inactive" from "Status"
+    And I press "Filter"
+    Then I should see "Beta"
+    And I should see "Epsilon"
+    And I should not see "Alpha"
+    And I should not see "Gamma"
+    And I should see "Showing all 2"
+    And I should not see pagination
+
+  Scenario: Filter narrows the result set to a single record
+    When I am on the index page for api_posts
+    And I fill in "Title contains" with "Bet"
+    And I press "Filter"
+    Then I should see "Beta"
+    And I should not see "Alpha"
+    And I should not see "Epsilon"
+    And I should see "Showing 1 of 1"
+    And I should not see pagination

--- a/lib/active_admin/filters/active.rb
+++ b/lib/active_admin/filters/active.rb
@@ -14,7 +14,8 @@ module ActiveAdmin
       # @see ActiveAdmin::ResourceController::DataAccess#apply_filtering
       def initialize(resource, search)
         @resource = resource
-        @filters = build_filters(search.conditions)
+        # Ransack::Search uses method_missing for #conditions, so gate on the class.
+        @filters = search.is_a?(::Ransack::Search) ? build_filters(search.conditions) : []
         @scopes = search.instance_variable_get(:@scope_args)
       end
 

--- a/lib/active_admin/filters/formtastic_addons.rb
+++ b/lib/active_admin/filters/formtastic_addons.rb
@@ -32,9 +32,9 @@ module ActiveAdmin
       # The below are custom methods that Formtastic does not provide.
       #
 
-      # The resource class, unwrapped from Ransack
+      # The resource class, unwrapped from Ransack. Nil for non-Ransack search objects.
       def klass
-        @object.object.klass
+        @object.object.klass if @object.respond_to?(:object) && @object.object.respond_to?(:klass)
       end
 
       def polymorphic_foreign_type?(method)
@@ -66,6 +66,8 @@ module ActiveAdmin
 
       # Ransack supports exposing selected scopes on your model for advanced searches.
       def scope?
+        return false if klass.nil?
+
         context = Ransack::Context.for klass
         context.respond_to?(:ransackable_scope?) && context.ransackable_scope?(method.to_s, klass)
       end

--- a/lib/active_admin/filters/formtastic_addons.rb
+++ b/lib/active_admin/filters/formtastic_addons.rb
@@ -32,7 +32,7 @@ module ActiveAdmin
       # The below are custom methods that Formtastic does not provide.
       #
 
-      # The resource class, unwrapped from Ransack. Nil for non-Ransack search objects.
+      # The resource class, unwrapped from Ransack or `nil` for non-Ransack search objects.
       def klass
         @object.object.klass if @object.respond_to?(:object) && @object.object.respond_to?(:klass)
       end

--- a/lib/active_admin/resource/attributes.rb
+++ b/lib/active_admin/resource/attributes.rb
@@ -5,6 +5,8 @@ module ActiveAdmin
     module Attributes
 
       def default_attributes
+        return {} unless resource_class.respond_to?(:columns)
+
         resource_class.columns.each_with_object({}) do |c, attrs|
           unless reject_col?(c)
             name = c.name.to_sym

--- a/lib/active_admin/views/components/table_for.rb
+++ b/lib/active_admin/views/components/table_for.rb
@@ -160,7 +160,7 @@ module ActiveAdmin
         def sortable?
           if @options.has_key?(:sortable)
             !!@options[:sortable]
-          elsif @resource_class
+          elsif @resource_class.respond_to?(:column_names)
             @resource_class.column_names.include?(sort_column_name)
           else
             @title.present?

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -49,6 +49,8 @@ template File.expand_path("templates/migrations/create_taggings.tt", __dir__), "
 
 copy_file File.expand_path("templates/models/tagging.rb", __dir__), "app/models/tagging.rb"
 
+copy_file File.expand_path("templates/models/api_post.rb", __dir__), "app/models/api_post.rb"
+
 copy_file File.expand_path("templates/helpers/time_helper.rb", __dir__), "app/helpers/time_helper.rb"
 
 copy_file File.expand_path("templates/models/company.rb", __dir__), "app/models/company.rb"

--- a/spec/support/templates/models/api_post.rb
+++ b/spec/support/templates/models/api_post.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# A non-ActiveRecord resource used in features to prove ActiveAdmin's
+# filter DSL works for resources that bypass the AR DataAccess path.
+# `.fetch` returns a page of records plus total_count, like an HTTP API client.
+class ApiPost
+  extend ActiveModel::Naming
+
+  Record = Data.define(:id, :title, :status)
+
+  # The filter form pre-fills inputs via `@search.<filter_name>`, so this needs a reader per filter.
+  Search = Data.define(:title_cont, :status_eq)
+
+  ALL_RECORDS = [
+    Record.new(id: 1, title: "Alpha", status: "active"),
+    Record.new(id: 2, title: "Beta", status: "inactive"),
+    Record.new(id: 3, title: "Gamma", status: "active"),
+    Record.new(id: 4, title: "Delta", status: "active"),
+    Record.new(id: 5, title: "Epsilon", status: "inactive"),
+    Record.new(id: 6, title: "Zeta", status: "active"),
+    Record.new(id: 7, title: "Eta", status: "active")
+  ].freeze
+
+  Result = Data.define(:records, :total_count, :limit, :offset)
+
+  def self.fetch(page: 1, per_page: 5, title_cont: nil, status_eq: nil)
+    page = [page.to_i, 1].max
+    per_page = per_page.to_i
+
+    records = ALL_RECORDS
+    records = records.select { |r| r.title.include?(title_cont) } if title_cont.present?
+    records = records.select { |r| r.status == status_eq } if status_eq.present?
+
+    offset = (page - 1) * per_page
+
+    Result.new(
+      records: records[offset, per_page] || [],
+      total_count: records.size,
+      limit: per_page,
+      offset: offset
+    )
+  end
+end

--- a/spec/support/templates/models/api_post.rb
+++ b/spec/support/templates/models/api_post.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # A non-ActiveRecord resource used in features to prove ActiveAdmin's
-# filter DSL works for resources that bypass the AR DataAccess path.
+# filter DSL works for resources that bypass the ActiveRecord DataAccess path.
 # `.fetch` returns a page of records plus total_count, like an HTTP API client.
 class ApiPost
   extend ActiveModel::Naming


### PR DESCRIPTION
ActiveAdmin's filter pipeline assumed an ActiveRecord-backed resource and a Ransack::Search-shaped `@search` in spots that raised for resources backed by ActiveResource, API client wrappers, ActiveModel, or POROs:

* `FormtasticAddons#klass`, `#scope?`
* `Resource::Attributes#default_attributes`
* `Views::TableFor::Column#sortable?`
* `Filters::Active#initialize`

Each now short-circuits when the resource/search doesn't respond to the AR/Ransack-specific method, returning `nil` / `[]` / `{}` / `false` instead of raising. The AR path is unchanged; no rescues, no monkey-patches.

Covered by `features/index/non_ar_filters.feature`: a PORO `ApiPost` resource with a `find_collection` override and a small `Data`-based `@search` hydrated from `params[:q]`, demonstrating server-side pagination and filter narrowing.

Known limitation: the "Active Search" chips sidebar is tightly coupled to `Ransack::Condition` (predicate / attributes / klass / reflect_on_all_associations). It no longer raises but renders "No filters applied" for non-Ransack searches. Hide it with `config.current_filters = false` or provide a Ransack-shaped wrapper.