### PR TITLE
feat: Support `:if` option on `member_action` and `collection_action`

### DIFF
--- a/app/controllers/active_admin/resource_controller/action_builder.rb
+++ b/app/controllers/active_admin/resource_controller/action_builder.rb
@@ -5,6 +5,20 @@ module ActiveAdmin
     module ActionBuilder
       extend ActiveSupport::Concern
 
+      private
+
+      def restrict_action_access!(condition)
+        allowed =
+          case condition
+          when Symbol, String
+            send condition
+          when Proc
+            instance_exec(&condition)
+          end
+
+        raise ActionController::RoutingError, "Not Found" unless allowed
+      end
+
       module ClassMethods
 
         def clear_member_actions!

--- a/docs/8-custom-actions.md
+++ b/docs/8-custom-actions.md
@@ -70,6 +70,24 @@ member_action :foo, method: [:get, :post] do
 end
 ```
 
+## Conditionally Enabling Actions
+
+The `collection_action` and `member_action` methods both accept
+the `:if` argument to guard the action on a per-request basis.
+It accepts a proc (evaluated in the controller context) or a symbol naming a controller method.
+When it returns a falsey value, the request raises `ActionController::RoutingError`,
+which Rails renders as a 404 in production.
+
+```ruby
+member_action :archive, method: :post, if: -> { resource.archivable? } do
+  resource.archive!
+  redirect_to resource_path, notice: "Archived!"
+end
+```
+
+Note that this only guards the controller action itself. If you also display a
+link to the action with `action_item`, hide it with its own `:if` option.
+
 ## Rendering
 
 Custom controller actions support rendering within the standard Active Admin

--- a/lib/active_admin/resource_dsl.rb
+++ b/lib/active_admin/resource_dsl.rb
@@ -139,9 +139,11 @@ module ActiveAdmin
 
       set << ControllerAction.new(name, options)
       title = options.delete(:title)
+      condition = options.delete(:if)
 
       controller do
         before_action(only: [name]) { @page_title = title } if title
+        before_action(only: [name]) { restrict_action_access!(condition) } if condition
         define_method(name, &block || Proc.new {})
       end
     end

--- a/spec/unit/action_builder_spec.rb
+++ b/spec/unit/action_builder_spec.rb
@@ -64,6 +64,62 @@ RSpec.describe "defining actions from registration blocks", type: :controller do
         expect(controller.instance_variable_get(:@page_title)).to eq "My Awesome Comment"
       end
     end
+
+    context "with :if proc" do
+      let(:action!) do
+        ActiveAdmin.register Post do
+          member_action :comment, if: -> { params[:allowed] == "true" } do
+            render json: { a: 2 }
+          end
+        end
+      end
+
+      context "when the proc returns a truthy value" do
+        it "allows the request" do
+          get :comment, params: { id: 1, allowed: "true" }
+
+          expect(response).to be_successful
+        end
+      end
+
+      context "when the proc returns a falsey value" do
+        it "raises a routing error" do
+          expect { get :comment, params: { id: 1 } }.to raise_error ActionController::RoutingError
+        end
+      end
+    end
+
+    context "with :if symbol" do
+      let(:action!) do
+        ActiveAdmin.register Post do
+          member_action :comment, if: :comment_allowed? do
+            render json: { a: 2 }
+          end
+
+          controller do
+            private
+
+            def comment_allowed?
+              params[:allowed] == "true"
+            end
+          end
+        end
+      end
+
+      context "when the method returns a truthy value" do
+        it "allows the request" do
+          get :comment, params: { id: 1, allowed: "true" }
+
+          expect(response).to be_successful
+        end
+      end
+
+      context "when the method returns a falsey value" do
+        it "raises a routing error" do
+          expect { get :comment, params: { id: 1 } }.to raise_error ActionController::RoutingError
+        end
+      end
+    end
   end
 
   describe "creates a collection action" do
@@ -118,6 +174,30 @@ RSpec.describe "defining actions from registration blocks", type: :controller do
         get :comments
 
         expect(controller.instance_variable_get(:@page_title)).to eq "My Awesome Comments"
+      end
+    end
+
+    context "with :if proc" do
+      let(:action!) do
+        ActiveAdmin.register Post do
+          collection_action :comments, if: -> { params[:allowed] == "true" } do
+            render json: { a: 2 }
+          end
+        end
+      end
+
+      context "when the proc returns a truthy value" do
+        it "allows the request" do
+          get :comments, params: { allowed: "true" }
+
+          expect(response).to be_successful
+        end
+      end
+
+      context "when the proc returns a falsey value" do
+        it "raises a routing error" do
+          expect { get :comments }.to raise_error ActionController::RoutingError
+        end
       end
     end
   end


### PR DESCRIPTION
I proposed this in #9050 a while ago, so I've decided to open a PR since it's easier to evaluate the idea with working code.

## Problem

`member_action` and `collection_action` accept an options hash, but silently ignore the `:if` option:

```ruby
member_action :archive, method: :post, if: -> { resource.archivable? } do
  # always reachable; the proc does nothing
end
```

This is surprising because `:if` is honored almost everywhere else in the DSL (action items, sidebars, etc.) via `OptionalDisplay`, so it is easy to assume it works here too. As a result, the custom action stays reachable for anyone who crafts the request, even when the corresponding `action_item` link is hidden.

## Solution

Both methods now accept `:if` as a per-request guard, mirroring the `OptionalDisplay` semantics:

* A `Proc` is evaluated in the controller context on each request, so `resource`, `params` and other controller helpers are available.
* A `Symbol` (or `String`) names a controller method to call, including private ones.

When the condition returns a falsey value, the request raises `ActionController::RoutingError`, which Rails renders as a 404 in production. A guarded-off action therefore renders as if it does not exist.

Implementation-wise:
- `ResourceDSL#action` extracts the `:if` option and installs a `before_action` scoped to that action only. 
- The condition evaluation lives in a new private controller method, `restrict_action_access!`, in `ResourceController::ActionBuilder`, named after the existing [restrict_download_format_access!](https://github.com/activeadmin/activeadmin/blob/0f853ce27e549de320fcb113a247eb782b2c7e7c/app/controllers/active_admin/resource_controller.rb#L92-L100) guard that follows the same pattern.

```ruby
controller do
  before_action(only: [name]) { @page_title = title } if title
  before_action(only: [name]) { restrict_action_access!(condition) } if condition
  define_method(name, &block || Proc.new {})
end
```

The documentation was also updated and gained a **"Conditionally Enabling Actions"** section, describing new behavior.