### PR TITLE
Backport PR #7437 to 3-0-stable - run update_resource inside a transaction

### DIFF
--- a/features/edit_page.feature
+++ b/features/edit_page.feature
@@ -136,3 +136,18 @@ Feature: Edit Page
     And I follow "Edit"
     Then I should see a fieldset titled "Details"
     And the "Name" field should contain "Bugs"
+
+  Scenario: Save resource within a transaction
+    Given a company named "My company" with a store named "First store" exists
+    And a store named "Second store" exists
+    When I am on the index page for companies
+    And I follow "Edit"
+    Then the "Stores" select should have "First store" selected
+    When I fill in "Name" with ""
+    And I select "Second store" from "Stores"
+    And I press "Update Company"
+    Then I should see "can't be blank"
+    When I follow "Cancel"
+    And I follow "View"
+    Then I should see the attribute "Stores" with "First store"
+    And I should not see the attribute "Stores" with "Second store"

--- a/features/step_definitions/attribute_steps.rb
+++ b/features/step_definitions/attribute_steps.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
-Then /^I should see the attribute "([^"]*)" with "([^"]*)"$/ do |title, value|
+Then /^I should( not)? see the attribute "([^"]*)" with "([^"]*)"$/ do |negate, title, value|
   elems = all ".attributes_table th:contains('#{title}') ~ td:contains('#{value}')"
-  expect(elems.first).to_not eq(nil), "attribute missing"
+
+  if negate
+    expect(elems.first).to eq(nil), "attribute missing"
+  else
+    expect(elems.first).to_not eq(nil), "attribute missing"
+  end
 end
 
 Then /^I should see the attribute "([^"]*)" with a nicely formatted datetime$/ do |title|

--- a/features/step_definitions/factory_steps.rb
+++ b/features/step_definitions/factory_steps.rb
@@ -32,6 +32,12 @@ Given /^a tag named "([^"]*)" exists$/ do |name|
   Tag.create! name: name
 end
 
+Given /^a company named "([^"]*)"(?: with a store named "([^"]*)")? exists$/ do |name, store_name|
+  store = Store.create! name: store_name if store_name
+
+  Company.create! name: name, stores: [store].compact
+end
+
 Given /^I create a new post with the title "([^"]*)"$/ do |title|
   first(:link, "Posts").click
   click_link "New Post"

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -105,6 +105,12 @@ Then /^the "([^"]*)" field(?: within (.*))? should contain "([^"]*)"$/ do |field
   end
 end
 
+Then /^the "([^"]*)" select(?: within (.*))? should have "([^"]+)" selected$/ do |label, parent, option|
+  with_scope(parent) do
+    expect(page).to have_select(label, selected: option)
+  end
+end
+
 Then /^the "([^"]*)" checkbox(?: within (.*))? should( not)? be checked$/ do |label, parent, negate|
   with_scope(parent) do
     checkbox = find_field(label)

--- a/lib/active_admin/resource_controller/data_access.rb
+++ b/lib/active_admin/resource_controller/data_access.rb
@@ -168,11 +168,16 @@ module ActiveAdmin
       #
       # @return [void]
       def update_resource(object, attributes)
-        object = assign_attributes(object, attributes)
+        status = nil
+        ActiveRecord::Base.transaction do
+          object = assign_attributes(object, attributes)
 
-        run_update_callbacks object do
-          save_resource(object)
+          run_update_callbacks object do
+            status = save_resource(object)
+            raise ActiveRecord::Rollback unless status
+          end
         end
+        status
       end
 
       # Destroys an object from the database and calls appropriate callbacks.

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -45,6 +45,10 @@ copy_file File.expand_path("templates/models/tagging.rb", __dir__), "app/models/
 
 copy_file File.expand_path("templates/helpers/time_helper.rb", __dir__), "app/helpers/time_helper.rb"
 
+copy_file File.expand_path("templates/models/company.rb", __dir__), "app/models/company.rb"
+template File.expand_path("templates/migrations/create_companies.tt", __dir__), "db/migrate/#{initial_timestamp + 8}_create_companies.rb"
+template File.expand_path("templates/migrations/create_join_table_companies_stores.tt", __dir__), "db/migrate/#{initial_timestamp + 9}_create_join_table_companies_stores.rb"
+
 inject_into_file "app/models/application_record.rb", before: "end" do
   <<-RUBY
 

--- a/spec/support/templates/admin/companies.rb
+++ b/spec/support/templates/admin/companies.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+ActiveAdmin.register Company do
+  permit_params :name, store_ids: []
+
+  form do |f|
+    f.inputs "Company" do
+      f.input :name
+      f.input :stores
+    end
+    f.actions
+  end
+
+  show do
+    attributes_table :name, :stores, :created_at, :update_at
+  end
+end

--- a/spec/support/templates/migrations/create_companies.tt
+++ b/spec/support/templates/migrations/create_companies.tt
@@ -1,0 +1,9 @@
+class CreateCompanies < ActiveRecord::Migration[<%= Rails::VERSION::MAJOR %>.<%= Rails::VERSION::MINOR %>]
+  def change
+    create_table :companies do |t|
+      t.string :name
+      t.datetime :created_at
+      t.datetime :updated_at
+    end
+  end
+end

--- a/spec/support/templates/migrations/create_join_table_companies_stores.tt
+++ b/spec/support/templates/migrations/create_join_table_companies_stores.tt
@@ -1,0 +1,5 @@
+class CreateJoinTableCompaniesStores < ActiveRecord::Migration[<%= Rails::VERSION::MAJOR %>.<%= Rails::VERSION::MINOR %>]
+  def change
+    create_join_table :companies, :stores
+  end
+end

--- a/spec/support/templates/models/company.rb
+++ b/spec/support/templates/models/company.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class Company < ApplicationRecord
+  has_and_belongs_to_many :stores
+
+  validates :name, presence: true
+end

--- a/spec/support/templates/policies/company_policy.rb
+++ b/spec/support/templates/policies/company_policy.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+class CompanyPolicy < ApplicationPolicy
+end

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe ActiveAdmin::Application do
 
   describe "files in load path" do
     it "it should load sorted files" do
-      expect(application.files.map { |f| File.basename(f) }).to eq(%w(admin_users.rb dashboard.rb stores.rb))
+      expect(application.files.map { |f| File.basename(f) }).to eq(%w(admin_users.rb companies.rb dashboard.rb stores.rb))
     end
 
     it "should load files in the first level directory" do
@@ -153,7 +153,7 @@ RSpec.describe ActiveAdmin::Application do
       begin
         FileUtils.mkdir_p(test_dir)
         FileUtils.touch(test_file)
-        expect(application.files.map { |f| File.basename(f) }).to eq(%w(posts.rb admin_users.rb dashboard.rb stores.rb))
+        expect(application.files.map { |f| File.basename(f) }).to eq(%w(posts.rb admin_users.rb companies.rb dashboard.rb stores.rb))
       ensure
         FileUtils.remove_entry_secure(test_dir, force: true)
       end

--- a/spec/unit/resource_controller_spec.rb
+++ b/spec/unit/resource_controller_spec.rb
@@ -124,6 +124,24 @@ RSpec.describe ActiveAdmin::ResourceController, type: :controller do
       expect(controller.action_methods.sort).to eq ["batch_action", "create", "destroy", "edit", "index", "new", "show", "update"]
     end
   end
+
+  describe "resource update" do
+   let(:controller) { Admin::CompaniesController.new }
+
+   around do |example|
+     with_resources_during(example) do
+       ActiveAdmin.register Company
+     end
+   end
+
+   it "should not update habtm associations when the resource validation fails" do
+     resource = Company.create! name: "my company", stores: [Store.create!(name: "store 1")]
+
+     controller.send(:update_resource, resource, [{ name: "", store_ids: [] }])
+
+     expect(resource.reload.stores).not_to be_empty
+   end
+ end
 end
 
 RSpec.describe "A specific resource controller", type: :controller do


### PR DESCRIPTION
Backport of https://github.com/activeadmin/activeadmin/pull/7437 (run update_resource inside a transaction) to 3-0-stable.

A copy of https://github.com/activeadmin/activeadmin/pull/6202, to not let it be forgotten.

Fixes https://github.com/activeadmin/activeadmin/issues/5430

When submitting a form with invalid attributes, some associations are autosaved via assign_attributes before calling save_resource. As a consequence, when updating a resource, the user sees a validation error and is not aware that the changes to the associations got persisted.

This PR runs the code inside the update_resource method in an ActiveRecord::Transaction so that everything is rolled back when the model is not valid.