### PR TITLE
Migrate SimpleCov to 1.0

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
-SimpleCov.start do
-  add_filter %r{^/spec/}
-  add_filter "tmp/development_apps/"
-  add_filter "tmp/test_apps/"
-  add_filter "tasks/test_application.rb"
-end
 
-if ENV["COVERAGE"] == "true"
-  require "simplecov-cobertura"
-  SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
+SimpleCov.profiles.define "activeadmin" do
+  # Opt out of SimpleCov 1.0's default test_frameworks profile to reintroduce
+  # `/features` coverage and surface dead code there.
+  remove_filter %r{\A(test|features|spec|autotest)/}
+  skip %r{\Aspec/}
+  skip "tmp/development_apps/"
+  skip "tmp/test_apps/"
+  skip "tasks/test_application.rb"
+
+  if ENV["COVERAGE"] == "true"
+    require "simplecov-cobertura"
+    formatter SimpleCov::Formatter::CoberturaFormatter
+  end
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,7 +163,6 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.6.2)
-    docile (1.4.1)
     draper (4.0.6)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -227,7 +226,7 @@ GEM
       reline (>= 0.4.2)
     iso (0.4.0)
       i18n
-    json (2.20.0)
+    json (2.21.1)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)
@@ -247,10 +246,10 @@ GEM
       logger (~> 1.6)
     lint_roller (1.1.0)
     logger (1.7.0)
-    loofah (2.25.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mail (2.9.0)
+    mail (2.9.1)
       logger
       mini_mime (>= 0.1.1)
       net-imap
@@ -286,7 +285,7 @@ GEM
     parallel (2.1.0)
     parallel_tests (5.7.0)
       parallel
-    parser (3.3.11.1)
+    parser (3.3.12.0)
       ast (~> 2.4.1)
       racc
     pp (0.6.4)
@@ -323,8 +322,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.7.0)
-      loofah (~> 2.25)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rails-i18n (8.1.0)
       i18n (>= 0.7, < 2)
@@ -403,7 +402,7 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
-    rubocop-rails (2.35.5)
+    rubocop-rails (2.36.0)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)
@@ -416,15 +415,10 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     securerandom (0.4.1)
-    simplecov (0.22.0)
-      docile (~> 1.1)
-      simplecov-html (~> 0.11)
-      simplecov_json_formatter (~> 0.1)
-    simplecov-cobertura (3.2.0)
+    simplecov (1.0.1)
+    simplecov-cobertura (4.0.0)
       rexml
-      simplecov (~> 0.19)
-    simplecov-html (0.13.2)
-    simplecov_json_formatter (0.1.4)
+      simplecov (~> 1.0)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
       logger
@@ -504,4 +498,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-  4.0.15
+  4.0.16

--- a/features/step_definitions/configuration_steps.rb
+++ b/features/step_definitions/configuration_steps.rb
@@ -25,9 +25,9 @@ Given(/^a(?:n? (index|show))? configuration of:$/) do |action, config_content|
     when "User"
       step "I am on the index page for users"
     else
-      # :nocov:
+      # simplecov:disable
       raise "#{resource} is not supported"
-      # :nocov:
+      # simplecov:enable
     end
   when "show"
     case resource = config_content.match(/ActiveAdmin\.register (\w+)/)[1]
@@ -48,9 +48,9 @@ Given(/^a(?:n? (index|show))? configuration of:$/) do |action, config_content|
       Tag.create!
       visit admin_tag_path Tag.last
     else
-      # :nocov:
+      # simplecov:disable
       raise "#{resource} is not supported"
-      # :nocov:
+      # simplecov:enable
     end
   end
 end

--- a/features/step_definitions/table_steps.rb
+++ b/features/step_definitions/table_steps.rb
@@ -49,9 +49,9 @@ class HtmlTableToTextHelper
     when "checkbox"
       "[ ]"
     else
-      # :nocov:
+      # simplecov:disable
       raise "I don't know what to do with #{input}"
-      # :nocov:
+      # simplecov:enable
     end
   end
 end
@@ -75,14 +75,14 @@ module TableMatchHelper
         begin
           assert_cells_match(cell, expected_cell)
         rescue
-          # :nocov:
+          # simplecov:disable
           puts "Cell at line #{row_index} and column #{column_index}: #{cell.inspect} does not match #{expected_cell.inspect}"
           puts "Expecting:"
           table.each { |row| puts row.inspect }
           puts "to match:"
           expected_table.each { |row| puts row.inspect }
           raise $!
-          # :nocov:
+          # simplecov:enable
         end
       end
     end

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -34,10 +34,10 @@ module WithinHelpers
       $1
 
     else
-      # :nocov:
+      # simplecov:disable
       raise "Can't find mapping from \"#{locator}\" to a selector.\n" +
         "Now, go and add a mapping in #{__FILE__}"
-      # :nocov:
+      # simplecov:enable
     end
   end
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 ENV["RAILS_ENV"] = "test"
 
-require "simplecov" if ENV["COVERAGE"] == "true"
+require_relative "../../spec/support/simplecov_helper"
+
+ActiveAdmin::TestSupport::SimpleCovHelper.start("features")
 
 Dir["#{File.expand_path('../step_definitions', __dir__)}/*.rb"].each do |f|
   require f
@@ -30,9 +32,9 @@ Around "@mocks" do |scenario, block|
 end
 
 After "@debug" do |scenario|
-  # :nocov:
+  # simplecov:disable
   save_and_open_page if scenario.failed?
-  # :nocov:
+  # simplecov:enable
 end
 
 require "capybara/cuprite"

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -65,11 +65,11 @@ module NavigationHelpers
         page_name =~ /the (.*) page/
         path_components = $1.split(/\s+/)
         self.send path_components.push("path").join("_")
-        # :nocov:
+        # simplecov:disable
       rescue Object
         raise "Can't find mapping from \"#{page_name}\" to a path.\n" +
           "Now, go and add a mapping in #{__FILE__}"
-        # :nocov:
+        # simplecov:enable
       end
     end
   end

--- a/features/support/simplecov_changes_env.rb
+++ b/features/support/simplecov_changes_env.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
-if ENV["COVERAGE"] == "true"
-  require "simplecov"
+require_relative "../../spec/support/simplecov_helper"
 
-  SimpleCov.command_name "filesystem changes features"
-end
+ActiveAdmin::TestSupport::SimpleCovHelper.start("filesystem changes features")
 
 require_relative "env"

--- a/features/support/simplecov_regular_env.rb
+++ b/features/support/simplecov_regular_env.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
-if ENV["COVERAGE"] == "true"
-  require "simplecov"
+require_relative "../../spec/support/simplecov_helper"
 
-  SimpleCov.command_name ["regular features", ENV["TEST_ENV_NUMBER"]].join(" ").rstrip
-end
+ActiveAdmin::TestSupport::SimpleCovHelper.start(["regular features", ENV["TEST_ENV_NUMBER"]].join(" ").rstrip)
 
 require_relative "env"

--- a/features/support/simplecov_reload_env.rb
+++ b/features/support/simplecov_reload_env.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
-if ENV["COVERAGE"] == "true"
-  require "simplecov"
+require_relative "../../spec/support/simplecov_helper"
 
-  SimpleCov.command_name "reload features"
-end
+ActiveAdmin::TestSupport::SimpleCovHelper.start("reload features")
 
 require_relative "env"

--- a/gemfiles/rails_72/Gemfile.lock
+++ b/gemfiles/rails_72/Gemfile.lock
@@ -164,7 +164,6 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.6.2)
-    docile (1.4.1)
     draper (4.0.6)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -245,10 +244,10 @@ GEM
       childprocess (~> 5.0)
       logger (~> 1.6)
     logger (1.7.0)
-    loofah (2.25.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mail (2.9.0)
+    mail (2.9.1)
       logger
       mini_mime (>= 0.1.1)
       net-imap
@@ -282,7 +281,7 @@ GEM
     parallel (2.1.0)
     parallel_tests (5.7.0)
       parallel
-    parser (3.3.11.1)
+    parser (3.3.12.0)
       ast (~> 2.4.1)
       racc
     pp (0.6.4)
@@ -319,8 +318,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.7.0)
-      loofah (~> 2.25)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rails-i18n (7.0.10)
       i18n (>= 0.7, < 2)
@@ -379,15 +378,10 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     securerandom (0.4.1)
-    simplecov (0.22.0)
-      docile (~> 1.1)
-      simplecov-html (~> 0.11)
-      simplecov_json_formatter (~> 0.1)
-    simplecov-cobertura (3.2.0)
+    simplecov (1.0.1)
+    simplecov-cobertura (4.0.0)
       rexml
-      simplecov (~> 0.19)
-    simplecov-html (0.13.2)
-    simplecov_json_formatter (0.1.4)
+      simplecov (~> 1.0)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
       logger
@@ -460,4 +454,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-  4.0.15
+  4.0.16

--- a/gemfiles/rails_80/Gemfile.lock
+++ b/gemfiles/rails_80/Gemfile.lock
@@ -161,7 +161,6 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.6.2)
-    docile (1.4.1)
     draper (4.0.6)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -242,10 +241,10 @@ GEM
       childprocess (~> 5.0)
       logger (~> 1.6)
     logger (1.7.0)
-    loofah (2.25.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mail (2.9.0)
+    mail (2.9.1)
       logger
       mini_mime (>= 0.1.1)
       net-imap
@@ -281,7 +280,7 @@ GEM
     parallel (2.1.0)
     parallel_tests (5.7.0)
       parallel
-    parser (3.3.11.1)
+    parser (3.3.12.0)
       ast (~> 2.4.1)
       racc
     pp (0.6.4)
@@ -318,8 +317,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.7.0)
-      loofah (~> 2.25)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rails-i18n (8.1.0)
       i18n (>= 0.7, < 2)
@@ -377,15 +376,10 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     securerandom (0.4.1)
-    simplecov (0.22.0)
-      docile (~> 1.1)
-      simplecov-html (~> 0.11)
-      simplecov_json_formatter (~> 0.1)
-    simplecov-cobertura (3.2.0)
+    simplecov (1.0.1)
+    simplecov-cobertura (4.0.0)
       rexml
-      simplecov (~> 0.19)
-    simplecov-html (0.13.2)
-    simplecov_json_formatter (0.1.4)
+      simplecov (~> 1.0)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
       logger
@@ -459,4 +453,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-  4.0.15
+  4.0.16

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,16 +23,16 @@
       }
     },
     "node_modules/@algolia/abtesting": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.21.1.tgz",
-      "integrity": "sha512-Wia5/mNTfiU0PIUN25UMfAGGdASkkwuCS9nBAdmhqrNPY/ff7U/6MgBVdwFDPsa3sA1msutPtO50gvOzx6MOXA==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.21.2.tgz",
+      "integrity": "sha512-uXj0rgk30EpsKvOpuS+R+1XFDrnm56hED1Lz56e8uBkZdKCxw99LS2U8eXBqAHYU8kpkbsnV1GC8velBG070Hg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -88,41 +88,41 @@
       }
     },
     "node_modules/@algolia/client-abtesting": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.55.1.tgz",
-      "integrity": "sha512-miW8RzAtBgNiEJ9fGEhsOPgWUpekAe64YcVufqXrlykj0Jjmo5nj0a5f/HAzRVX5ZuU1GAVd7BkzFDx7q50P3A==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.55.2.tgz",
+      "integrity": "sha512-y7Epol8HcjlBxKXHhyhfFPFhm78B3P6x9cCbCyGTdxjsdVCptXCy5hpkZWxjGpnaLHvWsHS4QRF0TiBOLst2xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.55.1.tgz",
-      "integrity": "sha512-eR3J3kB9JX6DdCvDRi3I4KPfwO6fR9HWYRXhVke2TXIoOQafMKCRAneg33JRmIrb+DnnJ/eWApJLF1O1CLPERg==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.55.2.tgz",
+      "integrity": "sha512-8Pxj2VVmpM2d+UZufnlTq7T1QIcYPVugLV5XC50PnHsV5uRM9CSoYkg2Y+CwqwRk2La0xK5QsfZ0obIU+9XftQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.55.1.tgz",
-      "integrity": "sha512-P5ak7EurwYqgAiDyb95mgA3WRR/Zu8CPMv36lWTISvL2AmlPyqQPy2nX/KEJRTcwaeTWwrk6wJV4/M93GfjOWw==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.55.2.tgz",
+      "integrity": "sha512-9L4IpIYUqA63a7sw1trnHQGUvwiAjKz67nsgDnal98JGAc7wyposRb0Iag+eiMuyzFFaSHLe2/rGyIo+PafRBA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -130,151 +130,151 @@
       }
     },
     "node_modules/@algolia/client-insights": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.55.1.tgz",
-      "integrity": "sha512-OVtj9uA//+pjvKQI5INnzbyLrf3ClNv3XRbWswwJ2kHIStQNHtBfHo+LofNB/WhM9xjuXlW5ANn2aMj65UGx7w==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.55.2.tgz",
+      "integrity": "sha512-ZBm2ytY5EHFcj+kjNsXxMNO/TGlOHe2fBFXGKHJOM1bk1rAy4o2YI+d9oV/w/jrqx44pvJMJlc8X6vKnCuDgUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.55.1.tgz",
-      "integrity": "sha512-oKlVFlp+qbIEe4p7E54zSiP2gEV/vDu972Ykv8VDMFwEvreS7m0YKA3a8hGGHwc7yiBUGGiR3LlwzMLfnJmy6Q==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.55.2.tgz",
+      "integrity": "sha512-3FGVW/jDk7sdYwqa2NKnF/qXWcttc4bvGrwNbvqz3VoWSRv42CNvRk+3Y9QJFIUf1vY50hAuVWUoFKdyc8vaXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.55.1.tgz",
-      "integrity": "sha512-BOVrld6vdtsFmotVDMTVQfYXwrVplJ+DUvy60JFi+tkWV698q2J9NNPKEO3dr5qxtSLKQP4vHF8n+3U5PDWhOQ==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.55.2.tgz",
+      "integrity": "sha512-JsG8LovDAYul5t8e533tZ3O1uZILxso5zsTtB7ONc5RJ8ACdTxAAC/jaOnsBNYb+x+STP7fzx/Iro55v5DNgoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.55.1.tgz",
-      "integrity": "sha512-GAqHl9zERhC3bbBfubwUu07G3UXO06gORvOcsiTBZB3et0s3auNUbHlYdYNp4VKa3sUZqH5AcD3OKzU/KDGXjQ==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.55.2.tgz",
+      "integrity": "sha512-5wDnoIfC75zJ2MSHv5SSzTlRL2z7jQMbqQ5jrzottuq2p3oBObv8pD/JpXWu8pRaimaxNr3/Bs/KZIGVXxJ7hg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/ingestion": {
-      "version": "1.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.55.1.tgz",
-      "integrity": "sha512-BXZw+C+gsWL7pZvbnhJUnCXASiDLGcQxVV7h55Pyh2DmSzwdZIVccE5xc9RVD2trtrhIqk5smuODTxtaZqd0IA==",
+      "version": "1.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.55.2.tgz",
+      "integrity": "sha512-da+SC6ikpza98W7C5ChsKEQDvZc8PQLQ0sxmQ5yMRsHpdD3iPKnclJA6ViB5Nr5T9qOX+IDswC6AyqY4V3rtug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/monitoring": {
-      "version": "1.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.55.1.tgz",
-      "integrity": "sha512-9g/ceZrZTqA62FA3588Xj0onRPjDNfu0pVQqefK0rrHp9H6Wblph/YmzGjZ2g8uqbTh0ZGIvAGCzErU8f7MHpA==",
+      "version": "1.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.55.2.tgz",
+      "integrity": "sha512-Y8kEcPqCiIEeaGv83l9RRA09mfYECqAJHNnOyEtZc9UirI6XBMUyFVss/sSeYUiV/Lf30hkbWcl00V1uXsf86Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.55.1.tgz",
-      "integrity": "sha512-cZTIrGyAP+W4A6jDVwvWM/JOaoJKQkD/2a5eLUEeNdKAD45jN7BCpsMDONyhZlosLa4UwL8uiINQzj4iFy9nqg==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.55.2.tgz",
+      "integrity": "sha512-5zmobuCQqFZkx+84Nt+suL7vo6jTh2CfAs2ndDSeTS2QHvnzP8YEEGWtWftjyACI0cK/FuH8urWwCHP+d2j8TA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.55.1.tgz",
-      "integrity": "sha512-N6I3leW0UO8Y9Zv90yo2UHgYGuxZO0mjbvzNxDIJDjO0qECEF7Z9XMvSNeUWXQh/iNDA9lr8MfEy3rmZGIcclw==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.55.2.tgz",
+      "integrity": "sha512-qnGUUuWG66dRMnr33owLsrYIh9fHVxtU4R2rd3SpneAHuoAUcGbDOWNrj05glVU6M8yOqo9gQ22K8zpz0I8Xpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1"
+        "@algolia/client-common": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-fetch": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.55.1.tgz",
-      "integrity": "sha512-ukU5zeeFs44rQkzv+TRdYard+d+3lmPGs8lPZhHtWE8rfz+LlBSF6s9kP3VQ7LeOYL8Dz0u6tZfnyTrqrumbHQ==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.55.2.tgz",
+      "integrity": "sha512-lKZ5uhafMvR7dWCJEyuaeyZitid1I3ICx+k0vGf5x/ktdIQvc7bndCiOPpmIDqUmN26FE3jTehkAzSqee95G2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1"
+        "@algolia/client-common": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.55.1.tgz",
-      "integrity": "sha512-lCwXyijwPm3vbYHpBXPRomMcD6mgiptmps27gnMCf4HK+u/AOeFPBnIFh4V3l4A5SnP9VRiKBZqwGBpUH0vaTg==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.55.2.tgz",
+      "integrity": "sha512-Zc90xvKWUvxcNicvvTO9Pr/hT2TAnkixOIzJm/KMj5Ptm2pKjk71ngTsdkbRtJQvhZ2Kr9N1YdIjLrNHB5P2xw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1"
+        "@algolia/client-common": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -967,9 +967,9 @@
       }
     },
     "node_modules/@iconify-json/simple-icons": {
-      "version": "1.2.87",
-      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.87.tgz",
-      "integrity": "sha512-8YciStObhSji3OZFmWAWK6kBujyqO5bLCxeDwLxf3CR3F4PVelq7keC2LBvgTqviWzSTysj5/g4PCFLiAMVGsw==",
+      "version": "1.2.90",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.90.tgz",
+      "integrity": "sha512-zt2o2ZvQpHVvZJARIkZ51RnaHY2oqcPJMvHE+mVnxkSr+c33fnX4gciiXu+wyX5ei+s0qbVX1wD0DWBbaGBYMA==",
       "dev": true,
       "license": "CC0-1.0",
       "dependencies": {
@@ -1067,9 +1067,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -1228,6 +1228,9 @@
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1240,6 +1243,9 @@
       "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1254,6 +1260,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1266,6 +1275,9 @@
       "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1280,6 +1292,9 @@
       "cpu": [
         "loong64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1292,6 +1307,9 @@
       "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
       "cpu": [
         "loong64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1306,6 +1324,9 @@
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1318,6 +1339,9 @@
       "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
       "cpu": [
         "ppc64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1332,6 +1356,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1344,6 +1371,9 @@
       "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
       "cpu": [
         "riscv64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1358,6 +1388,9 @@
       "cpu": [
         "s390x"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1371,6 +1404,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1383,6 +1419,9 @@
       "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1569,9 +1608,9 @@
       "license": "MIT"
     },
     "node_modules/@types/hast": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
-      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1628,9 +1667,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.0.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
-      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1665,9 +1704,9 @@
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
-      "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
       "dev": true,
       "license": "ISC"
     },
@@ -1740,23 +1779,23 @@
       }
     },
     "node_modules/@vue/devtools-api": {
-      "version": "7.7.9",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
-      "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+      "version": "7.7.10",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.10.tgz",
+      "integrity": "sha512-KxtEpUOOpFz/qOGRrAwA36QF7DqIA+FXgCYit9mk9wjbaZt0sXOFz81ElOZtKA4HbWHUdwNjZHBFsFFyp5BZiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-kit": "^7.7.9"
+        "@vue/devtools-kit": "^7.7.10"
       }
     },
     "node_modules/@vue/devtools-kit": {
-      "version": "7.7.9",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
-      "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+      "version": "7.7.10",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.10.tgz",
+      "integrity": "sha512-3WNi2Kq4tbpVbmhml7RiphmAt0279oh3fKNeWMQIrltfX8Q91b4i5PL8DtyNKdwmcsGrV4fg+erwWOmD05CLIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-shared": "^7.7.9",
+        "@vue/devtools-shared": "^7.7.10",
         "birpc": "^2.3.0",
         "hookable": "^5.5.3",
         "mitt": "^3.0.1",
@@ -1766,9 +1805,9 @@
       }
     },
     "node_modules/@vue/devtools-shared": {
-      "version": "7.7.9",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
-      "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+      "version": "7.7.10",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.10.tgz",
+      "integrity": "sha512-wOPslzB8vTvpxwdaOcR2qAbwmuSP0L+rhpoC6Cf56V3Jip+HWb7PQQXOUPgBNQARpXsbQX/+mvi8kKucmBGRwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1977,26 +2016,26 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.55.1.tgz",
-      "integrity": "sha512-FyaFnnsbVPtevQwqSj/SdxE3jAsSsY0BEH8IVLf9rXxEBdAhAmT6VKCVSMWoaPIHVN1Eufh/1w8q6k8URpIkWw==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.55.2.tgz",
+      "integrity": "sha512-OyacJsaeuLUvGWOynNqYc6sx88XvyoG39wMT8SYqL3l9wwaorDW/LPRbUPfhzw0bWsUWzNCZTnFYOrWFBKsUaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/abtesting": "1.21.1",
-        "@algolia/client-abtesting": "5.55.1",
-        "@algolia/client-analytics": "5.55.1",
-        "@algolia/client-common": "5.55.1",
-        "@algolia/client-insights": "5.55.1",
-        "@algolia/client-personalization": "5.55.1",
-        "@algolia/client-query-suggestions": "5.55.1",
-        "@algolia/client-search": "5.55.1",
-        "@algolia/ingestion": "1.55.1",
-        "@algolia/monitoring": "1.55.1",
-        "@algolia/recommend": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/abtesting": "1.21.2",
+        "@algolia/client-abtesting": "5.55.2",
+        "@algolia/client-analytics": "5.55.2",
+        "@algolia/client-common": "5.55.2",
+        "@algolia/client-insights": "5.55.2",
+        "@algolia/client-personalization": "5.55.2",
+        "@algolia/client-query-suggestions": "5.55.2",
+        "@algolia/client-search": "5.55.2",
+        "@algolia/ingestion": "1.55.2",
+        "@algolia/monitoring": "1.55.2",
+        "@algolia/recommend": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -2023,9 +2062,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2306,9 +2345,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
-      "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
+      "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -2702,9 +2741,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3151,9 +3190,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -3297,9 +3336,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3309,9 +3348,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -3337,14 +3376,22 @@
       }
     },
     "node_modules/preact": {
-      "version": "10.29.2",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
-      "integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==",
+      "version": "10.29.7",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.7.tgz",
+      "integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==",
       "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
       }
     },
     "node_modules/prelude-ls": {
@@ -3672,9 +3719,9 @@
       "license": "MIT"
     },
     "node_modules/tailwindcss": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
-      "integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.2.tgz",
+      "integrity": "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==",
       "dev": true,
       "license": "MIT"
     },

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
-require "simplecov" if ENV["COVERAGE"] == "true"
+require_relative "support/simplecov_helper"
+
+ActiveAdmin::TestSupport::SimpleCovHelper.start("RSpec")
 
 require_relative "support/matchers/perform_database_query_matcher"
 require_relative "support/shared_contexts/capture_stderr"

--- a/spec/support/simplecov_changes_env.rb
+++ b/spec/support/simplecov_changes_env.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
-if ENV["COVERAGE"] == "true"
-  require "simplecov"
+require_relative "simplecov_helper"
 
-  SimpleCov.command_name "filesystem changes specs"
-end
+ActiveAdmin::TestSupport::SimpleCovHelper.start("filesystem changes specs")

--- a/spec/support/simplecov_helper.rb
+++ b/spec/support/simplecov_helper.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module ActiveAdmin
+  module TestSupport
+    module SimpleCovHelper
+      module_function
+
+      def start(command_name = nil)
+        return unless ENV["COVERAGE"] == "true"
+        return if @started
+
+        require "simplecov"
+
+        ::SimpleCov.command_name(command_name) if command_name
+        ::SimpleCov.start "activeadmin"
+
+        @started = true
+      end
+    end
+  end
+end

--- a/spec/support/simplecov_regular_env.rb
+++ b/spec/support/simplecov_regular_env.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
-if ENV["COVERAGE"] == "true"
-  require "simplecov"
+require_relative "simplecov_helper"
 
-  SimpleCov.command_name ["regular specs", ENV["TEST_ENV_NUMBER"]].join(" ").rstrip
-end
+ActiveAdmin::TestSupport::SimpleCovHelper.start(["regular specs", ENV["TEST_ENV_NUMBER"]].join(" ").rstrip)

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -15,9 +15,9 @@ namespace :setup do
   desc "Makes test app creation code available"
   task :require do
     if ENV["COVERAGE"] == "true"
-      require "simplecov"
+      require_relative "../spec/support/simplecov_helper"
 
-      SimpleCov.command_name "test app creation"
+      ActiveAdmin::TestSupport::SimpleCovHelper.start("test app creation")
     end
 
     require_relative "test_application"


### PR DESCRIPTION
SimpleCov 1.0 deprecates starting coverage from `.simplecov` and
warns on the legacy `add_filter` and `:nocov:` APIs.

ActiveAdmin also merges coverage across parallel RSpec, Cucumber, and
the test-app setup task, so the start point must stay explicit in
each test entrypoint.

Define an ActiveAdmin profile in .simplecov, start it from the RSpec,
Cucumber, and rake helpers, and keep the old filtering semantics by
removing SimpleCov's default test-suite filter before skipping `spec/`
again.