### PR TITLE
Mitigate supply-chain attacks with bundle cooldown

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-source "https://rubygems.org"
+source "https://rubygems.org", cooldown: 5
 
 group :development, :test do
   gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    action_text-trix (2.1.18)
+    action_text-trix (2.1.19)
       railties
     actioncable (8.1.3)
       actionpack (= 8.1.3)
@@ -136,9 +136,9 @@ GEM
       cucumber-gherkin (> 36, < 40)
       cucumber-messages (> 31, < 33)
       cucumber-tag-expressions (> 6, < 9)
-    cucumber-cucumber-expressions (19.0.0)
+    cucumber-cucumber-expressions (19.0.1)
       bigdecimal
-    cucumber-gherkin (39.0.0)
+    cucumber-gherkin (39.1.0)
       cucumber-messages (>= 31, < 33)
     cucumber-html-formatter (22.3.0)
       cucumber-messages (> 23, < 33)
@@ -154,7 +154,7 @@ GEM
     database_cleaner-active_record (2.2.2)
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0)
-    database_cleaner-core (2.0.1)
+    database_cleaner-core (2.1.0)
     date (3.5.1)
     devise (5.0.4)
       bcrypt (~> 3.0)
@@ -256,7 +256,7 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.1.0)
+    marcel (1.2.1)
     matrix (0.4.3)
     memoist3 (1.0.0)
     mini_mime (1.1.5)
@@ -293,7 +293,7 @@ GEM
       prettyprint
     prettyprint (0.2.0)
     prism (1.9.0)
-    psych (5.3.1)
+    psych (5.4.0)
       date
       stringio
     public_suffix (7.0.5)
@@ -377,7 +377,7 @@ GEM
       rspec-mocks (>= 3.13.0, < 5.0.0)
       rspec-support (>= 3.13.0, < 5.0.0)
     rspec-support (3.13.7)
-    rubocop (1.86.2)
+    rubocop (1.87.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -459,7 +459,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.8.0)
+    zeitwerk (2.8.2)
 
 PLATFORMS
   aarch64-linux
@@ -502,4 +502,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-  4.0.11
+  4.0.13

--- a/gemfiles/rails_72/Gemfile
+++ b/gemfiles/rails_72/Gemfile
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-source "https://rubygems.org"
+source "https://rubygems.org", cooldown: 5
 
 group :development, :test do
   gem "rake"

--- a/gemfiles/rails_72/Gemfile.lock
+++ b/gemfiles/rails_72/Gemfile.lock
@@ -137,9 +137,9 @@ GEM
       cucumber-gherkin (> 36, < 40)
       cucumber-messages (> 31, < 33)
       cucumber-tag-expressions (> 6, < 9)
-    cucumber-cucumber-expressions (19.0.0)
+    cucumber-cucumber-expressions (19.0.1)
       bigdecimal
-    cucumber-gherkin (39.0.0)
+    cucumber-gherkin (39.1.0)
       cucumber-messages (>= 31, < 33)
     cucumber-html-formatter (22.3.0)
       cucumber-messages (> 23, < 33)
@@ -155,7 +155,7 @@ GEM
     database_cleaner-active_record (2.2.2)
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0)
-    database_cleaner-core (2.0.1)
+    database_cleaner-core (2.1.0)
     date (3.5.1)
     devise (5.0.4)
       bcrypt (~> 3.0)
@@ -254,13 +254,13 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.1.0)
+    marcel (1.2.1)
     matrix (0.4.3)
     memoist3 (1.0.0)
     mini_mime (1.1.5)
     minitest (5.27.0)
     multi_test (1.1.0)
-    net-imap (0.6.3)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)
@@ -279,7 +279,7 @@ GEM
     nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
     orm_adapter (0.5.0)
-    parallel (2.0.1)
+    parallel (2.1.0)
     parallel_tests (5.7.0)
       parallel
     parser (3.3.11.1)
@@ -289,7 +289,7 @@ GEM
       prettyprint
     prettyprint (0.2.0)
     prism (1.9.0)
-    psych (5.3.1)
+    psych (5.4.0)
       date
       stringio
     public_suffix (7.0.5)
@@ -422,7 +422,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.8.0)
+    zeitwerk (2.8.2)
 
 PLATFORMS
   aarch64-linux
@@ -459,4 +459,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-  4.0.11
+  4.0.13

--- a/gemfiles/rails_80/Gemfile
+++ b/gemfiles/rails_80/Gemfile
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-source "https://rubygems.org"
+source "https://rubygems.org", cooldown: 5
 
 group :development, :test do
   gem "rake"

--- a/gemfiles/rails_80/Gemfile.lock
+++ b/gemfiles/rails_80/Gemfile.lock
@@ -134,9 +134,9 @@ GEM
       cucumber-gherkin (> 36, < 40)
       cucumber-messages (> 31, < 33)
       cucumber-tag-expressions (> 6, < 9)
-    cucumber-cucumber-expressions (19.0.0)
+    cucumber-cucumber-expressions (19.0.1)
       bigdecimal
-    cucumber-gherkin (39.0.0)
+    cucumber-gherkin (39.1.0)
       cucumber-messages (>= 31, < 33)
     cucumber-html-formatter (22.3.0)
       cucumber-messages (> 23, < 33)
@@ -152,7 +152,7 @@ GEM
     database_cleaner-active_record (2.2.2)
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0)
-    database_cleaner-core (2.0.1)
+    database_cleaner-core (2.1.0)
     date (3.5.1)
     devise (5.0.4)
       bcrypt (~> 3.0)
@@ -251,7 +251,7 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.1.0)
+    marcel (1.2.1)
     matrix (0.4.3)
     memoist3 (1.0.0)
     mini_mime (1.1.5)
@@ -259,7 +259,7 @@ GEM
       drb (~> 2.0)
       prism (~> 1.5)
     multi_test (1.1.0)
-    net-imap (0.6.3)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)
@@ -278,7 +278,7 @@ GEM
     nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
     orm_adapter (0.5.0)
-    parallel (2.0.1)
+    parallel (2.1.0)
     parallel_tests (5.7.0)
       parallel
     parser (3.3.11.1)
@@ -288,7 +288,7 @@ GEM
       prettyprint
     prettyprint (0.2.0)
     prism (1.9.0)
-    psych (5.3.1)
+    psych (5.4.0)
       date
       stringio
     public_suffix (7.0.5)
@@ -421,7 +421,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.8.0)
+    zeitwerk (2.8.2)
 
 PLATFORMS
   aarch64-linux
@@ -458,4 +458,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-  4.0.11
+  4.0.13


### PR DESCRIPTION
Introduces the new time-based 'cooldown' filter shipped in Bundler  4.0.13. Most supply-chain attacks exploit a tiny window immediately  after a gem version is published. This feature prevents Bundler from  resolving to any gem version until it has been public for a minimum  number of days, allowing time for community vetting.

Ref: https://blog.rubygems.org/2026/06/03/cooldown-let-new-gems-be-vetted.html
