### PR TITLE
Render StringInput instead of select for large associations on the form

### DIFF
--- a/lib/active_admin/form_builder.rb
+++ b/lib/active_admin/form_builder.rb
@@ -17,6 +17,18 @@ module ActiveAdmin
 
     self.input_namespaces = [::Object, ::ActiveAdmin::Inputs, ::Formtastic::Inputs]
 
+    def default_input_type(method, options = {})
+      return super unless method.present? && options[:as].nil?
+      return super if options.key?(:collection)
+
+      reflection = reflection_for(method)
+      if reflection && reflection.macro == :belongs_to && !reflection.polymorphic? && large_association_for_form?(reflection)
+        :association
+      else
+        super
+      end
+    end
+
     def cancel_link(url = { action: "index" }, html_options = {}, li_attrs = {})
       li_attrs[:class] ||= "action cancel"
       html_options[:class] ||= "cancel-link"
@@ -28,6 +40,24 @@ module ActiveAdmin
 
     def has_many(assoc, options = {}, &block)
       HasManyBuilder.new(self, assoc, options).render(&block)
+    end
+
+    private
+
+    def active_admin_config
+      return unless template.respond_to?(:active_admin_config)
+
+      template.active_admin_config
+    end
+
+    def large_association_for_form?(reflection)
+      return false unless active_admin_config
+      max = active_admin_config.namespace.maximum_association_form_arity
+      return false if max.nil? || max == :unlimited
+
+      reflection.klass.reorder(nil).limit(max + 1).count > max
+    rescue StandardError
+      false
     end
   end
 

--- a/lib/active_admin/inputs.rb
+++ b/lib/active_admin/inputs.rb
@@ -15,5 +15,7 @@ module ActiveAdmin
       autoload :CheckBoxesInput
       autoload :BooleanInput
     end
+
+    autoload :AssociationInput
   end
 end

--- a/lib/active_admin/inputs/association_input.rb
+++ b/lib/active_admin/inputs/association_input.rb
@@ -3,6 +3,12 @@
 module ActiveAdmin
   module Inputs
     class AssociationInput < ::Formtastic::Inputs::StringInput
+      def to_html
+        input_wrapping do
+          label_html << builder.text_field(reflection.foreign_key, input_html_options)
+        end
+      end
+
       def input_html_options
         options = super
         options.merge(

--- a/lib/active_admin/inputs/association_input.rb
+++ b/lib/active_admin/inputs/association_input.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module ActiveAdmin
+  module Inputs
+    class AssociationInput < ::Formtastic::Inputs::StringInput
+      def input_html_options
+        options = super
+        options.merge(
+          name: input_name,
+          id: input_html_options_id(options)
+        )
+      end
+
+      def input_html_options_id(options)
+        options[:id] || "#{object_name}_#{reflection.foreign_key}"
+      end
+
+      def input_name
+        if builder.options.key?(:index)
+          "#{object_name}[#{builder.options[:index]}][#{reflection.foreign_key}]"
+        else
+          "#{object_name}[#{reflection.foreign_key}]"
+        end
+      end
+
+      def reflection
+        @reflection ||= object.class.reflect_on_association(method)
+      end
+    end
+  end
+end

--- a/lib/active_admin/namespace_settings.rb
+++ b/lib/active_admin/namespace_settings.rb
@@ -80,6 +80,11 @@ module ActiveAdmin
 
     register :maximum_association_filter_arity, :unlimited
 
+    # When a belongs_to association has more than this many records, Active Admin
+    # will render an association text input on the edit/new form instead of a
+    # select box to avoid loading too many options.
+    register :maximum_association_form_arity, :unlimited
+
     register :filter_columns_for_large_association, [
         :display_name,
         :full_name,

--- a/lib/generators/active_admin/install/templates/active_admin.rb.erb
+++ b/lib/generators/active_admin/install/templates/active_admin.rb.erb
@@ -255,6 +255,7 @@ ActiveAdmin.setup do |config|
   # config.include_default_association_filters = true
 
   # config.maximum_association_filter_arity = 256 # default value of :unlimited will change to 256 in a future version
+  # config.maximum_association_form_arity = 256
   # config.filter_columns_for_large_association = [
   #    :display_name,
   #    :full_name,

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -330,6 +330,35 @@ RSpec.describe ActiveAdmin::FormBuilder do
     end
   end
 
+  context "with large belongs_to associations" do
+    before do
+      allow_any_instance_of(ActiveAdmin::FormBuilder).to receive(:active_admin_config).and_return(
+        double(namespace: double(maximum_association_form_arity: 2))
+      )
+    end
+
+    it "renders text input instead of select when association cardinality is above threshold" do
+      User.create first_name: "John", last_name: "Doe"
+      User.create first_name: "Jane", last_name: "Doe"
+      User.create first_name: "Jim", last_name: "Beam"
+
+      body = build_form do |f|
+        f.input :author
+      end
+
+      expect(body).to have_field("post[author_id]", type: "text")
+      expect(body).to have_no_select("post[author_id]")
+    end
+
+    it "still renders select when association cardinality is below threshold" do
+      body = build_form do |f|
+        f.input :author
+      end
+
+      expect(body).to have_select("post[author_id]")
+    end
+  end
+
   context "with inputs component inside has_many" do
     def user
       u = User.new

--- a/spec/unit/form_builder_spec.rb
+++ b/spec/unit/form_builder_spec.rb
@@ -338,16 +338,29 @@ RSpec.describe ActiveAdmin::FormBuilder do
     end
 
     it "renders text input instead of select when association cardinality is above threshold" do
+      author = User.create first_name: "John", last_name: "Doe"
+      User.create first_name: "Jane", last_name: "Doe"
+      User.create first_name: "Jim", last_name: "Beam"
+
+      post = Post.new(author: author)
+      body = build_form({}, post) do |f|
+        f.input :author
+      end
+
+      expect(body).to have_field("post[author_id]", type: "text", with: author.id.to_s)
+      expect(body).to have_no_select("post[author_id]")
+    end
+
+    it "preserves explicit select override when association cardinality is above threshold" do
       User.create first_name: "John", last_name: "Doe"
       User.create first_name: "Jane", last_name: "Doe"
       User.create first_name: "Jim", last_name: "Beam"
 
       body = build_form do |f|
-        f.input :author
+        f.input :author, as: :select
       end
 
-      expect(body).to have_field("post[author_id]", type: "text")
-      expect(body).to have_no_select("post[author_id]")
+      expect(body).to have_select("post[author_id]")
     end
 
     it "still renders select when association cardinality is below threshold" do


### PR DESCRIPTION
Related to https://github.com/activeadmin/activeadmin/discussions/7863

Add configuration allowing for a text input to replace a select box on the form when there are large belongs_to associations
