### PR TITLE
Update docs to reflect removed site_title and footer configs

### DIFF
--- a/docs/1-general-configuration.md
+++ b/docs/1-general-configuration.md
@@ -38,11 +38,10 @@ If you want, you can customize it.
 
 ```ruby
 config.site_title       = "My Admin Site"
-config.site_title_link  = "/"
-config.site_title_image = "site_image.png"
-config.site_title_image = "https://www.google.com/images/logos/google_logo_41.png"
-config.site_title_image = ->(context) { context.current_user.company.logo_url }
 ```
+
+> **Note**: To customize the site title linking or image, you can override the `app/views/active_admin/_site_header.html.erb` partial in your application.
+
 
 ## Internationalization (I18n)
 
@@ -215,9 +214,13 @@ end
 
 ## Footer Customization
 
-By default, Active Admin displays a "Powered by ActiveAdmin" message on every
-page. You can override this message and show domain-specific messaging:
+By default, Active Admin displays a "Powered by ActiveAdmin" message on the footer of every
+page. To customize or override this message and show domain-specific messaging, you can override the `app/views/active_admin/_site_footer.html.erb` partial in your application.
 
-```ruby
-config.footer = "MyApp Revision v1.3"
+For example, create the file `app/views/active_admin/_site_footer.html.erb` with the following content:
+
+```erb
+<div class="text-sm text-center mt-16 mx-8 pt-9 pb-12 text-gray-500 border-t border-gray-200 dark:border-gray-800">
+  MyApp Revision v1.3
+</div>
 ```


### PR DESCRIPTION
These configs (config.footer, config.site_title_link, and
config.site_title_image) were removed in favor of overriding simple
partials in activeadmin/activeadmin#8156. However, the
docs were not updated at the time.

This removes the outdated ruby configurations and instead provides
instructions for overriding the `_site_footer.html.erb` and
`_site_header.html.erb` partials.
<!--

Thanks for contributing to ActiveAdmin!

You can find the instructions in our contributing guide: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md

Before submitting your PR make sure that:
* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are separated.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all CI checks are passing, but feel free to ask for early feedback if you need guidance.

[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->
