### PR TITLE
Remove docs/CNAME file as it is not required

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-activeadmin.info


### PR DESCRIPTION
The repo uses a custom GitHub Actions workflow (`docs-deployment.yml`)
to publish to GitHub Pages via `actions/deploy-pages`. Per GitHub
documentation, CNAME files are ignored when publishing from a custom
workflow.

See: https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/troubleshooting-custom-domains-and-github-pages#cname-errors